### PR TITLE
fix(typescript): guard _handleAbort against duplicate close events

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.53.1
+  changelogEntry:
+    - summary: |
+        Fix duplicate close event in WebSocket `_handleAbort` when `close()` was already called.
+        The abort handler now checks `_closeCalled` before dispatching a close event, preventing
+        applications from receiving duplicate close notifications.
+      type: fix
+  createdAt: "2026-03-02"
+  irVersion: 65
+
 - version: 3.53.0
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/websocket/ws.ts
+++ b/generators/typescript/utils/core-utilities/src/core/websocket/ws.ts
@@ -407,6 +407,9 @@ export class ReconnectingWebSocket {
     }
 
     private _handleAbort = () => {
+        if (this._closeCalled) {
+            return;
+        }
         this._debug("abort signal fired");
         this._shouldReconnect = false;
         this._closeCalled = true;

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/websocket/ws.ts
@@ -407,6 +407,9 @@ export class ReconnectingWebSocket {
     }
 
     private _handleAbort = () => {
+        if (this._closeCalled) {
+            return;
+        }
         this._debug("abort signal fired");
         this._shouldReconnect = false;
         this._closeCalled = true;

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/websocket/ws.ts
@@ -407,6 +407,9 @@ export class ReconnectingWebSocket {
     }
 
     private _handleAbort = () => {
+        if (this._closeCalled) {
+            return;
+        }
         this._debug("abort signal fired");
         this._shouldReconnect = false;
         this._closeCalled = true;

--- a/seed/ts-sdk/websocket/no-serde/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/websocket/ws.ts
@@ -407,6 +407,9 @@ export class ReconnectingWebSocket {
     }
 
     private _handleAbort = () => {
+        if (this._closeCalled) {
+            return;
+        }
         this._debug("abort signal fired");
         this._shouldReconnect = false;
         this._closeCalled = true;

--- a/seed/ts-sdk/websocket/serde/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/websocket/ws.ts
@@ -407,6 +407,9 @@ export class ReconnectingWebSocket {
     }
 
     private _handleAbort = () => {
+        if (this._closeCalled) {
+            return;
+        }
         this._debug("abort signal fired");
         this._shouldReconnect = false;
         this._closeCalled = true;


### PR DESCRIPTION
## Description

Refs FER-5100

Fixes a bug in the WebSocket `ReconnectingWebSocket._handleAbort` handler where calling `close()` followed by `controller.abort()` would dispatch a duplicate close event to all registered `onclose` handlers and `close` event listeners.

[Link to Devin Session](https://app.devin.ai/sessions/0ac79e44b3f542bb92bc512dc1fffd97)
Requested by: @Swimburger

## Changes Made

- Added an early `if (this._closeCalled) return;` guard at the top of `_handleAbort` in `ReconnectingWebSocket` to skip abort handling when the connection was already closed via `close()` or `_disconnect()`
- Regenerated all websocket seed fixtures (`websocket-bearer-auth`, `websocket-inferred-auth`, `websocket/serde`, `websocket/no-serde`)
- Added `versions.yml` entry for v3.53.1 (fix)

## Testing

- [ ] Unit tests added/updated
- [x] Seed fixtures regenerated and passing
- [x] Manual verification: `close()` sets `_closeCalled = true` before the native close fires, so a subsequent abort signal correctly no-ops

## Review Checklist

- Verify the `_closeCalled` guard is sufficient — are there edge cases where `_closeCalled` is false but `_handleAbort` should still be skipped?
- Confirm no other paths set `_closeCalled` unexpectedly early, which could cause legitimate abort signals to be swallowed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
