### PR TITLE
fix(java): replace vulnerable jackson-core 2.16.1 in Gradle base image (GHSA-72hv-8253-57qq)

### DIFF
--- a/generators/java/model/Dockerfile
+++ b/generators/java/model/Dockerfile
@@ -1,6 +1,12 @@
 # Apple Silicon: FROM gradle:latest
 FROM gradle:8.5.0-jdk17-jammy
 
+# Replace vulnerable jackson-core in Gradle distribution to fix GHSA-72hv-8253-57qq
+# (async parser bypasses maxNumberLength constraint, leading to potential DoS)
+RUN rm -f /opt/gradle/lib/jackson-core-*.jar && \
+    curl -sL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.18.6/jackson-core-2.18.6.jar \
+      -o /opt/gradle/lib/jackson-core-2.18.6.jar
+
 COPY build/distributions/model.tar init.sh /
 RUN cd / \
     && tar -xvf model.tar \

--- a/generators/java/model/Dockerfile
+++ b/generators/java/model/Dockerfile
@@ -5,7 +5,8 @@ FROM gradle:8.5.0-jdk17-jammy
 # (async parser bypasses maxNumberLength constraint, leading to potential DoS)
 RUN rm -f /opt/gradle/lib/jackson-core-*.jar && \
     curl -sL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.18.6/jackson-core-2.18.6.jar \
-      -o /opt/gradle/lib/jackson-core-2.18.6.jar
+      -o /opt/gradle/lib/jackson-core-2.18.6.jar && \
+    echo "e7e1bfa50f0a79db37e6aa37db111cf03aebf4a484b359d21127ab43ab2398c6  /opt/gradle/lib/jackson-core-2.18.6.jar" | sha256sum -c -
 
 COPY build/distributions/model.tar init.sh /
 RUN cd / \

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -25,6 +25,12 @@ RUN rm -f /opt/gradle/lib/plugins/org.eclipse.jgit-*.jar \
        /opt/gradle/lib/plugins/eddsa-*.jar \
        /opt/gradle/lib/kotlin-stdlib-*.jar
 
+# Replace vulnerable jackson-core in Gradle distribution to fix GHSA-72hv-8253-57qq
+# (async parser bypasses maxNumberLength constraint, leading to potential DoS)
+RUN rm -f /opt/gradle/lib/jackson-core-*.jar && \
+    curl -sL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.18.6/jackson-core-2.18.6.jar \
+      -o /opt/gradle/lib/jackson-core-2.18.6.jar
+
 # Update packages to get latest security fixes and remove unnecessary packages
 # Amazon Linux 2023 uses dnf instead of apt-get
 # Note: Amazon Linux 2023 has fewer pre-installed packages than Ubuntu, so we only

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -29,7 +29,8 @@ RUN rm -f /opt/gradle/lib/plugins/org.eclipse.jgit-*.jar \
 # (async parser bypasses maxNumberLength constraint, leading to potential DoS)
 RUN rm -f /opt/gradle/lib/jackson-core-*.jar && \
     curl -sL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.18.6/jackson-core-2.18.6.jar \
-      -o /opt/gradle/lib/jackson-core-2.18.6.jar
+      -o /opt/gradle/lib/jackson-core-2.18.6.jar && \
+    echo "e7e1bfa50f0a79db37e6aa37db111cf03aebf4a484b359d21127ab43ab2398c6  /opt/gradle/lib/jackson-core-2.18.6.jar" | sha256sum -c -
 
 # Update packages to get latest security fixes and remove unnecessary packages
 # Amazon Linux 2023 uses dnf instead of apt-get

--- a/generators/java/spring/Dockerfile
+++ b/generators/java/spring/Dockerfile
@@ -1,6 +1,12 @@
 # Apple Silicon: FROM gradle:latest
 FROM gradle:8.5.0-jdk17-jammy
 
