### PR TITLE
chore(csharp): make BaseUrl optional in BaseRequest and omit from generated code

### DIFF
--- a/generators/csharp/base/src/asIs/BaseRequest.Template.cs
+++ b/generators/csharp/base/src/asIs/BaseRequest.Template.cs
@@ -6,7 +6,7 @@ namespace <%= namespace%>;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/generators/csharp/base/src/asIs/RawClient.Template.cs
+++ b/generators/csharp/base/src/asIs/RawClient.Template.cs
@@ -260,9 +260,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::<%= namespace%>.BaseRequest request)
+    private string BuildUrl(global::<%= namespace%>.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/generators/csharp/base/src/asIs/RawClient.Template.cs
+++ b/generators/csharp/base/src/asIs/RawClient.Template.cs
@@ -260,9 +260,15 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
+<% if (hasBaseUrl) { %>
     private string BuildUrl(global::<%= namespace%>.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+<% } else { %>
+    private static string BuildUrl(global::<%= namespace%>.BaseRequest request)
+    {
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+<% } %>
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/generators/csharp/base/src/context/GeneratorContext.ts
+++ b/generators/csharp/base/src/context/GeneratorContext.ts
@@ -177,6 +177,10 @@ export abstract class GeneratorContext extends AbstractGeneratorContext {
         return this.getIdempotencyHeaders().length > 0;
     }
 
+    public hasBaseUrl(): boolean {
+        return this.ir.environments?.environments.type !== "multipleBaseUrls";
+    }
+
     public getCoreDirectory(): RelativeFilePath {
         return RelativeFilePath.of(CORE_DIRECTORY_NAME);
     }

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -595,6 +595,7 @@ dotnet_diagnostic.IDE0005.severity = error
                 variables: {
                     grpc: this.context.hasGrpcEndpoints(),
                     idempotencyHeaders: this.context.hasIdempotencyHeaders(),
+                    hasBaseUrl: this.context.hasBaseUrl(),
                     namespace,
                     testNamespace: this.namespaces.test,
                     additionalProperties: true,
@@ -615,6 +616,7 @@ dotnet_diagnostic.IDE0005.severity = error
                 variables: {
                     grpc: this.context.hasGrpcEndpoints(),
                     idempotencyHeaders: this.context.hasIdempotencyHeaders(),
+                    hasBaseUrl: this.context.hasBaseUrl(),
                     namespace,
                     additionalProperties: true,
                     context: this.context,
@@ -643,6 +645,7 @@ dotnet_diagnostic.IDE0005.severity = error
                     variables: {
                         grpc: this.context.hasGrpcEndpoints(),
                         idempotencyHeaders: this.context.hasIdempotencyHeaders(),
+                        hasBaseUrl: this.context.hasBaseUrl(),
                         namespace: this.namespaces.core,
                         additionalProperties: true,
                         context: this.context,
@@ -658,6 +661,7 @@ dotnet_diagnostic.IDE0005.severity = error
                     variables: {
                         grpc: this.context.hasGrpcEndpoints(),
                         idempotencyHeaders: this.context.hasIdempotencyHeaders(),
+                        hasBaseUrl: this.context.hasBaseUrl(),
                         namespace: this.namespaces.core,
                         additionalProperties: true,
                         context: this.context,
@@ -678,6 +682,7 @@ dotnet_diagnostic.IDE0005.severity = error
                 variables: {
                     grpc: this.context.hasGrpcEndpoints(),
                     idempotencyHeaders: this.context.hasIdempotencyHeaders(),
+                    hasBaseUrl: this.context.hasBaseUrl(),
                     namespace: this.namespaces.testUtils,
                     testNamespace: this.namespaces.test,
                     additionalProperties: true,

--- a/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -616,7 +616,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
         writer.popScope();
     }
 
-    private getBaseURLForEndpoint({ endpoint }: { endpoint: HttpEndpoint }): ast.CodeBlock {
+    private getBaseURLForEndpoint({ endpoint }: { endpoint: HttpEndpoint }): ast.CodeBlock | undefined {
         if (endpoint.baseUrl != null && this.context.ir.environments?.environments.type === "multipleBaseUrls") {
             const baseUrl = this.context.ir.environments?.environments.baseUrls.find(
                 (baseUrlWithId) => baseUrlWithId.id === endpoint.baseUrl
@@ -625,7 +625,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                 return this.csharp.codeblock(`_client.Options.Environment.${baseUrl.name.pascalCase.safeName}`);
             }
         }
-        return this.csharp.codeblock("_client.Options.BaseUrl");
+        return undefined;
     }
 
     private getEndpointErrorHandling({ endpoint }: { endpoint: HttpEndpoint }): ast.CodeBlock {

--- a/generators/csharp/sdk/src/endpoint/http/RawClient.ts
+++ b/generators/csharp/sdk/src/endpoint/http/RawClient.ts
@@ -40,7 +40,7 @@ export declare namespace RawClient {
     }
 
     export interface CreateHttpRequestWrapperArgs {
-        baseUrl: ast.CodeBlock;
+        baseUrl?: ast.CodeBlock;
         /** the endpoint for the endpoint */
         endpoint: HttpEndpoint;
         /** reference to a variable that is the body */
@@ -84,10 +84,14 @@ export class RawClient extends WithGeneration {
         requestType
     }: RawClient.CreateHttpRequestWrapperArgs): RawClient.CreateHttpRequestWrapperCodeBlock {
         const args: Arguments = [
-            {
-                name: "BaseUrl",
-                assignment: baseUrl
-            },
+            ...(baseUrl != null
+                ? [
+                      {
+                          name: "BaseUrl",
+                          assignment: baseUrl
+                      }
+                  ]
+                : []),
             {
                 name: "Method",
                 assignment: this.getCsharpHttpMethod(endpoint.method)

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.22.9
+  changelogEntry:
+    - summary: |
+        Make `BaseUrl` optional in `BaseRequest` and omit it from generated
+        endpoint code unless required (e.g. multiple-base-URL environments).
+        The `RawClient` now falls back to `Options.BaseUrl` when `BaseUrl` is
+        not set on the request, removing the redundant
+        `BaseUrl = _client.Options.BaseUrl` from every generated API call.
+      type: chore
+  createdAt: "2026-03-02"
+  irVersion: 62
+
 - version: 2.22.8
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedAccept.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/RawClient.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedAccept.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/RawClient.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedAccept.Core.BaseRequest request)
+    private string BuildUrl(global::SeedAccept.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Service/ServiceClient.cs
@@ -30,7 +30,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = "/container/",
                     Headers = _headers,

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedAliasExtends.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/RawClient.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedAliasExtends.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/RawClient.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedAliasExtends.Core.BaseRequest request)
+    private string BuildUrl(global::SeedAliasExtends.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/SeedAliasExtendsClient.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/SeedAliasExtendsClient.cs
@@ -49,7 +49,6 @@ public partial class SeedAliasExtendsClient : ISeedAliasExtendsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/extends/extended-inline-request-body",
                     Body = request,

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedAlias.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/RawClient.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedAlias.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/RawClient.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedAlias.Core.BaseRequest request)
+    private string BuildUrl(global::SeedAlias.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/alias/src/SeedAlias/SeedAliasClient.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/SeedAliasClient.cs
@@ -47,7 +47,6 @@ public partial class SeedAliasClient : ISeedAliasClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(typeId)),
                     Headers = _headers,

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Auth/AuthClient.cs
@@ -28,7 +28,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedAnyAuth.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedAnyAuth.Core.BaseRequest request)
+    private string BuildUrl(global::SeedAnyAuth.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedAnyAuth.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/User/UserClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/User/UserClient.cs
@@ -27,7 +27,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "users",
                     Headers = _headers,
@@ -88,7 +87,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "admins",
                     Headers = _headers,

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApiWideBasePath.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/RawClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApiWideBasePath.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/RawClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApiWideBasePath.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApiWideBasePath.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Service/ServiceClient.cs
@@ -33,7 +33,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/test/{0}/{1}/{2}/{3}",

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedAudiences.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/RawClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedAudiences.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/RawClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedAudiences.Core.BaseRequest request)
+    private string BuildUrl(global::SeedAudiences.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderA/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderA/Service/ServiceClient.cs
@@ -34,7 +34,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/Service/ServiceClient.cs
@@ -28,7 +28,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/partner-path",
                     Headers = _headers,

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Foo/FooClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Foo/FooClient.cs
@@ -32,7 +32,6 @@ public partial class FooClient : IFooClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/BasicAuth/BasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/BasicAuth/BasicAuthClient.cs
@@ -27,7 +27,6 @@ public partial class BasicAuthClient : IBasicAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "basic-auth",
                     Headers = _headers,
@@ -103,7 +102,6 @@ public partial class BasicAuthClient : IBasicAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "basic-auth",
                     Body = request,

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedBasicAuthEnvironmentVariables.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/RawClient.cs
@@ -274,11 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
-        global::SeedBasicAuthEnvironmentVariables.Core.BaseRequest request
-    )
+    private string BuildUrl(global::SeedBasicAuthEnvironmentVariables.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedBasicAuthEnvironmentVariables.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/BasicAuth/BasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/BasicAuth/BasicAuthClient.cs
@@ -27,7 +27,6 @@ public partial class BasicAuthClient : IBasicAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "basic-auth",
                     Headers = _headers,
@@ -103,7 +102,6 @@ public partial class BasicAuthClient : IBasicAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "basic-auth",
                     Body = request,

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedBasicAuth.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedBasicAuth.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedBasicAuth.Core.BaseRequest request)
+    private string BuildUrl(global::SeedBasicAuth.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedBearerTokenEnvironmentVariable.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedBearerTokenEnvironmentVariable.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
@@ -274,11 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
-        global::SeedBearerTokenEnvironmentVariable.Core.BaseRequest request
-    )
+    private string BuildUrl(global::SeedBearerTokenEnvironmentVariable.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Service/ServiceClient.cs
@@ -27,7 +27,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "apiKey",
                     Headers = _headers,

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedBytesDownload.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/RawClient.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedBytesDownload.Core.BaseRequest request)
+    private string BuildUrl(global::SeedBytesDownload.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/RawClient.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedBytesDownload.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Service/ServiceClient.cs
@@ -29,7 +29,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "snippet",
                     Headers = _headers,
@@ -68,7 +67,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "download-content/{0}",

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedBytesUpload.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/RawClient.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedBytesUpload.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/RawClient.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedBytesUpload.Core.BaseRequest request)
+    private string BuildUrl(global::SeedBytesUpload.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Service/ServiceClient.cs
@@ -30,7 +30,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new StreamRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "upload-content",
                     Body = request,

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedClientSideParams.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/RawClient.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedClientSideParams.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/RawClient.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedClientSideParams.Core.BaseRequest request)
+    private string BuildUrl(global::SeedClientSideParams.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Service/ServiceClient.cs
@@ -38,7 +38,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/api/resources",
                     QueryString = _queryString,
@@ -107,7 +106,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/api/resources/{0}",
@@ -178,7 +176,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/api/resources/search",
                     Body = request,
@@ -253,7 +250,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/api/users",
                     QueryString = _queryString,
@@ -322,7 +318,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/api/users/{0}",
@@ -388,7 +383,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/api/users",
                     Body = request,
@@ -452,7 +446,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/api/users/{0}",
@@ -524,7 +517,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/api/connections",
                     QueryString = _queryString,
@@ -592,7 +584,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/api/connections/{0}",
@@ -669,7 +660,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/api/clients",
                     QueryString = _queryString,
@@ -738,7 +728,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/api/clients/{0}",
@@ -1026,7 +1015,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = string.Format(
                         "/api/users/{0}",

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedContentTypes.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/RawClient.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedContentTypes.Core.BaseRequest request)
+    private string BuildUrl(global::SeedContentTypes.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/RawClient.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedContentTypes.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Service/ServiceClient.cs
@@ -32,7 +32,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,
@@ -110,7 +109,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format("complex/{0}", ValueConvert.ToPathParameterString(id)),
                     Body = request,
@@ -167,7 +165,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format("named-mixed/{0}", ValueConvert.ToPathParameterString(id)),
                     Body = request,
@@ -226,7 +223,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "optional-merge-patch-test",
                     Body = request,
@@ -277,7 +273,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format("regular/{0}", ValueConvert.ToPathParameterString(id)),
                     Body = request,

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedCrossPackageTypeNames.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/RawClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedCrossPackageTypeNames.Core.BaseRequest request)
+    private string BuildUrl(global::SeedCrossPackageTypeNames.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/RawClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedCrossPackageTypeNames.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/Service/ServiceClient.cs
@@ -28,7 +28,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "",
                     Headers = _headers,

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/Service/ServiceClient.cs
@@ -28,7 +28,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "",
                     Headers = _headers,

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Foo/FooClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Foo/FooClient.cs
@@ -34,7 +34,6 @@ public partial class FooClient : IFooClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Dataservice/DataserviceClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Dataservice/DataserviceClient.cs
@@ -38,7 +38,6 @@ public partial class DataserviceClient : IDataserviceClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "foo",
                             Headers = _headers,

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Dataservice/DataserviceClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Dataservice/DataserviceClient.cs
@@ -27,7 +27,6 @@ public partial class DataserviceClient : IDataserviceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "foo",
                     Headers = _headers,

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Dataservice/DataserviceClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Dataservice/DataserviceClient.cs
@@ -27,7 +27,6 @@ public partial class DataserviceClient : IDataserviceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "foo",
                     Headers = _headers,

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Dataservice/DataserviceClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Dataservice/DataserviceClient.cs
@@ -27,7 +27,6 @@ public partial class DataserviceClient : IDataserviceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "foo",
                     Headers = _headers,

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/BaseRequest.cs
@@ -5,7 +5,7 @@ namespace SeedCsharpNamespaceCollision.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/RawClient.cs
@@ -265,9 +265,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(BaseRequest request)
+    private string BuildUrl(BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/RawClient.cs
@@ -268,6 +268,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollisionClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollisionClient.cs
@@ -49,7 +49,6 @@ public partial class SeedCsharpNamespaceCollisionClient : ISeedCsharpNamespaceCo
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
@@ -112,7 +111,6 @@ public partial class SeedCsharpNamespaceCollisionClient : ISeedCsharpNamespaceCo
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/System/SystemClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/System/SystemClient.cs
@@ -28,7 +28,6 @@ public partial class SystemClient : ISystemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class SystemClient : ISystemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedCsharpNamespaceConflict.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedCsharpNamespaceConflict.Core.BaseRequest request)
+    private string BuildUrl(global::SeedCsharpNamespaceConflict.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedCsharpNamespaceConflict.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Tasktest/TasktestClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Tasktest/TasktestClient.cs
@@ -29,7 +29,6 @@ public partial class TasktestClient : ITasktestClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "hello",
                     Headers = _headers,

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedCsharpReadonlyRequest.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedCsharpReadonlyRequest.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedCsharpReadonlyRequest.Core.BaseRequest request)
+    private string BuildUrl(global::SeedCsharpReadonlyRequest.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequestClient.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequestClient.cs
@@ -45,7 +45,6 @@ public partial class SeedCsharpReadonlyRequestClient : ISeedCsharpReadonlyReques
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/vendors/batch",
                     Body = request,

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedCsharpSystemCollision.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedCsharpSystemCollision.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedCsharpSystemCollision.Core.BaseRequest request)
+    private string BuildUrl(global::SeedCsharpSystemCollision.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/System.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/System.cs
@@ -45,7 +45,6 @@ public partial class System : ISystem
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
@@ -108,7 +107,6 @@ public partial class System : ISystem
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
@@ -240,7 +238,6 @@ public partial class System : ISystem
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users/empty",
                     Body = request,

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedCsharpXmlEntities.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedCsharpXmlEntities.Core.BaseRequest request)
+    private string BuildUrl(global::SeedCsharpXmlEntities.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedCsharpXmlEntities.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/SeedCsharpXmlEntitiesClient.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/SeedCsharpXmlEntitiesClient.cs
@@ -44,7 +44,6 @@ public partial class SeedCsharpXmlEntitiesClient : ISeedCsharpXmlEntitiesClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/timezone",
                     Headers = _headers,

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedDollarStringExamples.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedDollarStringExamples.Core.BaseRequest request)
+    private string BuildUrl(global::SeedDollarStringExamples.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedDollarStringExamples.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedEmptyClients.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/RawClient.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedEmptyClients.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/RawClient.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedEmptyClients.Core.BaseRequest request)
+    private string BuildUrl(global::SeedEmptyClients.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Auth/AuthClient.cs
@@ -28,7 +28,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedEndpointSecurityAuth.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedEndpointSecurityAuth.Core.BaseRequest request)
+    private string BuildUrl(global::SeedEndpointSecurityAuth.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedEndpointSecurityAuth.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/User/UserClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/User/UserClient.cs
@@ -27,7 +27,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "users",
                     Headers = _headers,
@@ -88,7 +87,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "users",
                     Headers = _headers,
@@ -149,7 +147,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "users",
                     Headers = _headers,
@@ -210,7 +207,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "users",
                     Headers = _headers,
@@ -271,7 +267,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "users",
                     Headers = _headers,
@@ -332,7 +327,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "users",
                     Headers = _headers,
@@ -393,7 +387,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "users",
                     Headers = _headers,

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedEnum.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/RawClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedEnum.Core.BaseRequest request)
+    private string BuildUrl(global::SeedEnum.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/RawClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedEnum.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Headers/HeadersClient.cs
@@ -42,7 +42,6 @@ public partial class HeadersClient : IHeadersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "headers",
                     Headers = _headers,

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
@@ -32,7 +32,6 @@ public partial class InlinedRequestClient : IInlinedRequestClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "inlined",
                     Body = request,

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
@@ -25,7 +25,6 @@ public partial class MultipartFormClient : IMultipartFormClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new SeedEnum.Core.MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "multipart",
             Headers = _headers,

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/PathParam/PathParamClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/PathParam/PathParamClient.cs
@@ -32,7 +32,6 @@ public partial class PathParamClient : IPathParamClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "path/{0}/{1}",

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/QueryParam/QueryParamClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/QueryParam/QueryParamClient.cs
@@ -39,7 +39,6 @@ public partial class QueryParamClient : IQueryParamClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "query",
                     QueryString = _queryString,
@@ -97,7 +96,6 @@ public partial class QueryParamClient : IQueryParamClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "query-list",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedEnum.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/RawClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedEnum.Core.BaseRequest request)
+    private string BuildUrl(global::SeedEnum.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/RawClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedEnum.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Headers/HeadersClient.cs
@@ -42,7 +42,6 @@ public partial class HeadersClient : IHeadersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "headers",
                     Headers = _headers,

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
@@ -32,7 +32,6 @@ public partial class InlinedRequestClient : IInlinedRequestClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "inlined",
                     Body = request,

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
@@ -25,7 +25,6 @@ public partial class MultipartFormClient : IMultipartFormClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new SeedEnum.Core.MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "multipart",
             Headers = _headers,

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/PathParam/PathParamClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/PathParam/PathParamClient.cs
@@ -32,7 +32,6 @@ public partial class PathParamClient : IPathParamClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "path/{0}/{1}",

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/QueryParam/QueryParamClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/QueryParam/QueryParamClient.cs
@@ -39,7 +39,6 @@ public partial class QueryParamClient : IQueryParamClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "query",
                     QueryString = _queryString,
@@ -97,7 +96,6 @@ public partial class QueryParamClient : IQueryParamClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "query-list",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedErrorProperty.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedErrorProperty.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedErrorProperty.Core.BaseRequest request)
+    private string BuildUrl(global::SeedErrorProperty.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/PropertyBasedError/PropertyBasedErrorClient.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/PropertyBasedError/PropertyBasedErrorClient.cs
@@ -27,7 +27,6 @@ public partial class PropertyBasedErrorClient : IPropertyBasedErrorClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "property-based-error",
                     Headers = _headers,

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedErrors.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/RawClient.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedErrors.Core.BaseRequest request)
+    private string BuildUrl(global::SeedErrors.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/RawClient.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedErrors.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/errors/src/SeedErrors/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Simple/SimpleClient.cs
@@ -28,7 +28,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "foo1",
                     Body = request,
@@ -109,7 +108,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "foo2",
                     Body = request,
@@ -190,7 +188,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "foo3",
                     Body = request,

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedExamples.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedExamples.Core.BaseRequest request)
+    private string BuildUrl(global::SeedExamples.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedExamples.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
@@ -29,7 +29,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/file/notification/{0}",

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Service/ServiceClient.cs
@@ -31,7 +31,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/file/{0}", ValueConvert.ToPathParameterString(filename)),
                     Headers = _headers,

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/Service/ServiceClient.cs
@@ -28,7 +28,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/ping",
                     Headers = _headers,
@@ -96,7 +95,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/check/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamplesClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamplesClient.cs
@@ -65,7 +65,6 @@ public partial class SeedExamplesClient : ISeedExamplesClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
@@ -128,7 +127,6 @@ public partial class SeedExamplesClient : ISeedExamplesClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Service/ServiceClient.cs
@@ -28,7 +28,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/movie/{0}", ValueConvert.ToPathParameterString(movieId)),
                     Headers = _headers,
@@ -90,7 +89,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/movie",
                     Body = request,
@@ -159,7 +157,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/metadata",
                     QueryString = _queryString,
@@ -222,7 +219,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/big-entity",
                     Body = request,
@@ -591,7 +587,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/refresh-token",
                     Body = request,

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedExamples.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedExamples.Core.BaseRequest request)
+    private string BuildUrl(global::SeedExamples.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedExamples.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
@@ -29,7 +29,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/file/notification/{0}",

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Service/ServiceClient.cs
@@ -31,7 +31,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/file/{0}", ValueConvert.ToPathParameterString(filename)),
                     Headers = _headers,

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/Service/ServiceClient.cs
@@ -28,7 +28,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/ping",
                     Headers = _headers,
@@ -96,7 +95,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/check/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamplesClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamplesClient.cs
@@ -65,7 +65,6 @@ public partial class SeedExamplesClient : ISeedExamplesClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
@@ -128,7 +127,6 @@ public partial class SeedExamplesClient : ISeedExamplesClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Service/ServiceClient.cs
@@ -28,7 +28,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/movie/{0}", ValueConvert.ToPathParameterString(movieId)),
                     Headers = _headers,
@@ -90,7 +89,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/movie",
                     Body = request,
@@ -159,7 +157,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/metadata",
                     QueryString = _queryString,
@@ -222,7 +219,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/big-entity",
                     Body = request,
@@ -591,7 +587,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/refresh-token",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
+    private string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -31,7 +31,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-primitives",
                     Body = request,
@@ -96,7 +95,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-objects",
                     Body = request,
@@ -161,7 +159,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-primitives",
                     Body = request,
@@ -226,7 +223,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-objects",
                     Body = request,
@@ -293,7 +289,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-prim",
                     Body = request,
@@ -358,7 +353,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-object",
                     Body = request,
@@ -425,7 +419,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-union",
                     Body = request,
@@ -492,7 +485,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/opt-objects",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -49,7 +49,6 @@ public partial class ContentTypeClient : IContentTypeClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/foo/bar",
                     Body = request,
@@ -110,7 +109,6 @@ public partial class ContentTypeClient : IContentTypeClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/foo/baz",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -30,7 +30,6 @@ public partial class EnumClient : IEnumClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/enum",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -30,7 +30,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -95,7 +94,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/http-methods",
                     Body = request,
@@ -159,7 +157,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -226,7 +223,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -292,7 +288,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = string.Format(
                         "/http-methods/{0}",

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -32,7 +32,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-optional-field",
                     Body = request,
@@ -97,7 +96,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-field",
                     Body = request,
@@ -160,7 +158,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-map-of-map",
                     Body = request,
@@ -225,7 +222,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-optional-field",
                     Body = request,
@@ -293,7 +289,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/object/get-and-return-nested-with-required-field/{0}",
@@ -363,7 +358,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-required-field-list",
                     Body = request,
@@ -430,7 +424,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-unknown-field",
                     Body = request,
@@ -495,7 +488,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-datetime-like-string",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -49,7 +49,6 @@ public partial class PaginationClient : IPaginationClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/pagination",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -30,7 +30,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -95,7 +94,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -161,7 +159,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -227,7 +224,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -294,7 +290,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new StreamRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -405,7 +400,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/params",
                     QueryString = _queryString,
@@ -458,7 +452,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/params",
                     QueryString = _queryString,
@@ -512,7 +505,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path-query/{0}",
@@ -567,7 +559,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path-query/{0}",

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -29,7 +29,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/string",
                     Body = request,
@@ -92,7 +91,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/integer",
                     Body = request,
@@ -155,7 +153,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/long",
                     Body = request,
@@ -218,7 +215,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/double",
                     Body = request,
@@ -281,7 +277,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/boolean",
                     Body = request,
@@ -344,7 +339,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/datetime",
                     Body = request,
@@ -407,7 +401,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/date",
                     Body = request,
@@ -470,7 +463,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/uuid",
                     Body = request,
@@ -533,7 +525,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/base64",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -29,7 +29,6 @@ public partial class PutClient : IPutClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format("{0}", ValueConvert.ToPathParameterString(request.Id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -30,7 +30,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/union",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -28,7 +28,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/MixedCase",
                     Headers = _headers,
@@ -89,7 +88,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/no-ending-slash",
                     Headers = _headers,
@@ -150,7 +148,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/with-ending-slash/",
                     Headers = _headers,
@@ -211,7 +208,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/with_underscores",
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -33,7 +33,6 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/object",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -30,7 +30,6 @@ public partial class NoAuthClient : INoAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/no-auth",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -29,7 +29,6 @@ public partial class NoReqBodyClient : INoReqBodyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/no-req-body",
                     Headers = _headers,
@@ -90,7 +89,6 @@ public partial class NoReqBodyClient : INoReqBodyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/no-req-body",
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -40,7 +40,6 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/test-headers/custom-header",
                     Body = request.Body,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
+    private string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -42,7 +42,6 @@ public partial class ContainerClient : IContainerClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/container/list-of-primitives",
                             Body = request,
@@ -116,7 +115,6 @@ public partial class ContainerClient : IContainerClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/container/list-of-objects",
                             Body = request,
@@ -188,7 +186,6 @@ public partial class ContainerClient : IContainerClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/container/set-of-primitives",
                             Body = request,
@@ -260,7 +257,6 @@ public partial class ContainerClient : IContainerClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/container/set-of-objects",
                             Body = request,
@@ -334,7 +330,6 @@ public partial class ContainerClient : IContainerClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/container/map-prim-to-prim",
                             Body = request,
@@ -408,7 +403,6 @@ public partial class ContainerClient : IContainerClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/container/map-prim-to-object",
                             Body = request,
@@ -482,7 +476,6 @@ public partial class ContainerClient : IContainerClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/container/map-prim-to-union",
                             Body = request,
@@ -556,7 +549,6 @@ public partial class ContainerClient : IContainerClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/container/opt-objects",
                             Body = request,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -60,7 +60,6 @@ public partial class ContentTypeClient : IContentTypeClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/foo/bar",
                             Body = request,
@@ -126,7 +125,6 @@ public partial class ContentTypeClient : IContentTypeClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/foo/baz",
                             Body = request,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -41,7 +41,6 @@ public partial class EnumClient : IEnumClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/enum",
                             Body = request,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -41,7 +41,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = string.Format(
                                 "/http-methods/{0}",
@@ -113,7 +112,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/http-methods",
                             Body = request,
@@ -186,7 +184,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Put,
                             Path = string.Format(
                                 "/http-methods/{0}",
@@ -262,7 +259,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethodExtensions.Patch,
                             Path = string.Format(
                                 "/http-methods/{0}",
@@ -337,7 +333,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Delete,
                             Path = string.Format(
                                 "/http-methods/{0}",

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -43,7 +43,6 @@ public partial class ObjectClient : IObjectClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-optional-field",
                             Body = request,
@@ -117,7 +116,6 @@ public partial class ObjectClient : IObjectClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-required-field",
                             Body = request,
@@ -189,7 +187,6 @@ public partial class ObjectClient : IObjectClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-map-of-map",
                             Body = request,
@@ -261,7 +258,6 @@ public partial class ObjectClient : IObjectClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-nested-with-optional-field",
                             Body = request,
@@ -336,7 +332,6 @@ public partial class ObjectClient : IObjectClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = string.Format(
                                 "/object/get-and-return-nested-with-required-field/{0}",
@@ -413,7 +408,6 @@ public partial class ObjectClient : IObjectClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-nested-with-required-field-list",
                             Body = request,
@@ -487,7 +481,6 @@ public partial class ObjectClient : IObjectClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-unknown-field",
                             Body = request,
@@ -561,7 +554,6 @@ public partial class ObjectClient : IObjectClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-datetime-like-string",
                             Body = request,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -60,7 +60,6 @@ public partial class PaginationClient : IPaginationClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/pagination",
                             QueryString = _queryString,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -41,7 +41,6 @@ public partial class ParamsClient : IParamsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = string.Format(
                                 "/params/path/{0}",
@@ -113,7 +112,6 @@ public partial class ParamsClient : IParamsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = string.Format(
                                 "/params/path/{0}",
@@ -186,7 +184,6 @@ public partial class ParamsClient : IParamsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Put,
                             Path = string.Format(
                                 "/params/path/{0}",
@@ -259,7 +256,6 @@ public partial class ParamsClient : IParamsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Put,
                             Path = string.Format(
                                 "/params/path/{0}",
@@ -333,7 +329,6 @@ public partial class ParamsClient : IParamsClient
                     .SendRequestAsync(
                         new StreamRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = string.Format(
                                 "/params/path/{0}",
@@ -453,7 +448,6 @@ public partial class ParamsClient : IParamsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/params",
                             QueryString = _queryString,
@@ -511,7 +505,6 @@ public partial class ParamsClient : IParamsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/params",
                             QueryString = _queryString,
@@ -570,7 +563,6 @@ public partial class ParamsClient : IParamsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = string.Format(
                                 "/params/path-query/{0}",
@@ -630,7 +622,6 @@ public partial class ParamsClient : IParamsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = string.Format(
                                 "/params/path-query/{0}",

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -40,7 +40,6 @@ public partial class PrimitiveClient : IPrimitiveClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/primitive/string",
                             Body = request,
@@ -110,7 +109,6 @@ public partial class PrimitiveClient : IPrimitiveClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/primitive/integer",
                             Body = request,
@@ -180,7 +178,6 @@ public partial class PrimitiveClient : IPrimitiveClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/primitive/long",
                             Body = request,
@@ -250,7 +247,6 @@ public partial class PrimitiveClient : IPrimitiveClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/primitive/double",
                             Body = request,
@@ -320,7 +316,6 @@ public partial class PrimitiveClient : IPrimitiveClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/primitive/boolean",
                             Body = request,
@@ -390,7 +385,6 @@ public partial class PrimitiveClient : IPrimitiveClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/primitive/datetime",
                             Body = request,
@@ -460,7 +454,6 @@ public partial class PrimitiveClient : IPrimitiveClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/primitive/date",
                             Body = request,
@@ -530,7 +523,6 @@ public partial class PrimitiveClient : IPrimitiveClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/primitive/uuid",
                             Body = request,
@@ -600,7 +592,6 @@ public partial class PrimitiveClient : IPrimitiveClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/primitive/base64",
                             Body = request,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -40,7 +40,6 @@ public partial class PutClient : IPutClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Put,
                             Path = string.Format(
                                 "{0}",

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -41,7 +41,6 @@ public partial class UnionClient : IUnionClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/union",
                             Body = request,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -39,7 +39,6 @@ public partial class UrlsClient : IUrlsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/urls/MixedCase",
                             Headers = _headers,
@@ -107,7 +106,6 @@ public partial class UrlsClient : IUrlsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/urls/no-ending-slash",
                             Headers = _headers,
@@ -175,7 +173,6 @@ public partial class UrlsClient : IUrlsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/urls/with-ending-slash/",
                             Headers = _headers,
@@ -243,7 +240,6 @@ public partial class UrlsClient : IUrlsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/urls/with_underscores",
                             Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -42,7 +42,6 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/req-bodies/object",
                             Body = request,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -39,7 +39,6 @@ public partial class NoAuthClient : INoAuthClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/no-auth",
                             Body = request,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -39,7 +39,6 @@ public partial class NoReqBodyClient : INoReqBodyClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/no-req-body",
                             Headers = _headers,
@@ -109,7 +108,6 @@ public partial class NoReqBodyClient : INoReqBodyClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/no-req-body",
                             Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -50,7 +50,6 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/test-headers/custom-header",
                             Body = request.Body,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
+    private string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -31,7 +31,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-primitives",
                     Body = request,
@@ -96,7 +95,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-objects",
                     Body = request,
@@ -161,7 +159,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-primitives",
                     Body = request,
@@ -226,7 +223,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-objects",
                     Body = request,
@@ -293,7 +289,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-prim",
                     Body = request,
@@ -358,7 +353,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-object",
                     Body = request,
@@ -425,7 +419,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-union",
                     Body = request,
@@ -492,7 +485,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/opt-objects",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -49,7 +49,6 @@ public partial class ContentTypeClient : IContentTypeClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/foo/bar",
                     Body = request,
@@ -110,7 +109,6 @@ public partial class ContentTypeClient : IContentTypeClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/foo/baz",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -30,7 +30,6 @@ public partial class EnumClient : IEnumClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/enum",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -30,7 +30,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -95,7 +94,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/http-methods",
                     Body = request,
@@ -159,7 +157,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -226,7 +223,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -292,7 +288,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = string.Format(
                         "/http-methods/{0}",

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -32,7 +32,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-optional-field",
                     Body = request,
@@ -97,7 +96,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-field",
                     Body = request,
@@ -160,7 +158,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-map-of-map",
                     Body = request,
@@ -225,7 +222,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-optional-field",
                     Body = request,
@@ -293,7 +289,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/object/get-and-return-nested-with-required-field/{0}",
@@ -363,7 +358,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-required-field-list",
                     Body = request,
@@ -430,7 +424,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-unknown-field",
                     Body = request,
@@ -495,7 +488,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-datetime-like-string",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -49,7 +49,6 @@ public partial class PaginationClient : IPaginationClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/pagination",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -30,7 +30,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -95,7 +94,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -161,7 +159,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -227,7 +224,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -294,7 +290,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new StreamRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -405,7 +400,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/params",
                     QueryString = _queryString,
@@ -458,7 +452,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/params",
                     QueryString = _queryString,
@@ -512,7 +505,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path-query/{0}",
@@ -567,7 +559,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path-query/{0}",

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -29,7 +29,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/string",
                     Body = request,
@@ -92,7 +91,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/integer",
                     Body = request,
@@ -155,7 +153,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/long",
                     Body = request,
@@ -218,7 +215,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/double",
                     Body = request,
@@ -281,7 +277,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/boolean",
                     Body = request,
@@ -344,7 +339,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/datetime",
                     Body = request,
@@ -407,7 +401,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/date",
                     Body = request,
@@ -470,7 +463,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/uuid",
                     Body = request,
@@ -533,7 +525,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/base64",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -29,7 +29,6 @@ public partial class PutClient : IPutClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format("{0}", ValueConvert.ToPathParameterString(request.Id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -30,7 +30,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/union",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -28,7 +28,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/MixedCase",
                     Headers = _headers,
@@ -89,7 +88,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/no-ending-slash",
                     Headers = _headers,
@@ -150,7 +148,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/with-ending-slash/",
                     Headers = _headers,
@@ -211,7 +208,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/with_underscores",
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -31,7 +31,6 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/object",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -28,7 +28,6 @@ public partial class NoAuthClient : INoAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/no-auth",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -28,7 +28,6 @@ public partial class NoReqBodyClient : INoReqBodyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/no-req-body",
                     Headers = _headers,
@@ -89,7 +88,6 @@ public partial class NoReqBodyClient : INoReqBodyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/no-req-body",
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -39,7 +39,6 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/test-headers/custom-header",
                     Body = request.Body,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
+    private string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -31,7 +31,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-primitives",
                     Body = request,
@@ -96,7 +95,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-objects",
                     Body = request,
@@ -161,7 +159,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-primitives",
                     Body = request,
@@ -226,7 +223,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-objects",
                     Body = request,
@@ -293,7 +289,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-prim",
                     Body = request,
@@ -358,7 +353,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-object",
                     Body = request,
@@ -425,7 +419,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-union",
                     Body = request,
@@ -492,7 +485,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/opt-objects",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -48,7 +48,6 @@ public partial class ContentTypeClient : IContentTypeClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/foo/bar",
                     Body = request,
@@ -109,7 +108,6 @@ public partial class ContentTypeClient : IContentTypeClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/foo/baz",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -30,7 +30,6 @@ public partial class EnumClient : IEnumClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/enum",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -30,7 +30,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -95,7 +94,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/http-methods",
                     Body = request,
@@ -159,7 +157,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -226,7 +223,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -292,7 +288,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = string.Format(
                         "/http-methods/{0}",

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -32,7 +32,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-optional-field",
                     Body = request,
@@ -97,7 +96,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-field",
                     Body = request,
@@ -160,7 +158,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-map-of-map",
                     Body = request,
@@ -225,7 +222,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-optional-field",
                     Body = request,
@@ -293,7 +289,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/object/get-and-return-nested-with-required-field/{0}",
@@ -363,7 +358,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-required-field-list",
                     Body = request,
@@ -430,7 +424,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-unknown-field",
                     Body = request,
@@ -495,7 +488,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-datetime-like-string",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -49,7 +49,6 @@ public partial class PaginationClient : IPaginationClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/pagination",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -30,7 +30,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -95,7 +94,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -161,7 +159,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -227,7 +224,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -294,7 +290,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new StreamRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -405,7 +400,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/params",
                     QueryString = _queryString,
@@ -458,7 +452,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/params",
                     QueryString = _queryString,
@@ -512,7 +505,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path-query/{0}",
@@ -567,7 +559,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path-query/{0}",

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -29,7 +29,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/string",
                     Body = request,
@@ -92,7 +91,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/integer",
                     Body = request,
@@ -155,7 +153,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/long",
                     Body = request,
@@ -218,7 +215,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/double",
                     Body = request,
@@ -281,7 +277,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/boolean",
                     Body = request,
@@ -344,7 +339,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/datetime",
                     Body = request,
@@ -407,7 +401,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/date",
                     Body = request,
@@ -470,7 +463,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/uuid",
                     Body = request,
@@ -533,7 +525,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/base64",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -29,7 +29,6 @@ public partial class PutClient : IPutClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format("{0}", ValueConvert.ToPathParameterString(request.Id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -30,7 +30,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/union",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -28,7 +28,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/MixedCase",
                     Headers = _headers,
@@ -89,7 +88,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/no-ending-slash",
                     Headers = _headers,
@@ -150,7 +148,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/with-ending-slash/",
                     Headers = _headers,
@@ -211,7 +208,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/with_underscores",
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -31,7 +31,6 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/object",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -28,7 +28,6 @@ public partial class NoAuthClient : INoAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/no-auth",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -28,7 +28,6 @@ public partial class NoReqBodyClient : INoReqBodyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/no-req-body",
                     Headers = _headers,
@@ -89,7 +88,6 @@ public partial class NoReqBodyClient : INoReqBodyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/no-req-body",
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -39,7 +39,6 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/test-headers/custom-header",
                     Body = request.Body,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
+    private string BuildUrl(global::SeedExhaustive.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -31,7 +31,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-primitives",
                     Body = request,
@@ -96,7 +95,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-objects",
                     Body = request,
@@ -161,7 +159,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-primitives",
                     Body = request,
@@ -226,7 +223,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-objects",
                     Body = request,
@@ -293,7 +289,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-prim",
                     Body = request,
@@ -358,7 +353,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-object",
                     Body = request,
@@ -425,7 +419,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-union",
                     Body = request,
@@ -492,7 +485,6 @@ public partial class ContainerClient : IContainerClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/container/opt-objects",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -49,7 +49,6 @@ public partial class ContentTypeClient : IContentTypeClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/foo/bar",
                     Body = request,
@@ -110,7 +109,6 @@ public partial class ContentTypeClient : IContentTypeClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/foo/baz",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -30,7 +30,6 @@ public partial class EnumClient : IEnumClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/enum",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -30,7 +30,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -95,7 +94,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/http-methods",
                     Body = request,
@@ -159,7 +157,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -226,7 +223,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/http-methods/{0}",
@@ -292,7 +288,6 @@ public partial class HttpMethodsClient : IHttpMethodsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = string.Format(
                         "/http-methods/{0}",

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -32,7 +32,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-optional-field",
                     Body = request,
@@ -97,7 +96,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-field",
                     Body = request,
@@ -160,7 +158,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-map-of-map",
                     Body = request,
@@ -225,7 +222,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-optional-field",
                     Body = request,
@@ -293,7 +289,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/object/get-and-return-nested-with-required-field/{0}",
@@ -363,7 +358,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-required-field-list",
                     Body = request,
@@ -430,7 +424,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-unknown-field",
                     Body = request,
@@ -495,7 +488,6 @@ public partial class ObjectClient : IObjectClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-datetime-like-string",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -49,7 +49,6 @@ public partial class PaginationClient : IPaginationClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/pagination",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -30,7 +30,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -95,7 +94,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -161,7 +159,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -227,7 +224,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -294,7 +290,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new StreamRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/params/path/{0}",
@@ -405,7 +400,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/params",
                     QueryString = _queryString,
@@ -458,7 +452,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/params",
                     QueryString = _queryString,
@@ -512,7 +505,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path-query/{0}",
@@ -567,7 +559,6 @@ public partial class ParamsClient : IParamsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/params/path-query/{0}",

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -29,7 +29,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/string",
                     Body = request,
@@ -92,7 +91,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/integer",
                     Body = request,
@@ -155,7 +153,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/long",
                     Body = request,
@@ -218,7 +215,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/double",
                     Body = request,
@@ -281,7 +277,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/boolean",
                     Body = request,
@@ -344,7 +339,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/datetime",
                     Body = request,
@@ -407,7 +401,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/date",
                     Body = request,
@@ -470,7 +463,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/uuid",
                     Body = request,
@@ -533,7 +525,6 @@ public partial class PrimitiveClient : IPrimitiveClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/primitive/base64",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -29,7 +29,6 @@ public partial class PutClient : IPutClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format("{0}", ValueConvert.ToPathParameterString(request.Id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -30,7 +30,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/union",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -28,7 +28,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/MixedCase",
                     Headers = _headers,
@@ -89,7 +88,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/no-ending-slash",
                     Headers = _headers,
@@ -150,7 +148,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/with-ending-slash/",
                     Headers = _headers,
@@ -211,7 +208,6 @@ public partial class UrlsClient : IUrlsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/urls/with_underscores",
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -31,7 +31,6 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/object",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -28,7 +28,6 @@ public partial class NoAuthClient : INoAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/no-auth",
                     Body = request,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -28,7 +28,6 @@ public partial class NoReqBodyClient : INoReqBodyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/no-req-body",
                     Headers = _headers,
@@ -89,7 +88,6 @@ public partial class NoReqBodyClient : INoReqBodyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/no-req-body",
                     Headers = _headers,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -39,7 +39,6 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/test-headers/custom-header",
                     Body = request.Body,

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedExtends.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/RawClient.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedExtends.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/RawClient.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedExtends.Core.BaseRequest request)
+    private string BuildUrl(global::SeedExtends.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/extends/src/SeedExtends/SeedExtendsClient.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/SeedExtendsClient.cs
@@ -54,7 +54,6 @@ public partial class SeedExtendsClient : ISeedExtendsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/extends/extended-inline-request-body",
                     Body = request,

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedExtraProperties.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/RawClient.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedExtraProperties.Core.BaseRequest request)
+    private string BuildUrl(global::SeedExtraProperties.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/RawClient.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedExtraProperties.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/User/UserClient.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/User/UserClient.cs
@@ -28,7 +28,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/user",
                     Body = request,

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedFileDownload.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedFileDownload.Core.BaseRequest request)
+    private string BuildUrl(global::SeedFileDownload.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedFileDownload.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Service/ServiceClient.cs
@@ -26,7 +26,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Headers = _headers,
@@ -77,7 +76,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/snippet",
                     Headers = _headers,

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/FileUploadExample/FileUploadExampleClient.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/FileUploadExample/FileUploadExampleClient.cs
@@ -26,7 +26,6 @@ public partial class FileUploadExampleClient : IFileUploadExampleClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "upload-file",
             Headers = _headers,

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedFileUpload.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedFileUpload.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedFileUpload.Core.BaseRequest request)
+    private string BuildUrl(global::SeedFileUpload.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Service/ServiceClient.cs
@@ -26,7 +26,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "/optional-args",
             Headers = _headers,
@@ -92,7 +91,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "/inline-type",
             Headers = _headers,
@@ -154,7 +152,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "/with-json-property",
             Headers = _headers,
@@ -216,7 +213,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "/with-literal-enum",
             Headers = _headers,
@@ -280,7 +276,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "",
             Headers = _headers,
@@ -338,7 +333,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "/just-file",
             Headers = _headers,
@@ -384,7 +378,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "/just-file-with-query-params",
             QueryString = _queryString,
@@ -428,7 +421,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "/just-file-with-optional-query-params",
             QueryString = _queryString,
@@ -467,7 +459,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "/with-content-type",
             Headers = _headers,
@@ -512,7 +503,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "/with-form-encoding",
             Headers = _headers,
@@ -556,7 +546,6 @@ public partial class ServiceClient : IServiceClient
             .ConfigureAwait(false);
         var multipartFormRequest_ = new MultipartFormRequest
         {
-            BaseUrl = _client.Options.BaseUrl,
             Method = HttpMethod.Post,
             Path = "",
             Headers = _headers,
@@ -664,7 +653,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/snippet",
                     Headers = _headers,

--- a/seed/csharp-sdk/folders/src/SeedApi/A/B/BClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/A/B/BClient.cs
@@ -30,7 +30,6 @@ public partial class BClient : IBClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Headers = _headers,

--- a/seed/csharp-sdk/folders/src/SeedApi/A/C/CClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/A/C/CClient.cs
@@ -30,7 +30,6 @@ public partial class CClient : ICClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Headers = _headers,

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/folders/src/SeedApi/Folder/FolderClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Folder/FolderClient.cs
@@ -33,7 +33,6 @@ public partial class FolderClient : IFolderClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Headers = _headers,

--- a/seed/csharp-sdk/folders/src/SeedApi/Folder/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Folder/Service/ServiceClient.cs
@@ -31,7 +31,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/service",
                     Headers = _headers,
@@ -75,7 +74,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/service",
                     Body = request,

--- a/seed/csharp-sdk/folders/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/SeedApiClient.cs
@@ -54,7 +54,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Headers = _headers,

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedHeaderTokenEnvironmentVariable.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/RawClient.cs
@@ -274,11 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
-        global::SeedHeaderTokenEnvironmentVariable.Core.BaseRequest request
-    )
+    private string BuildUrl(global::SeedHeaderTokenEnvironmentVariable.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedHeaderTokenEnvironmentVariable.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Service/ServiceClient.cs
@@ -27,7 +27,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "apiKey",
                     Headers = _headers,

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedHeaderToken.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/RawClient.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedHeaderToken.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/RawClient.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedHeaderToken.Core.BaseRequest request)
+    private string BuildUrl(global::SeedHeaderToken.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Service/ServiceClient.cs
@@ -27,7 +27,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "apiKey",
                     Headers = _headers,

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedHttpHead.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/RawClient.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedHttpHead.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/RawClient.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedHttpHead.Core.BaseRequest request)
+    private string BuildUrl(global::SeedHttpHead.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/User/UserClient.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/User/UserClient.cs
@@ -28,7 +28,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Head,
                     Path = "/users",
                     Headers = _headers,
@@ -80,7 +79,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedIdempotencyHeaders.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedIdempotencyHeaders.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedIdempotencyHeaders.Core.BaseRequest request)
+    private string BuildUrl(global::SeedIdempotencyHeaders.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Payment/PaymentClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Payment/PaymentClient.cs
@@ -29,7 +29,6 @@ public partial class PaymentClient : IPaymentClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/payment",
                     Body = request,
@@ -109,7 +108,6 @@ public partial class PaymentClient : IPaymentClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = string.Format(
                         "/payment/{0}",

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Imdb/ImdbClient.cs
@@ -28,7 +28,6 @@ public partial class ImdbClient : IImdbClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/movies/create-movie",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class ImdbClient : IImdbClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/movies/{0}",

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Imdb/ImdbClient.cs
@@ -28,7 +28,6 @@ public partial class ImdbClient : IImdbClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/movies/create-movie",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class ImdbClient : IImdbClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/movies/{0}",

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Imdb/ImdbClient.cs
@@ -28,7 +28,6 @@ public partial class ImdbClient : IImdbClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/movies/create-movie",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class ImdbClient : IImdbClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/movies/{0}",

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Imdb/ImdbClient.cs
@@ -39,7 +39,6 @@ public partial class ImdbClient : IImdbClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/movies/create-movie",
                             Body = request,
@@ -109,7 +108,6 @@ public partial class ImdbClient : IImdbClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = string.Format(
                                 "/movies/{0}",

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Imdb/ImdbClient.cs
@@ -28,7 +28,6 @@ public partial class ImdbClient : IImdbClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/movies/create-movie",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class ImdbClient : IImdbClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/movies/{0}",

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Auth/AuthClient.cs
@@ -29,7 +29,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
@@ -93,7 +92,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token/refresh",
                     Body = request,

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedInferredAuthExplicit.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedInferredAuthExplicit.Core.BaseRequest request)
+    private string BuildUrl(global::SeedInferredAuthExplicit.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedInferredAuthExplicit.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Simple/SimpleClient.cs
@@ -29,7 +29,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Auth/AuthClient.cs
@@ -29,7 +29,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedInferredAuthImplicitApiKey.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedInferredAuthImplicitApiKey.Core.BaseRequest request)
+    private string BuildUrl(global::SeedInferredAuthImplicitApiKey.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedInferredAuthImplicitApiKey.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Simple/SimpleClient.cs
@@ -29,7 +29,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Auth/AuthClient.cs
@@ -29,7 +29,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
@@ -93,7 +92,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token/refresh",
                     Body = request,

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedInferredAuthImplicitNoExpiry.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/RawClient.cs
@@ -274,11 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
-        global::SeedInferredAuthImplicitNoExpiry.Core.BaseRequest request
-    )
+    private string BuildUrl(global::SeedInferredAuthImplicitNoExpiry.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedInferredAuthImplicitNoExpiry.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Simple/SimpleClient.cs
@@ -29,7 +29,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
@@ -28,7 +28,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token/refresh",
                     Body = request,

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedInferredAuthImplicit.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedInferredAuthImplicit.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedInferredAuthImplicit.Core.BaseRequest request)
+    private string BuildUrl(global::SeedInferredAuthImplicit.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
@@ -29,7 +29,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
@@ -29,7 +29,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
@@ -93,7 +92,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token/refresh",
                     Body = request,

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedInferredAuthImplicit.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedInferredAuthImplicit.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedInferredAuthImplicit.Core.BaseRequest request)
+    private string BuildUrl(global::SeedInferredAuthImplicit.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
@@ -29,7 +29,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedLicense.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/RawClient.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedLicense.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/RawClient.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedLicense.Core.BaseRequest request)
+    private string BuildUrl(global::SeedLicense.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/SeedLicenseClient.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/SeedLicenseClient.cs
@@ -46,7 +46,6 @@ public partial class SeedLicenseClient : ISeedLicenseClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/",
                     Headers = _headers,

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedLicense.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/RawClient.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedLicense.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/RawClient.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedLicense.Core.BaseRequest request)
+    private string BuildUrl(global::SeedLicense.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/SeedLicenseClient.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/SeedLicenseClient.cs
@@ -46,7 +46,6 @@ public partial class SeedLicenseClient : ISeedLicenseClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/",
                     Headers = _headers,

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedLiteral.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedLiteral.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedLiteral.Core.BaseRequest request)
+    private string BuildUrl(global::SeedLiteral.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Headers/HeadersClient.cs
@@ -30,7 +30,6 @@ public partial class HeadersClient : IHeadersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "headers",
                     Body = request,

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Inlined/InlinedClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Inlined/InlinedClient.cs
@@ -28,7 +28,6 @@ public partial class InlinedClient : IInlinedClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "inlined",
                     Body = request,

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Path/PathClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Path/PathClient.cs
@@ -28,7 +28,6 @@ public partial class PathClient : IPathClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format("path/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Query/QueryClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Query/QueryClient.cs
@@ -40,7 +40,6 @@ public partial class QueryClient : IQueryClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "query",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Reference/ReferenceClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Reference/ReferenceClient.cs
@@ -28,7 +28,6 @@ public partial class ReferenceClient : IReferenceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "reference",
                     Body = request,

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedLiteral.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedLiteral.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedLiteral.Core.BaseRequest request)
+    private string BuildUrl(global::SeedLiteral.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Headers/HeadersClient.cs
@@ -30,7 +30,6 @@ public partial class HeadersClient : IHeadersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "headers",
                     Body = request,

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Inlined/InlinedClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Inlined/InlinedClient.cs
@@ -28,7 +28,6 @@ public partial class InlinedClient : IInlinedClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "inlined",
                     Body = request,

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Path/PathClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Path/PathClient.cs
@@ -28,7 +28,6 @@ public partial class PathClient : IPathClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format("path/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Query/QueryClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Query/QueryClient.cs
@@ -40,7 +40,6 @@ public partial class QueryClient : IQueryClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "query",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Reference/ReferenceClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Reference/ReferenceClient.cs
@@ -28,7 +28,6 @@ public partial class ReferenceClient : IReferenceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "reference",
                     Body = request,

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedLiteralsUnions.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedLiteralsUnions.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedLiteralsUnions.Core.BaseRequest request)
+    private string BuildUrl(global::SeedLiteralsUnions.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedMixedCase.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/RawClient.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedMixedCase.Core.BaseRequest request)
+    private string BuildUrl(global::SeedMixedCase.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/RawClient.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedMixedCase.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Service/ServiceClient.cs
@@ -28,7 +28,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/resource/{0}",
@@ -98,7 +97,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/resource",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedMixedFileDirectory.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/RawClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedMixedFileDirectory.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/RawClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedMixedFileDirectory.Core.BaseRequest request)
+    private string BuildUrl(global::SeedMixedFileDirectory.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Organization/OrganizationClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Organization/OrganizationClient.cs
@@ -28,7 +28,6 @@ public partial class OrganizationClient : IOrganizationClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/organizations/",
                     Body = request,

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/EventsClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/EventsClient.cs
@@ -37,7 +37,6 @@ public partial class EventsClient : IEventsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users/events/",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/Metadata/MetadataClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/Metadata/MetadataClient.cs
@@ -33,7 +33,6 @@ public partial class MetadataClient : IMetadataClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users/events/metadata/",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/UserClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/UserClient.cs
@@ -36,7 +36,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users/",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedMultiLineDocs.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedMultiLineDocs.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedMultiLineDocs.Core.BaseRequest request)
+    private string BuildUrl(global::SeedMultiLineDocs.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/User/UserClient.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/User/UserClient.cs
@@ -28,7 +28,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "users",
                     Body = request,
@@ -98,7 +97,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("users/{0}", ValueConvert.ToPathParameterString(userId)),
                     Headers = _headers,

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedMultiUrlEnvironmentNoDefault.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/RawClient.cs
@@ -274,9 +274,12 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private string BuildUrl(global::SeedMultiUrlEnvironmentNoDefault.Core.BaseRequest request)
+    private static string BuildUrl(
+        global::SeedMultiUrlEnvironmentNoDefault.Core.BaseRequest request
+    )
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/RawClient.cs
@@ -274,11 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
-        global::SeedMultiUrlEnvironmentNoDefault.Core.BaseRequest request
-    )
+    private string BuildUrl(global::SeedMultiUrlEnvironmentNoDefault.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedMultiUrlEnvironment.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedMultiUrlEnvironment.Core.BaseRequest request)
+    private string BuildUrl(global::SeedMultiUrlEnvironment.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/RawClient.cs
@@ -274,9 +274,10 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private string BuildUrl(global::SeedMultiUrlEnvironment.Core.BaseRequest request)
+    private static string BuildUrl(global::SeedMultiUrlEnvironment.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedMultiUrlEnvironment.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedMultiUrlEnvironment.Core.BaseRequest request)
+    private string BuildUrl(global::SeedMultiUrlEnvironment.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/RawClient.cs
@@ -274,9 +274,10 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private string BuildUrl(global::SeedMultiUrlEnvironment.Core.BaseRequest request)
+    private static string BuildUrl(global::SeedMultiUrlEnvironment.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/SeedApiClient.cs
@@ -56,7 +56,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "documents/upload",
                     Body = request,
@@ -124,7 +123,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new StreamRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "documents/upload",
                     Body = request,

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedNoEnvironment.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedNoEnvironment.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedNoEnvironment.Core.BaseRequest request)
+    private string BuildUrl(global::SeedNoEnvironment.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Dummy/DummyClient.cs
@@ -27,7 +27,6 @@ public partial class DummyClient : IDummyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "dummy",
                     Headers = _headers,

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedNoRetries.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedNoRetries.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedNoRetries.Core.BaseRequest request)
+    private string BuildUrl(global::SeedNoRetries.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Retries/RetriesClient.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Retries/RetriesClient.cs
@@ -27,7 +27,6 @@ public partial class RetriesClient : IRetriesClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     Headers = _headers,

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/SeedApiClient.cs
@@ -44,7 +44,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "test",
                     Headers = _headers,
@@ -106,7 +105,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "test",
                     Body = request,

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedNullableOptional.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedNullableOptional.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedNullableOptional.Core.BaseRequest request)
+    private string BuildUrl(global::SeedNullableOptional.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
@@ -28,7 +28,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/api/users/{0}",
@@ -93,7 +92,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/api/users",
                     Body = request,
@@ -157,7 +155,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/api/users/{0}",
@@ -230,7 +227,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/api/users",
                     QueryString = _queryString,
@@ -300,7 +296,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/api/users/search",
                     QueryString = _queryString,
@@ -363,7 +358,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/api/profiles/complex",
                     Body = request,
@@ -426,7 +420,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/api/profiles/complex/{0}",
@@ -492,7 +485,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/api/profiles/complex/{0}",
@@ -558,7 +550,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/api/test/deserialization",
                     Body = request,
@@ -632,7 +623,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/api/users/filter",
                     QueryString = _queryString,
@@ -695,7 +685,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/api/users/{0}/notifications",
@@ -761,7 +750,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/api/users/{0}/tags",
@@ -827,7 +815,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/api/search",
                     Body = request,

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedNullableOptional.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedNullableOptional.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedNullableOptional.Core.BaseRequest request)
+    private string BuildUrl(global::SeedNullableOptional.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
@@ -28,7 +28,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/api/users/{0}",
@@ -93,7 +92,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/api/users",
                     Body = request,
@@ -157,7 +155,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/api/users/{0}",
@@ -230,7 +227,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/api/users",
                     QueryString = _queryString,
@@ -300,7 +296,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/api/users/search",
                     QueryString = _queryString,
@@ -363,7 +358,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/api/profiles/complex",
                     Body = request,
@@ -426,7 +420,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/api/profiles/complex/{0}",
@@ -492,7 +485,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/api/profiles/complex/{0}",
@@ -558,7 +550,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/api/test/deserialization",
                     Body = request,
@@ -629,7 +620,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/api/users/filter",
                     QueryString = _queryString,
@@ -692,7 +682,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/api/users/{0}/notifications",
@@ -758,7 +747,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/api/users/{0}/tags",
@@ -824,7 +812,6 @@ public partial class NullableOptionalClient : INullableOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/api/search",
                     Body = request,

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/TestGroup/TestGroupClient.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/TestGroup/TestGroupClient.cs
@@ -33,7 +33,6 @@ public partial class TestGroupClient : ITestGroupClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "optional-request-body/{0}",

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedNullable.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedNullable.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedNullable.Core.BaseRequest request)
+    private string BuildUrl(global::SeedNullable.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Nullable/NullableClient.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Nullable/NullableClient.cs
@@ -36,7 +36,6 @@ public partial class NullableClient : INullableClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -99,7 +98,6 @@ public partial class NullableClient : INullableClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
@@ -162,7 +160,6 @@ public partial class NullableClient : INullableClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = "/users",
                     Body = request,

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedNullable.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedNullable.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedNullable.Core.BaseRequest request)
+    private string BuildUrl(global::SeedNullable.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Nullable/NullableClient.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Nullable/NullableClient.cs
@@ -36,7 +36,6 @@ public partial class NullableClient : INullableClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -99,7 +98,6 @@ public partial class NullableClient : INullableClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
@@ -162,7 +160,6 @@ public partial class NullableClient : INullableClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = "/users",
                     Body = request,

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -28,7 +28,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedOauthClientCredentials.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
+    private string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -29,7 +29,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Auth/AuthClient.cs
@@ -28,7 +28,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedOauthClientCredentialsDefault.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedOauthClientCredentialsDefault.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/RawClient.cs
@@ -274,11 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
-        global::SeedOauthClientCredentialsDefault.Core.BaseRequest request
-    )
+    private string BuildUrl(global::SeedOauthClientCredentialsDefault.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Simple/SimpleClient.cs
@@ -29,7 +29,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Auth/AuthClient.cs
@@ -29,7 +29,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
@@ -93,7 +92,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedOauthClientCredentialsEnvironmentVariables.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/RawClient.cs
@@ -274,11 +274,11 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
+    private string BuildUrl(
         global::SeedOauthClientCredentialsEnvironmentVariables.Core.BaseRequest request
     )
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/RawClient.cs
@@ -279,6 +279,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/Api/ApiClient.cs
@@ -31,7 +31,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/Api/ApiClient.cs
@@ -31,7 +31,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Simple/SimpleClient.cs
@@ -30,7 +30,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Auth/AuthClient.cs
@@ -29,7 +29,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
@@ -93,7 +92,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedOauthClientCredentialsMandatoryAuth.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
@@ -274,11 +274,11 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
+    private string BuildUrl(
         global::SeedOauthClientCredentialsMandatoryAuth.Core.BaseRequest request
     )
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
@@ -279,6 +279,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Nested/Api/ApiClient.cs
@@ -31,7 +31,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Simple/SimpleClient.cs
@@ -30,7 +30,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -29,7 +29,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedOauthClientCredentials.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
+    private string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -29,7 +29,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Auth/AuthClient.cs
@@ -28,7 +28,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedOauthClientCredentialsReference.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/RawClient.cs
@@ -274,11 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
-        global::SeedOauthClientCredentialsReference.Core.BaseRequest request
-    )
+    private string BuildUrl(global::SeedOauthClientCredentialsReference.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedOauthClientCredentialsReference.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Simple/SimpleClient.cs
@@ -29,7 +29,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Auth/AuthClient.cs
@@ -29,7 +29,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
@@ -93,7 +92,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedOauthClientCredentialsWithVariables.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/RawClient.cs
@@ -274,11 +274,11 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
+    private string BuildUrl(
         global::SeedOauthClientCredentialsWithVariables.Core.BaseRequest request
     )
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/RawClient.cs
@@ -279,6 +279,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/Api/ApiClient.cs
@@ -31,7 +31,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/Api/ApiClient.cs
@@ -31,7 +31,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Service/ServiceClient.cs
@@ -31,7 +31,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/service/{0}",

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Simple/SimpleClient.cs
@@ -30,7 +30,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -39,7 +39,6 @@ public partial class AuthClient : IAuthClient
                     .SendRequestAsync(
                         new FormRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/token",
                             Body = request,
@@ -110,7 +109,6 @@ public partial class AuthClient : IAuthClient
                     .SendRequestAsync(
                         new FormRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/token",
                             Body = request,

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedOauthClientCredentials.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
+    private string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -41,7 +41,6 @@ public partial class ApiClient : IApiClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/nested/get-something",
                             Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -41,7 +41,6 @@ public partial class ApiClient : IApiClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/nested-no-auth/get-something",
                             Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -40,7 +40,6 @@ public partial class SimpleClient : ISimpleClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/get-something",
                             Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -28,7 +28,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new FormRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
@@ -92,7 +91,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new FormRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedOauthClientCredentials.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
+    private string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedOauthClientCredentials.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -30,7 +30,6 @@ public partial class ApiClient : IApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -29,7 +29,6 @@ public partial class SimpleClient : ISimpleClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/get-something",
                     Headers = _headers,

--- a/seed/csharp-sdk/object/src/SeedObject/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedObject.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/object/src/SeedObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedObject.Core.BaseRequest request)
+    private string BuildUrl(global::SeedObject.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/object/src/SeedObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedObject.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedObjectsWithImports.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedObjectsWithImports.Core.BaseRequest request)
+    private string BuildUrl(global::SeedObjectsWithImports.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedObjectsWithImports.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedObjectsWithImports.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedObjectsWithImports.Core.BaseRequest request)
+    private string BuildUrl(global::SeedObjectsWithImports.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedObjectsWithImports.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Optional/OptionalClient.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Optional/OptionalClient.cs
@@ -28,7 +28,6 @@ public partial class OptionalClient : IOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "send-optional-body",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class OptionalClient : IOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "send-optional-typed-body",
                     Body = request,
@@ -158,7 +156,6 @@ public partial class OptionalClient : IOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "deploy/{0}/versions/{1}",

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedObjectsWithImports.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedObjectsWithImports.Core.BaseRequest request)
+    private string BuildUrl(global::SeedObjectsWithImports.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedObjectsWithImports.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Optional/OptionalClient.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Optional/OptionalClient.cs
@@ -28,7 +28,6 @@ public partial class OptionalClient : IOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "send-optional-body",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class OptionalClient : IOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "send-optional-typed-body",
                     Body = request,
@@ -158,7 +156,6 @@ public partial class OptionalClient : IOptionalClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "deploy/{0}/versions/{1}",

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPackageYml.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/RawClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPackageYml.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPackageYml.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/RawClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPackageYml.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYmlClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYmlClient.cs
@@ -49,7 +49,6 @@ public partial class SeedPackageYmlClient : ISeedPackageYmlClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format("/{0}/", ValueConvert.ToPathParameterString(id)),
                     Body = request,

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Service/ServiceClient.cs
@@ -31,7 +31,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}//{1}",

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPagination.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPagination.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPagination.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPagination.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Users/UsersClient.cs
@@ -35,7 +35,6 @@ public partial class UsersClient : IUsersClient
         var httpRequest = await _client.CreateHttpRequestAsync(
             new JsonRequest
             {
-                BaseUrl = _client.Options.BaseUrl,
                 Method = HttpMethod.Get,
                 Path = "/users",
                 QueryString = _queryString,

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPaginationUriPath.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPaginationUriPath.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPaginationUriPath.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPaginationUriPath.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Users/UsersClient.cs
@@ -29,7 +29,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users/uri",
                     Headers = _headers,
@@ -94,7 +93,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users/path",
                     Headers = _headers,

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Complex/ComplexClient.cs
@@ -52,7 +52,6 @@ public partial class ComplexClient : IComplexClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = string.Format(
                                 "{0}/conversations/search",

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPagination.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPagination.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPagination.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPagination.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -60,7 +60,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/inline-users",
                             QueryString = _queryString,
@@ -149,7 +148,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/inline-users",
                             QueryString = _queryString,
@@ -235,7 +233,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/inline-users",
                             Body = request,
@@ -327,7 +324,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/inline-users",
                             QueryString = _queryString,
@@ -419,7 +415,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/inline-users",
                             QueryString = _queryString,
@@ -504,7 +499,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/inline-users",
                             Body = request,
@@ -595,7 +589,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/inline-users",
                             QueryString = _queryString,
@@ -690,7 +683,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/inline-users",
                             QueryString = _queryString,
@@ -779,7 +771,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/inline-users",
                             QueryString = _queryString,
@@ -872,7 +863,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/inline-users",
                             QueryString = _queryString,
@@ -960,7 +950,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/inline-users",
                             QueryString = _queryString,
@@ -1045,7 +1034,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/inline-users",
                             QueryString = _queryString,

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Users/UsersClient.cs
@@ -59,7 +59,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users",
                             QueryString = _queryString,
@@ -148,7 +147,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/users",
                             QueryString = _queryString,
@@ -234,7 +232,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/users",
                             Body = request,
@@ -328,7 +325,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/users/top-level-cursor",
                             Body = request,
@@ -421,7 +417,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users",
                             QueryString = _queryString,
@@ -513,7 +508,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users",
                             QueryString = _queryString,
@@ -598,7 +592,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Post,
                             Path = "/users",
                             Body = request,
@@ -689,7 +682,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users",
                             QueryString = _queryString,
@@ -784,7 +776,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users",
                             QueryString = _queryString,
@@ -873,7 +864,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users",
                             QueryString = _queryString,
@@ -966,7 +956,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users",
                             QueryString = _queryString,
@@ -1054,7 +1043,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users",
                             QueryString = _queryString,
@@ -1141,7 +1129,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users",
                             QueryString = _queryString,
@@ -1226,7 +1213,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users",
                             QueryString = _queryString,
@@ -1313,7 +1299,6 @@ public partial class UsersClient : IUsersClient
                     .SendRequestAsync(
                         new JsonRequest
                         {
-                            BaseUrl = _client.Options.BaseUrl,
                             Method = HttpMethod.Get,
                             Path = "/users/optional-data",
                             QueryString = _queryString,

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Complex/ComplexClient.cs
@@ -41,7 +41,6 @@ public partial class ComplexClient : IComplexClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "{0}/conversations/search",

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPagination.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPagination.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPagination.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPagination.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -49,7 +49,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -131,7 +130,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -209,7 +207,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     Body = request,
@@ -294,7 +291,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -379,7 +375,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -457,7 +452,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     Body = request,
@@ -541,7 +535,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -629,7 +622,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -711,7 +703,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -795,7 +786,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -875,7 +865,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -953,7 +942,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Users/UsersClient.cs
@@ -48,7 +48,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -130,7 +129,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     QueryString = _queryString,
@@ -208,7 +206,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
@@ -295,7 +292,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users/top-level-cursor",
                     Body = request,
@@ -380,7 +376,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -465,7 +460,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -543,7 +537,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
@@ -627,7 +620,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -715,7 +707,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -797,7 +788,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -881,7 +871,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -961,7 +950,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -1041,7 +1029,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -1119,7 +1106,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -1199,7 +1185,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users/optional-data",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Complex/ComplexClient.cs
@@ -41,7 +41,6 @@ public partial class ComplexClient : IComplexClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "{0}/conversations/search",

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPagination.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPagination.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPagination.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPagination.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -49,7 +49,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -131,7 +130,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -209,7 +207,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     Body = request,
@@ -294,7 +291,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -379,7 +375,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -457,7 +452,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     Body = request,
@@ -541,7 +535,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -629,7 +622,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -711,7 +703,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -795,7 +786,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -875,7 +865,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,
@@ -953,7 +942,6 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/inline-users",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Users/UsersClient.cs
@@ -48,7 +48,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -130,7 +129,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     QueryString = _queryString,
@@ -208,7 +206,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
@@ -295,7 +292,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users/top-level-cursor",
                     Body = request,
@@ -380,7 +376,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -465,7 +460,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -543,7 +537,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
@@ -627,7 +620,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -715,7 +707,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -797,7 +788,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -881,7 +871,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -961,7 +950,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -1041,7 +1029,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -1119,7 +1106,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users",
                     QueryString = _queryString,
@@ -1199,7 +1185,6 @@ public partial class UsersClient : IUsersClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/users/optional-data",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPathParameters.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPathParameters.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPathParameters.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPathParameters.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Organizations/OrganizationsClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Organizations/OrganizationsClient.cs
@@ -29,7 +29,6 @@ public partial class OrganizationsClient : IOrganizationsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/organizations/{1}/",
@@ -95,7 +94,6 @@ public partial class OrganizationsClient : IOrganizationsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/organizations/{1}/users/{2}",
@@ -168,7 +166,6 @@ public partial class OrganizationsClient : IOrganizationsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/organizations/{1}/search",

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/User/UserClient.cs
@@ -28,7 +28,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/user/{1}",
@@ -95,7 +94,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/{0}/user/",
@@ -161,7 +159,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/{0}/user/{1}",
@@ -232,7 +229,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/user/{1}/search",
@@ -299,7 +295,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/user/{1}/metadata/v{2}",
@@ -366,7 +361,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/user/{1}/specifics/{2}/{3}",

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPathParameters.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPathParameters.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPathParameters.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPathParameters.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Organizations/OrganizationsClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Organizations/OrganizationsClient.cs
@@ -29,7 +29,6 @@ public partial class OrganizationsClient : IOrganizationsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/organizations/{1}/",
@@ -98,7 +97,6 @@ public partial class OrganizationsClient : IOrganizationsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/organizations/{1}/users/{2}",
@@ -171,7 +169,6 @@ public partial class OrganizationsClient : IOrganizationsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/organizations/{1}/search",

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/User/UserClient.cs
@@ -30,7 +30,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/user/{1}",
@@ -97,7 +96,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/{0}/user/",
@@ -165,7 +163,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format(
                         "/{0}/user/{1}",
@@ -238,7 +235,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/user/{1}/search",
@@ -308,7 +304,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/user/{1}/metadata/v{2}",
@@ -379,7 +374,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/{0}/user/{1}/specifics/{2}/{3}",

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPlainText.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/RawClient.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPlainText.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/RawClient.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPlainText.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPlainText.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Service/ServiceClient.cs
@@ -26,7 +26,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "text",
                     Headers = _headers,

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPropertyAccess.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/RawClient.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPropertyAccess.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPropertyAccess.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/RawClient.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPropertyAccess.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/SeedPropertyAccessClient.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/SeedPropertyAccessClient.cs
@@ -45,7 +45,6 @@ public partial class SeedPropertyAccessClient : ISeedPropertyAccessClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedPublicObject.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedPublicObject.Core.BaseRequest request)
+    private string BuildUrl(global::SeedPublicObject.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedPublicObject.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Service/ServiceClient.cs
@@ -26,7 +26,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/helloworld.txt",
                     Headers = _headers,

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/SeedApiClient.cs
@@ -66,7 +66,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "user/getUsername",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/SeedApiClient.cs
@@ -66,7 +66,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "user/getUsername",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedQueryParameters.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedQueryParameters.Core.BaseRequest request)
+    private string BuildUrl(global::SeedQueryParameters.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedQueryParameters.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/User/UserClient.cs
@@ -45,7 +45,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/user",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedRequestParameters.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedRequestParameters.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedRequestParameters.Core.BaseRequest request)
+    private string BuildUrl(global::SeedRequestParameters.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/User/UserClient.cs
@@ -47,7 +47,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/user",
                     QueryString = _queryString,
@@ -125,7 +124,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/user/username",
                     Body = request,
@@ -184,7 +182,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/user/username-referenced",
                     Body = request.Body,
@@ -228,7 +225,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/user/username-optional",
                     Body = request,

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedRequestParameters.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedRequestParameters.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedRequestParameters.Core.BaseRequest request)
+    private string BuildUrl(global::SeedRequestParameters.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/User/UserClient.cs
@@ -47,7 +47,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/user",
                     QueryString = _queryString,
@@ -125,7 +124,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/user/username",
                     Body = request,
@@ -184,7 +182,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/user/username-referenced",
                     Body = request.Body,
@@ -228,7 +225,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/user/username-optional",
                     Body = request,

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/SeedApiClient.cs
@@ -55,7 +55,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "foo",
                     QueryString = _queryString,
@@ -120,7 +119,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format("foo/{0}", ValueConvert.ToPathParameterString(id)),
                     Body = request,

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/SeedApiClient.cs
@@ -52,7 +52,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "foo",
                     QueryString = _queryString,
@@ -117,7 +116,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format("foo/{0}", ValueConvert.ToPathParameterString(id)),
                     Body = request,

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedNurseryApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedNurseryApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedNurseryApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedNurseryApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Package/PackageClient.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Package/PackageClient.cs
@@ -34,7 +34,6 @@ public partial class PackageClient : IPackageClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedResponseProperty.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedResponseProperty.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedResponseProperty.Core.BaseRequest request)
+    private string BuildUrl(global::SeedResponseProperty.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Service/ServiceClient.cs
@@ -28,7 +28,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
@@ -154,7 +152,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
@@ -217,7 +214,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
@@ -280,7 +276,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
@@ -343,7 +338,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
@@ -406,7 +400,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Completions/CompletionsClient.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Completions/CompletionsClient.cs
@@ -31,7 +31,6 @@ public partial class CompletionsClient : ICompletionsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "stream",
                     Body = request,
@@ -99,7 +98,6 @@ public partial class CompletionsClient : ICompletionsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "stream-events",
                     Body = request,

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedServerSentEvents.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedServerSentEvents.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedServerSentEvents.Core.BaseRequest request)
+    private string BuildUrl(global::SeedServerSentEvents.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Completions/CompletionsClient.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Completions/CompletionsClient.cs
@@ -31,7 +31,6 @@ public partial class CompletionsClient : ICompletionsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "stream",
                     Body = request,
@@ -101,7 +100,6 @@ public partial class CompletionsClient : ICompletionsClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "stream-no-terminator",
                     Body = request,

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedServerSentEvents.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedServerSentEvents.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedServerSentEvents.Core.BaseRequest request)
+    private string BuildUrl(global::SeedServerSentEvents.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,10 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedSimpleApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedSimpleApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedSimpleApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedSimpleApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/User/UserClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/User/UserClient.cs
@@ -28,7 +28,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedSimpleApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedSimpleApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedSimpleApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedSimpleApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/User/UserClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/User/UserClient.cs
@@ -28,7 +28,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedSimpleApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedSimpleApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedSimpleApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedSimpleApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/User/UserClient.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/User/UserClient.cs
@@ -28,7 +28,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/SeedApiClient.cs
@@ -45,7 +45,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "account/{0}",

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedSingleUrlEnvironmentDefault.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedSingleUrlEnvironmentDefault.Core.BaseRequest request)
+    private string BuildUrl(global::SeedSingleUrlEnvironmentDefault.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedSingleUrlEnvironmentDefault.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Dummy/DummyClient.cs
@@ -27,7 +27,6 @@ public partial class DummyClient : IDummyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "dummy",
                     Headers = _headers,

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedSingleUrlEnvironmentNoDefault.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/RawClient.cs
@@ -274,11 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
-        global::SeedSingleUrlEnvironmentNoDefault.Core.BaseRequest request
-    )
+    private string BuildUrl(global::SeedSingleUrlEnvironmentNoDefault.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedSingleUrlEnvironmentNoDefault.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Dummy/DummyClient.cs
@@ -27,7 +27,6 @@ public partial class DummyClient : IDummyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "dummy",
                     Headers = _headers,

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedStreaming.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedStreaming.Core.BaseRequest request)
+    private string BuildUrl(global::SeedStreaming.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedStreaming.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Dummy/DummyClient.cs
@@ -30,7 +30,6 @@ public partial class DummyClient : IDummyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "generate",
                     Body = request,

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedStreaming.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedStreaming.Core.BaseRequest request)
+    private string BuildUrl(global::SeedStreaming.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedStreaming.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Dummy/DummyClient.cs
@@ -28,7 +28,6 @@ public partial class DummyClient : IDummyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "generate",
                     Body = request,
@@ -94,7 +93,6 @@ public partial class DummyClient : IDummyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "generate-stream",
                     Body = request,

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedStreaming.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedStreaming.Core.BaseRequest request)
+    private string BuildUrl(global::SeedStreaming.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedStreaming.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Dummy/DummyClient.cs
@@ -28,7 +28,6 @@ public partial class DummyClient : IDummyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "generate",
                     Body = request,
@@ -94,7 +93,6 @@ public partial class DummyClient : IDummyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "generate-stream",
                     Body = request,

--- a/seed/csharp-sdk/trace/src/SeedTrace/Admin/AdminClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Admin/AdminClient.cs
@@ -34,7 +34,6 @@ public partial class AdminClient : IAdminClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/admin/store-test-submission-status/{0}",
@@ -90,7 +89,6 @@ public partial class AdminClient : IAdminClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/admin/store-test-submission-status-v2/{0}",
@@ -140,7 +138,6 @@ public partial class AdminClient : IAdminClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/admin/store-workspace-submission-status/{0}",
@@ -196,7 +193,6 @@ public partial class AdminClient : IAdminClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/admin/store-workspace-submission-status-v2/{0}",
@@ -355,7 +351,6 @@ public partial class AdminClient : IAdminClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/admin/store-test-trace/submission/{0}/testCase/{1}",
@@ -492,7 +487,6 @@ public partial class AdminClient : IAdminClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/admin/store-test-trace-v2/submission/{0}/testCase/{1}",
@@ -656,7 +650,6 @@ public partial class AdminClient : IAdminClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/admin/store-workspace-trace/submission/{0}",
@@ -790,7 +783,6 @@ public partial class AdminClient : IAdminClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/admin/store-workspace-trace-v2/submission/{0}",

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedTrace.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/RawClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedTrace.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/RawClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedTrace.Core.BaseRequest request)
+    private string BuildUrl(global::SeedTrace.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/trace/src/SeedTrace/Homepage/HomepageClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Homepage/HomepageClient.cs
@@ -27,7 +27,6 @@ public partial class HomepageClient : IHomepageClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/homepage-problems",
                     Headers = _headers,
@@ -105,7 +104,6 @@ public partial class HomepageClient : IHomepageClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/homepage-problems",
                     Body = request,

--- a/seed/csharp-sdk/trace/src/SeedTrace/Migration/MigrationClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Migration/MigrationClient.cs
@@ -29,7 +29,6 @@ public partial class MigrationClient : IMigrationClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/migration-info/all",
                     Headers = _headers,

--- a/seed/csharp-sdk/trace/src/SeedTrace/Playlist/PlaylistClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Playlist/PlaylistClient.cs
@@ -34,7 +34,6 @@ public partial class PlaylistClient : IPlaylistClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/v2/playlist/{0}/create",
@@ -110,7 +109,6 @@ public partial class PlaylistClient : IPlaylistClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/v2/playlist/{0}/all",
@@ -177,7 +175,6 @@ public partial class PlaylistClient : IPlaylistClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/v2/playlist/{0}/{1}",
@@ -245,7 +242,6 @@ public partial class PlaylistClient : IPlaylistClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/v2/playlist/{0}/{1}",
@@ -422,7 +418,6 @@ public partial class PlaylistClient : IPlaylistClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = string.Format(
                         "/v2/playlist/{0}/{1}",

--- a/seed/csharp-sdk/trace/src/SeedTrace/Problem/ProblemClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Problem/ProblemClient.cs
@@ -28,7 +28,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/problem-crud/create",
                     Body = request,
@@ -92,7 +91,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/problem-crud/update/{0}",
@@ -160,7 +158,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/problem-crud/default-starter-files",
                     Body = request,
@@ -419,7 +416,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = string.Format(
                         "/problem-crud/delete/{0}",

--- a/seed/csharp-sdk/trace/src/SeedTrace/Submission/SubmissionClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Submission/SubmissionClient.cs
@@ -28,7 +28,6 @@ public partial class SubmissionClient : ISubmissionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format(
                         "/sessions/create-session/{0}",
@@ -93,7 +92,6 @@ public partial class SubmissionClient : ISubmissionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/sessions/{0}",
@@ -159,7 +157,6 @@ public partial class SubmissionClient : ISubmissionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/sessions/execution-sessions-state",
                     Headers = _headers,
@@ -263,7 +260,6 @@ public partial class SubmissionClient : ISubmissionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Delete,
                     Path = string.Format(
                         "/sessions/stop/{0}",

--- a/seed/csharp-sdk/trace/src/SeedTrace/Sysprop/SyspropClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Sysprop/SyspropClient.cs
@@ -27,7 +27,6 @@ public partial class SyspropClient : ISyspropClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/sysprop/num-warm-instances",
                     Headers = _headers,
@@ -93,7 +92,6 @@ public partial class SyspropClient : ISyspropClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = string.Format(
                         "/sysprop/num-warm-instances/{0}/{1}",

--- a/seed/csharp-sdk/trace/src/SeedTrace/V2/Problem/ProblemClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/V2/Problem/ProblemClient.cs
@@ -30,7 +30,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/problems-v2/lightweight-problem-info",
                     Headers = _headers,
@@ -93,7 +92,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/problems-v2/problem-info",
                     Headers = _headers,
@@ -155,7 +153,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/problems-v2/problem-info/{0}",
@@ -221,7 +218,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/problems-v2/problem-info/{0}/version/{1}",

--- a/seed/csharp-sdk/trace/src/SeedTrace/V2/V2Client.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/V2/V2Client.cs
@@ -37,7 +37,6 @@ public partial class V2Client : IV2Client
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "",
                     Headers = _headers,

--- a/seed/csharp-sdk/trace/src/SeedTrace/V2/V3/Problem/ProblemClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/V2/V3/Problem/ProblemClient.cs
@@ -30,7 +30,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/problems-v2/lightweight-problem-info",
                     Headers = _headers,
@@ -93,7 +92,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/problems-v2/problem-info",
                     Headers = _headers,
@@ -155,7 +153,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/problems-v2/problem-info/{0}",
@@ -221,7 +218,6 @@ public partial class ProblemClient : IProblemClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format(
                         "/problems-v2/problem-info/{0}/version/{1}",

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedUndiscriminatedUnionWithResponseProperty.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/RawClient.cs
@@ -274,11 +274,11 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(
+    private string BuildUrl(
         global::SeedUndiscriminatedUnionWithResponseProperty.Core.BaseRequest request
     )
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/RawClient.cs
@@ -279,6 +279,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponsePropertyClient.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponsePropertyClient.cs
@@ -46,7 +46,6 @@ public partial class SeedUndiscriminatedUnionWithResponsePropertyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/union",
                     Headers = _headers,
@@ -108,7 +107,6 @@ public partial class SeedUndiscriminatedUnionWithResponsePropertyClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/unions",
                     Headers = _headers,

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedUndiscriminatedUnions.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedUndiscriminatedUnions.Core.BaseRequest request)
+    private string BuildUrl(global::SeedUndiscriminatedUnions.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedUndiscriminatedUnions.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
@@ -47,7 +47,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
@@ -129,7 +128,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/metadata",
                     Headers = _headers,
@@ -193,7 +191,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = "/metadata",
                     Body = request,
@@ -256,7 +253,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/call",
                     Body = request,
@@ -321,7 +317,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/duplicate",
                     Body = request,
@@ -397,7 +392,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/nested",
                     Body = request,
@@ -460,7 +454,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/camel-case",
                     Body = request,

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedUndiscriminatedUnions.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedUndiscriminatedUnions.Core.BaseRequest request)
+    private string BuildUrl(global::SeedUndiscriminatedUnions.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedUndiscriminatedUnions.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
@@ -28,7 +28,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
@@ -90,7 +89,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "/metadata",
                     Headers = _headers,
@@ -152,7 +150,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Put,
                     Path = "/metadata",
                     Body = request,
@@ -215,7 +212,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/call",
                     Body = request,
@@ -278,7 +274,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/duplicate",
                     Body = request,
@@ -341,7 +336,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/nested",
                     Body = request,
@@ -404,7 +398,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/camel-case",
                     Body = request,

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Bigunion/BigunionClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Bigunion/BigunionClient.cs
@@ -28,7 +28,6 @@ public partial class BigunionClient : IBigunionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,
@@ -90,7 +89,6 @@ public partial class BigunionClient : IBigunionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,
@@ -153,7 +151,6 @@ public partial class BigunionClient : IBigunionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "/many",
                     Body = request,

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedUnions.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedUnions.Core.BaseRequest request)
+    private string BuildUrl(global::SeedUnions.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedUnions.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Types/TypesClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Types/TypesClient.cs
@@ -28,7 +28,6 @@ public partial class TypesClient : ITypesClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/time/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,
@@ -90,7 +89,6 @@ public partial class TypesClient : ITypesClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "/time",
                     Body = request,

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Union/UnionClient.cs
@@ -28,7 +28,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,
@@ -90,7 +89,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Bigunion/BigunionClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Bigunion/BigunionClient.cs
@@ -28,7 +28,6 @@ public partial class BigunionClient : IBigunionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,
@@ -90,7 +89,6 @@ public partial class BigunionClient : IBigunionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,
@@ -153,7 +151,6 @@ public partial class BigunionClient : IBigunionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "/many",
                     Body = request,

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedUnions.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedUnions.Core.BaseRequest request)
+    private string BuildUrl(global::SeedUnions.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedUnions.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Union/UnionClient.cs
@@ -28,7 +28,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,
@@ -90,7 +89,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Bigunion/BigunionClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Bigunion/BigunionClient.cs
@@ -28,7 +28,6 @@ public partial class BigunionClient : IBigunionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,
@@ -90,7 +89,6 @@ public partial class BigunionClient : IBigunionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,
@@ -153,7 +151,6 @@ public partial class BigunionClient : IBigunionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "/many",
                     Body = request,

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedUnions.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedUnions.Core.BaseRequest request)
+    private string BuildUrl(global::SeedUnions.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedUnions.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Union/UnionClient.cs
@@ -28,7 +28,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(id)),
                     Headers = _headers,
@@ -90,7 +89,6 @@ public partial class UnionClient : IUnionClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedUnknownAsAny.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/RawClient.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedUnknownAsAny.Core.BaseRequest request)
+    private string BuildUrl(global::SeedUnknownAsAny.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/RawClient.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedUnknownAsAny.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Unknown/UnknownClient.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Unknown/UnknownClient.cs
@@ -28,7 +28,6 @@ public partial class UnknownClient : IUnknownClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
@@ -91,7 +90,6 @@ public partial class UnknownClient : IUnknownClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/with-object",
                     Body = request,

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/SeedApiClient.cs
@@ -45,7 +45,6 @@ public partial class SeedApiClient : ISeedApiClient
             .SendRequestAsync(
                 new FormRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "submit",
                     Body = request,

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedValidation.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/RawClient.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedValidation.Core.BaseRequest request)
+    private string BuildUrl(global::SeedValidation.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/RawClient.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedValidation.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/validation/src/SeedValidation/SeedValidationClient.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/SeedValidationClient.cs
@@ -45,7 +45,6 @@ public partial class SeedValidationClient : ISeedValidationClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/create",
                     Body = request,
@@ -114,7 +113,6 @@ public partial class SeedValidationClient : ISeedValidationClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = "",
                     QueryString = _queryString,

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedVariables.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedVariables.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedVariables.Core.BaseRequest request)
+    private string BuildUrl(global::SeedVariables.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/variables/src/SeedVariables/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Service/ServiceClient.cs
@@ -30,7 +30,6 @@ public partial class ServiceClient : IServiceClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(endpointParam)),
                     Headers = _headers,

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedVersion.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/RawClient.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedVersion.Core.BaseRequest request)
+    private string BuildUrl(global::SeedVersion.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/RawClient.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedVersion.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/User/UserClient.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/User/UserClient.cs
@@ -28,7 +28,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(userId)),
                     Headers = _headers,

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedVersion.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/RawClient.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedVersion.Core.BaseRequest request)
+    private string BuildUrl(global::SeedVersion.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/RawClient.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedVersion.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/version/src/SeedVersion/User/UserClient.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/User/UserClient.cs
@@ -28,7 +28,6 @@ public partial class UserClient : IUserClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(userId)),
                     Headers = _headers,

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedApi.Core.BaseRequest request)
+    private string BuildUrl(global::SeedApi.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedWebhooks.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/RawClient.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedWebhooks.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/RawClient.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedWebhooks.Core.BaseRequest request)
+    private string BuildUrl(global::SeedWebhooks.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedWebsocketBearerAuth.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedWebsocketBearerAuth.Core.BaseRequest request)
+    private string BuildUrl(global::SeedWebsocketBearerAuth.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedWebsocketBearerAuth.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Auth/AuthClient.cs
@@ -29,7 +29,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
@@ -93,7 +92,6 @@ public partial class AuthClient : IAuthClient
             .SendRequestAsync(
                 new JsonRequest
                 {
-                    BaseUrl = _client.Options.BaseUrl,
                     Method = HttpMethod.Post,
                     Path = "/token/refresh",
                     Body = request,

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedWebsocketAuth.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedWebsocketAuth.Core.BaseRequest request)
+    private string BuildUrl(global::SeedWebsocketAuth.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedWebsocketAuth.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedWebsocket.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedWebsocket.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedWebsocket.Core.BaseRequest request)
+    private string BuildUrl(global::SeedWebsocket.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/BaseRequest.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/BaseRequest.cs
@@ -6,7 +6,7 @@ namespace SeedWebsocket.Core;
 
 internal abstract record BaseRequest
 {
-    internal required string BaseUrl { get; init; }
+    internal string? BaseUrl { get; init; }
 
     internal required HttpMethod Method { get; init; }
 

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/RawClient.cs
@@ -277,6 +277,7 @@ internal partial class RawClient(ClientOptions clientOptions)
     private string BuildUrl(global::SeedWebsocket.Core.BaseRequest request)
     {
         var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
+
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/RawClient.cs
@@ -274,9 +274,9 @@ internal partial class RawClient(ClientOptions clientOptions)
         return httpRequest;
     }
 
-    private static string BuildUrl(global::SeedWebsocket.Core.BaseRequest request)
+    private string BuildUrl(global::SeedWebsocket.Core.BaseRequest request)
     {
-        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl;
+        var baseUrl = request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl;
         var trimmedBaseUrl = baseUrl.TrimEnd('/');
         var trimmedBasePath = request.Path.TrimStart('/');
         var url = $"{trimmedBaseUrl}/{trimmedBasePath}";


### PR DESCRIPTION
## Description

Linear ticket: Closes [FER-2768](https://linear.app/buildwithfern/issue/FER-2768/make-baseurl-optional-in-apirequest)

Removes the redundant `BaseUrl = _client.Options.BaseUrl` from every generated API request. `BaseUrl` is now only emitted when explicitly needed (i.e., multiple-base-URL environments). The `RawClient` falls back to `Options.BaseUrl` automatically for single-base-URL environments.

Link to Devin Session: https://app.devin.ai/sessions/5ff1ec2a1f684169bf4a9584bfc9ecd5
Requested by: @Swimburger

## Changes Made

- **`BaseRequest.Template.cs`**: Changed `BaseUrl` from `required string` to `string?` (optional, nullable)
- **`RawClient.Template.cs`**: Uses EJS conditional (`hasBaseUrl`) to select the correct `BuildUrl` implementation:
  - **Single-base-URL / no environment**: instance method with `Options.BaseUrl` fallback (`request.Options?.BaseUrl ?? request.BaseUrl ?? Options.BaseUrl`)
  - **Multiple-base-URL**: static method without `Options.BaseUrl` fallback (`request.Options?.BaseUrl ?? request.BaseUrl`), since `ClientOptions` has an `Environment` property instead of `BaseUrl`
- **`GeneratorContext.ts`**: Added `hasBaseUrl()` method — returns `true` when the IR environment type is NOT `multipleBaseUrls`
- **`CsharpProject.ts`**: Passes `hasBaseUrl` template variable to all template rendering call sites
- **`HttpEndpointGenerator.ts`**: `getBaseURLForEndpoint` now returns `undefined` for single-base-URL cases instead of always returning `_client.Options.BaseUrl`
- **`RawClient.ts`**: Made `baseUrl` parameter optional; conditionally includes it in the request args only when provided
- **`versions.yml`**: Added version 2.22.9 changelog entry
- 580+ seed snapshot files updated (removed `BaseUrl = _client.Options.BaseUrl` from generated single-URL endpoint code)
- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- [ ] Unit tests added/updated — existing test templates (`RetriesTests`, `MultipartFormTests`) still explicitly set `BaseUrl` and continue to work
- [x] All 144 seed test fixtures pass (`pnpm seed test --generator csharp-sdk --skip-scripts`)
- [x] Multi-base-URL fixtures (`multi-url-environment`, `multi-url-environment-no-default`) verified: `BuildUrl` is `static` with no `Options.BaseUrl` reference
- [x] Single-base-URL fixtures verified: `BuildUrl` is an instance method with `Options.BaseUrl` fallback

## Review Checklist

> **⚠️ NullReferenceException risk**: If all of `request.Options?.BaseUrl`, `request.BaseUrl`, and `Options.BaseUrl` are null, `BuildUrl` will call `TrimEnd('/')` on null. This should not happen in practice since client construction always sets a base URL, but worth confirming.

> **Multi-base-URL safety**: The `hasBaseUrl` conditional ensures `Options.BaseUrl` is never referenced for `multipleBaseUrls` environments (where `ClientOptions` has `Environment` instead of `BaseUrl`). Verify the `hasBaseUrl()` logic in `GeneratorContext.ts` covers all environment type variants correctly.

> **Seed tests run with `--skip-scripts`**: Snapshot generation passed but actual C# compilation was not run as part of this PR's local testing. CI should run full compilation to confirm no compile errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
