### PR TITLE
fix(cli): port allOf+oneOf property extraction to v3-importer-commons pipeline

### DIFF
--- a/packages/cli/api-importers/v3-importer-commons/src/converters/schema/ObjectSchemaConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/schema/ObjectSchemaConverter.ts
@@ -108,6 +108,80 @@ export class ObjectSchemaConverter extends AbstractConverter<
                 hasAdditionalProperties = true;
             }
 
+            // Handle bare oneOf/anyOf elements used for mutual exclusion patterns
+            // (e.g., oneOf with variants containing `not: {}` properties).
+            // Extract properties from each variant as optional properties on the parent object.
+            const variants = allOfSchema.oneOf ?? allOfSchema.anyOf;
+            if (variants != null && allOfSchema.type == null && allOfSchema.properties == null) {
+                const seenKeys = new Set(properties.map((p) => p.name.wireValue));
+                for (const [variantIndex, variantSchemaOrRef] of variants.entries()) {
+                    const variantBreadcrumbs = [
+                        ...breadcrumbs,
+                        allOfSchema.oneOf != null ? "oneOf" : "anyOf",
+                        variantIndex.toString()
+                    ];
+                    const variantSchema = this.context.isReferenceObject(variantSchemaOrRef)
+                        ? this.context.resolveMaybeReference<OpenAPIV3_1.SchemaObject>({
+                              schemaOrReference: variantSchemaOrRef,
+                              breadcrumbs: variantBreadcrumbs
+                          })
+                        : variantSchemaOrRef;
+                    if (variantSchema == null) {
+                        continue;
+                    }
+
+                    // Filter out properties with `not: {}` schema (meaning "property must not exist")
+                    const filteredProperties: Record<string, OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject> =
+                        {};
+                    for (const [key, propertySchema] of Object.entries(variantSchema.properties ?? {})) {
+                        if (!this.context.isReferenceObject(propertySchema) && "not" in propertySchema) {
+                            continue;
+                        }
+                        filteredProperties[key] = propertySchema;
+                    }
+
+                    // All properties from oneOf/anyOf variants are optional on the parent object
+                    // since only one variant's properties are present at a time
+                    const filteredKeys = Object.keys(filteredProperties).filter((key) => !seenKeys.has(key));
+                    if (filteredKeys.length === 0) {
+                        continue;
+                    }
+
+                    const filteredPropertiesForConvert: Record<
+                        string,
+                        OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject
+                    > = {};
+                    for (const key of filteredKeys) {
+                        const prop = filteredProperties[key];
+                        if (prop != null) {
+                            filteredPropertiesForConvert[key] = prop;
+                            seenKeys.add(key);
+                        }
+                    }
+
+                    const {
+                        convertedProperties: variantProperties,
+                        inlinedTypesFromProperties: inlinedTypesFromVariant,
+                        referencedTypes: variantReferencedTypes,
+                        propertiesByAudience: variantPropertiesByAudience
+                    } = convertProperties({
+                        properties: filteredPropertiesForConvert,
+                        required: [], // All variant properties are optional on the parent
+                        breadcrumbs: variantBreadcrumbs,
+                        context: this.context,
+                        errorCollector: this.context.errorCollector
+                    });
+
+                    properties.push(...variantProperties);
+                    inlinedTypes = { ...inlinedTypes, ...inlinedTypesFromVariant };
+                    propertiesByAudience = { ...propertiesByAudience, ...variantPropertiesByAudience };
+                    variantReferencedTypes.forEach((typeId) => {
+                        referencedTypes.add(typeId);
+                    });
+                }
+                continue;
+            }
+
             const {
                 convertedProperties: allOfProperties,
                 inlinedTypesFromProperties: inlinedTypesFromAllOf,

--- a/packages/cli/api-importers/v3-importer-commons/src/converters/schema/SchemaConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/schema/SchemaConverter.ts
@@ -196,6 +196,21 @@ export class SchemaConverter extends AbstractConverter<AbstractConverterContext<
             this.schema.allOf.length >= 1;
 
         if (shouldMergeAllOf) {
+            // Check if any allOf element is a bare oneOf/anyOf used for mutual exclusion
+            // (e.g., oneOf with variants containing `not: {}` properties).
+            // In this case, skip merging and let ObjectSchemaConverter handle it properly
+            // by extracting properties from each variant as optional.
+            const hasBareOneOfOrAnyOf = (this.schema.allOf ?? []).some((elem) => {
+                if (this.context.isReferenceObject(elem)) {
+                    return false;
+                }
+                return (elem.oneOf != null || elem.anyOf != null) && elem.type == null && elem.properties == null;
+            });
+
+            if (hasBareOneOfOrAnyOf) {
+                return undefined;
+            }
+
             let mergedSchema: Record<string, unknown> = {};
             for (const allOfSchema of this.schema.allOf ?? []) {
                 if (this.context.isReferenceObject(allOfSchema)) {

--- a/packages/cli/api-importers/v3-importer-commons/src/converters/schema/SchemaConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/schema/SchemaConverter.ts
@@ -196,26 +196,53 @@ export class SchemaConverter extends AbstractConverter<AbstractConverterContext<
             this.schema.allOf.length >= 1;
 
         if (shouldMergeAllOf) {
-            // Check if any allOf element is a bare oneOf/anyOf used for mutual exclusion
-            // (e.g., oneOf with variants containing `not: {}` properties).
-            // In this case, skip merging and let ObjectSchemaConverter handle it properly
-            // by extracting properties from each variant as optional.
-            const hasBareOneOfOrAnyOf = (this.schema.allOf ?? []).some((elem) => {
-                if (this.context.isReferenceObject(elem)) {
-                    return false;
-                }
-                return (elem.oneOf != null || elem.anyOf != null) && elem.type == null && elem.properties == null;
-            });
-
-            if (hasBareOneOfOrAnyOf) {
-                return undefined;
-            }
-
             let mergedSchema: Record<string, unknown> = {};
             for (const allOfSchema of this.schema.allOf ?? []) {
                 if (this.context.isReferenceObject(allOfSchema)) {
                     return undefined;
                 }
+
+                // Handle bare oneOf/anyOf elements used for mutual exclusion patterns
+                // (e.g., oneOf with variants containing `not: {}` properties).
+                // Flatten variant properties into the merged schema as optional properties.
+                const variants =
+                    (allOfSchema as OpenAPIV3_1.SchemaObject).oneOf ?? (allOfSchema as OpenAPIV3_1.SchemaObject).anyOf;
+                if (variants != null && allOfSchema.type == null && allOfSchema.properties == null) {
+                    const flattenedProperties: Record<string, unknown> = {};
+                    for (const variantSchemaOrRef of variants) {
+                        const variantSchema = this.context.isReferenceObject(variantSchemaOrRef)
+                            ? this.context.resolveMaybeReference<OpenAPIV3_1.SchemaObject>({
+                                  schemaOrReference: variantSchemaOrRef,
+                                  breadcrumbs: this.breadcrumbs
+                              })
+                            : variantSchemaOrRef;
+                        if (variantSchema == null) {
+                            continue;
+                        }
+                        for (const [key, propertySchema] of Object.entries(variantSchema.properties ?? {})) {
+                            // Filter out properties with `not: {}` schema (meaning "property must not exist")
+                            if (
+                                !this.context.isReferenceObject(
+                                    propertySchema as OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject
+                                ) &&
+                                "not" in (propertySchema as OpenAPIV3_1.SchemaObject)
+                            ) {
+                                continue;
+                            }
+                            if (!(key in flattenedProperties)) {
+                                flattenedProperties[key] = propertySchema;
+                            }
+                        }
+                    }
+                    if (Object.keys(flattenedProperties).length > 0) {
+                        // Add flattened properties as optional on the merged schema
+                        const existingProperties = (mergedSchema.properties as Record<string, unknown>) ?? {};
+                        mergedSchema.properties = { ...existingProperties, ...flattenedProperties };
+                        // Do not add to required — variant properties are optional on the parent
+                    }
+                    continue;
+                }
+
                 mergedSchema = mergeWith(mergedSchema, allOfSchema, (objValue, srcValue) => {
                     if (srcValue === allOfSchema) {
                         return objValue;


### PR DESCRIPTION
## Description

Refs [getbrevo/brevo-python#20](https://github.com/getbrevo/brevo-python/issues/20)
Follow-up to #13058

PR #13058 fixed the `allOf` + `oneOf` + `not: {}` mutual exclusion pattern in the **old** `openapi-ir-parser` pipeline (used by `write-definition`, `generate`). However, the **docs pipeline** (register/publish) and `ir --from-openapi` use a separate `v3-importer-commons` pipeline that still had the same bug — variant properties like `content` and `templateId` were silently dropped.

This PR ports the identical fix to the v3-importer-commons pipeline.

Link to Devin session: https://app.devin.ai/sessions/791f7ffe2e1048a98405e5592683bb8a
Requested by: @iamnamananand996

## Changes Made

- **`SchemaConverter.ts`**: During the allOf merge loop in `tryConvertSingularAllOfSchema`, when an allOf element is a bare `oneOf`/`anyOf` (no `type`, no `properties`), flatten the variant properties directly into the merged schema as optional properties instead of merging the raw oneOf element. Properties with `not: {}` schema are filtered out. This produces a single flat object in the IR rather than an undiscriminated union.
- **`ObjectSchemaConverter.ts`**: In the allOf processing loop within `tryConvertObjectAllOfSchema`, detect bare `oneOf`/`anyOf` elements and extract properties from each variant as **optional** on the parent object. Properties with `not: {}` schema (JSON Schema for "must not exist") are filtered out. Duplicate keys are skipped via a `seenKeys` set.

## Updates since last revision

- **Revised `SchemaConverter.ts` approach**: The initial commit returned `undefined` from `tryConvertSingularAllOfSchema` to skip the merge entirely. This caused the schema to fall through to `ObjectSchemaConverter`, which worked but still produced an `undiscriminatedUnion` in the IR (two variant types). The new approach flattens oneOf variant properties directly into the merged schema during the merge step, producing a cleaner flat object in the IR.

## ⚠️ Human Review Checklist

1. **No v3 pipeline tests added**: This PR has no new test coverage for the v3-importer-commons path. The original PR #13058 only tested the old parser. Consider whether snapshot tests should be added for the v3 converter.

2. **Dual handling in both SchemaConverter and ObjectSchemaConverter**: Both files now contain bare oneOf/anyOf handling logic. `SchemaConverter` flattens during the merge step (for allOf-only schemas that hit the merge path), while `ObjectSchemaConverter` handles it for schemas that reach the object conversion path directly. Verify these don't double-process the same schema. The `seenKeys` set in `ObjectSchemaConverter` should prevent duplicate properties, but worth tracing both paths.

3. **`"not" in propertySchema` filter breadth**: The filter catches *any* property with a `not` key, not just `not: {}`. In practice, `not` on a property-level schema is almost exclusively `not: {}`, but it would also filter a hypothetical `not: { type: "string" }`. Only runs within the oneOf-inside-allOf extraction path.

4. **Type casts in SchemaConverter**: The SchemaConverter merge loop uses `as OpenAPIV3_1.SchemaObject` and `as Record<string, unknown>` casts on the allOf elements and merged properties. These are necessary because the merge accumulator is `Record<string, unknown>`, but worth confirming the casts are safe.

5. **Behavioral change**: Any customer whose OpenAPI spec uses `allOf` with bare `oneOf`/`anyOf` will see additional optional properties surfaced in docs output that were previously silently dropped. This is a bug fix but changes generated output.

## Testing

- [x] Lint/format passes (`biome check`)
- [x] Manually verified against brevo-fern-config — docs preview shows single tab with all 9 properties
- [ ] No new unit tests — v3 pipeline path not covered by existing test fixtures