### PR TITLE
chore(cli): add versions.yml entry 3.98.4 for v3-importer-commons allOf+oneOf fix

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.98.4
+  changelogEntry:
+    - summary: |
+        Fix docs pipeline (v3-importer-commons) dropping properties from `oneOf`/`anyOf` variants
+        inside `allOf`. The old OpenAPI importer was fixed in 3.98.2, but the docs/register pipeline
+        used a separate v3-importer-commons path that still had the same bug. Properties like `content`
+        and `templateId` in mutual exclusion patterns (`not: {}`) are now correctly surfaced as optional
+        properties in generated docs.
+      type: fix
+  createdAt: "2026-03-02"
+  irVersion: 65
+
 - version: 3.98.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs #13068

Adds the missing `versions.yml` entry for PR #13068, which ported the `allOf` + `oneOf` + `not: {}` property extraction fix to the v3-importer-commons pipeline (used by docs/register). The code fix was merged without a version bump.

Link to Devin session: https://app.devin.ai/sessions/791f7ffe2e1048a98405e5592683bb8a
Requested by: @iamnamananand996

## Changes Made

- Added `versions.yml` entry for version **3.98.4** describing the v3-importer-commons fix

## ⚠️ Human Review Checklist

1. **Version number**: 3.98.4 is the next version after 3.98.3 — verify this is the intended version and no other PR has claimed it.
2. **Changelog accuracy**: The summary references the v3-importer-commons fix from #13068. Verify the description matches what was actually merged.

## Testing

- [ ] N/A — changelog-only change, no code modifications