### PR TITLE
fix(cli): extract properties from `oneOf/anyOf` variants inside allOf in OpenAPI importer

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
@@ -178,9 +178,60 @@ export function convertObject({
                 }
                 return property;
             });
-            const allOfSchema = convertSchema(allOfElement, false, false, context, breadcrumbs, source, namespace);
-            if (allOfSchema.type === "object") {
-                inlinedParentProperties.push(...allOfSchema.properties);
+
+            // When an inline allOf element is a oneOf/anyOf (no type, no properties of its own),
+            // extract properties from each variant and make them optional.
+            // This handles patterns like allOf + oneOf used for mutual exclusion (e.g. content vs templateId).
+            const variants = allOfElement.oneOf ?? allOfElement.anyOf;
+            if (variants != null && allOfElement.type == null && allOfElement.properties == null) {
+                const seenKeys = new Set(inlinedParentProperties.map((p) => p.key));
+                for (const variantSchema of variants) {
+                    const resolvedVariantSchema = isReferenceObject(variantSchema)
+                        ? context.resolveSchemaReference(variantSchema)
+                        : variantSchema;
+                    // Filter out properties with `not: {}` schema (meaning "property must not exist")
+                    const filteredSchema = filterNotProperties(resolvedVariantSchema);
+                    const convertedVariantSchema = convertSchema(
+                        filteredSchema,
+                        false,
+                        false,
+                        context,
+                        breadcrumbs,
+                        source,
+                        namespace
+                    );
+                    if (convertedVariantSchema.type === "object") {
+                        for (const property of convertedVariantSchema.properties) {
+                            if (seenKeys.has(property.key)) {
+                                continue;
+                            }
+                            seenKeys.add(property.key);
+                            if (property.schema.type !== "optional" && property.schema.type !== "nullable") {
+                                inlinedParentProperties.push({
+                                    ...property,
+                                    schema: SchemaWithExample.optional({
+                                        nameOverride: undefined,
+                                        generatedName: "",
+                                        title: undefined,
+                                        value: property.schema,
+                                        description: undefined,
+                                        availability: property.availability,
+                                        namespace: undefined,
+                                        groupName: undefined,
+                                        inline: undefined
+                                    })
+                                });
+                            } else {
+                                inlinedParentProperties.push(property);
+                            }
+                        }
+                    }
+                }
+            } else {
+                const allOfSchema = convertSchema(allOfElement, false, false, context, breadcrumbs, source, namespace);
+                if (allOfSchema.type === "object") {
+                    inlinedParentProperties.push(...allOfSchema.properties);
+                }
             }
         }
     }
@@ -421,6 +472,26 @@ function getNonIgnoredProperties({
             return !shouldIgnore;
         })
     );
+}
+
+/**
+ * Filters out properties with `not: {}` schema from an OpenAPI schema object.
+ * In OpenAPI/JSON Schema, `not: {}` means "does not match any schema", effectively
+ * meaning the property must not be present. This pattern is commonly used in oneOf
+ * variants for mutual exclusion (e.g., content vs templateId).
+ */
+function filterNotProperties(schema: OpenAPIV3.SchemaObject): OpenAPIV3.SchemaObject {
+    if (schema.properties == null) {
+        return schema;
+    }
+    const filteredProperties: Record<string, OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject> = {};
+    for (const [key, propertySchema] of Object.entries(schema.properties)) {
+        if (!isReferenceObject(propertySchema) && "not" in propertySchema) {
+            continue;
+        }
+        filteredProperties[key] = propertySchema;
+    }
+    return { ...schema, properties: filteredProperties };
 }
 
 function getAllProperties({

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/allof-oneof-anyof-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/allof-oneof-anyof-edge-cases.json
@@ -872,9 +872,130 @@
             "type": "reference"
           }
         ],
