### PR TITLE
fix(typescript): don't attempt to decode 204 No Content responses

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedNonThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedNonThrowingEndpointResponse.ts
@@ -176,7 +176,10 @@ export class GeneratedNonThrowingEndpointResponse implements GeneratedEndpointRe
                       ts.factory.createToken(ts.SyntaxKind.QuestionToken),
                       this.getOkResponseBody(context),
                       ts.factory.createToken(ts.SyntaxKind.ColonToken),
-                      ts.factory.createIdentifier("undefined")
+                      ts.factory.createAsExpression(
+                          ts.factory.createIdentifier("undefined"),
+                          ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)
+                      )
                   )
                 : ts.factory.createIdentifier("undefined");
 

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedNonThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedNonThrowingEndpointResponse.ts
@@ -159,10 +159,31 @@ export class GeneratedNonThrowingEndpointResponse implements GeneratedEndpointRe
     }
 
     private getReturnValueForOkResponse(context: SdkContext): ts.Expression | undefined {
-        return context.coreUtilities.fetcher.APIResponse.SuccessfulResponse._build(
+        // For endpoints with a defined response body, use a conditional to guard against
+        // 204 No Content responses: if the body is null/undefined, return undefined data
+        // instead of attempting to deserialize an empty body.
+        const bodyExpression =
             this.endpoint.response?.body != null
-                ? this.getOkResponseBody(context)
-                : ts.factory.createIdentifier("undefined"),
+                ? ts.factory.createConditionalExpression(
+                      ts.factory.createBinaryExpression(
+                          ts.factory.createPropertyAccessExpression(
+                              ts.factory.createIdentifier(
+                                  GeneratedNonThrowingEndpointResponse.RESPONSE_VARIABLE_NAME
+                              ),
+                              context.coreUtilities.fetcher.APIResponse.SuccessfulResponse.body
+                          ),
+                          ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsToken),
+                          ts.factory.createNull()
+                      ),
+                      ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+                      this.getOkResponseBody(context),
+                      ts.factory.createToken(ts.SyntaxKind.ColonToken),
+                      ts.factory.createIdentifier("undefined")
+                  )
+                : ts.factory.createIdentifier("undefined");
+
+        return context.coreUtilities.fetcher.APIResponse.SuccessfulResponse._build(
+            bodyExpression,
             ts.factory.createPropertyAccessExpression(
                 ts.factory.createIdentifier(GeneratedNonThrowingEndpointResponse.RESPONSE_VARIABLE_NAME),
                 context.coreUtilities.fetcher.APIResponse.SuccessfulResponse.headers

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedNonThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedNonThrowingEndpointResponse.ts
@@ -167,9 +167,7 @@ export class GeneratedNonThrowingEndpointResponse implements GeneratedEndpointRe
                 ? ts.factory.createConditionalExpression(
                       ts.factory.createBinaryExpression(
                           ts.factory.createPropertyAccessExpression(
-                              ts.factory.createIdentifier(
-                                  GeneratedNonThrowingEndpointResponse.RESPONSE_VARIABLE_NAME
-                              ),
+                              ts.factory.createIdentifier(GeneratedNonThrowingEndpointResponse.RESPONSE_VARIABLE_NAME),
                               context.coreUtilities.fetcher.APIResponse.SuccessfulResponse.body
                           ),
                           ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsToken),

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
@@ -1024,7 +1024,45 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
 
     private getReturnStatementsForOkResponse(context: SdkContext): ts.Statement[] {
         if (this.endpoint.response?.body != null) {
-            return this.getReturnStatementsForOkResponseBody(context);
+            const bodyStatements = this.getReturnStatementsForOkResponseBody(context);
+            // Add a runtime guard for 204 No Content responses: if the response body is null/undefined,
+            // return early with undefined data instead of attempting to deserialize an empty body.
+            const noContentGuard = ts.factory.createIfStatement(
+                ts.factory.createBinaryExpression(
+                    ts.factory.createPropertyAccessExpression(
+                        ts.factory.createIdentifier(GeneratedThrowingEndpointResponse.RESPONSE_VARIABLE_NAME),
+                        context.coreUtilities.fetcher.APIResponse.SuccessfulResponse.body
+                    ),
+                    ts.factory.createToken(ts.SyntaxKind.EqualsEqualsToken),
+                    ts.factory.createNull()
+                ),
+                ts.factory.createBlock(
+                    [
+                        ts.factory.createReturnStatement(
+                            ts.factory.createObjectLiteralExpression(
+                                [
+                                    ts.factory.createPropertyAssignment(
+                                        ts.factory.createIdentifier("data"),
+                                        ts.factory.createIdentifier("undefined")
+                                    ),
+                                    ts.factory.createPropertyAssignment(
+                                        ts.factory.createIdentifier("rawResponse"),
+                                        ts.factory.createPropertyAccessExpression(
+                                            ts.factory.createIdentifier(
+                                                GeneratedThrowingEndpointResponse.RESPONSE_VARIABLE_NAME
+                                            ),
+                                            ts.factory.createIdentifier("rawResponse")
+                                        )
+                                    )
+                                ],
+                                false
+                            )
+                        )
+                    ],
+                    true
+                )
+            );
+            return [noContentGuard, ...bodyStatements];
         }
 
         const dataInitializer =

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
@@ -1043,7 +1043,10 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
                                 [
                                     ts.factory.createPropertyAssignment(
                                         ts.factory.createIdentifier("data"),
-                                        ts.factory.createIdentifier("undefined")
+                                        ts.factory.createAsExpression(
+                                            ts.factory.createIdentifier("undefined"),
+                                            ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)
+                                        )
                                     ),
                                     ts.factory.createPropertyAssignment(
                                         ts.factory.createIdentifier("rawResponse"),

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.52.9
+  changelogEntry:
+    - summary: |
+        Don't attempt to decode 204 No Content responses. When an endpoint has a defined
+        response body type but the server returns a 204 with no body, the generated SDK
+        now returns `undefined` instead of attempting to deserialize the empty response,
+        which would previously throw a parse error.
+      type: fix
+  createdAt: "2026-03-02"
+  irVersion: 65
+
 - version: 3.52.8
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/auth/client/Client.ts
@@ -64,6 +64,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedAnyAuth.TokenResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/auth/client/Client.ts
@@ -65,7 +65,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedAnyAuth.TokenResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/user/client/Client.ts
@@ -61,7 +61,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedAnyAuth.User[], rawResponse: _response.rawResponse };
         }
@@ -117,7 +117,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedAnyAuth.User[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/user/client/Client.ts
@@ -60,6 +60,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedAnyAuth.User[], rawResponse: _response.rawResponse };
         }
 
@@ -113,6 +116,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedAnyAuth.User[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -63,7 +63,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedAnyAuth.TokenResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -62,6 +62,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedAnyAuth.TokenResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/user/client/Client.ts
@@ -54,6 +54,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedAnyAuth.User[], rawResponse: _response.rawResponse };
         }
 
@@ -103,6 +106,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedAnyAuth.User[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/user/client/Client.ts
@@ -55,7 +55,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedAnyAuth.User[], rawResponse: _response.rawResponse };
         }
@@ -107,7 +107,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedAnyAuth.User[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
@@ -62,6 +62,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedAudiences.folderA.Response, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
@@ -63,7 +63,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedAudiences.folderA.Response, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
@@ -54,7 +54,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedAudiences.folderD.Response, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
@@ -53,6 +53,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedAudiences.folderD.Response, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/audiences/no-custom-config/src/api/resources/foo/client/Client.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/api/resources/foo/client/Client.ts
@@ -66,7 +66,7 @@ export class FooClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedAudiences.ImportingType, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/audiences/no-custom-config/src/api/resources/foo/client/Client.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/api/resources/foo/client/Client.ts
@@ -65,6 +65,9 @@ export class FooClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedAudiences.ImportingType, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/audiences/with-partner-audience/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/api/resources/folderD/resources/service/client/Client.ts
@@ -54,7 +54,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedAudiences.folderD.Response, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/audiences/with-partner-audience/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/api/resources/folderD/resources/service/client/Client.ts
@@ -53,6 +53,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedAudiences.folderD.Response, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/basic-auth-environment-variables/src/api/resources/basicAuth/client/Client.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/api/resources/basicAuth/client/Client.ts
@@ -61,7 +61,7 @@ export class BasicAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -136,7 +136,7 @@ export class BasicAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/basic-auth-environment-variables/src/api/resources/basicAuth/client/Client.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/api/resources/basicAuth/client/Client.ts
@@ -60,6 +60,9 @@ export class BasicAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -132,6 +135,9 @@ export class BasicAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/basic-auth/src/api/resources/basicAuth/client/Client.ts
+++ b/seed/ts-sdk/basic-auth/src/api/resources/basicAuth/client/Client.ts
@@ -61,7 +61,7 @@ export class BasicAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -136,7 +136,7 @@ export class BasicAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/basic-auth/src/api/resources/basicAuth/client/Client.ts
+++ b/seed/ts-sdk/basic-auth/src/api/resources/basicAuth/client/Client.ts
@@ -60,6 +60,9 @@ export class BasicAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -132,6 +135,9 @@ export class BasicAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/bearer-token-environment-variable/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/api/resources/service/client/Client.ts
@@ -59,7 +59,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/bearer-token-environment-variable/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/api/resources/service/client/Client.ts
@@ -58,6 +58,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/bytes-download/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/bytes-download/src/api/resources/service/client/Client.ts
@@ -91,6 +91,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/bytes-download/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/bytes-download/src/api/resources/service/client/Client.ts
@@ -92,7 +92,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/client-side-params/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/client-side-params/src/api/resources/service/client/Client.ts
@@ -78,7 +78,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedClientSideParams.Resource[], rawResponse: _response.rawResponse };
         }
@@ -143,7 +143,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedClientSideParams.Resource, rawResponse: _response.rawResponse };
         }
@@ -214,7 +214,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedClientSideParams.SearchResponse, rawResponse: _response.rawResponse };
         }
@@ -297,7 +297,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedClientSideParams.PaginatedUserResponse,
@@ -365,7 +365,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedClientSideParams.User, rawResponse: _response.rawResponse };
         }
@@ -440,7 +440,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedClientSideParams.User, rawResponse: _response.rawResponse };
         }
@@ -518,7 +518,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedClientSideParams.User, rawResponse: _response.rawResponse };
         }
@@ -630,7 +630,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedClientSideParams.Connection[], rawResponse: _response.rawResponse };
         }
@@ -693,7 +693,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedClientSideParams.Connection, rawResponse: _response.rawResponse };
         }
@@ -781,7 +781,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedClientSideParams.PaginatedClientResponse,
@@ -849,7 +849,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedClientSideParams.Client, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/client-side-params/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/client-side-params/src/api/resources/service/client/Client.ts
@@ -77,6 +77,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedClientSideParams.Resource[], rawResponse: _response.rawResponse };
         }
 
@@ -139,6 +142,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedClientSideParams.Resource, rawResponse: _response.rawResponse };
         }
 
@@ -207,6 +213,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedClientSideParams.SearchResponse, rawResponse: _response.rawResponse };
         }
 
@@ -287,6 +296,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedClientSideParams.PaginatedUserResponse,
                 rawResponse: _response.rawResponse,
@@ -352,6 +364,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedClientSideParams.User, rawResponse: _response.rawResponse };
         }
 
@@ -424,6 +439,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedClientSideParams.User, rawResponse: _response.rawResponse };
         }
 
@@ -499,6 +517,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedClientSideParams.User, rawResponse: _response.rawResponse };
         }
 
@@ -608,6 +629,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedClientSideParams.Connection[], rawResponse: _response.rawResponse };
         }
 
@@ -668,6 +692,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedClientSideParams.Connection, rawResponse: _response.rawResponse };
         }
 
@@ -753,6 +780,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedClientSideParams.PaginatedClientResponse,
                 rawResponse: _response.rawResponse,
@@ -818,6 +848,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedClientSideParams.Client, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
@@ -52,7 +52,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedCrossPackageTypeNames.folderA.Response,

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
@@ -51,6 +51,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedCrossPackageTypeNames.folderA.Response,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
@@ -51,6 +51,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedCrossPackageTypeNames.folderD.Response,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
@@ -52,7 +52,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedCrossPackageTypeNames.folderD.Response,

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/foo/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/foo/client/Client.ts
@@ -66,7 +66,7 @@ export class FooClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedCrossPackageTypeNames.ImportingType,

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/foo/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/foo/client/Client.ts
@@ -65,6 +65,9 @@ export class FooClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedCrossPackageTypeNames.ImportingType,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderA/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderA/resources/service/client/Client.ts
@@ -52,6 +52,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.folderA.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderA/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderA/resources/service/client/Client.ts
@@ -53,7 +53,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.folderA.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderD/resources/service/client/Client.ts
@@ -53,7 +53,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.folderD.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderD/resources/service/client/Client.ts
@@ -52,6 +52,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.folderD.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/foo/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/foo/client/Client.ts
@@ -66,6 +66,9 @@ export class FooClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.ImportingType.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/foo/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/foo/client/Client.ts
@@ -67,7 +67,7 @@ export class FooClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.ImportingType.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/endpoint-security-auth/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/api/resources/auth/client/Client.ts
@@ -65,7 +65,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedEndpointSecurityAuth.TokenResponse,

--- a/seed/ts-sdk/endpoint-security-auth/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/api/resources/auth/client/Client.ts
@@ -64,6 +64,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedEndpointSecurityAuth.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/endpoint-security-auth/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/api/resources/user/client/Client.ts
@@ -62,6 +62,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
 
@@ -117,6 +120,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
 
@@ -172,6 +178,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
 
@@ -227,6 +236,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
 
@@ -282,6 +294,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
 
@@ -339,6 +354,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
 
@@ -396,6 +414,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/endpoint-security-auth/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/api/resources/user/client/Client.ts
@@ -63,7 +63,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
@@ -121,7 +121,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
@@ -179,7 +179,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
@@ -237,7 +237,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
@@ -295,7 +295,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
@@ -355,7 +355,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }
@@ -415,7 +415,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedEndpointSecurityAuth.User[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/error-property/no-custom-config/src/api/resources/propertyBasedError/client/Client.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/api/resources/propertyBasedError/client/Client.ts
@@ -55,6 +55,9 @@ export class PropertyBasedErrorClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/error-property/no-custom-config/src/api/resources/propertyBasedError/client/Client.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/api/resources/propertyBasedError/client/Client.ts
@@ -56,7 +56,7 @@ export class PropertyBasedErrorClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/error-property/union-utils/src/api/resources/propertyBasedError/client/Client.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/api/resources/propertyBasedError/client/Client.ts
@@ -55,6 +55,9 @@ export class PropertyBasedErrorClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/error-property/union-utils/src/api/resources/propertyBasedError/client/Client.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/api/resources/propertyBasedError/client/Client.ts
@@ -56,7 +56,7 @@ export class PropertyBasedErrorClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/errors/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/errors/src/api/resources/simple/client/Client.ts
@@ -66,7 +66,7 @@ export class SimpleClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedErrors.FooResponse, rawResponse: _response.rawResponse };
         }
@@ -147,7 +147,7 @@ export class SimpleClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedErrors.FooResponse, rawResponse: _response.rawResponse };
         }
@@ -233,7 +233,7 @@ export class SimpleClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedErrors.FooResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/errors/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/errors/src/api/resources/simple/client/Client.ts
@@ -65,6 +65,9 @@ export class SimpleClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedErrors.FooResponse, rawResponse: _response.rawResponse };
         }
 
@@ -143,6 +146,9 @@ export class SimpleClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedErrors.FooResponse, rawResponse: _response.rawResponse };
         }
 
