### PR TITLE
chore(generator-cli): extract StringWriter to @fern-api/core-utils and reuse in formatter

### DIFF
--- a/packages/cli/fern-definition/formatter/src/FernDefinitionFileFormatter.ts
+++ b/packages/cli/fern-definition/formatter/src/FernDefinitionFileFormatter.ts
@@ -1,4 +1,4 @@
-import { assertNever, assertNeverNoThrow } from "@fern-api/core-utils";
+import { assertNever, assertNeverNoThrow, StringWriter } from "@fern-api/core-utils";
 import { RawSchemas } from "@fern-api/fern-definition-schema";
 import * as YAML from "yaml";
 
@@ -28,7 +28,7 @@ export class FernDefinitionFileFormatter {
         if (this.formatted == null) {
             const { header, body } = await this.splitFileAtHeader();
 
-            const writer = new FileWriter();
+            const writer = new StringWriter();
 
             if (!this.fileContents.includes("yaml-language-server")) {
                 writer.writeLine(LANG_SERVER_BANNER);
@@ -46,7 +46,7 @@ export class FernDefinitionFileFormatter {
             while (!reader.isEof()) {
                 location = this.writeNextLine({ nextLine: reader.readNextLine(), writer, location });
             }
-            this.formatted = await this.prettierFormat(writer.getContent());
+            this.formatted = await this.prettierFormat(writer.toString());
         }
         return this.formatted;
     }
@@ -83,7 +83,7 @@ export class FernDefinitionFileFormatter {
         location: previousLocation
     }: {
         nextLine: string;
-        writer: FileWriter;
+        writer: StringWriter;
         location: FernFileCursorLocation;
     }): FernFileCursorLocation {
         const newCursorLocation = this.getNewCursorLocation({ previousLocation, line: nextLine });
@@ -199,24 +199,5 @@ class LineReader {
             throw new Error("EOF");
         }
         return nextLine;
-    }
-}
-
-class FileWriter {
-    private content = "";
-
-    public write(content: string): void {
-        this.content += content;
-    }
-
-    public writeLine(content?: string): void {
-        if (content != null) {
-            this.write(content);
-        }
-        this.write("\n");
-    }
-
-    public getContent(): string {
-        return this.content;
     }
 }

--- a/packages/commons/core-utils/src/StringWriter.ts
+++ b/packages/commons/core-utils/src/StringWriter.ts
@@ -1,0 +1,23 @@
+/**
+ * A simple in-memory string accumulator for building text content.
+ * Use this instead of creating custom writer classes or using Node.js
+ * streams when you just need to collect string output.
+ */
+export class StringWriter {
+    private content = "";
+
+    public write(content: string): void {
+        this.content += content;
+    }
+
+    public writeLine(content?: string): void {
+        if (content != null) {
+            this.write(content);
+        }
+        this.write("\n");
+    }
+
+    public toString(): string {
+        return this.content;
+    }
+}

--- a/packages/commons/core-utils/src/index.ts
+++ b/packages/commons/core-utils/src/index.ts
@@ -38,6 +38,7 @@ export { parseEndpointLocator } from "./parseEndpointLocator.js";
 export { PLATFORM, type Platform } from "./platform.js";
 export { removeSuffix } from "./removeSuffix.js";
 export { replaceEnvVariables } from "./replaceEnvVars.js";
+export { StringWriter } from "./StringWriter.js";
 export { SymbolRegistry, type SymbolRegistryOptions } from "./SymbolRegistry.js";
 export { SKIP_MARKER, sanitizeNullValues } from "./sanitizeNullValues.js";
 export { diffSemverOrThrow, parseSemverOrThrow } from "./semverUtils.js";

--- a/packages/generator-cli/build.mjs
+++ b/packages/generator-cli/build.mjs
@@ -37,7 +37,7 @@ async function main() {
     await tsup.build({
         ...commonConfig,
         entry: ["src/api.ts"],
-        noExternal: ["@fern-api/github", "@fern-api/fs-utils"],
+        noExternal: ["@fern-api/core-utils", "@fern-api/github", "@fern-api/fs-utils"],
         external: ["@fern-api/replay", "@octokit/rest", "es-toolkit", "tmp-promise"],
         clean: false
     });

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -23,6 +23,7 @@
   },
   "files": ["bin", "dist", "lib"],
   "dependencies": {
+    "@fern-api/core-utils": "workspace:*",
     "@fern-api/replay": "^0.6.2",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/src/utils/Writer.ts
+++ b/packages/generator-cli/src/utils/Writer.ts
@@ -1,3 +1,4 @@
+import { StringWriter as CoreStringWriter } from "@fern-api/core-utils";
 import fs from "fs";
 
 export abstract class Writer {
@@ -81,15 +82,15 @@ export class StreamWriter extends Writer {
 }
 
 export class StringWriter extends Writer {
-    private content: string;
+    private delegate: CoreStringWriter;
 
     constructor() {
         super();
-        this.content = "";
+        this.delegate = new CoreStringWriter();
     }
 
     public async write(content: string): Promise<void> {
-        this.content += content;
+        this.delegate.write(content);
     }
 
     public async end(): Promise<void> {
@@ -97,6 +98,6 @@ export class StringWriter extends Writer {
     }
 
     public toString(): string {
-        return this.content;
+        return this.delegate.toString();
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8228,6 +8228,9 @@ importers:
 
   packages/generator-cli:
     dependencies:
+      '@fern-api/core-utils':
+        specifier: workspace:*
+        version: link:../commons/core-utils
       '@fern-api/replay':
         specifier: ^0.6.2
         version: 0.6.2


### PR DESCRIPTION
## Description

Refs #13040

Extracts the in-memory string accumulator pattern into a shared `StringWriter` class in `@fern-api/core-utils`, replacing the duplicated `FileWriter` in `FernDefinitionFileFormatter` and consolidating with `generator-cli`'s `StringWriter`.

[Link to Devin Session](https://app.devin.ai/sessions/5cef9ea268b04a5ea345f60712f1d1f8) | Requested by: @Swimburger

## Changes Made

- Created `StringWriter` in `@fern-api/core-utils` — a simple synchronous string accumulator with `write()`, `writeLine()`, and `toString()`
- Replaced the local `FileWriter` class in `FernDefinitionFileFormatter` with the shared `StringWriter` (note: `getContent()` → `toString()`)
- Updated `generator-cli`'s async `StringWriter` to delegate to the core-utils one internally
- Added `@fern-api/core-utils` as a runtime dependency of `@fern-api/generator-cli`
- **Added `@fern-api/core-utils` to `noExternal` in `build.mjs`** so the unpublished workspace dep is bundled into the API build (caught by Devin Review — without this, published npm package would fail to resolve the dependency)

## Testing

- [x] Unit tests pass (`pnpm --filter @fern-api/generator-cli test` — 83 passed)
- [x] Formatter tests pass (`pnpm --filter @fern-api/fern-definition-formatter test` — 6 passed)
- [x] Lint passes (`pnpm run check`)

### Review Checklist
- [ ] Verify the `build.mjs` change correctly bundles `@fern-api/core-utils` into the API build output — the CLI build already bundles everything via `noExternal: [/.*/]`
- [ ] Consider whether the delegation pattern in `generator-cli`'s `StringWriter` (wrapping core-utils `StringWriter`) is worth the indirection vs. keeping the one-liner `this.content += content` inline
- [ ] No dedicated unit tests for the new core-utils `StringWriter` — it's tested indirectly through formatter and generator-cli tests. Decide if standalone tests are desired.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
