### PR TITLE
chore(csharp): mark Stringify extension methods as obsolete

### DIFF
--- a/generators/csharp/base/src/asIs/Extensions.cs
+++ b/generators/csharp/base/src/asIs/Extensions.cs
@@ -5,6 +5,7 @@ namespace <%= namespace%>;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/generators/csharp/base/src/asIs/StringEnumExtensions.Template.cs
+++ b/generators/csharp/base/src/asIs/StringEnumExtensions.Template.cs
@@ -2,5 +2,6 @@ namespace <%= namespace%>;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.0.11
+  changelogEntry:
+    - summary: |
+        Mark the `Stringify` extension methods on `Enum` and `IStringEnum` as
+        `[Obsolete]`. Use `ValueConvert.ToString()` instead.
+      type: chore
+  createdAt: "2026-03-02"
+  irVersion: 62
+
 - version: 0.0.10
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.22.9
+  changelogEntry:
+    - summary: |
+        Mark the `Stringify` extension methods on `Enum` and `IStringEnum` as
+        `[Obsolete]`. Use `ValueConvert.ToString()` instead.
+      type: chore
+  createdAt: "2026-03-02"
+  irVersion: 62
+
 - version: 2.22.8
   changelogEntry:
     - summary: |

--- a/seed/csharp-model/accept-header/src/SeedAccept/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/accept-header/src/SeedAccept/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedAccept.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/alias-extends/src/SeedAliasExtends/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/alias-extends/src/SeedAliasExtends/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedAliasExtends.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/alias/src/SeedAlias/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/alias/src/SeedAlias/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedAlias.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/any-auth/src/SeedAnyAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/any-auth/src/SeedAnyAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedAnyAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApiWideBasePath.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/audiences/src/SeedAudiences/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/audiences/src/SeedAudiences/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedAudiences.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedBasicAuthEnvironmentVariables.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/basic-auth/src/SeedBasicAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/basic-auth/src/SeedBasicAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedBasicAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedBearerTokenEnvironmentVariable.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/bytes-download/src/SeedBytesDownload/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/bytes-download/src/SeedBytesDownload/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedBytesDownload.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/bytes-upload/src/SeedBytesUpload/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/bytes-upload/src/SeedBytesUpload/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedBytesUpload.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/circular-references-advanced/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/circular-references-advanced/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/circular-references/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/circular-references/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/client-side-params/src/SeedClientSideParams/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/client-side-params/src/SeedClientSideParams/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedClientSideParams.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/content-type/src/SeedContentTypes/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/content-type/src/SeedContentTypes/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedContentTypes.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCrossPackageTypeNames.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/csharp-grpc-proto/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/csharp-grpc-proto/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCsharpNamespaceCollision.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCsharpNamespaceConflict.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCsharpReadonlyRequest.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCsharpSystemCollision.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCsharpXmlEntities.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedDollarStringExamples.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/empty-clients/src/SeedEmptyClients/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/empty-clients/src/SeedEmptyClients/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedEmptyClients.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedEndpointSecurityAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedEnum.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/error-property/src/SeedErrorProperty/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/error-property/src/SeedErrorProperty/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedErrorProperty.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/errors/src/SeedErrors/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/errors/src/SeedErrors/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedErrors.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/examples/src/SeedExamples/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/examples/src/SeedExamples/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExamples.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/exhaustive/src/SeedExhaustive/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/exhaustive/src/SeedExhaustive/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExhaustive.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/extends/src/SeedExtends/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/extends/src/SeedExtends/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExtends.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/extra-properties/src/SeedExtraProperties/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/extra-properties/src/SeedExtraProperties/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExtraProperties.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/file-download/src/SeedFileDownload/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/file-download/src/SeedFileDownload/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedFileDownload.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/file-upload-openapi/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/file-upload-openapi/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/file-upload/src/SeedFileUpload/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/file-upload/src/SeedFileUpload/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedFileUpload.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/folders/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/folders/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedHeaderTokenEnvironmentVariable.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/header-auth/src/SeedHeaderToken/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/header-auth/src/SeedHeaderToken/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedHeaderToken.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/http-head/src/SeedHttpHead/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/http-head/src/SeedHttpHead/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedHttpHead.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedIdempotencyHeaders.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/imdb/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/imdb/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedInferredAuthExplicit.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedInferredAuthImplicitApiKey.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedInferredAuthImplicitNoExpiry.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedInferredAuthImplicit.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedInferredAuthImplicit.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/license/src/SeedLicense/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/license/src/SeedLicense/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedLicense.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/literal/src/SeedLiteral/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/literal/src/SeedLiteral/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedLiteral.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedLiteralsUnions.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/mixed-case/src/SeedMixedCase/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/mixed-case/src/SeedMixedCase/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMixedCase.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMixedFileDirectory.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMultiLineDocs.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMultiUrlEnvironmentNoDefault.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMultiUrlEnvironment.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/multiple-request-bodies/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/multiple-request-bodies/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/no-environment/src/SeedNoEnvironment/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/no-environment/src/SeedNoEnvironment/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNoEnvironment.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/no-retries/src/SeedNoRetries/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/no-retries/src/SeedNoRetries/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNoRetries.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/nullable-allof-extends/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/nullable-allof-extends/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/nullable-optional/src/SeedNullableOptional/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/nullable-optional/src/SeedNullableOptional/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNullableOptional.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/nullable-request-body/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/nullable-request-body/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/nullable/src/SeedNullable/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/nullable/src/SeedNullable/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNullable.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentialsDefault.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentialsEnvironmentVariables.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentialsMandatoryAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentialsReference.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentialsWithVariables.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/object/src/SeedObject/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/object/src/SeedObject/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedObject.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedObjectsWithImports.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/optional/src/SeedObjectsWithImports/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/optional/src/SeedObjectsWithImports/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedObjectsWithImports.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/package-yml/src/SeedPackageYml/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/package-yml/src/SeedPackageYml/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPackageYml.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/pagination-custom/src/SeedPagination/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/pagination-custom/src/SeedPagination/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPagination.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPaginationUriPath.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/pagination/src/SeedPagination/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/pagination/src/SeedPagination/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPagination.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/path-parameters/src/SeedPathParameters/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/path-parameters/src/SeedPathParameters/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPathParameters.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/plain-text/src/SeedPlainText/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/plain-text/src/SeedPlainText/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPlainText.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/property-access/src/SeedPropertyAccess/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/property-access/src/SeedPropertyAccess/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPropertyAccess.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/public-object/src/SeedPublicObject/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/public-object/src/SeedPublicObject/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPublicObject.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/query-parameters-openapi/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/query-parameters-openapi/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/query-parameters/src/SeedQueryParameters/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/query-parameters/src/SeedQueryParameters/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedQueryParameters.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/request-parameters/src/SeedRequestParameters/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/request-parameters/src/SeedRequestParameters/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedRequestParameters.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/required-nullable/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/required-nullable/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNurseryApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/response-property/src/SeedResponseProperty/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/response-property/src/SeedResponseProperty/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedResponseProperty.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedServerSentEvents.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedServerSentEvents.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/server-url-templating/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/server-url-templating/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/simple-api/src/SeedSimpleApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/simple-api/src/SeedSimpleApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedSimpleApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/simple-fhir/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/simple-fhir/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedSingleUrlEnvironmentDefault.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedSingleUrlEnvironmentNoDefault.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/streaming-parameter/src/SeedStreaming/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/streaming-parameter/src/SeedStreaming/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedStreaming.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/streaming/src/SeedStreaming/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/streaming/src/SeedStreaming/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedStreaming.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/trace/src/SeedTrace/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/trace/src/SeedTrace/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedTrace.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUndiscriminatedUnionWithResponseProperty.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUndiscriminatedUnions.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/unions-with-local-date/src/SeedUnions/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/unions-with-local-date/src/SeedUnions/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUnions.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/unions/src/SeedUnions/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/unions/src/SeedUnions/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUnions.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/unknown/src/SeedUnknownAsAny/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/unknown/src/SeedUnknownAsAny/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUnknownAsAny.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/url-form-encoded/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/url-form-encoded/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/validation/src/SeedValidation/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/validation/src/SeedValidation/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedValidation.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/variables/src/SeedVariables/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/variables/src/SeedVariables/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedVariables.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/version-no-default/src/SeedVersion/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/version-no-default/src/SeedVersion/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedVersion.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/version/src/SeedVersion/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/version/src/SeedVersion/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedVersion.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/webhook-audience/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/webhook-audience/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/webhooks/src/SeedWebhooks/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/webhooks/src/SeedWebhooks/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedWebhooks.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedWebsocketBearerAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedWebsocketAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-model/websocket/src/SeedWebsocket/Core/StringEnumExtensions.cs
+++ b/seed/csharp-model/websocket/src/SeedWebsocket/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedWebsocket.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/Extensions.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedAccept.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedAccept.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/Extensions.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedAliasExtends.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedAliasExtends.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/Extensions.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedAlias.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedAlias.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/Extensions.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedAnyAuth.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedAnyAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/Extensions.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApiWideBasePath.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApiWideBasePath.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/Extensions.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedAudiences.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedAudiences.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/Extensions.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedBasicAuthEnvironmentVariables.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedBasicAuthEnvironmentVariables.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/Extensions.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedBasicAuth.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedBasicAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/Extensions.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedBearerTokenEnvironmentVariable.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedBearerTokenEnvironmentVariable.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/Extensions.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedBytesDownload.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedBytesDownload.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/Extensions.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedBytesUpload.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedBytesUpload.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/Extensions.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedClientSideParams.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedClientSideParams.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/Extensions.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedContentTypes.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedContentTypes.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/Extensions.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedCrossPackageTypeNames.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCrossPackageTypeNames.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/Extensions.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedCsharpNamespaceCollision.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCsharpNamespaceCollision.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/Extensions.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedCsharpNamespaceConflict.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCsharpNamespaceConflict.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/Extensions.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedCsharpReadonlyRequest.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCsharpReadonlyRequest.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/Extensions.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedCsharpSystemCollision.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCsharpSystemCollision.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/Extensions.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedCsharpXmlEntities.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedCsharpXmlEntities.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/Extensions.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedDollarStringExamples.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedDollarStringExamples.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/Extensions.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedEmptyClients.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedEmptyClients.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/Extensions.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedEndpointSecurityAuth.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedEndpointSecurityAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/Extensions.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedEnum.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedEnum.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/Extensions.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedEnum.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/Extensions.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedErrorProperty.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedErrorProperty.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/Extensions.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedErrors.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedErrors.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/Extensions.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedExamples.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExamples.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/Extensions.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedExamples.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExamples.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Extensions.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedExhaustive.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExhaustive.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Extensions.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedExhaustive.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExhaustive.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Extensions.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedExhaustive.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExhaustive.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Extensions.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedExhaustive.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExhaustive.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Extensions.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedExhaustive.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExhaustive.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/Extensions.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedExtends.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExtends.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/Extensions.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedExtraProperties.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedExtraProperties.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/Extensions.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedFileDownload.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedFileDownload.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/Extensions.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedFileUpload.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedFileUpload.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/Extensions.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedHeaderTokenEnvironmentVariable.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedHeaderTokenEnvironmentVariable.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/Extensions.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedHeaderToken.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedHeaderToken.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/Extensions.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedHttpHead.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedHttpHead.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/Extensions.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedIdempotencyHeaders.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedIdempotencyHeaders.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/Extensions.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedInferredAuthExplicit.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedInferredAuthExplicit.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/Extensions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedInferredAuthImplicitApiKey.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedInferredAuthImplicitApiKey.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/Extensions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedInferredAuthImplicitNoExpiry.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedInferredAuthImplicitNoExpiry.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/Extensions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedInferredAuthImplicit.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedInferredAuthImplicit.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/Extensions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedInferredAuthImplicit.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedInferredAuthImplicit.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/Extensions.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedLicense.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedLicense.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/Extensions.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedLicense.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedLicense.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/Extensions.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedLiteral.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedLiteral.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/Extensions.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedLiteral.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedLiteral.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/Extensions.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedLiteralsUnions.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedLiteralsUnions.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/Extensions.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedMixedCase.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMixedCase.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/Extensions.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedMixedFileDirectory.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMixedFileDirectory.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/Extensions.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedMultiLineDocs.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMultiLineDocs.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/Extensions.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedMultiUrlEnvironmentNoDefault.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMultiUrlEnvironmentNoDefault.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/Extensions.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedMultiUrlEnvironment.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMultiUrlEnvironment.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/Extensions.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedMultiUrlEnvironment.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedMultiUrlEnvironment.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/Extensions.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedNoEnvironment.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNoEnvironment.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/Extensions.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedNoRetries.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNoRetries.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/Extensions.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedNullableOptional.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNullableOptional.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/Extensions.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedNullableOptional.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNullableOptional.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/Extensions.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedNullable.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNullable.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/Extensions.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedNullable.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNullable.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/Extensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/Extensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedOauthClientCredentialsDefault.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentialsDefault.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/Extensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedOauthClientCredentialsEnvironmentVariables.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentialsEnvironmentVariables.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/Extensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedOauthClientCredentialsMandatoryAuth.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentialsMandatoryAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/Extensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/Extensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedOauthClientCredentialsReference.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentialsReference.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/Extensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedOauthClientCredentialsWithVariables.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentialsWithVariables.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/Extensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/Extensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedOauthClientCredentials.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/object/src/SeedObject/Core/Extensions.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedObject.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/object/src/SeedObject/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedObject.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/Extensions.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedObjectsWithImports.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedObjectsWithImports.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/Extensions.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedObjectsWithImports.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedObjectsWithImports.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/Extensions.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedObjectsWithImports.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedObjectsWithImports.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/Extensions.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPackageYml.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPackageYml.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Extensions.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPagination.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPagination.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Extensions.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPaginationUriPath.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPaginationUriPath.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Extensions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPagination.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPagination.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Extensions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPagination.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPagination.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Extensions.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPagination.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPagination.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/Extensions.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPathParameters.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPathParameters.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/Extensions.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPathParameters.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPathParameters.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/Extensions.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPlainText.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPlainText.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/Extensions.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPropertyAccess.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPropertyAccess.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/Extensions.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedPublicObject.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedPublicObject.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/Extensions.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedQueryParameters.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedQueryParameters.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/Extensions.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedRequestParameters.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedRequestParameters.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/Extensions.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedRequestParameters.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedRequestParameters.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedNurseryApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedNurseryApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/Extensions.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedResponseProperty.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedResponseProperty.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/Extensions.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedServerSentEvents.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedServerSentEvents.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/Extensions.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedServerSentEvents.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedServerSentEvents.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedSimpleApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedSimpleApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedSimpleApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedSimpleApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedSimpleApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedSimpleApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/Extensions.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedSingleUrlEnvironmentDefault.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedSingleUrlEnvironmentDefault.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/Extensions.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedSingleUrlEnvironmentNoDefault.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedSingleUrlEnvironmentNoDefault.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/Extensions.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedStreaming.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedStreaming.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/Extensions.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedStreaming.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedStreaming.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/Extensions.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedStreaming.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedStreaming.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/Extensions.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedTrace.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedTrace.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/Extensions.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedUndiscriminatedUnionWithResponseProperty.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUndiscriminatedUnionWithResponseProperty.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/Extensions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedUndiscriminatedUnions.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUndiscriminatedUnions.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/Extensions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedUndiscriminatedUnions.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUndiscriminatedUnions.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/Extensions.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedUnions.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUnions.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/Extensions.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedUnions.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUnions.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/Extensions.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedUnions.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUnions.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/Extensions.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedUnknownAsAny.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedUnknownAsAny.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/Extensions.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedValidation.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedValidation.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/Extensions.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedVariables.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedVariables.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/Extensions.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedVersion.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedVersion.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/Extensions.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedVersion.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedVersion.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/Extensions.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedApi.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedApi.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/Extensions.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedWebhooks.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedWebhooks.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/Extensions.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedWebsocketBearerAuth.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedWebsocketBearerAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/Extensions.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedWebsocketAuth.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedWebsocketAuth.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/Extensions.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedWebsocket.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedWebsocket.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/Extensions.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/Extensions.cs
@@ -5,6 +5,7 @@ namespace SeedWebsocket.Core;
 
 internal static class Extensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this Enum value)
     {
         var field = value.GetType().GetField(value.ToString());

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/StringEnumExtensions.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/StringEnumExtensions.cs
@@ -2,5 +2,6 @@ namespace SeedWebsocket.Core;
 
 internal static class StringEnumExtensions
 {
+    [global::System.Obsolete("Use ValueConvert.ToString() instead.")]
     public static string Stringify(this IStringEnum stringEnum) => stringEnum.Value;
 }


### PR DESCRIPTION
## Description

Refs [FER-3103](https://linear.app/buildwithfern/issue/FER-3103/c-revisit-stringify-extension-method-path-parameter-usage)

The `Stringify` extension methods on `Enum` and `IStringEnum` are no longer used anywhere in generated code — path parameters, query parameters, and headers all use `ValueConvert.ToPathParameterString()` / `ValueConvert.ToString()` instead (introduced in #6368). This PR marks both methods as `[Obsolete]` to signal deprecation.

## Changes Made

- Add `[global::System.Obsolete("Use ValueConvert.ToString() instead.")]` to `Stringify(this Enum)` in `Extensions.cs`
- Add `[global::System.Obsolete("Use ValueConvert.ToString() instead.")]` to `Stringify(this IStringEnum)` in `StringEnumExtensions.Template.cs`
- Update all seed snapshot files (400+ files) to reflect the new attribute
- Bump `csharp-sdk` version to `2.22.9` and `csharp-model` version to `0.0.11`
- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- [ ] Unit tests added/updated — N/A (no behavioral change, attribute-only addition)
- [x] Manual testing completed — Verified seed snapshots match templates

## Review Checklist

- [ ] Confirm no internal generated code calls `Stringify` (would now produce compiler warnings)
- [ ] Seed snapshots were updated via `sed` rather than full regeneration — verify a sample looks correct

[Link to Devin Session](https://app.devin.ai/sessions/ea89db843ec8456cb304ab2739fd2342) | Requested by @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