@@ -226,6 +232,9 @@ export class SimpleClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedErrors.FooResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/Client.ts
@@ -72,6 +72,9 @@ export class SeedExamplesClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -122,6 +125,9 @@ export class SeedExamplesClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.Identifier, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/Client.ts
@@ -73,7 +73,7 @@ export class SeedExamplesClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -126,7 +126,7 @@ export class SeedExamplesClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.Identifier, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/notification/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/notification/resources/service/client/Client.ts
@@ -64,6 +64,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.Exception, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/notification/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/notification/resources/service/client/Client.ts
@@ -65,7 +65,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.Exception, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/service/client/Client.ts
@@ -72,6 +72,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.File_, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/service/client/Client.ts
@@ -73,7 +73,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.File_, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/health/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/health/resources/service/client/Client.ts
@@ -112,7 +112,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/health/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/health/resources/service/client/Client.ts
@@ -111,6 +111,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/service/client/Client.ts
@@ -57,7 +57,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.Movie, rawResponse: _response.rawResponse };
         }
@@ -133,7 +133,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.MovieId, rawResponse: _response.rawResponse };
         }
@@ -198,7 +198,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.Metadata, rawResponse: _response.rawResponse };
         }
@@ -413,7 +413,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.Response, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/service/client/Client.ts
@@ -56,6 +56,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.Movie, rawResponse: _response.rawResponse };
         }
 
@@ -129,6 +132,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.MovieId, rawResponse: _response.rawResponse };
         }
 
@@ -191,6 +197,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.Metadata, rawResponse: _response.rawResponse };
         }
 
@@ -403,6 +412,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.Response, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/examples/retain-original-casing/src/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/Client.ts
@@ -72,6 +72,9 @@ export class SeedExamplesClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -122,6 +125,9 @@ export class SeedExamplesClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.Identifier, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/examples/retain-original-casing/src/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/Client.ts
@@ -73,7 +73,7 @@ export class SeedExamplesClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -126,7 +126,7 @@ export class SeedExamplesClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.Identifier, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/notification/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/notification/resources/service/client/Client.ts
@@ -64,6 +64,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.Exception, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/notification/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/notification/resources/service/client/Client.ts
@@ -65,7 +65,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.Exception, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/service/client/Client.ts
@@ -72,6 +72,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.File_, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/service/client/Client.ts
@@ -73,7 +73,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.File_, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/health/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/health/resources/service/client/Client.ts
@@ -112,7 +112,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/health/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/health/resources/service/client/Client.ts
@@ -111,6 +111,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/service/client/Client.ts
@@ -57,7 +57,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.Movie, rawResponse: _response.rawResponse };
         }
@@ -133,7 +133,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.MovieId, rawResponse: _response.rawResponse };
         }
@@ -198,7 +198,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.Metadata, rawResponse: _response.rawResponse };
         }
@@ -413,7 +413,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExamples.Response, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/service/client/Client.ts
@@ -56,6 +56,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.Movie, rawResponse: _response.rawResponse };
         }
 
@@ -129,6 +132,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.MovieId, rawResponse: _response.rawResponse };
         }
 
@@ -191,6 +197,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.Metadata, rawResponse: _response.rawResponse };
         }
 
