### PR TITLE
fix(ci): add retry logic to Gradle build step in grype scan workflow

### DIFF
--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -382,7 +382,17 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Build the Java SDK distribution tar (Gradle)
-        run: cd generators/java && ./gradlew :sdk:distTar
+        run: |
+          cd generators/java
+          for attempt in 1 2 3; do
+            if ./gradlew :sdk:distTar; then
+              exit 0
+            fi
+            echo "::warning::Gradle build attempt $attempt/3 failed. Retrying in 15 seconds..."
+            sleep 15
+          done
+          echo "::error::Gradle build failed after 3 attempts"
+          exit 1
 
       - name: Build the Java v2 SDK CLI (TypeScript/Node)
         run: pnpm turbo run dist:cli --filter @fern-api/java-sdk


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/actions/runs/22576600711/job/65397391313

The nightly grype security scan workflow was failing because the Gradle wrapper download of `gradle-7.4.2-bin.zip` from `services.gradle.org` hit a transient network error (`SocketException: Unexpected end of file from server`).

## Changes Made

- Added a bash retry loop (up to 3 attempts with 15s delay) around the `./gradlew :sdk:distTar` step in the `create-grype-pr-java-sdk` job to handle transient network failures when downloading the Gradle distribution.

## Testing

- [ ] This is a CI workflow change — can only be validated by re-running the workflow

## Reviewer Checklist

- [ ] Verify the retry bash loop logic handles success/failure correctly
- [ ] Consider whether upgrading from Gradle 7.4.2 (from 2022) to a newer wrapper version should also be done as a follow-up to reduce likelihood of download issues

---

Link to Devin session: https://app.devin.ai/sessions/e1a3a0c4cf604db68f97c9abb1d6e7d1
Requested by: @davidkonigsberg