### PR TITLE
chore(generator-cli): use generateToString() in reference generator tests

### DIFF
--- a/packages/generator-cli/src/__test__/reference-generator.test.ts
+++ b/packages/generator-cli/src/__test__/reference-generator.test.ts
@@ -1,4 +1,3 @@
-import { PassThrough } from "stream";
 import type { FernGeneratorCli } from "../configuration/sdk/index.js";
 import { ReferenceGenerator } from "../reference/ReferenceGenerator.js";
 
@@ -31,13 +30,7 @@ describe("ReferenceGenerator", () => {
             };
 
             const generator = new ReferenceGenerator({ referenceConfig: config });
-            const output = new PassThrough();
-            const chunks: Buffer[] = [];
-
-            output.on("data", (chunk) => chunks.push(chunk));
-
-            await generator.generate({ output: output as any });
-            const result = Buffer.concat(chunks).toString();
+            const result = await generator.generateToString();
 
             // Snapshot the output for visual inspection
             await expect(result).toMatchFileSnapshot("./__snapshots__/html-encoding-code-blocks.md");
@@ -79,13 +72,7 @@ describe("ReferenceGenerator", () => {
             };
 
             const generator = new ReferenceGenerator({ referenceConfig: config });
-            const output = new PassThrough();
-            const chunks: Buffer[] = [];
-
-            output.on("data", (chunk) => chunks.push(chunk));
-
-            await generator.generate({ output: output as any });
-            const result = Buffer.concat(chunks).toString();
+            const result = await generator.generateToString();
 
             // Snapshot the output for visual inspection
             await expect(result).toMatchFileSnapshot("./__snapshots__/no-encoding-parameter-backticks.md");
@@ -125,13 +112,7 @@ describe("ReferenceGenerator", () => {
             };
 
             const generator = new ReferenceGenerator({ referenceConfig: config });
-            const output = new PassThrough();
-            const chunks: Buffer[] = [];
-
-            output.on("data", (chunk) => chunks.push(chunk));
-
-            await generator.generate({ output: output as any });
-            const result = Buffer.concat(chunks).toString();
+            const result = await generator.generateToString();
 
             // Snapshot the output for visual inspection
             await expect(result).toMatchFileSnapshot("./__snapshots__/linked-parameter-no-encoding.md");
@@ -166,13 +147,7 @@ describe("ReferenceGenerator", () => {
             };
 
             const generator = new ReferenceGenerator({ referenceConfig: config });
-            const output = new PassThrough();
-            const chunks: Buffer[] = [];
-
-            output.on("data", (chunk) => chunks.push(chunk));
-
-            await generator.generate({ output: output as any });
-            const result = Buffer.concat(chunks).toString();
+            const result = await generator.generateToString();
 
             // Snapshot the output for visual inspection
             await expect(result).toMatchFileSnapshot("./__snapshots__/linked-return-value-encoding.md");
@@ -338,13 +313,7 @@ describe("ReferenceGenerator", () => {
             };
 
             const generator = new ReferenceGenerator({ referenceConfig: config });
-            const output = new PassThrough();
-            const chunks: Buffer[] = [];
-
-            output.on("data", (chunk) => chunks.push(chunk));
-
-            await generator.generate({ output: output as any });
-            const result = Buffer.concat(chunks).toString();
+            const result = await generator.generateToString();
 
             // Snapshot the comprehensive output
             await expect(result).toMatchFileSnapshot("./__snapshots__/comprehensive-reference.md");


### PR DESCRIPTION
## Description

Refs #13040

Follows up on the `StringWriter` reliability fix by consolidating duplicated string-accumulator patterns and simplifying reference generator tests.

[Link to Devin Session](https://app.devin.ai/sessions/5cef9ea268b04a5ea345f60712f1d1f8) | Requested by: @Swimburger

## Changes Made

### 1. Reference generator tests → `generateToString()`

- Replaced the `PassThrough` stream + chunk collection pattern in all 5 `ReferenceGenerator` test cases with direct `generateToString()` calls
- Removed the `import { PassThrough } from "stream"` import (no longer needed)
- Eliminated `as any` casts that were required because `PassThrough` doesn't satisfy the `fs.WriteStream` type

Each test case previously had this boilerplate:
```ts
const output = new PassThrough();
const chunks: Buffer[] = [];
output.on("data", (chunk) => chunks.push(chunk));
await generator.generate({ output: output as any });
const result = Buffer.concat(chunks).toString();
```
Now simplified to:
```ts
const result = await generator.generateToString();
```

No snapshot files or assertions were changed — only the mechanism for obtaining the output string.

### 2. Extract `StringWriter` to `@fern-api/core-utils`

- Created a shared `StringWriter` class in `@fern-api/core-utils` — a simple synchronous in-memory string accumulator with `write()`, `writeLine()`, and `toString()`
- Updated `generator-cli`'s async `StringWriter` to delegate to the core-utils one internally (preserving the `Writer` abstract class contract)
- Replaced the local `FileWriter` class in `FernDefinitionFileFormatter` with the shared `StringWriter`, eliminating a duplicated pattern
- Added `@fern-api/core-utils` as a runtime dependency of `@fern-api/generator-cli`

## Testing

- [x] Unit tests pass (`pnpm --filter @fern-api/generator-cli test` — 83 passed)
- [x] Formatter tests pass (`pnpm --filter @fern-api/fern-definition-formatter test` — 6 passed)
- [x] Lint passes (`pnpm run check`)

### Human Review Checklist
- [ ] Verify no test cases were dropped — there should still be exactly 5 test cases under the "HTML encoding" describe block
- [ ] Confirm all snapshot assertions remain unchanged
- [ ] Verify adding `@fern-api/core-utils` as a runtime dep of `generator-cli` doesn't introduce circular dependencies or bundle issues
- [ ] Confirm `StringWriter.toString()` is a suitable replacement for the old `FileWriter.getContent()` in the formatter (same behavior, different method name)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