@@ -403,6 +412,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExamples.Response, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -68,6 +68,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnListOfPrimitives.Response.parseOrThrow(
                     _response.body,
@@ -149,6 +152,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnListOfObjects.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -218,6 +224,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnSetOfPrimitives.Response.parseOrThrow(
                     _response.body,
@@ -292,6 +301,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnSetOfObjects.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -363,6 +375,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnMapPrimToPrim.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -436,6 +451,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnMapOfPrimToObject.Response.parseOrThrow(
                     _response.body,
@@ -517,6 +535,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion.Response.parseOrThrow(
                     _response.body,
@@ -591,6 +612,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnOptional.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -69,7 +69,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnListOfPrimitives.Response.parseOrThrow(
@@ -153,7 +153,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnListOfObjects.Response.parseOrThrow(_response.body, {
@@ -225,7 +225,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnSetOfPrimitives.Response.parseOrThrow(
@@ -302,7 +302,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnSetOfObjects.Response.parseOrThrow(_response.body, {
@@ -376,7 +376,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnMapPrimToPrim.Response.parseOrThrow(_response.body, {
@@ -452,7 +452,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnMapOfPrimToObject.Response.parseOrThrow(
@@ -536,7 +536,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion.Response.parseOrThrow(
@@ -613,7 +613,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnOptional.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -69,7 +69,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.WeatherReport.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -68,6 +68,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.WeatherReport.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,6 +59,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.httpMethods.testGet.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -132,6 +135,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -208,6 +214,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -298,6 +307,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -363,6 +375,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.httpMethods.testDelete.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -60,7 +60,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.httpMethods.testGet.Response.parseOrThrow(_response.body, {
@@ -136,7 +136,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -215,7 +215,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -308,7 +308,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -376,7 +376,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.httpMethods.testDelete.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -85,7 +85,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -164,7 +164,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithRequiredField.parseOrThrow(_response.body, {
@@ -247,7 +247,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithMapOfMap.parseOrThrow(_response.body, {
@@ -345,7 +345,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.NestedObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -446,7 +446,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.NestedObjectWithRequiredField.parseOrThrow(_response.body, {
@@ -563,7 +563,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.NestedObjectWithRequiredField.parseOrThrow(_response.body, {
@@ -644,7 +644,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithUnknownField.parseOrThrow(_response.body, {
@@ -728,7 +728,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithDatetimeLikeString.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -84,6 +84,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -160,6 +163,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithRequiredField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -240,6 +246,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithMapOfMap.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -335,6 +344,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.NestedObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -433,6 +445,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.NestedObjectWithRequiredField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -547,6 +562,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.NestedObjectWithRequiredField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -625,6 +643,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithUnknownField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -706,6 +727,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithDatetimeLikeString.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,6 +69,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: serializers.endpoints.PaginatedResponse.parseOrThrow(_response.body, {
                             unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -70,7 +70,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: serializers.endpoints.PaginatedResponse.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,6 +61,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.params.getWithPath.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -129,6 +132,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.params.getWithInlinePath.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -459,6 +465,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.params.modifyWithPath.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -534,6 +543,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.params.modifyWithInlinePath.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -608,6 +620,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithRequiredField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -62,7 +62,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.params.getWithPath.Response.parseOrThrow(_response.body, {
@@ -133,7 +133,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.params.getWithInlinePath.Response.parseOrThrow(_response.body, {
@@ -466,7 +466,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.params.modifyWithPath.Response.parseOrThrow(_response.body, {
@@ -544,7 +544,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.params.modifyWithInlinePath.Response.parseOrThrow(_response.body, {
@@ -621,7 +621,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithRequiredField.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -67,6 +67,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnString.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -136,6 +139,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnInt.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -205,6 +211,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnLong.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -274,6 +283,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDouble.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -343,6 +355,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnBool.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -412,6 +427,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDatetime.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -481,6 +499,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDate.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -550,6 +571,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnUuid.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -619,6 +643,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnBase64.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -68,7 +68,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnString.Response.parseOrThrow(_response.body, {
@@ -140,7 +140,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnInt.Response.parseOrThrow(_response.body, {
@@ -212,7 +212,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnLong.Response.parseOrThrow(_response.body, {
@@ -284,7 +284,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDouble.Response.parseOrThrow(_response.body, {
@@ -356,7 +356,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnBool.Response.parseOrThrow(_response.body, {
@@ -428,7 +428,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDatetime.Response.parseOrThrow(_response.body, {
@@ -500,7 +500,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDate.Response.parseOrThrow(_response.body, {
@@ -572,7 +572,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnUuid.Response.parseOrThrow(_response.body, {
@@ -644,7 +644,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnBase64.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -66,7 +66,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.PutResponse.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,6 +65,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.PutResponse.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -73,7 +73,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.Animal.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -72,6 +72,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.Animal.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,6 +54,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.urls.withMixedCase.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -110,6 +113,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.urls.noEndingSlash.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -166,6 +172,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.urls.withEndingSlash.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -222,6 +231,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.urls.withUnderscores.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -55,7 +55,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.urls.withMixedCase.Response.parseOrThrow(_response.body, {
@@ -114,7 +114,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.urls.noEndingSlash.Response.parseOrThrow(_response.body, {
@@ -173,7 +173,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.urls.withEndingSlash.Response.parseOrThrow(_response.body, {
@@ -232,7 +232,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.urls.withUnderscores.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/inlinedRequests/client/Client.ts
@@ -88,7 +88,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/inlinedRequests/client/Client.ts
@@ -87,6 +87,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noAuth/client/Client.ts
@@ -67,7 +67,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.noAuth.postWithNoAuth.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noAuth/client/Client.ts
@@ -66,6 +66,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.noAuth.postWithNoAuth.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noReqBody/client/Client.ts
@@ -60,7 +60,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -121,7 +121,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.noReqBody.postWithNoRequestBody.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noReqBody/client/Client.ts
@@ -59,6 +59,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -117,6 +120,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.noReqBody.postWithNoRequestBody.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number | bigint, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number | bigint, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/container/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/container/client/Client.js
@@ -83,6 +83,9 @@ class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -129,6 +132,9 @@ class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -174,6 +180,9 @@ class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -218,6 +227,9 @@ class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -265,6 +277,9 @@ class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -311,6 +326,9 @@ class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -358,6 +376,9 @@ class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -405,6 +426,9 @@ class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/enum/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/enum/client/Client.js
@@ -83,6 +83,9 @@ class EnumClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/httpMethods/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/httpMethods/client/Client.js
@@ -80,6 +80,9 @@ class HttpMethodsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -126,6 +129,9 @@ class HttpMethodsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -176,6 +182,9 @@ class HttpMethodsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -240,6 +249,9 @@ class HttpMethodsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -284,6 +296,9 @@ class HttpMethodsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/object/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/object/client/Client.js
@@ -99,6 +99,9 @@ class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -146,6 +149,9 @@ class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -197,6 +203,9 @@ class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -261,6 +270,9 @@ class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -409,6 +424,9 @@ class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -458,6 +476,9 @@ class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -510,6 +531,9 @@ class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/pagination/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/pagination/client/Client.js
@@ -88,6 +88,9 @@ class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/params/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/params/client/Client.js
@@ -82,6 +82,9 @@ class ParamsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -126,6 +129,9 @@ class ParamsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -365,6 +371,9 @@ class ParamsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -413,6 +422,9 @@ class ParamsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -460,6 +472,9 @@ class ParamsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/primitive/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/primitive/client/Client.js
@@ -83,6 +83,9 @@ class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -125,6 +128,9 @@ class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -167,6 +173,9 @@ class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -209,6 +218,9 @@ class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -251,6 +263,9 @@ class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -293,6 +308,9 @@ class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -335,6 +353,9 @@ class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -377,6 +398,9 @@ class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -419,6 +443,9 @@ class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/put/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/put/client/Client.js
@@ -83,6 +83,9 @@ class PutClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/union/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/union/client/Client.js
@@ -87,6 +87,9 @@ class UnionClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/urls/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/urls/client/Client.js
@@ -79,6 +79,9 @@ class UrlsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -117,6 +120,9 @@ class UrlsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -155,6 +161,9 @@ class UrlsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -193,6 +202,9 @@ class UrlsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/inlinedRequests/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/inlinedRequests/client/Client.js
@@ -107,6 +107,9 @@ class InlinedRequestsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noAuth/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noAuth/client/Client.js
@@ -89,6 +89,9 @@ class NoAuthClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noReqBody/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noReqBody/client/Client.js
@@ -79,6 +79,9 @@ class NoReqBodyClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -120,6 +123,9 @@ class NoReqBodyClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/container/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/container/client/Client.mjs
@@ -47,6 +47,9 @@ export class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -93,6 +96,9 @@ export class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -138,6 +144,9 @@ export class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -182,6 +191,9 @@ export class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -229,6 +241,9 @@ export class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -275,6 +290,9 @@ export class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -322,6 +340,9 @@ export class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -369,6 +390,9 @@ export class ContainerClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/enum/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/enum/client/Client.mjs
@@ -47,6 +47,9 @@ export class EnumClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/httpMethods/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/httpMethods/client/Client.mjs
@@ -44,6 +44,9 @@ export class HttpMethodsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -90,6 +93,9 @@ export class HttpMethodsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -140,6 +146,9 @@ export class HttpMethodsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -204,6 +213,9 @@ export class HttpMethodsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -248,6 +260,9 @@ export class HttpMethodsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/object/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/object/client/Client.mjs
@@ -63,6 +63,9 @@ export class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -161,6 +167,9 @@ export class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -225,6 +234,9 @@ export class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -290,6 +302,9 @@ export class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -373,6 +388,9 @@ export class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -422,6 +440,9 @@ export class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -474,6 +495,9 @@ export class ObjectClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/pagination/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/pagination/client/Client.mjs
@@ -52,6 +52,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/params/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/params/client/Client.mjs
@@ -46,6 +46,9 @@ export class ParamsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -90,6 +93,9 @@ export class ParamsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -329,6 +335,9 @@ export class ParamsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -377,6 +386,9 @@ export class ParamsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -424,6 +436,9 @@ export class ParamsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/primitive/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/primitive/client/Client.mjs
@@ -47,6 +47,9 @@ export class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -89,6 +92,9 @@ export class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -131,6 +137,9 @@ export class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -173,6 +182,9 @@ export class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -215,6 +227,9 @@ export class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -257,6 +272,9 @@ export class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -299,6 +317,9 @@ export class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -341,6 +362,9 @@ export class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -383,6 +407,9 @@ export class PrimitiveClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/put/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/put/client/Client.mjs
@@ -47,6 +47,9 @@ export class PutClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/union/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/union/client/Client.mjs
@@ -51,6 +51,9 @@ export class UnionClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/urls/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/urls/client/Client.mjs
@@ -43,6 +43,9 @@ export class UrlsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -81,6 +84,9 @@ export class UrlsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -119,6 +125,9 @@ export class UrlsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {
@@ -157,6 +166,9 @@ export class UrlsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/inlinedRequests/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/inlinedRequests/client/Client.mjs
@@ -71,6 +71,9 @@ export class InlinedRequestsClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noAuth/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noAuth/client/Client.mjs
@@ -53,6 +53,9 @@ export class NoAuthClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noReqBody/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noReqBody/client/Client.mjs
@@ -43,6 +43,9 @@ export class NoReqBodyClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return {
                     data: _response.body,
                     rawResponse: _response.rawResponse,
@@ -84,6 +87,9 @@ export class NoReqBodyClient {
                 logging: this._options.logging,
             });
             if (_response.ok) {
+                if (_response.body == null) {
+                    return { data: undefined, rawResponse: _response.rawResponse };
+                }
                 return { data: _response.body, rawResponse: _response.rawResponse };
             }
             if (_response.error.reason === "status-code") {

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -71,7 +71,7 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string[]) : undefined,
+                    body: _response.body != null ? (_response.body as string[]) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -154,7 +154,7 @@ export class ContainerClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithRequiredField[])
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -224,7 +224,7 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string[]) : undefined,
+                    body: _response.body != null ? (_response.body as string[]) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -305,7 +305,7 @@ export class ContainerClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithRequiredField[])
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -377,7 +377,7 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as Record<string, string>) : undefined,
+                    body: _response.body != null ? (_response.body as Record<string, string>) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -460,7 +460,7 @@ export class ContainerClient {
                     body:
                         _response.body != null
                             ? (_response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -543,7 +543,7 @@ export class ContainerClient {
                     body:
                         _response.body != null
                             ? (_response.body as Record<string, SeedExhaustive.types.MixedType>)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -626,7 +626,7 @@ export class ContainerClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -71,7 +71,7 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string[],
+                    body: _response.body != null ? (_response.body as string[]) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -151,7 +151,10 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithRequiredField[])
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -221,7 +224,7 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string[],
+                    body: _response.body != null ? (_response.body as string[]) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -299,7 +302,10 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithRequiredField[])
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -371,7 +377,7 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as Record<string, string>,
+                    body: _response.body != null ? (_response.body as Record<string, string>) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -451,7 +457,10 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
+                    body:
+                        _response.body != null
+                            ? (_response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -531,7 +540,10 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as Record<string, SeedExhaustive.types.MixedType>,
+                    body:
+                        _response.body != null
+                            ? (_response.body as Record<string, SeedExhaustive.types.MixedType>)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -611,7 +623,10 @@ export class ContainerClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -71,7 +71,7 @@ export class EnumClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.WeatherReport,
+                    body: _response.body != null ? (_response.body as SeedExhaustive.types.WeatherReport) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -71,7 +71,10 @@ export class EnumClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedExhaustive.types.WeatherReport) : undefined,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.WeatherReport)
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -62,7 +62,7 @@ export class HttpMethodsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -145,7 +145,7 @@ export class HttpMethodsClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -231,7 +231,7 @@ export class HttpMethodsClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -331,7 +331,7 @@ export class HttpMethodsClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -394,7 +394,7 @@ export class HttpMethodsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as boolean) : undefined,
+                    body: _response.body != null ? (_response.body as boolean) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -62,7 +62,7 @@ export class HttpMethodsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -142,7 +142,10 @@ export class HttpMethodsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -225,7 +228,10 @@ export class HttpMethodsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -322,7 +328,10 @@ export class HttpMethodsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -385,7 +394,7 @@ export class HttpMethodsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as boolean,
+                    body: _response.body != null ? (_response.body as boolean) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -93,7 +93,10 @@ export class ObjectClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -171,7 +174,10 @@ export class ObjectClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithRequiredField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -253,7 +259,10 @@ export class ObjectClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithMapOfMap)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -350,7 +359,10 @@ export class ObjectClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.NestedObjectWithOptionalField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -452,7 +464,10 @@ export class ObjectClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.NestedObjectWithRequiredField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -570,7 +585,10 @@ export class ObjectClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.NestedObjectWithRequiredField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -652,7 +670,10 @@ export class ObjectClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithUnknownField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -735,7 +756,10 @@ export class ObjectClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -96,7 +96,7 @@ export class ObjectClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -177,7 +177,7 @@ export class ObjectClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithRequiredField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -262,7 +262,7 @@ export class ObjectClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithMapOfMap)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -362,7 +362,7 @@ export class ObjectClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.NestedObjectWithOptionalField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -467,7 +467,7 @@ export class ObjectClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.NestedObjectWithRequiredField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -588,7 +588,7 @@ export class ObjectClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.NestedObjectWithRequiredField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -673,7 +673,7 @@ export class ObjectClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithUnknownField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -759,7 +759,7 @@ export class ObjectClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -84,7 +84,10 @@ export class PaginationClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.endpoints.PaginatedResponse)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -87,7 +87,7 @@ export class PaginationClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.endpoints.PaginatedResponse)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -64,7 +64,7 @@ export class ParamsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -132,7 +132,7 @@ export class ParamsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -495,7 +495,7 @@ export class ParamsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -567,7 +567,7 @@ export class ParamsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -651,7 +651,10 @@ export class ParamsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithRequiredField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -64,7 +64,7 @@ export class ParamsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -132,7 +132,7 @@ export class ParamsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -495,7 +495,7 @@ export class ParamsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -567,7 +567,7 @@ export class ParamsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -654,7 +654,7 @@ export class ParamsClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithRequiredField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -67,7 +67,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -133,7 +133,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as number,
+                    body: _response.body != null ? (_response.body as number) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -199,7 +199,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as number,
+                    body: _response.body != null ? (_response.body as number) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -265,7 +265,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as number,
+                    body: _response.body != null ? (_response.body as number) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -331,7 +331,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as boolean,
+                    body: _response.body != null ? (_response.body as boolean) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -399,7 +399,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -465,7 +465,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -531,7 +531,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -597,7 +597,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -67,7 +67,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -133,7 +133,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as number) : undefined,
+                    body: _response.body != null ? (_response.body as number) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -199,7 +199,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as number) : undefined,
+                    body: _response.body != null ? (_response.body as number) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -265,7 +265,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as number) : undefined,
+                    body: _response.body != null ? (_response.body as number) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -331,7 +331,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as boolean) : undefined,
+                    body: _response.body != null ? (_response.body as boolean) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -399,7 +399,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -465,7 +465,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -531,7 +531,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -597,7 +597,7 @@ export class PrimitiveClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -71,7 +71,10 @@ export class PutClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedExhaustive.endpoints.PutResponse) : undefined,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.endpoints.PutResponse)
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -71,7 +71,7 @@ export class PutClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.endpoints.PutResponse,
+                    body: _response.body != null ? (_response.body as SeedExhaustive.endpoints.PutResponse) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -75,7 +75,7 @@ export class UnionClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.Animal,
+                    body: _response.body != null ? (_response.body as SeedExhaustive.types.Animal) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -75,7 +75,7 @@ export class UnionClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedExhaustive.types.Animal) : undefined,
+                    body: _response.body != null ? (_response.body as SeedExhaustive.types.Animal) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -59,7 +59,7 @@ export class UrlsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -117,7 +117,7 @@ export class UrlsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -175,7 +175,7 @@ export class UrlsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -233,7 +233,7 @@ export class UrlsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -59,7 +59,7 @@ export class UrlsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -117,7 +117,7 @@ export class UrlsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -175,7 +175,7 @@ export class UrlsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -233,7 +233,7 @@ export class UrlsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/inlinedRequests/client/Client.ts
@@ -94,7 +94,10 @@ export class InlinedRequestsClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/inlinedRequests/client/Client.ts
@@ -97,7 +97,7 @@ export class InlinedRequestsClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/noAuth/client/Client.ts
@@ -64,7 +64,7 @@ export class NoAuthClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as boolean,
+                    body: _response.body != null ? (_response.body as boolean) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/noAuth/client/Client.ts
@@ -64,7 +64,7 @@ export class NoAuthClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as boolean) : undefined,
+                    body: _response.body != null ? (_response.body as boolean) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/noReqBody/client/Client.ts
@@ -74,7 +74,7 @@ export class NoReqBodyClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -132,7 +132,7 @@ export class NoReqBodyClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as string) : undefined,
+                    body: _response.body != null ? (_response.body as string) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/api/resources/noReqBody/client/Client.ts
@@ -71,7 +71,10 @@ export class NoReqBodyClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedExhaustive.types.ObjectWithOptionalField)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -129,7 +132,7 @@ export class NoReqBodyClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as string,
+                    body: _response.body != null ? (_response.body as string) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -68,6 +68,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnListOfPrimitives.Response.parseOrThrow(
                     _response.body,
@@ -149,6 +152,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnListOfObjects.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -218,6 +224,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnSetOfPrimitives.Response.parseOrThrow(
                     _response.body,
@@ -292,6 +301,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnSetOfObjects.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -363,6 +375,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnMapPrimToPrim.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -436,6 +451,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnMapOfPrimToObject.Response.parseOrThrow(
                     _response.body,
@@ -517,6 +535,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion.Response.parseOrThrow(
                     _response.body,
@@ -591,6 +612,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.container.getAndReturnOptional.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -69,7 +69,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnListOfPrimitives.Response.parseOrThrow(
@@ -153,7 +153,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnListOfObjects.Response.parseOrThrow(_response.body, {
@@ -225,7 +225,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnSetOfPrimitives.Response.parseOrThrow(
@@ -302,7 +302,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnSetOfObjects.Response.parseOrThrow(_response.body, {
@@ -376,7 +376,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnMapPrimToPrim.Response.parseOrThrow(_response.body, {
@@ -452,7 +452,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnMapOfPrimToObject.Response.parseOrThrow(
@@ -536,7 +536,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion.Response.parseOrThrow(
@@ -613,7 +613,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.container.getAndReturnOptional.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -69,7 +69,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.WeatherReport.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -68,6 +68,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.WeatherReport.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,6 +59,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.httpMethods.testGet.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -132,6 +135,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -208,6 +214,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -298,6 +307,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -363,6 +375,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.httpMethods.testDelete.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -60,7 +60,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.httpMethods.testGet.Response.parseOrThrow(_response.body, {
@@ -136,7 +136,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -215,7 +215,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -308,7 +308,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -376,7 +376,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.httpMethods.testDelete.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -85,7 +85,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -164,7 +164,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithRequiredField.parseOrThrow(_response.body, {
@@ -247,7 +247,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithMapOfMap.parseOrThrow(_response.body, {
@@ -345,7 +345,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.NestedObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -446,7 +446,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.NestedObjectWithRequiredField.parseOrThrow(_response.body, {
@@ -563,7 +563,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.NestedObjectWithRequiredField.parseOrThrow(_response.body, {
@@ -644,7 +644,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithUnknownField.parseOrThrow(_response.body, {
@@ -728,7 +728,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithDatetimeLikeString.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -84,6 +84,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -160,6 +163,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithRequiredField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -240,6 +246,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithMapOfMap.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -335,6 +344,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.NestedObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -433,6 +445,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.NestedObjectWithRequiredField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -547,6 +562,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.NestedObjectWithRequiredField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -625,6 +643,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithUnknownField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -706,6 +727,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithDatetimeLikeString.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,6 +69,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: serializers.endpoints.PaginatedResponse.parseOrThrow(_response.body, {
                             unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -70,7 +70,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: serializers.endpoints.PaginatedResponse.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,6 +61,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.params.getWithPath.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -129,6 +132,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.params.getWithInlinePath.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -459,6 +465,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.params.modifyWithPath.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -534,6 +543,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.params.modifyWithInlinePath.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -608,6 +620,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithRequiredField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -62,7 +62,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.params.getWithPath.Response.parseOrThrow(_response.body, {
@@ -133,7 +133,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.params.getWithInlinePath.Response.parseOrThrow(_response.body, {
@@ -466,7 +466,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.params.modifyWithPath.Response.parseOrThrow(_response.body, {
@@ -544,7 +544,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.params.modifyWithInlinePath.Response.parseOrThrow(_response.body, {
@@ -621,7 +621,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithRequiredField.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -67,6 +67,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnString.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -136,6 +139,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnInt.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -205,6 +211,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnLong.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -274,6 +283,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDouble.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -343,6 +355,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnBool.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -412,6 +427,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDatetime.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -481,6 +499,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDate.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -550,6 +571,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnUuid.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -619,6 +643,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.primitive.getAndReturnBase64.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -68,7 +68,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnString.Response.parseOrThrow(_response.body, {
@@ -140,7 +140,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnInt.Response.parseOrThrow(_response.body, {
@@ -212,7 +212,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnLong.Response.parseOrThrow(_response.body, {
@@ -284,7 +284,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDouble.Response.parseOrThrow(_response.body, {
@@ -356,7 +356,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnBool.Response.parseOrThrow(_response.body, {
@@ -428,7 +428,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDatetime.Response.parseOrThrow(_response.body, {
@@ -500,7 +500,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnDate.Response.parseOrThrow(_response.body, {
@@ -572,7 +572,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnUuid.Response.parseOrThrow(_response.body, {
@@ -644,7 +644,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.primitive.getAndReturnBase64.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -66,7 +66,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.PutResponse.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,6 +65,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.PutResponse.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -73,7 +73,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.Animal.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -72,6 +72,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.Animal.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,6 +54,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.urls.withMixedCase.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -110,6 +113,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.urls.noEndingSlash.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -166,6 +172,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.urls.withEndingSlash.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -222,6 +231,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.endpoints.urls.withUnderscores.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -55,7 +55,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.urls.withMixedCase.Response.parseOrThrow(_response.body, {
@@ -114,7 +114,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.urls.noEndingSlash.Response.parseOrThrow(_response.body, {
@@ -173,7 +173,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.urls.withEndingSlash.Response.parseOrThrow(_response.body, {
@@ -232,7 +232,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.endpoints.urls.withUnderscores.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/inlinedRequests/client/Client.ts
@@ -88,7 +88,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/inlinedRequests/client/Client.ts
@@ -87,6 +87,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noAuth/client/Client.ts
@@ -67,7 +67,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.noAuth.postWithNoAuth.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noAuth/client/Client.ts
@@ -66,6 +66,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.noAuth.postWithNoAuth.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noReqBody/client/Client.ts
@@ -60,7 +60,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
@@ -121,7 +121,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.noReqBody.postWithNoRequestBody.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noReqBody/client/Client.ts
@@ -59,6 +59,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.types.ObjectWithOptionalField.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -117,6 +120,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.noReqBody.postWithNoRequestBody.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -65,7 +65,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -134,7 +134,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -197,7 +197,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -259,7 +259,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
@@ -324,7 +324,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
@@ -388,7 +388,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
@@ -460,7 +460,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
@@ -525,7 +525,7 @@ export class ContainerClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -64,6 +64,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -130,6 +133,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -190,6 +196,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -249,6 +258,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField[],
                 rawResponse: _response.rawResponse,
@@ -311,6 +323,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, string>, rawResponse: _response.rawResponse };
         }
 
@@ -372,6 +387,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.ObjectWithRequiredField>,
                 rawResponse: _response.rawResponse,
@@ -441,6 +459,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<string, SeedExhaustive.types.MixedType>,
                 rawResponse: _response.rawResponse,
@@ -503,6 +524,9 @@ export class ContainerClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -65,7 +65,7 @@ export class EnumClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -64,6 +64,9 @@ export class EnumClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.WeatherReport, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -58,6 +58,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -186,6 +192,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -267,6 +276,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -326,6 +338,9 @@ export class HttpMethodsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -59,7 +59,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -193,7 +193,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -277,7 +277,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -339,7 +339,7 @@ export class HttpMethodsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -80,6 +80,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -147,6 +150,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -218,6 +224,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
                 rawResponse: _response.rawResponse,
@@ -304,6 +313,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -393,6 +405,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -498,6 +513,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
                 rawResponse: _response.rawResponse,
@@ -567,6 +585,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
                 rawResponse: _response.rawResponse,
@@ -639,6 +660,9 @@ export class ObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -81,7 +81,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -151,7 +151,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
@@ -225,7 +225,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithMapOfMap,
@@ -314,7 +314,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithOptionalField,
@@ -406,7 +406,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -514,7 +514,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.NestedObjectWithRequiredField,
@@ -586,7 +586,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithUnknownField,
@@ -661,7 +661,7 @@ export class ObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithDatetimeLikeString,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -69,7 +69,7 @@ export class PaginationClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -68,6 +68,9 @@ export class PaginationClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedExhaustive.endpoints.PaginatedResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -60,6 +60,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -437,6 +443,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -500,6 +509,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -565,6 +577,9 @@ export class ParamsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -61,7 +61,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -444,7 +444,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -510,7 +510,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -578,7 +578,7 @@ export class ParamsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithRequiredField,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -63,6 +63,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -177,6 +183,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -234,6 +243,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
 
@@ -291,6 +303,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -348,6 +363,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -405,6 +423,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -462,6 +483,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -519,6 +543,9 @@ export class PrimitiveClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -64,7 +64,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -184,7 +184,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as number, rawResponse: _response.rawResponse };
         }
@@ -304,7 +304,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -364,7 +364,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -424,7 +424,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -484,7 +484,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -544,7 +544,7 @@ export class PrimitiveClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -65,7 +65,7 @@ export class PutClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -64,6 +64,9 @@ export class PutClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.endpoints.PutResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -69,7 +69,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -68,6 +68,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExhaustive.types.Animal, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -53,6 +53,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -100,6 +103,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -147,6 +153,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -194,6 +203,9 @@ export class UrlsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -54,7 +54,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -104,7 +104,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -154,7 +154,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -204,7 +204,7 @@ export class UrlsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/inlinedRequests/client/Client.ts
@@ -84,7 +84,7 @@ export class InlinedRequestsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/inlinedRequests/client/Client.ts
@@ -83,6 +83,9 @@ export class InlinedRequestsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noAuth/client/Client.ts
@@ -66,7 +66,7 @@ export class NoAuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noAuth/client/Client.ts
@@ -65,6 +65,9 @@ export class NoAuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noReqBody/client/Client.ts
@@ -59,7 +59,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
@@ -114,7 +114,7 @@ export class NoReqBodyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noReqBody/client/Client.ts
@@ -58,6 +58,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedExhaustive.types.ObjectWithOptionalField,
                 rawResponse: _response.rawResponse,
@@ -110,6 +113,9 @@ export class NoReqBodyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/extra-properties/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/extra-properties/src/api/resources/user/client/Client.ts
@@ -63,6 +63,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedExtraProperties.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/extra-properties/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/extra-properties/src/api/resources/user/client/Client.ts
@@ -64,7 +64,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedExtraProperties.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/api/resources/service/client/Client.ts
@@ -93,6 +93,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             const _contentLength = core.getHeader(_response.headers ?? {}, "Content-Length");
             return {
                 data: {

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/api/resources/service/client/Client.ts
@@ -94,7 +94,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             const _contentLength = core.getHeader(_response.headers ?? {}, "Content-Length");
             return {

--- a/seed/ts-sdk/file-download/no-custom-config/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/api/resources/service/client/Client.ts
@@ -86,7 +86,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/file-download/no-custom-config/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/api/resources/service/client/Client.ts
@@ -85,6 +85,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/file-download/stream-wrapper/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/src/api/resources/service/client/Client.ts
@@ -86,6 +86,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/file-download/stream-wrapper/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/src/api/resources/service/client/Client.ts
@@ -87,7 +87,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/file-upload-openapi/src/api/resources/fileUploadExample/client/Client.ts
+++ b/seed/ts-sdk/file-upload-openapi/src/api/resources/fileUploadExample/client/Client.ts
@@ -76,7 +76,7 @@ export class FileUploadExampleClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.FileId, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/file-upload-openapi/src/api/resources/fileUploadExample/client/Client.ts
+++ b/seed/ts-sdk/file-upload-openapi/src/api/resources/fileUploadExample/client/Client.ts
@@ -75,6 +75,9 @@ export class FileUploadExampleClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.FileId, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/file-upload/form-data-node16/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/api/resources/service/client/Client.ts
@@ -651,7 +651,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -711,7 +711,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -774,7 +774,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -887,7 +887,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/file-upload/form-data-node16/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/api/resources/service/client/Client.ts
@@ -650,6 +650,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -707,6 +710,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -767,6 +773,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -877,6 +886,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/file-upload/inline/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/inline/src/api/resources/service/client/Client.ts
@@ -651,7 +651,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -711,7 +711,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -774,7 +774,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -887,7 +887,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/file-upload/inline/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/inline/src/api/resources/service/client/Client.ts
@@ -650,6 +650,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -707,6 +710,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -767,6 +773,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -877,6 +886,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/file-upload/no-custom-config/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/api/resources/service/client/Client.ts
@@ -651,7 +651,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -711,7 +711,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -774,7 +774,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -887,7 +887,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/file-upload/no-custom-config/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/api/resources/service/client/Client.ts
@@ -650,6 +650,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -707,6 +710,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -767,6 +773,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -877,6 +886,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/file-upload/serde/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/serde/src/api/resources/service/client/Client.ts
@@ -689,6 +689,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.service.optionalArgs.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -763,6 +766,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.service.withInlineType.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -840,6 +846,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.service.withJsonProperty.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -971,6 +980,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.service.withLiteralAndEnumTypes.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/file-upload/serde/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/serde/src/api/resources/service/client/Client.ts
@@ -690,7 +690,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.service.optionalArgs.Response.parseOrThrow(_response.body, {
@@ -767,7 +767,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.service.withInlineType.Response.parseOrThrow(_response.body, {
@@ -847,7 +847,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.service.withJsonProperty.Response.parseOrThrow(_response.body, {
@@ -981,7 +981,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.service.withLiteralAndEnumTypes.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/file-upload/use-jest/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/use-jest/src/api/resources/service/client/Client.ts
@@ -651,7 +651,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -711,7 +711,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -774,7 +774,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -887,7 +887,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/file-upload/use-jest/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/use-jest/src/api/resources/service/client/Client.ts
@@ -650,6 +650,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -707,6 +710,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -767,6 +773,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -877,6 +886,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/file-upload/wrapper/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/api/resources/service/client/Client.ts
@@ -651,7 +651,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -711,7 +711,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -774,7 +774,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -887,7 +887,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/file-upload/wrapper/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/api/resources/service/client/Client.ts
@@ -650,6 +650,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -707,6 +710,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -767,6 +773,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -877,6 +886,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/header-auth-environment-variable/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/api/resources/service/client/Client.ts
@@ -58,7 +58,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/header-auth-environment-variable/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/api/resources/service/client/Client.ts
@@ -57,6 +57,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/header-auth/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/header-auth/src/api/resources/service/client/Client.ts
@@ -58,7 +58,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/header-auth/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/header-auth/src/api/resources/service/client/Client.ts
@@ -57,6 +57,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/http-head/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/http-head/src/api/resources/user/client/Client.ts
@@ -105,7 +105,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedHttpHead.User[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/http-head/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/http-head/src/api/resources/user/client/Client.ts
@@ -104,6 +104,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedHttpHead.User[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/idempotency-headers/src/api/resources/payment/client/Client.ts
+++ b/seed/ts-sdk/idempotency-headers/src/api/resources/payment/client/Client.ts
@@ -73,6 +73,9 @@ export class PaymentClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/idempotency-headers/src/api/resources/payment/client/Client.ts
+++ b/seed/ts-sdk/idempotency-headers/src/api/resources/payment/client/Client.ts
@@ -74,7 +74,7 @@ export class PaymentClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/api/resources/imdb/client/Client.ts
@@ -66,6 +66,9 @@ export class ImdbClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.MovieId, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ImdbClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.Movie, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/api/resources/imdb/client/Client.ts
@@ -67,7 +67,7 @@ export class ImdbClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.MovieId, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ImdbClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.Movie, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/imdb/no-custom-config/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/api/resources/imdb/client/Client.ts
@@ -66,6 +66,9 @@ export class ImdbClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.MovieId, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ImdbClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.Movie, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/imdb/no-custom-config/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/api/resources/imdb/client/Client.ts
@@ -67,7 +67,7 @@ export class ImdbClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.MovieId, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ImdbClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.Movie, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/imdb/omit-undefined/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/api/resources/imdb/client/Client.ts
@@ -66,6 +66,9 @@ export class ImdbClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.MovieId, rawResponse: _response.rawResponse };
         }
 
@@ -119,6 +122,9 @@ export class ImdbClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.Movie, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/imdb/omit-undefined/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/api/resources/imdb/client/Client.ts
@@ -67,7 +67,7 @@ export class ImdbClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.MovieId, rawResponse: _response.rawResponse };
         }
@@ -123,7 +123,7 @@ export class ImdbClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.Movie, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/inferred-auth-explicit/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/api/resources/auth/client/Client.ts
@@ -69,6 +69,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedInferredAuthExplicit.TokenResponse,
                 rawResponse: _response.rawResponse,
@@ -135,6 +138,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedInferredAuthExplicit.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/inferred-auth-explicit/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/api/resources/auth/client/Client.ts
@@ -70,7 +70,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedInferredAuthExplicit.TokenResponse,
@@ -139,7 +139,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedInferredAuthExplicit.TokenResponse,

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/auth/client/Client.ts
@@ -64,7 +64,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedInferredAuthImplicitApiKey.TokenResponse,

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/auth/client/Client.ts
@@ -63,6 +63,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedInferredAuthImplicitApiKey.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/auth/client/Client.ts
@@ -70,7 +70,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedInferredAuthImplicitNoExpiry.TokenResponse,
@@ -139,7 +139,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedInferredAuthImplicitNoExpiry.TokenResponse,

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/auth/client/Client.ts
@@ -69,6 +69,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedInferredAuthImplicitNoExpiry.TokenResponse,
                 rawResponse: _response.rawResponse,
@@ -135,6 +138,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedInferredAuthImplicitNoExpiry.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/inferred-auth-implicit/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/api/resources/auth/client/Client.ts
@@ -70,7 +70,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedInferredAuthImplicit.TokenResponse,
@@ -139,7 +139,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedInferredAuthImplicit.TokenResponse,

--- a/seed/ts-sdk/inferred-auth-implicit/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/api/resources/auth/client/Client.ts
@@ -69,6 +69,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedInferredAuthImplicit.TokenResponse,
                 rawResponse: _response.rawResponse,
@@ -135,6 +138,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedInferredAuthImplicit.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/literal/src/api/resources/headers/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/headers/client/Client.ts
@@ -71,7 +71,7 @@ export class HeadersClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/literal/src/api/resources/headers/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/headers/client/Client.ts
@@ -70,6 +70,9 @@ export class HeadersClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/literal/src/api/resources/inlined/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/inlined/client/Client.ts
@@ -81,6 +81,9 @@ export class InlinedClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/literal/src/api/resources/inlined/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/inlined/client/Client.ts
@@ -82,7 +82,7 @@ export class InlinedClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/literal/src/api/resources/path/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/path/client/Client.ts
@@ -63,6 +63,9 @@ export class PathClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/literal/src/api/resources/path/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/path/client/Client.ts
@@ -64,7 +64,7 @@ export class PathClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/literal/src/api/resources/query/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/query/client/Client.ts
@@ -95,6 +95,9 @@ export class QueryClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/literal/src/api/resources/query/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/query/client/Client.ts
@@ -96,7 +96,7 @@ export class QueryClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/literal/src/api/resources/reference/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/reference/client/Client.ts
@@ -79,7 +79,7 @@ export class ReferenceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/literal/src/api/resources/reference/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/reference/client/Client.ts
@@ -78,6 +78,9 @@ export class ReferenceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/api/resources/service/client/Client.ts
@@ -57,7 +57,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedMixedCase.Resource, rawResponse: _response.rawResponse };
         }
@@ -117,7 +117,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedMixedCase.Resource[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/api/resources/service/client/Client.ts
@@ -56,6 +56,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedMixedCase.Resource, rawResponse: _response.rawResponse };
         }
 
@@ -113,6 +116,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedMixedCase.Resource[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/api/resources/service/client/Client.ts
@@ -57,7 +57,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedMixedCase.Resource, rawResponse: _response.rawResponse };
         }
@@ -117,7 +117,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedMixedCase.Resource[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/api/resources/service/client/Client.ts
@@ -56,6 +56,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedMixedCase.Resource, rawResponse: _response.rawResponse };
         }
 
@@ -113,6 +116,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedMixedCase.Resource[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/organization/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/organization/client/Client.ts
@@ -64,7 +64,7 @@ export class OrganizationClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedMixedFileDirectory.Organization, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/organization/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/organization/client/Client.ts
@@ -63,6 +63,9 @@ export class OrganizationClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedMixedFileDirectory.Organization, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/user/client/Client.ts
@@ -70,6 +70,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedMixedFileDirectory.User[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/user/client/Client.ts
@@ -71,7 +71,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedMixedFileDirectory.User[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/client/Client.ts
@@ -71,7 +71,7 @@ export class EventsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedMixedFileDirectory.user.Event[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/client/Client.ts
@@ -70,6 +70,9 @@ export class EventsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedMixedFileDirectory.user.Event[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/resources/metadata/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/resources/metadata/client/Client.ts
@@ -65,7 +65,7 @@ export class MetadataClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedMixedFileDirectory.user.events.Metadata,

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/resources/metadata/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/resources/metadata/client/Client.ts
@@ -64,6 +64,9 @@ export class MetadataClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedMixedFileDirectory.user.events.Metadata,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/multi-line-docs/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/multi-line-docs/src/api/resources/user/client/Client.ts
@@ -116,7 +116,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedMultiLineDocs.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/multi-line-docs/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/multi-line-docs/src/api/resources/user/client/Client.ts
@@ -115,6 +115,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedMultiLineDocs.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/multi-url-environment-no-default/src/api/resources/s3/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/api/resources/s3/client/Client.ts
@@ -67,7 +67,7 @@ export class S3Client {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/multi-url-environment-no-default/src/api/resources/s3/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/api/resources/s3/client/Client.ts
@@ -66,6 +66,9 @@ export class S3Client {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/multi-url-environment/src/api/resources/s3/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment/src/api/resources/s3/client/Client.ts
@@ -71,7 +71,7 @@ export class S3Client {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/multi-url-environment/src/api/resources/s3/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment/src/api/resources/s3/client/Client.ts
@@ -70,6 +70,9 @@ export class S3Client {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/multiple-request-bodies/src/Client.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/Client.ts
@@ -67,7 +67,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.UploadDocumentResponse, rawResponse: _response.rawResponse };
         }
@@ -128,7 +128,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.UploadDocumentResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/multiple-request-bodies/src/Client.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/Client.ts
@@ -66,6 +66,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.UploadDocumentResponse, rawResponse: _response.rawResponse };
         }
 
@@ -124,6 +127,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.UploadDocumentResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/no-environment/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/no-environment/src/api/resources/dummy/client/Client.ts
@@ -53,6 +53,9 @@ export class DummyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/no-environment/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/no-environment/src/api/resources/dummy/client/Client.ts
@@ -54,7 +54,7 @@ export class DummyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/no-retries/src/api/resources/retries/client/Client.ts
+++ b/seed/ts-sdk/no-retries/src/api/resources/retries/client/Client.ts
@@ -51,6 +51,9 @@ export class RetriesClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNoRetries.User[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/no-retries/src/api/resources/retries/client/Client.ts
+++ b/seed/ts-sdk/no-retries/src/api/resources/retries/client/Client.ts
@@ -52,7 +52,7 @@ export class RetriesClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNoRetries.User[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/nullable-allof-extends/src/Client.ts
+++ b/seed/ts-sdk/nullable-allof-extends/src/Client.ts
@@ -56,7 +56,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.RootObject, rawResponse: _response.rawResponse };
         }
@@ -114,7 +114,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.RootObject, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/nullable-allof-extends/src/Client.ts
+++ b/seed/ts-sdk/nullable-allof-extends/src/Client.ts
@@ -55,6 +55,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.RootObject, rawResponse: _response.rawResponse };
         }
 
@@ -110,6 +113,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.RootObject, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/nullable-optional/src/api/resources/nullableOptional/client/Client.ts
+++ b/seed/ts-sdk/nullable-optional/src/api/resources/nullableOptional/client/Client.ts
@@ -59,7 +59,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullableOptional.UserResponse, rawResponse: _response.rawResponse };
         }
@@ -129,7 +129,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullableOptional.UserResponse, rawResponse: _response.rawResponse };
         }
@@ -202,7 +202,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullableOptional.UserResponse, rawResponse: _response.rawResponse };
         }
@@ -268,7 +268,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullableOptional.UserResponse[], rawResponse: _response.rawResponse };
         }
@@ -334,7 +334,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullableOptional.UserResponse[], rawResponse: _response.rawResponse };
         }
@@ -482,7 +482,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullableOptional.ComplexProfile, rawResponse: _response.rawResponse };
         }
@@ -536,7 +536,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullableOptional.ComplexProfile, rawResponse: _response.rawResponse };
         }
@@ -629,7 +629,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullableOptional.ComplexProfile, rawResponse: _response.rawResponse };
         }
@@ -741,7 +741,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedNullableOptional.DeserializationTestResponse,
@@ -808,7 +808,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullableOptional.UserResponse[], rawResponse: _response.rawResponse };
         }
@@ -862,7 +862,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedNullableOptional.NotificationMethod | null,
@@ -934,7 +934,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
@@ -997,7 +997,7 @@ export class NullableOptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedNullableOptional.SearchResult[] | null,

--- a/seed/ts-sdk/nullable-optional/src/api/resources/nullableOptional/client/Client.ts
+++ b/seed/ts-sdk/nullable-optional/src/api/resources/nullableOptional/client/Client.ts
@@ -58,6 +58,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullableOptional.UserResponse, rawResponse: _response.rawResponse };
         }
 
@@ -125,6 +128,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullableOptional.UserResponse, rawResponse: _response.rawResponse };
         }
 
@@ -195,6 +201,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullableOptional.UserResponse, rawResponse: _response.rawResponse };
         }
 
@@ -258,6 +267,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullableOptional.UserResponse[], rawResponse: _response.rawResponse };
         }
 
@@ -321,6 +333,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullableOptional.UserResponse[], rawResponse: _response.rawResponse };
         }
 
@@ -466,6 +481,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullableOptional.ComplexProfile, rawResponse: _response.rawResponse };
         }
 
@@ -517,6 +535,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullableOptional.ComplexProfile, rawResponse: _response.rawResponse };
         }
 
@@ -607,6 +628,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullableOptional.ComplexProfile, rawResponse: _response.rawResponse };
         }
 
@@ -716,6 +740,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedNullableOptional.DeserializationTestResponse,
                 rawResponse: _response.rawResponse,
@@ -780,6 +807,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullableOptional.UserResponse[], rawResponse: _response.rawResponse };
         }
 
@@ -831,6 +861,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedNullableOptional.NotificationMethod | null,
                 rawResponse: _response.rawResponse,
@@ -900,6 +933,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string[], rawResponse: _response.rawResponse };
         }
 
@@ -960,6 +996,9 @@ export class NullableOptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedNullableOptional.SearchResult[] | null,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/nullable-request-body/src/api/resources/testGroup/client/Client.ts
+++ b/seed/ts-sdk/nullable-request-body/src/api/resources/testGroup/client/Client.ts
@@ -76,6 +76,9 @@ export class TestGroupClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/nullable-request-body/src/api/resources/testGroup/client/Client.ts
+++ b/seed/ts-sdk/nullable-request-body/src/api/resources/testGroup/client/Client.ts
@@ -77,7 +77,7 @@ export class TestGroupClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/nullable/src/api/resources/nullable/client/Client.ts
+++ b/seed/ts-sdk/nullable/src/api/resources/nullable/client/Client.ts
@@ -70,6 +70,9 @@ export class NullableClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullable.User[], rawResponse: _response.rawResponse };
         }
 
@@ -138,6 +141,9 @@ export class NullableClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedNullable.User, rawResponse: _response.rawResponse };
         }
 
@@ -192,6 +198,9 @@ export class NullableClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/nullable/src/api/resources/nullable/client/Client.ts
+++ b/seed/ts-sdk/nullable/src/api/resources/nullable/client/Client.ts
@@ -71,7 +71,7 @@ export class NullableClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullable.User[], rawResponse: _response.rawResponse };
         }
@@ -142,7 +142,7 @@ export class NullableClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedNullable.User, rawResponse: _response.rawResponse };
         }
@@ -199,7 +199,7 @@ export class NullableClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/auth/client/Client.ts
@@ -65,6 +65,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentials.TokenResponse,
                 rawResponse: _response.rawResponse,
@@ -125,6 +128,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentials.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/auth/client/Client.ts
@@ -66,7 +66,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentials.TokenResponse,
@@ -129,7 +129,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentials.TokenResponse,

--- a/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/auth/client/Client.ts
@@ -62,6 +62,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentialsDefault.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/auth/client/Client.ts
@@ -63,7 +63,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentialsDefault.TokenResponse,

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -63,6 +63,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentialsEnvironmentVariables.TokenResponse,
                 rawResponse: _response.rawResponse,
@@ -123,6 +126,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentialsEnvironmentVariables.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -64,7 +64,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentialsEnvironmentVariables.TokenResponse,
@@ -127,7 +127,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentialsEnvironmentVariables.TokenResponse,

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -64,7 +64,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentialsMandatoryAuth.TokenResponse,
@@ -127,7 +127,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentialsMandatoryAuth.TokenResponse,

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -63,6 +63,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentialsMandatoryAuth.TokenResponse,
                 rawResponse: _response.rawResponse,
@@ -123,6 +126,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentialsMandatoryAuth.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/api/resources/auth/client/Client.ts
@@ -76,7 +76,7 @@ export class AuthClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedOauthClientCredentials.auth.TokenResponse)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/api/resources/auth/client/Client.ts
@@ -73,7 +73,10 @@ export class AuthClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedOauthClientCredentials.auth.TokenResponse,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedOauthClientCredentials.auth.TokenResponse)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -63,6 +63,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentials.auth.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -64,7 +64,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentials.auth.TokenResponse,

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/api/resources/auth/client/Client.ts
@@ -62,6 +62,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentialsReference.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/api/resources/auth/client/Client.ts
@@ -63,7 +63,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentialsReference.TokenResponse,

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/auth/client/Client.ts
@@ -63,6 +63,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentialsWithVariables.TokenResponse,
                 rawResponse: _response.rawResponse,
@@ -123,6 +126,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentialsWithVariables.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/auth/client/Client.ts
@@ -64,7 +64,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentialsWithVariables.TokenResponse,
@@ -127,7 +127,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentialsWithVariables.TokenResponse,

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -64,7 +64,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentials.TokenResponse,
@@ -127,7 +127,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedOauthClientCredentials.TokenResponse,

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -63,6 +63,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentials.TokenResponse,
                 rawResponse: _response.rawResponse,
@@ -123,6 +126,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedOauthClientCredentials.TokenResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/auth/client/Client.ts
@@ -71,6 +71,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.TokenResponse.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -144,6 +147,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.TokenResponse.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/auth/client/Client.ts
@@ -72,7 +72,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.TokenResponse.parseOrThrow(_response.body, {
@@ -148,7 +148,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.TokenResponse.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/optional/src/api/resources/optional/client/Client.ts
+++ b/seed/ts-sdk/optional/src/api/resources/optional/client/Client.ts
@@ -63,6 +63,9 @@ export class OptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -117,6 +120,9 @@ export class OptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -182,6 +188,9 @@ export class OptionalClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedObjectsWithImports.DeployResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/optional/src/api/resources/optional/client/Client.ts
+++ b/seed/ts-sdk/optional/src/api/resources/optional/client/Client.ts
@@ -64,7 +64,7 @@ export class OptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -121,7 +121,7 @@ export class OptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -189,7 +189,7 @@ export class OptionalClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedObjectsWithImports.DeployResponse,

--- a/seed/ts-sdk/package-yml/src/Client.ts
+++ b/seed/ts-sdk/package-yml/src/Client.ts
@@ -68,6 +68,9 @@ export class SeedPackageYmlClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/package-yml/src/Client.ts
+++ b/seed/ts-sdk/package-yml/src/Client.ts
@@ -69,7 +69,7 @@ export class SeedPackageYmlClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/pagination-uri-path/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/api/resources/users/client/Client.ts
@@ -54,7 +54,7 @@ export class UsersClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedPaginationUriPath.ListUsersUriPaginationResponse,
@@ -106,7 +106,7 @@ export class UsersClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedPaginationUriPath.ListUsersPathPaginationResponse,

--- a/seed/ts-sdk/pagination-uri-path/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/api/resources/users/client/Client.ts
@@ -53,6 +53,9 @@ export class UsersClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedPaginationUriPath.ListUsersUriPaginationResponse,
                 rawResponse: _response.rawResponse,
@@ -102,6 +105,9 @@ export class UsersClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedPaginationUriPath.ListUsersPathPaginationResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/complex/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/complex/client/Client.ts
@@ -73,6 +73,9 @@ export class ComplexClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.PaginatedConversationResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/complex/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/complex/client/Client.ts
@@ -74,7 +74,7 @@ export class ComplexClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.PaginatedConversationResponse,

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -73,6 +73,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -154,6 +157,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersMixedTypePaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -232,6 +238,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -319,6 +328,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -403,6 +415,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -482,6 +497,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -564,6 +582,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -646,6 +667,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -725,6 +749,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersExtendedResponse,
                         rawResponse: _response.rawResponse,
@@ -802,6 +829,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersExtendedOptionalListResponse,
                         rawResponse: _response.rawResponse,
@@ -874,6 +904,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor,
                         rawResponse: _response.rawResponse,
@@ -944,6 +977,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.UsernameContainer,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -74,7 +74,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -158,7 +158,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersMixedTypePaginationResponse,
@@ -239,7 +239,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -329,7 +329,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -416,7 +416,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -498,7 +498,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -583,7 +583,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -668,7 +668,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -750,7 +750,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersExtendedResponse,
@@ -830,7 +830,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersExtendedOptionalListResponse,
@@ -905,7 +905,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor,
@@ -978,7 +978,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.UsernameContainer,

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
@@ -68,6 +68,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -141,6 +144,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersMixedTypePaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -211,6 +217,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -288,6 +297,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersTopLevelCursorPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -369,6 +381,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -445,6 +460,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -516,6 +534,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -590,6 +611,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -664,6 +688,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -735,6 +762,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersExtendedResponse,
                         rawResponse: _response.rawResponse,
@@ -804,6 +834,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersExtendedOptionalListResponse,
                         rawResponse: _response.rawResponse,
@@ -873,6 +906,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor,
                         rawResponse: _response.rawResponse,
@@ -943,6 +979,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor | undefined,
                         rawResponse: _response.rawResponse,
@@ -1013,6 +1052,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.UsernameContainer,
                         rawResponse: _response.rawResponse,
@@ -1083,6 +1125,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersOptionalDataPaginationResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
@@ -69,7 +69,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -145,7 +145,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersMixedTypePaginationResponse,
@@ -218,7 +218,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -298,7 +298,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersTopLevelCursorPaginationResponse,
@@ -382,7 +382,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -461,7 +461,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -535,7 +535,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -612,7 +612,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -689,7 +689,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -763,7 +763,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersExtendedResponse,
@@ -835,7 +835,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersExtendedOptionalListResponse,
@@ -907,7 +907,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor,
@@ -980,7 +980,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor | undefined,
@@ -1053,7 +1053,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.UsernameContainer,
@@ -1126,7 +1126,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersOptionalDataPaginationResponse,

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/complex/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/complex/client/Client.ts
@@ -73,6 +73,9 @@ export class ComplexClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.PaginatedConversationResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/complex/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/complex/client/Client.ts
@@ -74,7 +74,7 @@ export class ComplexClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.PaginatedConversationResponse,

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -73,6 +73,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -154,6 +157,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersMixedTypePaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -232,6 +238,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -319,6 +328,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -403,6 +415,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -482,6 +497,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -564,6 +582,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -646,6 +667,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -725,6 +749,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersExtendedResponse,
                         rawResponse: _response.rawResponse,
@@ -802,6 +829,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersExtendedOptionalListResponse,
                         rawResponse: _response.rawResponse,
@@ -874,6 +904,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor,
                         rawResponse: _response.rawResponse,
@@ -944,6 +977,9 @@ export class InlineUsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.UsernameContainer,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -74,7 +74,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -158,7 +158,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersMixedTypePaginationResponse,
@@ -239,7 +239,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -329,7 +329,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -416,7 +416,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -498,7 +498,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -583,7 +583,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -668,7 +668,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersPaginationResponse,
@@ -750,7 +750,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersExtendedResponse,
@@ -830,7 +830,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.ListUsersExtendedOptionalListResponse,
@@ -905,7 +905,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor,
@@ -978,7 +978,7 @@ export class InlineUsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.inlineUsers.UsernameContainer,

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
@@ -68,6 +68,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -141,6 +144,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersMixedTypePaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -211,6 +217,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -288,6 +297,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersTopLevelCursorPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -369,6 +381,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -445,6 +460,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -516,6 +534,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -590,6 +611,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -664,6 +688,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
                         rawResponse: _response.rawResponse,
@@ -735,6 +762,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersExtendedResponse,
                         rawResponse: _response.rawResponse,
@@ -804,6 +834,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersExtendedOptionalListResponse,
                         rawResponse: _response.rawResponse,
@@ -873,6 +906,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor,
                         rawResponse: _response.rawResponse,
@@ -943,6 +979,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor | undefined,
                         rawResponse: _response.rawResponse,
@@ -1013,6 +1052,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.UsernameContainer,
                         rawResponse: _response.rawResponse,
@@ -1083,6 +1125,9 @@ export class UsersClient {
                     logging: this._options.logging,
                 });
                 if (_response.ok) {
+                    if (_response.body == null) {
+                        return { data: undefined, rawResponse: _response.rawResponse };
+                    }
                     return {
                         data: _response.body as SeedPagination.ListUsersOptionalDataPaginationResponse,
                         rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
@@ -69,7 +69,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -145,7 +145,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersMixedTypePaginationResponse,
@@ -218,7 +218,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -298,7 +298,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersTopLevelCursorPaginationResponse,
@@ -382,7 +382,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -461,7 +461,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -535,7 +535,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -612,7 +612,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -689,7 +689,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersPaginationResponse,
@@ -763,7 +763,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersExtendedResponse,
@@ -835,7 +835,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersExtendedOptionalListResponse,
@@ -907,7 +907,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor,
@@ -980,7 +980,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.UsernameCursor | undefined,
@@ -1053,7 +1053,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.UsernameContainer,
@@ -1126,7 +1126,7 @@ export class UsersClient {
                 });
                 if (_response.ok) {
                     if (_response.body == null) {
-                        return { data: undefined, rawResponse: _response.rawResponse };
+                        return { data: undefined as any, rawResponse: _response.rawResponse };
                     }
                     return {
                         data: _response.body as SeedPagination.ListUsersOptionalDataPaginationResponse,

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/organizations/client/Client.ts
@@ -57,7 +57,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -186,7 +186,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/organizations/client/Client.ts
@@ -56,6 +56,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -179,6 +185,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -180,7 +180,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -239,7 +239,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
@@ -302,7 +302,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -366,7 +366,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -173,6 +179,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -229,6 +238,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
 
@@ -289,6 +301,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -350,6 +365,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/organizations/client/Client.ts
@@ -56,6 +56,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
 
@@ -118,6 +121,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -183,6 +189,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/organizations/client/Client.ts
@@ -57,7 +57,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
@@ -122,7 +122,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -190,7 +190,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -175,6 +181,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -233,6 +242,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
 
@@ -295,6 +307,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -362,6 +377,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -182,7 +182,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -243,7 +243,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
@@ -308,7 +308,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -378,7 +378,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/organizations/client/Client.ts
@@ -58,7 +58,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.Organization.parseOrThrow(_response.body, {
@@ -132,7 +132,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
@@ -209,7 +209,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.organizations.searchOrganizations.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/organizations/client/Client.ts
@@ -57,6 +57,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.Organization.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -128,6 +131,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -202,6 +208,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.organizations.searchOrganizations.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/user/client/Client.ts
@@ -60,6 +60,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -124,6 +127,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -194,6 +200,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -261,6 +270,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.user.searchUsers.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -332,6 +344,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -408,6 +423,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/user/client/Client.ts
@@ -61,7 +61,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
@@ -128,7 +128,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
@@ -201,7 +201,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
@@ -271,7 +271,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.user.searchUsers.Response.parseOrThrow(_response.body, {
@@ -345,7 +345,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
@@ -424,7 +424,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/organizations/client/Client.ts
@@ -56,6 +56,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
 
@@ -118,6 +121,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -183,6 +189,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/organizations/client/Client.ts
@@ -57,7 +57,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
@@ -122,7 +122,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -190,7 +190,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -175,6 +181,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -233,6 +242,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
 
@@ -295,6 +307,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -362,6 +377,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -182,7 +182,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -243,7 +243,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
@@ -308,7 +308,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -378,7 +378,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/organizations/client/Client.ts
@@ -57,7 +57,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -186,7 +186,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/organizations/client/Client.ts
@@ -56,6 +56,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -179,6 +185,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -180,7 +180,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -239,7 +239,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
@@ -302,7 +302,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -366,7 +366,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -173,6 +179,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -229,6 +238,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
 
@@ -289,6 +301,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -350,6 +365,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/organizations/client/Client.ts
@@ -57,7 +57,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -186,7 +186,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/organizations/client/Client.ts
@@ -56,6 +56,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -179,6 +185,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -180,7 +180,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -239,7 +239,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
@@ -302,7 +302,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -366,7 +366,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -173,6 +179,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -229,6 +238,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
 
@@ -289,6 +301,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -350,6 +365,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/organizations/client/Client.ts
@@ -57,7 +57,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -186,7 +186,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/organizations/client/Client.ts
@@ -56,6 +56,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -179,6 +185,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -180,7 +180,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -239,7 +239,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
@@ -302,7 +302,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -366,7 +366,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -173,6 +179,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -229,6 +238,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
 
@@ -289,6 +301,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -350,6 +365,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/organizations/client/Client.ts
@@ -57,7 +57,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -186,7 +186,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/organizations/client/Client.ts
@@ -56,6 +56,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -179,6 +185,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -180,7 +180,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -239,7 +239,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
@@ -302,7 +302,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -366,7 +366,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -173,6 +179,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -229,6 +238,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
 
@@ -289,6 +301,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -350,6 +365,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/organizations/client/Client.ts
@@ -57,7 +57,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -186,7 +186,7 @@ export class OrganizationsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/organizations/client/Client.ts
@@ -56,6 +56,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -179,6 +185,9 @@ export class OrganizationsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.Organization[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -118,7 +118,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -180,7 +180,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -239,7 +239,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
@@ -302,7 +302,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
@@ -366,7 +366,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -114,6 +117,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -173,6 +179,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -229,6 +238,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User[], rawResponse: _response.rawResponse };
         }
 
@@ -289,6 +301,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 
@@ -350,6 +365,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPathParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/plain-text/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/plain-text/src/api/resources/service/client/Client.ts
@@ -50,7 +50,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/plain-text/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/plain-text/src/api/resources/service/client/Client.ts
@@ -49,6 +49,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/src/Client.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/src/Client.ts
@@ -66,6 +66,9 @@ export class SeedPropertyAccessClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPropertyAccess.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/src/Client.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/src/Client.ts
@@ -67,7 +67,7 @@ export class SeedPropertyAccessClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPropertyAccess.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/property-access/no-custom-config/src/Client.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/src/Client.ts
@@ -70,6 +70,9 @@ export class SeedPropertyAccessClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedPropertyAccess.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/property-access/no-custom-config/src/Client.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/src/Client.ts
@@ -71,7 +71,7 @@ export class SeedPropertyAccessClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedPropertyAccess.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/public-object/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/public-object/src/api/resources/service/client/Client.ts
@@ -46,7 +46,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/public-object/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/public-object/src/api/resources/service/client/Client.ts
@@ -45,6 +45,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/src/Client.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/src/Client.ts
@@ -142,6 +142,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.SearchResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/src/Client.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/src/Client.ts
@@ -143,7 +143,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.SearchResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/query-parameters-openapi/src/Client.ts
+++ b/seed/ts-sdk/query-parameters-openapi/src/Client.ts
@@ -142,6 +142,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.SearchResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/query-parameters-openapi/src/Client.ts
+++ b/seed/ts-sdk/query-parameters-openapi/src/Client.ts
@@ -143,7 +143,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.SearchResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/api/resources/user/client/Client.ts
@@ -128,7 +128,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedQueryParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/api/resources/user/client/Client.ts
@@ -127,6 +127,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedQueryParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
@@ -128,7 +128,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedQueryParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
@@ -127,6 +127,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedQueryParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
@@ -128,7 +128,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedQueryParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
@@ -127,6 +127,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedQueryParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
@@ -128,7 +128,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedQueryParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
@@ -127,6 +127,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedQueryParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
@@ -128,7 +128,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedQueryParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
@@ -127,6 +127,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedQueryParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/query-parameters/serde/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/serde/src/api/resources/user/client/Client.ts
@@ -168,7 +168,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/query-parameters/serde/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/serde/src/api/resources/user/client/Client.ts
@@ -167,6 +167,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/api/resources/user/client/Client.ts
@@ -308,7 +308,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedRequestParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/api/resources/user/client/Client.ts
@@ -307,6 +307,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedRequestParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/api/resources/user/client/Client.ts
@@ -309,6 +309,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedRequestParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/api/resources/user/client/Client.ts
@@ -310,7 +310,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedRequestParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/api/resources/user/client/Client.ts
@@ -309,6 +309,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedRequestParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/api/resources/user/client/Client.ts
@@ -310,7 +310,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedRequestParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/api/resources/user/client/Client.ts
@@ -309,6 +309,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedRequestParameters.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/api/resources/user/client/Client.ts
@@ -310,7 +310,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedRequestParameters.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/required-nullable/src/Client.ts
+++ b/seed/ts-sdk/required-nullable/src/Client.ts
@@ -71,6 +71,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.Foo, rawResponse: _response.rawResponse };
         }
 
@@ -136,6 +139,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.Foo, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/required-nullable/src/Client.ts
+++ b/seed/ts-sdk/required-nullable/src/Client.ts
@@ -72,7 +72,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.Foo, rawResponse: _response.rawResponse };
         }
@@ -140,7 +140,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.Foo, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/response-property/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/response-property/src/api/resources/service/client/Client.ts
@@ -60,7 +60,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedResponseProperty.Response, rawResponse: _response.rawResponse };
         }
@@ -115,7 +115,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedResponseProperty.Response, rawResponse: _response.rawResponse };
         }
@@ -170,7 +170,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedResponseProperty.StringResponse, rawResponse: _response.rawResponse };
         }
@@ -225,7 +225,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedResponseProperty.Response, rawResponse: _response.rawResponse };
         }
@@ -280,7 +280,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedResponseProperty.Response | undefined,
@@ -338,7 +338,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedResponseProperty.OptionalWithDocs | undefined,
@@ -396,7 +396,7 @@ export class ServiceClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedResponseProperty.OptionalStringResponse | undefined,

--- a/seed/ts-sdk/response-property/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/response-property/src/api/resources/service/client/Client.ts
@@ -59,6 +59,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedResponseProperty.Response, rawResponse: _response.rawResponse };
         }
 
@@ -111,6 +114,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedResponseProperty.Response, rawResponse: _response.rawResponse };
         }
 
@@ -163,6 +169,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedResponseProperty.StringResponse, rawResponse: _response.rawResponse };
         }
 
@@ -215,6 +224,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedResponseProperty.Response, rawResponse: _response.rawResponse };
         }
 
@@ -267,6 +279,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedResponseProperty.Response | undefined,
                 rawResponse: _response.rawResponse,
@@ -322,6 +337,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedResponseProperty.OptionalWithDocs | undefined,
                 rawResponse: _response.rawResponse,
@@ -377,6 +395,9 @@ export class ServiceClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedResponseProperty.OptionalStringResponse | undefined,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/client/Client.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/client/Client.ts
@@ -54,7 +54,7 @@ export class CompletionsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: new core.Stream({
@@ -114,7 +114,7 @@ export class CompletionsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: new core.Stream({

--- a/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/client/Client.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/client/Client.ts
@@ -53,6 +53,9 @@ export class CompletionsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: new core.Stream({
                     stream: _response.body,
@@ -110,6 +113,9 @@ export class CompletionsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: new core.Stream({
                     stream: _response.body,

--- a/seed/ts-sdk/server-sent-events/src/api/resources/completions/client/Client.ts
+++ b/seed/ts-sdk/server-sent-events/src/api/resources/completions/client/Client.ts
@@ -54,7 +54,7 @@ export class CompletionsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: new core.Stream({
@@ -114,7 +114,7 @@ export class CompletionsClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: new core.Stream({

--- a/seed/ts-sdk/server-sent-events/src/api/resources/completions/client/Client.ts
+++ b/seed/ts-sdk/server-sent-events/src/api/resources/completions/client/Client.ts
@@ -53,6 +53,9 @@ export class CompletionsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: new core.Stream({
                     stream: _response.body,
@@ -110,6 +113,9 @@ export class CompletionsClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: new core.Stream({
                     stream: _response.body,

--- a/seed/ts-sdk/server-url-templating/src/Client.ts
+++ b/seed/ts-sdk/server-url-templating/src/Client.ts
@@ -55,6 +55,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.User[], rawResponse: _response.rawResponse };
         }
 
@@ -110,6 +113,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.User, rawResponse: _response.rawResponse };
         }
 
@@ -168,6 +174,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.TokenResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/server-url-templating/src/Client.ts
+++ b/seed/ts-sdk/server-url-templating/src/Client.ts
@@ -56,7 +56,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.User[], rawResponse: _response.rawResponse };
         }
@@ -114,7 +114,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.User, rawResponse: _response.rawResponse };
         }
@@ -175,7 +175,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.TokenResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/bundle/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/bundle/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/custom-package-json/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/custom-package-json/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/jsr/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/jsr/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/legacy-exports/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/legacy-exports/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/api/resources/user/client/Client.ts
@@ -53,7 +53,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/api/resources/user/client/Client.ts
@@ -52,6 +52,9 @@ export class UserClient {
             logging: this._options.logging
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/no-scripts/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/api/resources/user/client/Client.ts
@@ -53,7 +53,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/no-scripts/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/api/resources/user/client/Client.ts
@@ -52,6 +52,9 @@ export class UserClient {
             logging: this._options.logging
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/oidc-token/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/oidc-token/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/use-oxc/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/use-oxc/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/use-oxlint/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/use-oxlint/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/api/resources/user/client/Client.ts
@@ -60,7 +60,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/api/resources/user/client/Client.ts
@@ -59,6 +59,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/use-prettier/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/use-prettier/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-api/use-yarn/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/api/resources/user/client/Client.ts
@@ -58,6 +58,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-api/use-yarn/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/api/resources/user/client/Client.ts
@@ -59,7 +59,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedSimpleApi.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/simple-fhir/src/Client.ts
+++ b/seed/ts-sdk/simple-fhir/src/Client.ts
@@ -56,6 +56,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.Account, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/simple-fhir/src/Client.ts
+++ b/seed/ts-sdk/simple-fhir/src/Client.ts
@@ -57,7 +57,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.Account, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/single-url-environment-default/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/api/resources/dummy/client/Client.ts
@@ -56,7 +56,7 @@ export class DummyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/single-url-environment-default/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/api/resources/dummy/client/Client.ts
@@ -55,6 +55,9 @@ export class DummyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/single-url-environment-no-default/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/api/resources/dummy/client/Client.ts
@@ -53,6 +53,9 @@ export class DummyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/single-url-environment-no-default/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/api/resources/dummy/client/Client.ts
@@ -54,7 +54,7 @@ export class DummyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/streaming-parameter/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming-parameter/src/api/resources/dummy/client/Client.ts
@@ -53,6 +53,9 @@ export class DummyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: new core.Stream({
                     stream: _response.body,

--- a/seed/ts-sdk/streaming-parameter/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming-parameter/src/api/resources/dummy/client/Client.ts
@@ -54,7 +54,7 @@ export class DummyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: new core.Stream({

--- a/seed/ts-sdk/streaming/no-custom-config/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/api/resources/dummy/client/Client.ts
@@ -54,7 +54,7 @@ export class DummyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: new core.Stream({
@@ -122,7 +122,7 @@ export class DummyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedStreaming.StreamResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/streaming/no-custom-config/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/api/resources/dummy/client/Client.ts
@@ -53,6 +53,9 @@ export class DummyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: new core.Stream({
                     stream: _response.body,
@@ -118,6 +121,9 @@ export class DummyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedStreaming.StreamResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/streaming/serde-layer/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/api/resources/dummy/client/Client.ts
@@ -60,6 +60,9 @@ export class DummyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: new core.Stream({
                     stream: _response.body,
@@ -139,6 +142,9 @@ export class DummyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.StreamResponse.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/streaming/serde-layer/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/api/resources/dummy/client/Client.ts
@@ -61,7 +61,7 @@ export class DummyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: new core.Stream({
@@ -143,7 +143,7 @@ export class DummyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.StreamResponse.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/streaming/wrapper/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/api/resources/dummy/client/Client.ts
@@ -55,7 +55,7 @@ export class DummyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: new core.Stream({
@@ -123,7 +123,7 @@ export class DummyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedStreaming.StreamResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/streaming/wrapper/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/api/resources/dummy/client/Client.ts
@@ -54,6 +54,9 @@ export class DummyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: new core.Stream({
                     stream: _response.body,
@@ -119,6 +122,9 @@ export class DummyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedStreaming.StreamResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/homepage/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/homepage/client/Client.ts
@@ -70,7 +70,7 @@ export class HomepageClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.ProblemId[],
+                    body: _response.body != null ? (_response.body as SeedTrace.ProblemId[]) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/homepage/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/homepage/client/Client.ts
@@ -70,7 +70,7 @@ export class HomepageClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.ProblemId[]) : undefined,
+                    body: _response.body != null ? (_response.body as SeedTrace.ProblemId[]) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/migration/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/migration/client/Client.ts
@@ -79,7 +79,7 @@ export class MigrationClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.Migration[]) : undefined,
+                    body: _response.body != null ? (_response.body as SeedTrace.Migration[]) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/migration/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/migration/client/Client.ts
@@ -79,7 +79,7 @@ export class MigrationClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.Migration[],
+                    body: _response.body != null ? (_response.body as SeedTrace.Migration[]) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/playlist/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/playlist/client/Client.ts
@@ -93,7 +93,7 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.Playlist) : undefined,
+                    body: _response.body != null ? (_response.body as SeedTrace.Playlist) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -183,7 +183,7 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.Playlist[]) : undefined,
+                    body: _response.body != null ? (_response.body as SeedTrace.Playlist[]) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -257,7 +257,7 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.Playlist) : undefined,
+                    body: _response.body != null ? (_response.body as SeedTrace.Playlist) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -363,7 +363,10 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.Playlist | undefined) : undefined,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedTrace.Playlist | undefined)
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/playlist/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/playlist/client/Client.ts
@@ -93,7 +93,7 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.Playlist,
+                    body: _response.body != null ? (_response.body as SeedTrace.Playlist) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -183,7 +183,7 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.Playlist[],
+                    body: _response.body != null ? (_response.body as SeedTrace.Playlist[]) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -257,7 +257,7 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.Playlist,
+                    body: _response.body != null ? (_response.body as SeedTrace.Playlist) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -363,7 +363,7 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.Playlist | undefined,
+                    body: _response.body != null ? (_response.body as SeedTrace.Playlist | undefined) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/problem/client/Client.ts
@@ -152,7 +152,7 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.CreateProblemResponse,
+                    body: _response.body != null ? (_response.body as SeedTrace.CreateProblemResponse) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -305,7 +305,7 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.UpdateProblemResponse,
+                    body: _response.body != null ? (_response.body as SeedTrace.UpdateProblemResponse) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -472,7 +472,10 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.GetDefaultStarterFilesResponse,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedTrace.GetDefaultStarterFilesResponse)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/problem/client/Client.ts
@@ -152,7 +152,10 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.CreateProblemResponse) : undefined,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedTrace.CreateProblemResponse)
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -305,7 +308,10 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.UpdateProblemResponse) : undefined,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedTrace.UpdateProblemResponse)
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -475,7 +481,7 @@ export class ProblemClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedTrace.GetDefaultStarterFilesResponse)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/submission/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/submission/client/Client.ts
@@ -82,7 +82,7 @@ export class SubmissionClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.ExecutionSessionResponse,
+                    body: _response.body != null ? (_response.body as SeedTrace.ExecutionSessionResponse) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -162,7 +162,10 @@ export class SubmissionClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.ExecutionSessionResponse | undefined,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedTrace.ExecutionSessionResponse | undefined)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -311,7 +314,10 @@ export class SubmissionClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.GetExecutionSessionStateResponse,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedTrace.GetExecutionSessionStateResponse)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/submission/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/submission/client/Client.ts
@@ -82,7 +82,10 @@ export class SubmissionClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.ExecutionSessionResponse) : undefined,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedTrace.ExecutionSessionResponse)
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -165,7 +168,7 @@ export class SubmissionClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedTrace.ExecutionSessionResponse | undefined)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -317,7 +320,7 @@ export class SubmissionClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedTrace.GetExecutionSessionStateResponse)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/sysprop/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/sysprop/client/Client.ts
@@ -151,7 +151,10 @@ export class SyspropClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as Record<SeedTrace.Language, number | undefined>,
+                    body:
+                        _response.body != null
+                            ? (_response.body as Record<SeedTrace.Language, number | undefined>)
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/sysprop/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/sysprop/client/Client.ts
@@ -154,7 +154,7 @@ export class SyspropClient {
                     body:
                         _response.body != null
                             ? (_response.body as Record<SeedTrace.Language, number | undefined>)
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/v2/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/v2/resources/problem/client/Client.ts
@@ -79,7 +79,7 @@ export class ProblemClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedTrace.v2.LightweightProblemInfoV2[])
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -151,7 +151,8 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.v2.ProblemInfoV2[]) : undefined,
+                    body:
+                        _response.body != null ? (_response.body as SeedTrace.v2.ProblemInfoV2[]) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -226,7 +227,7 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.v2.ProblemInfoV2) : undefined,
+                    body: _response.body != null ? (_response.body as SeedTrace.v2.ProblemInfoV2) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -306,7 +307,7 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.v2.ProblemInfoV2) : undefined,
+                    body: _response.body != null ? (_response.body as SeedTrace.v2.ProblemInfoV2) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/v2/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/v2/resources/problem/client/Client.ts
@@ -76,7 +76,10 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.v2.LightweightProblemInfoV2[],
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedTrace.v2.LightweightProblemInfoV2[])
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -148,7 +151,7 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.v2.ProblemInfoV2[],
+                    body: _response.body != null ? (_response.body as SeedTrace.v2.ProblemInfoV2[]) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -223,7 +226,7 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.v2.ProblemInfoV2,
+                    body: _response.body != null ? (_response.body as SeedTrace.v2.ProblemInfoV2) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -303,7 +306,7 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.v2.ProblemInfoV2,
+                    body: _response.body != null ? (_response.body as SeedTrace.v2.ProblemInfoV2) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
@@ -85,7 +85,7 @@ export class ProblemClient {
                     body:
                         _response.body != null
                             ? (_response.body as SeedTrace.v2.v3.LightweightProblemInfoV2[])
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -159,7 +159,10 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.v2.v3.ProblemInfoV2[]) : undefined,
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedTrace.v2.v3.ProblemInfoV2[])
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -236,7 +239,8 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.v2.v3.ProblemInfoV2) : undefined,
+                    body:
+                        _response.body != null ? (_response.body as SeedTrace.v2.v3.ProblemInfoV2) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -318,7 +322,8 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body != null ? (_response.body as SeedTrace.v2.v3.ProblemInfoV2) : undefined,
+                    body:
+                        _response.body != null ? (_response.body as SeedTrace.v2.v3.ProblemInfoV2) : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
@@ -82,7 +82,10 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.v2.v3.LightweightProblemInfoV2[],
+                    body:
+                        _response.body != null
+                            ? (_response.body as SeedTrace.v2.v3.LightweightProblemInfoV2[])
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -156,7 +159,7 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.v2.v3.ProblemInfoV2[],
+                    body: _response.body != null ? (_response.body as SeedTrace.v2.v3.ProblemInfoV2[]) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -233,7 +236,7 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.v2.v3.ProblemInfoV2,
+                    body: _response.body != null ? (_response.body as SeedTrace.v2.v3.ProblemInfoV2) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -315,7 +318,7 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: _response.body as SeedTrace.v2.v3.ProblemInfoV2,
+                    body: _response.body != null ? (_response.body as SeedTrace.v2.v3.ProblemInfoV2) : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/homepage/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/homepage/client/Client.ts
@@ -62,7 +62,7 @@ export class HomepageClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.ProblemId[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/homepage/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/homepage/client/Client.ts
@@ -61,6 +61,9 @@ export class HomepageClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.ProblemId[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/migration/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/migration/client/Client.ts
@@ -68,6 +68,9 @@ export class MigrationClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.Migration[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/migration/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/migration/client/Client.ts
@@ -69,7 +69,7 @@ export class MigrationClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.Migration[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/playlist/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/playlist/client/Client.ts
@@ -86,6 +86,9 @@ export class PlaylistClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.Playlist, rawResponse: _response.rawResponse };
         }
 
@@ -168,6 +171,9 @@ export class PlaylistClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.Playlist[], rawResponse: _response.rawResponse };
         }
 
@@ -237,6 +243,9 @@ export class PlaylistClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.Playlist, rawResponse: _response.rawResponse };
         }
 
@@ -328,6 +337,9 @@ export class PlaylistClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.Playlist | undefined, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/playlist/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/playlist/client/Client.ts
@@ -87,7 +87,7 @@ export class PlaylistClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.Playlist, rawResponse: _response.rawResponse };
         }
@@ -172,7 +172,7 @@ export class PlaylistClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.Playlist[], rawResponse: _response.rawResponse };
         }
@@ -244,7 +244,7 @@ export class PlaylistClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.Playlist, rawResponse: _response.rawResponse };
         }
@@ -338,7 +338,7 @@ export class PlaylistClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.Playlist | undefined, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/problem/client/Client.ts
@@ -142,7 +142,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.CreateProblemResponse, rawResponse: _response.rawResponse };
         }
@@ -281,7 +281,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.UpdateProblemResponse, rawResponse: _response.rawResponse };
         }
@@ -429,7 +429,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedTrace.GetDefaultStarterFilesResponse,

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/problem/client/Client.ts
@@ -141,6 +141,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.CreateProblemResponse, rawResponse: _response.rawResponse };
         }
 
@@ -277,6 +280,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.UpdateProblemResponse, rawResponse: _response.rawResponse };
         }
 
@@ -422,6 +428,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedTrace.GetDefaultStarterFilesResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/submission/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/submission/client/Client.ts
@@ -69,6 +69,9 @@ export class SubmissionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.ExecutionSessionResponse, rawResponse: _response.rawResponse };
         }
 
@@ -132,6 +135,9 @@ export class SubmissionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedTrace.ExecutionSessionResponse | undefined,
                 rawResponse: _response.rawResponse,
@@ -246,6 +252,9 @@ export class SubmissionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedTrace.GetExecutionSessionStateResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/submission/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/submission/client/Client.ts
@@ -70,7 +70,7 @@ export class SubmissionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.ExecutionSessionResponse, rawResponse: _response.rawResponse };
         }
@@ -136,7 +136,7 @@ export class SubmissionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedTrace.ExecutionSessionResponse | undefined,
@@ -253,7 +253,7 @@ export class SubmissionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedTrace.GetExecutionSessionStateResponse,

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/sysprop/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/sysprop/client/Client.ts
@@ -128,7 +128,7 @@ export class SyspropClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as Record<SeedTrace.Language, number | undefined>,

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/sysprop/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/sysprop/client/Client.ts
@@ -127,6 +127,9 @@ export class SyspropClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as Record<SeedTrace.Language, number | undefined>,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/problem/client/Client.ts
@@ -64,7 +64,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedTrace.v2.LightweightProblemInfoV2[],
@@ -130,7 +130,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.v2.ProblemInfoV2[], rawResponse: _response.rawResponse };
         }
@@ -191,7 +191,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.v2.ProblemInfoV2, rawResponse: _response.rawResponse };
         }
@@ -262,7 +262,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.v2.ProblemInfoV2, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/problem/client/Client.ts
@@ -63,6 +63,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedTrace.v2.LightweightProblemInfoV2[],
                 rawResponse: _response.rawResponse,
@@ -126,6 +129,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.v2.ProblemInfoV2[], rawResponse: _response.rawResponse };
         }
 
@@ -184,6 +190,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.v2.ProblemInfoV2, rawResponse: _response.rawResponse };
         }
 
@@ -252,6 +261,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.v2.ProblemInfoV2, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
@@ -63,6 +63,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedTrace.v2.v3.LightweightProblemInfoV2[],
                 rawResponse: _response.rawResponse,
@@ -126,6 +129,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.v2.v3.ProblemInfoV2[], rawResponse: _response.rawResponse };
         }
 
@@ -184,6 +190,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.v2.v3.ProblemInfoV2, rawResponse: _response.rawResponse };
         }
 
@@ -252,6 +261,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedTrace.v2.v3.ProblemInfoV2, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
@@ -64,7 +64,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedTrace.v2.v3.LightweightProblemInfoV2[],
@@ -130,7 +130,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.v2.v3.ProblemInfoV2[], rawResponse: _response.rawResponse };
         }
@@ -191,7 +191,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.v2.v3.ProblemInfoV2, rawResponse: _response.rawResponse };
         }
@@ -262,7 +262,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedTrace.v2.v3.ProblemInfoV2, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/homepage/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/homepage/client/Client.ts
@@ -65,13 +65,16 @@ export class HomepageClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.homepage.getHomepageProblems.Response.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.homepage.getHomepageProblems.Response.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/homepage/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/homepage/client/Client.ts
@@ -74,7 +74,7 @@ export class HomepageClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/migration/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/migration/client/Client.ts
@@ -83,7 +83,7 @@ export class MigrationClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/migration/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/migration/client/Client.ts
@@ -74,13 +74,16 @@ export class MigrationClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.migration.getAttemptedMigrations.Response.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.migration.getAttemptedMigrations.Response.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/playlist/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/playlist/client/Client.ts
@@ -100,7 +100,7 @@ export class PlaylistClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -193,7 +193,7 @@ export class PlaylistClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -270,7 +270,7 @@ export class PlaylistClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -391,7 +391,7 @@ export class PlaylistClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/playlist/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/playlist/client/Client.ts
@@ -91,13 +91,16 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.Playlist.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.Playlist.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -181,13 +184,16 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.playlist.getPlaylists.Response.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.playlist.getPlaylists.Response.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -255,13 +261,16 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.Playlist.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.Playlist.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -373,13 +382,16 @@ export class PlaylistClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.playlist.updatePlaylist.Response.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.playlist.updatePlaylist.Response.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/problem/client/Client.ts
@@ -150,13 +150,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.CreateProblemResponse.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.CreateProblemResponse.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -306,13 +309,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.UpdateProblemResponse.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.UpdateProblemResponse.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -470,13 +476,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.GetDefaultStarterFilesResponse.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.GetDefaultStarterFilesResponse.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/problem/client/Client.ts
@@ -159,7 +159,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -318,7 +318,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -485,7 +485,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/submission/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/submission/client/Client.ts
@@ -86,7 +86,7 @@ export class SubmissionClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -169,7 +169,7 @@ export class SubmissionClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -315,7 +315,7 @@ export class SubmissionClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/submission/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/submission/client/Client.ts
@@ -77,13 +77,16 @@ export class SubmissionClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.ExecutionSessionResponse.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.ExecutionSessionResponse.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -157,13 +160,16 @@ export class SubmissionClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.submission.getExecutionSession.Response.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.submission.getExecutionSession.Response.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -300,13 +306,16 @@ export class SubmissionClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.GetExecutionSessionStateResponse.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.GetExecutionSessionStateResponse.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/sysprop/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/sysprop/client/Client.ts
@@ -140,13 +140,16 @@ export class SyspropClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.sysprop.getNumWarmInstances.Response.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.sysprop.getNumWarmInstances.Response.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/sysprop/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/sysprop/client/Client.ts
@@ -149,7 +149,7 @@ export class SyspropClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/v2/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/v2/resources/problem/client/Client.ts
@@ -80,7 +80,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -155,7 +155,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -233,7 +233,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -316,7 +316,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/v2/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/v2/resources/problem/client/Client.ts
@@ -71,13 +71,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.v2.problem.getLightweightProblems.Response.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.v2.problem.getLightweightProblems.Response.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -143,13 +146,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.v2.problem.getProblems.Response.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.v2.problem.getProblems.Response.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -218,13 +224,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.v2.ProblemInfoV2.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.v2.ProblemInfoV2.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -298,13 +307,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.v2.ProblemInfoV2.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.v2.ProblemInfoV2.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
@@ -77,13 +77,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.v2.v3.problem.getLightweightProblems.Response.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.v2.v3.problem.getLightweightProblems.Response.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -151,13 +154,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.v2.v3.problem.getProblems.Response.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.v2.v3.problem.getProblems.Response.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -228,13 +234,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.v2.v3.ProblemInfoV2.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.v2.v3.ProblemInfoV2.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -310,13 +319,16 @@ export class ProblemClient {
             return {
                 data: {
                     ok: true,
-                    body: serializers.v2.v3.ProblemInfoV2.parseOrThrow(_response.body, {
-                        unrecognizedObjectKeys: "passthrough",
-                        allowUnrecognizedUnionMembers: true,
-                        allowUnrecognizedEnumValues: true,
-                        skipValidation: true,
-                        breadcrumbsPrefix: ["response"],
-                    }),
+                    body:
+                        _response.body != null
+                            ? serializers.v2.v3.ProblemInfoV2.parseOrThrow(_response.body, {
+                                  unrecognizedObjectKeys: "passthrough",
+                                  allowUnrecognizedUnionMembers: true,
+                                  allowUnrecognizedEnumValues: true,
+                                  skipValidation: true,
+                                  breadcrumbsPrefix: ["response"],
+                              })
+                            : undefined,
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
@@ -86,7 +86,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -163,7 +163,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -243,7 +243,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },
@@ -328,7 +328,7 @@ export class ProblemClient {
                                   skipValidation: true,
                                   breadcrumbsPrefix: ["response"],
                               })
-                            : undefined,
+                            : (undefined as any),
                     headers: _response.headers,
                     rawResponse: _response.rawResponse,
                 },

--- a/seed/ts-sdk/trace/serde/src/api/resources/homepage/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/homepage/client/Client.ts
@@ -62,6 +62,9 @@ export class HomepageClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.homepage.getHomepageProblems.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/trace/serde/src/api/resources/homepage/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/homepage/client/Client.ts
@@ -63,7 +63,7 @@ export class HomepageClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.homepage.getHomepageProblems.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/trace/serde/src/api/resources/migration/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/migration/client/Client.ts
@@ -70,7 +70,7 @@ export class MigrationClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.migration.getAttemptedMigrations.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/trace/serde/src/api/resources/migration/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/migration/client/Client.ts
@@ -69,6 +69,9 @@ export class MigrationClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.migration.getAttemptedMigrations.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/trace/serde/src/api/resources/playlist/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/playlist/client/Client.ts
@@ -91,7 +91,7 @@ export class PlaylistClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.Playlist.parseOrThrow(_response.body, {
@@ -185,7 +185,7 @@ export class PlaylistClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.playlist.getPlaylists.Response.parseOrThrow(_response.body, {
@@ -266,7 +266,7 @@ export class PlaylistClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.Playlist.parseOrThrow(_response.body, {
@@ -378,7 +378,7 @@ export class PlaylistClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.playlist.updatePlaylist.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/trace/serde/src/api/resources/playlist/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/playlist/client/Client.ts
@@ -90,6 +90,9 @@ export class PlaylistClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.Playlist.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -181,6 +184,9 @@ export class PlaylistClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.playlist.getPlaylists.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -259,6 +265,9 @@ export class PlaylistClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.Playlist.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -368,6 +377,9 @@ export class PlaylistClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.playlist.updatePlaylist.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/trace/serde/src/api/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/problem/client/Client.ts
@@ -146,7 +146,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.CreateProblemResponse.parseOrThrow(_response.body, {
@@ -297,7 +297,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.UpdateProblemResponse.parseOrThrow(_response.body, {
@@ -457,7 +457,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.GetDefaultStarterFilesResponse.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/trace/serde/src/api/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/problem/client/Client.ts
@@ -145,6 +145,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.CreateProblemResponse.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -293,6 +296,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.UpdateProblemResponse.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -450,6 +456,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.GetDefaultStarterFilesResponse.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/trace/serde/src/api/resources/submission/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/submission/client/Client.ts
@@ -70,6 +70,9 @@ export class SubmissionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.ExecutionSessionResponse.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -142,6 +145,9 @@ export class SubmissionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.submission.getExecutionSession.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -262,6 +268,9 @@ export class SubmissionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.GetExecutionSessionStateResponse.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/trace/serde/src/api/resources/submission/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/submission/client/Client.ts
@@ -71,7 +71,7 @@ export class SubmissionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.ExecutionSessionResponse.parseOrThrow(_response.body, {
@@ -146,7 +146,7 @@ export class SubmissionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.submission.getExecutionSession.Response.parseOrThrow(_response.body, {
@@ -269,7 +269,7 @@ export class SubmissionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.GetExecutionSessionStateResponse.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/trace/serde/src/api/resources/sysprop/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/sysprop/client/Client.ts
@@ -129,7 +129,7 @@ export class SyspropClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.sysprop.getNumWarmInstances.Response.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/trace/serde/src/api/resources/sysprop/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/sysprop/client/Client.ts
@@ -128,6 +128,9 @@ export class SyspropClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.sysprop.getNumWarmInstances.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/problem/client/Client.ts
@@ -65,7 +65,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.v2.problem.getLightweightProblems.Response.parseOrThrow(_response.body, {
@@ -137,7 +137,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.v2.problem.getProblems.Response.parseOrThrow(_response.body, {
@@ -207,7 +207,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.v2.ProblemInfoV2.parseOrThrow(_response.body, {
@@ -287,7 +287,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.v2.ProblemInfoV2.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/problem/client/Client.ts
@@ -64,6 +64,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.v2.problem.getLightweightProblems.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -133,6 +136,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.v2.problem.getProblems.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -200,6 +206,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.v2.ProblemInfoV2.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -277,6 +286,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.v2.ProblemInfoV2.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
@@ -64,6 +64,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.v2.v3.problem.getLightweightProblems.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -133,6 +136,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.v2.v3.problem.getProblems.Response.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -200,6 +206,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.v2.v3.ProblemInfoV2.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -277,6 +286,9 @@ export class ProblemClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.v2.v3.ProblemInfoV2.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
@@ -65,7 +65,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.v2.v3.problem.getLightweightProblems.Response.parseOrThrow(_response.body, {
@@ -137,7 +137,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.v2.v3.problem.getProblems.Response.parseOrThrow(_response.body, {
@@ -207,7 +207,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.v2.v3.ProblemInfoV2.parseOrThrow(_response.body, {
@@ -287,7 +287,7 @@ export class ProblemClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.v2.v3.ProblemInfoV2.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/ts-express-casing/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/ts-express-casing/src/api/resources/imdb/client/Client.ts
@@ -65,6 +65,9 @@ export class ImdbClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.MovieId, rawResponse: _response.rawResponse };
         }
 
@@ -116,6 +119,9 @@ export class ImdbClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.Movie, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/ts-express-casing/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/ts-express-casing/src/api/resources/imdb/client/Client.ts
@@ -66,7 +66,7 @@ export class ImdbClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.MovieId, rawResponse: _response.rawResponse };
         }
@@ -120,7 +120,7 @@ export class ImdbClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.Movie, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/ts-extra-properties/src/Client.ts
+++ b/seed/ts-sdk/ts-extra-properties/src/Client.ts
@@ -53,7 +53,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
@@ -122,7 +122,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {

--- a/seed/ts-sdk/ts-extra-properties/src/Client.ts
+++ b/seed/ts-sdk/ts-extra-properties/src/Client.ts
@@ -52,6 +52,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",
@@ -118,6 +121,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: serializers.User.parseOrThrow(_response.body, {
                     unrecognizedObjectKeys: "passthrough",

--- a/seed/ts-sdk/ts-inline-types/inline/src/Client.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/Client.ts
@@ -64,6 +64,9 @@ export class SeedObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedObject.RootType1, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/ts-inline-types/inline/src/Client.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/Client.ts
@@ -65,7 +65,7 @@ export class SeedObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedObject.RootType1, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/Client.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/Client.ts
@@ -64,6 +64,9 @@ export class SeedObjectClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedObject.RootType1, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/Client.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/Client.ts
@@ -65,7 +65,7 @@ export class SeedObjectClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedObject.RootType1, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/src/Client.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/src/Client.ts
@@ -54,7 +54,7 @@ export class SeedUndiscriminatedUnionWithResponsePropertyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedUndiscriminatedUnionWithResponseProperty.UnionResponse,
@@ -106,7 +106,7 @@ export class SeedUndiscriminatedUnionWithResponsePropertyClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedUndiscriminatedUnionWithResponseProperty.UnionListResponse,

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/src/Client.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/src/Client.ts
@@ -53,6 +53,9 @@ export class SeedUndiscriminatedUnionWithResponsePropertyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedUndiscriminatedUnionWithResponseProperty.UnionResponse,
                 rawResponse: _response.rawResponse,
@@ -102,6 +105,9 @@ export class SeedUndiscriminatedUnionWithResponsePropertyClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedUndiscriminatedUnionWithResponseProperty.UnionListResponse,
                 rawResponse: _response.rawResponse,

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/api/resources/union/client/Client.ts
@@ -57,6 +57,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedUndiscriminatedUnions.MyUnion, rawResponse: _response.rawResponse };
         }
 
@@ -103,6 +106,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedUndiscriminatedUnions.Metadata, rawResponse: _response.rawResponse };
         }
 
@@ -159,6 +165,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -217,6 +226,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -269,6 +281,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedUndiscriminatedUnions.UnionWithDuplicateTypes,
                 rawResponse: _response.rawResponse,
@@ -324,6 +339,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -381,6 +399,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/api/resources/union/client/Client.ts
@@ -58,7 +58,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedUndiscriminatedUnions.MyUnion, rawResponse: _response.rawResponse };
         }
@@ -107,7 +107,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedUndiscriminatedUnions.Metadata, rawResponse: _response.rawResponse };
         }
@@ -166,7 +166,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -227,7 +227,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -282,7 +282,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedUndiscriminatedUnions.UnionWithDuplicateTypes,
@@ -340,7 +340,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -400,7 +400,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/api/resources/union/client/Client.ts
@@ -57,6 +57,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedUndiscriminatedUnions.MyUnion, rawResponse: _response.rawResponse };
         }
 
@@ -103,6 +106,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedUndiscriminatedUnions.Metadata, rawResponse: _response.rawResponse };
         }
 
@@ -159,6 +165,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -217,6 +226,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -269,6 +281,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return {
                 data: _response.body as SeedUndiscriminatedUnions.UnionWithDuplicateTypes,
                 rawResponse: _response.rawResponse,
@@ -324,6 +339,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 
@@ -381,6 +399,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/api/resources/union/client/Client.ts
@@ -58,7 +58,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedUndiscriminatedUnions.MyUnion, rawResponse: _response.rawResponse };
         }
@@ -107,7 +107,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedUndiscriminatedUnions.Metadata, rawResponse: _response.rawResponse };
         }
@@ -166,7 +166,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -227,7 +227,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -282,7 +282,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return {
                 data: _response.body as SeedUndiscriminatedUnions.UnionWithDuplicateTypes,
@@ -340,7 +340,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }
@@ -400,7 +400,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as string, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/bigunion/client/Client.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/bigunion/client/Client.ts
@@ -56,6 +56,9 @@ export class BigunionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedUnions.BigUnion, rawResponse: _response.rawResponse };
         }
 
@@ -112,6 +115,9 @@ export class BigunionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -176,6 +182,9 @@ export class BigunionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, boolean>, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/bigunion/client/Client.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/bigunion/client/Client.ts
@@ -57,7 +57,7 @@ export class BigunionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedUnions.BigUnion, rawResponse: _response.rawResponse };
         }
@@ -116,7 +116,7 @@ export class BigunionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -183,7 +183,7 @@ export class BigunionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, boolean>, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/types/client/Client.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/types/client/Client.ts
@@ -60,7 +60,7 @@ export class TypesClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedUnions.UnionWithTime, rawResponse: _response.rawResponse };
         }
@@ -124,7 +124,7 @@ export class TypesClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/types/client/Client.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/types/client/Client.ts
@@ -59,6 +59,9 @@ export class TypesClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedUnions.UnionWithTime, rawResponse: _response.rawResponse };
         }
 
@@ -120,6 +123,9 @@ export class TypesClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/union/client/Client.ts
@@ -54,7 +54,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedUnions.Shape, rawResponse: _response.rawResponse };
         }
@@ -112,7 +112,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/union/client/Client.ts
@@ -53,6 +53,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedUnions.Shape, rawResponse: _response.rawResponse };
         }
 
@@ -108,6 +111,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/unions/src/api/resources/bigunion/client/Client.ts
+++ b/seed/ts-sdk/unions/src/api/resources/bigunion/client/Client.ts
@@ -56,6 +56,9 @@ export class BigunionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedUnions.BigUnion, rawResponse: _response.rawResponse };
         }
 
