### PR TITLE
fix(generator-cli): await toMatchFileSnapshot in testGenerateReference.ts

### DIFF
--- a/packages/generator-cli/src/__test__/testGenerateReference.ts
+++ b/packages/generator-cli/src/__test__/testGenerateReference.ts
@@ -21,7 +21,7 @@ export function testGenerateReference({
 
             const args = [path.join(__dirname, "../../bin/cli"), "generate-reference", "--config", file.path];
             const { stdout } = await execa("node", args);
-            expect(stdout).toMatchFileSnapshot(`__snapshots__/${fixtureName}.md`);
+            await expect(stdout).toMatchFileSnapshot(`__snapshots__/${fixtureName}.md`);
         });
     });
 }


### PR DESCRIPTION
## Description

Adds missing `await` to a `toMatchFileSnapshot` assertion in `testGenerateReference.ts`. Vitest currently auto-awaits hanging assertions at the end of tests, but this behavior is deprecated and will cause test failures in Vitest 3.

Link to Devin Session: https://app.devin.ai/sessions/6dc72696ceab4f2b983cae7d6a60d336
Requested by: @Swimburger

## Changes Made

- Added `await` to `expect(stdout).toMatchFileSnapshot(...)` call in `packages/generator-cli/src/__test__/testGenerateReference.ts`
- This was the only unwaited `toMatchFileSnapshot` call found across the entire repo (all other ~180 usages already had `await`)

## Review Checklist

- [ ] Confirm `testGenerateReference` helper's test callback is already `async` (it is — line 17)
- [ ] Verify no other unwaited `toMatchFileSnapshot` calls were missed

## Testing

- No new tests needed — this fixes an existing test to properly await an async assertion
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