-        "properties": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "complexTypeA",
+            "key": "typeA",
+            "schema": {
+              "generatedName": "ComplexTypeA",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "ComplexTypeA",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "complexTypeB",
+            "key": "typeB",
+            "schema": {
+              "generatedName": "ComplexTypeB",
+              "value": {
+                "schema": {
+                  "type": "double"
+                },
+                "generatedName": "ComplexTypeB",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
         "allOfPropertyConflicts": [],
         "generatedName": "Complex",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "SendTransacSms": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "sendTransacSmsRecipient",
+            "key": "recipient",
+            "schema": {
+              "description": "Mobile number to send SMS with the country code",
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "SendTransacSmsRecipient",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "sendTransacSmsSender",
+            "key": "sender",
+            "schema": {
+              "description": "Name of the sender",
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "SendTransacSmsSender",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "sendTransacSmsTemplateId",
+            "key": "templateId",
+            "schema": {
+              "generatedName": "",
+              "value": {
+                "description": "Template ID to send SMS",
+                "schema": {
+                  "type": "int"
+                },
+                "generatedName": "SendTransacSmsTemplateId",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "sendTransacSmsContent",
+            "key": "content",
+            "schema": {
+              "generatedName": "",
+              "value": {
+                "description": "Content of the message",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "SendTransacSmsContent",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "SendTransacSms",
         "groupName": [],
         "additionalProperties": false,
         "source": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/allof-oneof-anyof-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/allof-oneof-anyof-edge-cases.json
@@ -136,7 +136,10 @@
               "Base",
             ],
             "inline": undefined,
-            "properties": {},
+            "properties": {
+              "typeA": "optional<string>",
+              "typeB": "optional<double>",
+            },
             "source": {
               "openapi": "../openapi.yml",
             },
@@ -291,6 +294,31 @@
             "properties": {
               "data": "optional<string>",
               "success": "optional<boolean>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "SendTransacSms": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "content": {
+                "docs": "Content of the message",
+                "type": "optional<string>",
+              },
+              "recipient": {
+                "docs": "Mobile number to send SMS with the country code",
+                "type": "string",
+              },
+              "sender": {
+                "docs": "Name of the sender",
+                "type": "string",
+              },
+              "templateId": {
+                "docs": "Template ID to send SMS",
+                "type": "optional<integer>",
+              },
             },
             "source": {
               "openapi": "../openapi.yml",
@@ -460,9 +488,27 @@ types:
     source:
       openapi: ../openapi.yml
   Complex:
-    properties: {}
+    properties:
+      typeA: optional<string>
+      typeB: optional<double>
     extends:
       - Base
+    source:
+      openapi: ../openapi.yml
+  SendTransacSms:
+    properties:
+      recipient:
+        type: string
+        docs: Mobile number to send SMS with the country code
+      sender:
+        type: string
+        docs: Name of the sender
+      templateId:
+        type: optional<integer>
+        docs: Template ID to send SMS
+      content:
+        type: optional<string>
+        docs: Content of the message
     source:
       openapi: ../openapi.yml
 ",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/allof-oneof-anyof-edge-cases/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/allof-oneof-anyof-edge-cases/openapi.yml
@@ -173,3 +173,37 @@ components:
               properties:
                 typeB:
                   type: number
+
+    # Reproduces getbrevo/brevo-python#20: allOf + oneOf with not:{} for mutual exclusion
+    SendTransacSms:
+      allOf:
+        - type: object
+          properties:
+            recipient:
+              description: Mobile number to send SMS with the country code
+              type: string
+            sender:
+              description: Name of the sender
+              type: string
+          required:
+            - recipient
+            - sender
+        - oneOf:
+            - type: object
+              required:
+                - templateId
+              properties:
+                templateId:
+                  description: Template ID to send SMS
+                  type: integer
+                content:
+                  not: {}
+            - type: object
+              required:
+                - content
+              properties:
+                content:
+                  description: Content of the message
+                  type: string
+                templateId:
+                  not: {}

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.98.2
+  changelogEntry:
+    - summary: |
+        Fix OpenAPI importer dropping properties from `oneOf`/`anyOf` variants inside `allOf`.
+        When an `allOf` element is a bare `oneOf`/`anyOf` (commonly used for mutual exclusion
+        patterns like `content` vs `templateId`), the importer now extracts properties from
+        each variant as optional properties on the parent object. Also filters out properties
+        with `not: {}` schema (meaning "property must not exist").
+      type: fix
+  createdAt: "2026-03-02"
+  irVersion: 65
+
 - version: 3.98.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs [getbrevo/brevo-python#20](https://github.com/getbrevo/brevo-python/issues/20)

When an `allOf` element is a bare `oneOf`/`anyOf` (used for mutual exclusion patterns), the importer was silently dropping all properties from the variants. This caused parameters like `content` and `templateId` to be missing from generated SDKs and docs.

**Root cause:** The Fern CLI has **two separate OpenAPI importer pipelines**:
1. **`openapi-ir-parser`** (old) — used by `write-definition`, `generate`
2. **`v3-importer-commons`** (new) — used by `ir --direct-from-openapi`, docs registration/publishing

Both pipelines had the same bug: inline allOf elements that are bare `oneOf`/`anyOf` were either converted to undiscriminated unions (old) or merged incorrectly (new), causing variant properties to be silently dropped.

Link to Devin session: https://app.devin.ai/sessions/791f7ffe2e1048a98405e5592683bb8a
Requested by: @iamnamananand996

## Changes Made

### Old importer (`openapi-ir-parser`)
- **`convertObject.ts`**: When an inline allOf element is a bare `oneOf`/`anyOf` (no `type`, no `properties` of its own), extract properties from each variant as **optional** properties on the parent object, with deduplication by key
- **`convertObject.ts`**: Added `filterNotProperties()` helper to strip out properties with `not: {}` schema (JSON Schema pattern meaning "property must not exist"), commonly used in mutual exclusion patterns

### New importer (`v3-importer-commons`)
- **`SchemaConverter.ts`**: When `allOf` contains a bare `oneOf`/`anyOf` element, skip the allOf merge shortcut (which would lose the variant structure) and fall through to `ObjectSchemaConverter`
- **`ObjectSchemaConverter.ts`**: Added handling for bare `oneOf`/`anyOf` inside allOf — extracts properties from each variant as optional on the parent, filters `not: {}` properties, deduplicates by key

### Tests & config
- **Test fixture**: Added `SendTransacSms` schema to `allof-oneof-anyof-edge-cases` fixture reproducing the exact Brevo pattern (`allOf` + `oneOf` with `not: {}`)
- Updated snapshots — the existing `Complex` schema (which had the same underlying bug) now correctly exposes `typeA` and `typeB` as optional properties
- **`versions.yml`**: Added CLI changelog entry (v3.98.2)

## Testing

- [x] Existing test suite passes (259/259 tests)
- [x] Snapshot updates verified for both OpenAPI-IR and OpenAPI-to-Fern outputs
- [x] Lint (`biome check`) passes clean
- [x] All required CI checks pass

- [ ] **Manual testing needed**: v3-importer-commons path not covered by existing test fixtures (tests only exercise old parser)

## ⚠️ Human Review Checklist

1. **Behavioral change for existing `Complex` schema**: Previously `Complex` had `"properties": []` — now it correctly has `typeA: optional<string>` and `typeB: optional<double>`. This is a bug fix but changes generated output for any customer whose spec uses inline `oneOf` inside `allOf`.

2. **`filterNotProperties` breadth**: The filter checks for `"not" in propertySchema` — this catches `not: {}` but would also filter properties with `not: { type: "string" }` (i.e., any schema with a `not` keyword). This only runs within the oneOf-inside-allOf extraction path, but worth confirming this is acceptable.

3. **Properties made optional**: Properties that are `required` in individual oneOf variants (e.g., `templateId` required in variant 1, `content` required in variant 2) are extracted as **optional** on the parent schema. This is semantically correct for mutual exclusion patterns where the API validates exactly-one-of, but reviewers should verify this matches expectations.

4. **Two separate code paths**: The fix is implemented in both `openapi-ir-parser` (old) and `v3-importer-commons` (new). The logic is equivalent but not identical due to different APIs. The test fixture only exercises the old parser — v3 path should be tested manually or with additional fixtures.