@@ -112,6 +115,9 @@ export class BigunionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 
@@ -176,6 +182,9 @@ export class BigunionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as Record<string, boolean>, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/unions/src/api/resources/bigunion/client/Client.ts
+++ b/seed/ts-sdk/unions/src/api/resources/bigunion/client/Client.ts
@@ -57,7 +57,7 @@ export class BigunionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedUnions.BigUnion, rawResponse: _response.rawResponse };
         }
@@ -116,7 +116,7 @@ export class BigunionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
@@ -183,7 +183,7 @@ export class BigunionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as Record<string, boolean>, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/unions/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/unions/src/api/resources/union/client/Client.ts
@@ -54,7 +54,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedUnions.Shape, rawResponse: _response.rawResponse };
         }
@@ -112,7 +112,7 @@ export class UnionClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/unions/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/unions/src/api/resources/union/client/Client.ts
@@ -53,6 +53,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedUnions.Shape, rawResponse: _response.rawResponse };
         }
 
@@ -108,6 +111,9 @@ export class UnionClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as boolean, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/unknown/no-custom-config/src/api/resources/unknown/client/Client.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/api/resources/unknown/client/Client.ts
@@ -56,6 +56,9 @@ export class UnknownClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as unknown[], rawResponse: _response.rawResponse };
         }
 