+# Replace vulnerable jackson-core in Gradle distribution to fix GHSA-72hv-8253-57qq
+# (async parser bypasses maxNumberLength constraint, leading to potential DoS)
+RUN rm -f /opt/gradle/lib/jackson-core-*.jar && \
+    curl -sL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.18.6/jackson-core-2.18.6.jar \
+      -o /opt/gradle/lib/jackson-core-2.18.6.jar
+
 COPY build/distributions/spring.tar init.sh /
 RUN cd / \
     && tar -xvf spring.tar \

--- a/generators/java/spring/Dockerfile
+++ b/generators/java/spring/Dockerfile
@@ -5,7 +5,8 @@ FROM gradle:8.5.0-jdk17-jammy
 # (async parser bypasses maxNumberLength constraint, leading to potential DoS)
 RUN rm -f /opt/gradle/lib/jackson-core-*.jar && \
     curl -sL https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.18.6/jackson-core-2.18.6.jar \
-      -o /opt/gradle/lib/jackson-core-2.18.6.jar
+      -o /opt/gradle/lib/jackson-core-2.18.6.jar && \
+    echo "e7e1bfa50f0a79db37e6aa37db111cf03aebf4a484b359d21127ab43ab2398c6  /opt/gradle/lib/jackson-core-2.18.6.jar" | sha256sum -c -
 
 COPY build/distributions/spring.tar init.sh /
 RUN cd / \


### PR DESCRIPTION
## Description

Replaces the vulnerable `jackson-core` 2.16.1 jar bundled in the Gradle base Docker images with version 2.18.6, fixing [GHSA-72hv-8253-57qq](https://github.com/FasterXML/jackson-core/security/advisories/GHSA-72hv-8253-57qq) (HIGH severity — async JSON parser bypasses `maxNumberLength` constraint, potential DoS).

The generator's own dependencies were already bumped to 2.18.6 in `versions.props`, but the Gradle distribution embedded in the Docker image (`/opt/gradle/lib/jackson-core-2.16.1.jar`) still carried the vulnerable version, which is what the container scanner flagged.

Requested by: @davidkonigsberg
[Link to Devin Session](https://app.devin.ai/sessions/1551af51beb7414b8637143c5b2b4250)

## Changes Made

- **`generators/java/sdk/Dockerfile`**: Added `RUN` step to remove old jackson-core jar and download 2.18.6 from Maven Central (follows existing pattern for other CVE jar replacements)
- **`generators/java/model/Dockerfile`**: Same jackson-core replacement
- **`generators/java/spring/Dockerfile`**: Same jackson-core replacement
- All three Dockerfiles include SHA-256 checksum verification of the downloaded jar to guard against tampering

## Updates since last revision

- Added SHA-256 checksum verification (`sha256sum -c`) for the downloaded `jackson-core-2.18.6.jar` in all three Dockerfiles, addressing Graphite review bot feedback.

## Human Review Checklist

- [ ] Verify `curl` is available in the `gradle:8.5.0-jdk17-jammy` base image (used by model/spring). The SDK image (`gradle:jdk11-corretto`) already uses curl elsewhere.
- [ ] Confirm the hardcoded SHA-256 (`e7e1bfa50f0a...2398c6`) matches [Maven Central's published checksum](https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.18.6/jackson-core-2.18.6.jar.sha256) — it was computed by downloading the jar and hashing locally, not from an official `.sha256` file.
- [ ] Confirm jackson-core 2.18.6 is backward-compatible with Gradle's expectations (2.16.1 → 2.18.6, same 2.x line)
- [ ] Consider whether other jackson jars in `/opt/gradle/lib/` (e.g. jackson-databind, jackson-annotations) should also be replaced for consistency, even if not currently flagged by the scanner. A version mismatch between jackson-core and jackson-databind is low risk but worth noting.

## Testing

- [ ] Docker image builds (verified via CI)
- [ ] No unit test changes — this is a container-level dependency replacement