@@ -112,6 +115,9 @@ export class UnknownClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as unknown[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/unknown/no-custom-config/src/api/resources/unknown/client/Client.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/api/resources/unknown/client/Client.ts
@@ -57,7 +57,7 @@ export class UnknownClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as unknown[], rawResponse: _response.rawResponse };
         }
@@ -116,7 +116,7 @@ export class UnknownClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as unknown[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/unknown/unknown-as-any/src/api/resources/unknown/client/Client.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/api/resources/unknown/client/Client.ts
@@ -56,6 +56,9 @@ export class UnknownClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as any[], rawResponse: _response.rawResponse };
         }
 
@@ -112,6 +115,9 @@ export class UnknownClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as any[], rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/unknown/unknown-as-any/src/api/resources/unknown/client/Client.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/api/resources/unknown/client/Client.ts
@@ -57,7 +57,7 @@ export class UnknownClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as any[], rawResponse: _response.rawResponse };
         }
@@ -116,7 +116,7 @@ export class UnknownClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as any[], rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/url-form-encoded/src/Client.ts
+++ b/seed/ts-sdk/url-form-encoded/src/Client.ts
@@ -62,6 +62,9 @@ export class SeedApiClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedApi.PostSubmitResponse, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/url-form-encoded/src/Client.ts
+++ b/seed/ts-sdk/url-form-encoded/src/Client.ts
@@ -63,7 +63,7 @@ export class SeedApiClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedApi.PostSubmitResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/validation/src/Client.ts
+++ b/seed/ts-sdk/validation/src/Client.ts
@@ -65,7 +65,7 @@ export class SeedValidationClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedValidation.Type, rawResponse: _response.rawResponse };
         }
@@ -125,7 +125,7 @@ export class SeedValidationClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedValidation.Type, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/validation/src/Client.ts
+++ b/seed/ts-sdk/validation/src/Client.ts
@@ -64,6 +64,9 @@ export class SeedValidationClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedValidation.Type, rawResponse: _response.rawResponse };
         }
 
@@ -121,6 +124,9 @@ export class SeedValidationClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedValidation.Type, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/version-no-default/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/version-no-default/src/api/resources/user/client/Client.ts
@@ -60,6 +60,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedVersion.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/version-no-default/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/version-no-default/src/api/resources/user/client/Client.ts
@@ -61,7 +61,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedVersion.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/version/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/version/src/api/resources/user/client/Client.ts
@@ -60,6 +60,9 @@ export class UserClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedVersion.User, rawResponse: _response.rawResponse };
         }
 

--- a/seed/ts-sdk/version/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/version/src/api/resources/user/client/Client.ts
@@ -61,7 +61,7 @@ export class UserClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedVersion.User, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/api/resources/auth/client/Client.ts
@@ -70,7 +70,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedWebsocketAuth.TokenResponse, rawResponse: _response.rawResponse };
         }
@@ -136,7 +136,7 @@ export class AuthClient {
         });
         if (_response.ok) {
             if (_response.body == null) {
-                return { data: undefined, rawResponse: _response.rawResponse };
+                return { data: undefined as any, rawResponse: _response.rawResponse };
             }
             return { data: _response.body as SeedWebsocketAuth.TokenResponse, rawResponse: _response.rawResponse };
         }

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/api/resources/auth/client/Client.ts
@@ -69,6 +69,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedWebsocketAuth.TokenResponse, rawResponse: _response.rawResponse };
         }
 
@@ -132,6 +135,9 @@ export class AuthClient {
             logging: this._options.logging,
         });
         if (_response.ok) {
+            if (_response.body == null) {
+                return { data: undefined, rawResponse: _response.rawResponse };
+            }
             return { data: _response.body as SeedWebsocketAuth.TokenResponse, rawResponse: _response.rawResponse };
         }
 


### PR DESCRIPTION
## Description

Linear ticket: Closes [FER-4769](https://linear.app/buildwithfern/issue/FER-4769/elevenlabs-typescript-dont-attempt-to-decode-204-status-codes)

When an endpoint defines a response body type but the server returns a 204 No Content (which has no body per HTTP spec), the generated SDK would attempt to deserialize `undefined`, causing a parse error at runtime. This adds a runtime guard so that null/undefined bodies return `undefined` data instead of crashing.

Link to Devin session: https://app.devin.ai/sessions/35b7f3eef25042b398962235ec3d306f
Requested by: @Swimburger

## Changes Made

- **`GeneratedThrowingEndpointResponse.ts`**: Added an `if (_response.body == null)` guard before the deserialization block. Returns `{ data: undefined as any, rawResponse: _response.rawResponse }` early when the body is null/undefined.
- **`GeneratedNonThrowingEndpointResponse.ts`**: Wrapped the body expression in a ternary `_response.body != null ? deserialize(body) : (undefined as any)` to guard against null bodies.
- **`versions.yml`**: Bumped to `3.52.9` with a fix changelog entry.
- **Seed snapshots**: Regenerated all `ts-sdk` seed test outputs (498 files) reflecting the new guard in generated client code.
- [ ] Updated README.md generator (not applicable)

### Updates since last revision

- Added `as any` cast on the `undefined` return values in both throwing and non-throwing variants. Without this cast, the generated SDK code fails TypeScript compilation because `undefined` is not assignable to the expected response type (e.g., `boolean`, `User[]`, etc.). The `as any` silences the compiler while preserving the defensive runtime behavior.

## Important Review Notes

1. **The guard is unconditional** — it applies to every endpoint that has a defined response body, not only endpoints known to return 204. This is intentionally defensive since the server can return 204 regardless of the spec. The fetcher treats all 2xx–3xx as `ok: true` without exposing the status code, so there's no way to conditionally guard only on 204.
2. **`undefined as any` type safety** — The `as any` cast prevents compile-time errors in the generated code, but consumers will still receive `undefined` at runtime where they expect the response type. This is a deliberate tradeoff: crashing on `parseOrThrow(undefined)` is strictly worse. Changing the return type to `T | undefined` globally would be a larger breaking change.
3. **`== null` loose equality** — Catches both `null` and `undefined`. The fetcher's `getResponseBody` returns `undefined` (not `null`) for empty bodies, and the existing codebase uses `== null` for this pattern.
4. **No dedicated unit test** — the fix is validated through seed snapshot regeneration across all fixtures. No standalone test for the 204 edge case was added.

## Human Review Checklist

- [ ] Confirm that unconditional null-body guarding (on all endpoints, not just 204-specific ones) is the desired behavior
- [ ] Verify that `undefined as any` is acceptable vs. a more type-safe approach (e.g., widening the return type to `T | undefined`)
- [ ] Check whether the `== null` loose equality (catching both `null` and `undefined`) is correct vs. strict `=== null`

## Testing

- [x] Seed tests regenerated (`pnpm seed test --generator ts-sdk --skip-scripts --local`) — all pass
- [x] TypeScript compilation passes (`pnpm turbo run compile --filter=...sdk-client-class-generator`)
- [x] Biome formatting check passes (`pnpm check:biome`)
- [x] All CI checks passing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
