### PR TITLE
fix(go): resolve datetime aliases in marshal/unmarshal code generation

### DIFF
--- a/generators/go/internal/generator/model.go
+++ b/generators/go/internal/generator/model.go
@@ -588,7 +588,7 @@ func (t *typeVisitor) VisitUnion(union *ir.UnionTypeDeclaration) error {
 		if unionType.Shape.SingleProperty != nil {
 			isLiteral = isLiteralType(unionType.Shape.SingleProperty.Type, t.writer.types)
 			isOptional = isOptionalType(unionType.Shape.SingleProperty.Type, t.writer.types)
-			date = maybeDate(unionType.Shape.SingleProperty.Type, isOptional)
+			date = maybeDate(unionType.Shape.SingleProperty.Type, isOptional, t.writer.types)
 		}
 		zeroValue := "nil"
 		if unionType.Shape.PropertiesType == "singleProperty" {
@@ -720,7 +720,7 @@ func (t *typeVisitor) VisitUnion(union *ir.UnionTypeDeclaration) error {
 		if unionType.Shape.SingleProperty != nil {
 			isLiteral = isLiteralType(unionType.Shape.SingleProperty.Type, t.writer.types)
 			isOptional = isOptionalType(unionType.Shape.SingleProperty.Type, t.writer.types)
-			date = maybeDate(unionType.Shape.SingleProperty.Type, isOptional)
+			date = maybeDate(unionType.Shape.SingleProperty.Type, isOptional, t.writer.types)
 		}
 		zeroValue := "nil"
 		if unionType.Shape.PropertiesType == "singleProperty" {
@@ -771,7 +771,7 @@ func (t *typeVisitor) VisitUnion(union *ir.UnionTypeDeclaration) error {
 		if unionType.Shape.SingleProperty != nil {
 			isLiteral = isLiteralType(unionType.Shape.SingleProperty.Type, t.writer.types)
 			isOptional = isOptionalType(unionType.Shape.SingleProperty.Type, t.writer.types)
-			date = maybeDate(unionType.Shape.SingleProperty.Type, isOptional)
+			date = maybeDate(unionType.Shape.SingleProperty.Type, isOptional, t.writer.types)
 		}
 		zeroValue := "nil"
 		if unionType.Shape.PropertiesType == "singleProperty" {
@@ -896,7 +896,7 @@ func (t *typeVisitor) VisitUndiscriminatedUnion(union *ir.UndiscriminatedUnionTy
 		hasLiteral = hasLiteral || isLiteral
 
 		isOptional := isOptionalType(unionMember.Type, t.writer.types)
-		date := maybeDate(unionMember.Type, isOptional)
+		date := maybeDate(unionMember.Type, isOptional, t.writer.types)
 
 		var (
 			valueMarshalerValue          = ""
@@ -1229,7 +1229,7 @@ func (t *typeVisitor) visitObjectProperties(
 			names = append(names, goExportedFieldName(property.Name.Name.PascalCase.UnsafeName))
 		}
 		t.writer.WriteDocs(property.Docs)
-		if date := maybeDateProperty(property.ValueType, property.Name, false); date != nil {
+		if date := maybeDateProperty(property.ValueType, property.Name, false, t.writer.types); date != nil {
 			dates = append(dates, date)
 		}
 		goType := typeReferenceToGoType(property.ValueType, t.writer.types, t.writer.scope, t.baseImportPath, t.importPath, includeOptionals)
@@ -1596,7 +1596,7 @@ func (c *singleUnionTypePropertiesVisitor) VisitSingleProperty(property *ir.Sing
 	c.goType = typeReferenceToGoType(property.Type, c.types, c.scope, c.baseImportPath, c.importPath, false)
 	c.zeroValue = zeroValueForTypeReference(property.Type, c.types)
 
-	if date := maybeDateProperty(property.Type, property.Name, false); date != nil {
+	if date := maybeDateProperty(property.Type, property.Name, false, c.types); date != nil {
 		c.valueMarshalerGoType = date.TypeDeclaration
 		c.valueMarshalerConstructor = date.Constructor
 		c.valueUnmarshalerMethodSuffix = fmt.Sprintf(".%s", date.TimeMethod)
@@ -2140,7 +2140,7 @@ func primitiveToUndiscriminatedUnionField(primitive *ir.PrimitiveType) string {
 	}
 }
 
-func maybeDateProperty(valueType *ir.TypeReference, name *common.NameAndWireValue, isOptional bool) *date {
+func maybeDateProperty(valueType *ir.TypeReference, name *common.NameAndWireValue, isOptional bool, types map[common.TypeId]*ir.TypeDeclaration) *date {
 	if valueType.Primitive != nil && valueType.Primitive.V1 == common.PrimitiveTypeV1Date {
 		var (
 			typeDeclaration = "*internal.Date"
@@ -2186,9 +2186,18 @@ func maybeDateProperty(valueType *ir.TypeReference, name *common.NameAndWireValu
 			IsDateTime:      true,
 		}
 	}
+	// Resolve named type aliases (e.g. DatetimeAlias -> datetime) so that
+	// alias fields get the same custom marshal/unmarshal helpers as their
+	// underlying primitive date/datetime types.
+	if valueType.Named != nil && types != nil {
+		typeDeclaration := types[valueType.Named.TypeId]
+		if typeDeclaration != nil && typeDeclaration.Shape.Alias != nil {
+			return maybeDateProperty(typeDeclaration.Shape.Alias.AliasOf, name, isOptional, types)
+		}
+	}
 	optionalOrNullableContainer := getOptionalOrNullableContainer(valueType)
 	if optionalOrNullableContainer != nil {
-		return maybeDateProperty(optionalOrNullableContainer, name, true)
+		return maybeDateProperty(optionalOrNullableContainer, name, true, types)
 	}
 	return nil
 }
@@ -2196,7 +2205,7 @@ func maybeDateProperty(valueType *ir.TypeReference, name *common.NameAndWireValu
 // maybeDate retrieves the type information for the given date, excluding
 // any property-oriented information. This is tailored to the undiscriminated
 // union use case.
-func maybeDate(valueType *ir.TypeReference, isOptional bool) *date {
+func maybeDate(valueType *ir.TypeReference, isOptional bool, types map[common.TypeId]*ir.TypeDeclaration) *date {
 	if valueType.Primitive != nil && valueType.Primitive.V1 == common.PrimitiveTypeV1Date {
 		var (
 			typeDeclaration = "*internal.Date"
@@ -2234,9 +2243,16 @@ func maybeDate(valueType *ir.TypeReference, isOptional bool) *date {
 			IsDateTime:      true,
 		}
 	}
+	// Resolve named type aliases (e.g. DatetimeAlias -> datetime).
+	if valueType.Named != nil && types != nil {
+		typeDeclaration := types[valueType.Named.TypeId]
+		if typeDeclaration != nil && typeDeclaration.Shape.Alias != nil {
+			return maybeDate(typeDeclaration.Shape.Alias.AliasOf, isOptional, types)
+		}
+	}
 	optionalOrNullableContainer := getOptionalOrNullableContainer(valueType)
 	if optionalOrNullableContainer != nil {
-		return maybeDate(optionalOrNullableContainer, true)
+		return maybeDate(optionalOrNullableContainer, true, types)
 	}
 	return nil
 }

--- a/generators/go/internal/generator/model.go
+++ b/generators/go/internal/generator/model.go
@@ -1961,7 +1961,7 @@ func urlTagForType(
 		`json:"-"`,
 	}
 	structTags = append(structTags, fmt.Sprintf(tagFormat, "url", wireValue))
-	if formatStructTag := maybeFormatStructTag(valueType); formatStructTag != "" {
+	if formatStructTag := maybeFormatStructTag(valueType, types); formatStructTag != "" {
 		structTags = append(structTags, formatStructTag)
 	}
 	return fmt.Sprintf("`%s`", strings.Join(structTags, " "))
@@ -1986,7 +1986,7 @@ func structTagForType(
 	for _, tag := range ignoreTags {
 		structTags = append(structTags, fmt.Sprintf(`%s:"-"`, tag))
 	}
-	if formatStructTag := maybeFormatStructTag(valueType); formatStructTag != "" {
+	if formatStructTag := maybeFormatStructTag(valueType, types); formatStructTag != "" {
 		structTags = append(structTags, formatStructTag)
 	}
 	if len(structTags) == 0 {
@@ -2260,24 +2260,31 @@ func maybeDate(valueType *ir.TypeReference, isOptional bool, types map[common.Ty
 // maybeFormatStructTag returns the layout struct tag for [optional] date types.
 // Note that we don't need to include a custom layout for DateTime because that
 // is the default format used for time.Time types.
-func maybeFormatStructTag(valueType *ir.TypeReference) string {
+func maybeFormatStructTag(valueType *ir.TypeReference, types map[common.TypeId]*ir.TypeDeclaration) string {
 	if valueType.Primitive != nil && valueType.Primitive.V1 == common.PrimitiveTypeV1Date {
 		return `format:"date"`
+	}
+	// Resolve named type aliases (e.g. DateAlias -> date).
+	if valueType.Named != nil && types != nil {
+		typeDeclaration := types[valueType.Named.TypeId]
+		if typeDeclaration != nil && typeDeclaration.Shape.Alias != nil {
+			return maybeFormatStructTag(typeDeclaration.Shape.Alias.AliasOf, types)
+		}
 	}
 	if valueType.Type != "container" {
 		return ""
 	}
 	switch valueType.Container.Type {
 	case "list":
-		return maybeFormatStructTag(valueType.Container.List)
+		return maybeFormatStructTag(valueType.Container.List, types)
 	case "map":
-		return maybeFormatStructTag(valueType.Container.Map.ValueType)
+		return maybeFormatStructTag(valueType.Container.Map.ValueType, types)
 	case "nullable":
-		return maybeFormatStructTag(valueType.Container.Nullable)
+		return maybeFormatStructTag(valueType.Container.Nullable, types)
 	case "optional":
-		return maybeFormatStructTag(valueType.Container.Optional)
+		return maybeFormatStructTag(valueType.Container.Optional, types)
 	case "set":
-		return maybeFormatStructTag(valueType.Container.Set)
+		return maybeFormatStructTag(valueType.Container.Set, types)
 	}
 	return ""
 }

--- a/generators/go/internal/generator/model/internal/time.go
+++ b/generators/go/internal/generator/model/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/generators/go/internal/generator/model/internal/time.go
+++ b/generators/go/internal/generator/model/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.27.0
+  changelogEntry:
+    - summary: |
+        Resolve datetime aliases in marshal/unmarshal code generation. Fields typed as
+        aliases of `datetime` or `date` (e.g. `DatetimeAlias: type: datetime`) now
+        correctly use the custom `internal.DateTime` / `internal.Date` serialization
+        helpers instead of falling back to default `time.Time` JSON handling. Also
+        relaxes `DateTime.UnmarshalJSON` to accept ISO 8601 timestamps without a
+        timezone suffix (e.g. `2024-01-15T09:30:00`), falling back from RFC 3339
+        when the timezone is absent.
+      type: fix
+  createdAt: "2026-03-02"
+  irVersion: 61
+
 - version: 1.26.1
   changelogEntry:
     - summary: |

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_DatetimeAlias.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_DatetimeAlias.json
@@ -1,0 +1,5 @@
+{
+  "type": "string",
+  "format": "date-time",
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithDatetimeAlias.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithDatetimeAlias.json
@@ -1,0 +1,44 @@
+{
+  "type": "object",
+  "properties": {
+    "datetime": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "datetimeAlias": {
+      "$ref": "#/definitions/types.object.DatetimeAlias"
+    },
+    "optionalDatetime": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "optionalDatetimeAlias": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/types.object.DatetimeAlias"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "required": [
+    "datetime",
+    "datetimeAlias"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "types.object.DatetimeAlias": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/seed/go-sdk/accept-header/internal/time.go
+++ b/seed/go-sdk/accept-header/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/accept-header/internal/time.go
+++ b/seed/go-sdk/accept-header/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/alias/internal/time.go
+++ b/seed/go-sdk/alias/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/alias/internal/time.go
+++ b/seed/go-sdk/alias/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/any-auth/internal/time.go
+++ b/seed/go-sdk/any-auth/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/any-auth/internal/time.go
+++ b/seed/go-sdk/any-auth/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/api-wide-base-path/internal/time.go
+++ b/seed/go-sdk/api-wide-base-path/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/api-wide-base-path/internal/time.go
+++ b/seed/go-sdk/api-wide-base-path/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/audiences/internal/time.go
+++ b/seed/go-sdk/audiences/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/audiences/internal/time.go
+++ b/seed/go-sdk/audiences/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/basic-auth-environment-variables/internal/time.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/basic-auth-environment-variables/internal/time.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/basic-auth/internal/time.go
+++ b/seed/go-sdk/basic-auth/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/basic-auth/internal/time.go
+++ b/seed/go-sdk/basic-auth/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/bearer-token-environment-variable/internal/time.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/bearer-token-environment-variable/internal/time.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/bytes-upload/internal/time.go
+++ b/seed/go-sdk/bytes-upload/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/bytes-upload/internal/time.go
+++ b/seed/go-sdk/bytes-upload/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/circular-references-advanced/internal/time.go
+++ b/seed/go-sdk/circular-references-advanced/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/circular-references-advanced/internal/time.go
+++ b/seed/go-sdk/circular-references-advanced/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/circular-references/internal/time.go
+++ b/seed/go-sdk/circular-references/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/circular-references/internal/time.go
+++ b/seed/go-sdk/circular-references/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/client-side-params/internal/time.go
+++ b/seed/go-sdk/client-side-params/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/client-side-params/internal/time.go
+++ b/seed/go-sdk/client-side-params/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/content-type/internal/time.go
+++ b/seed/go-sdk/content-type/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/content-type/internal/time.go
+++ b/seed/go-sdk/content-type/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/cross-package-type-names/internal/time.go
+++ b/seed/go-sdk/cross-package-type-names/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/cross-package-type-names/internal/time.go
+++ b/seed/go-sdk/cross-package-type-names/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/dollar-string-examples/internal/time.go
+++ b/seed/go-sdk/dollar-string-examples/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/dollar-string-examples/internal/time.go
+++ b/seed/go-sdk/dollar-string-examples/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/empty-clients/internal/time.go
+++ b/seed/go-sdk/empty-clients/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/empty-clients/internal/time.go
+++ b/seed/go-sdk/empty-clients/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/endpoint-security-auth/internal/time.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/endpoint-security-auth/internal/time.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/enum/internal/time.go
+++ b/seed/go-sdk/enum/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/enum/internal/time.go
+++ b/seed/go-sdk/enum/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/error-property/internal/time.go
+++ b/seed/go-sdk/error-property/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/error-property/internal/time.go
+++ b/seed/go-sdk/error-property/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/errors/internal/time.go
+++ b/seed/go-sdk/errors/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/errors/internal/time.go
+++ b/seed/go-sdk/errors/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/examples/always-send-required-properties/internal/time.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/examples/always-send-required-properties/internal/time.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/time.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/time.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/examples/client-name/internal/time.go
+++ b/seed/go-sdk/examples/client-name/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/examples/client-name/internal/time.go
+++ b/seed/go-sdk/examples/client-name/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/time.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/time.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/examples/exported-client-name/internal/time.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/examples/exported-client-name/internal/time.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/time.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/time.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/examples/no-custom-config/internal/time.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/examples/no-custom-config/internal/time.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/examples/readme-config/internal/time.go
+++ b/seed/go-sdk/examples/readme-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/examples/readme-config/internal/time.go
+++ b/seed/go-sdk/examples/readme-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/examples/v0/internal/time.go
+++ b/seed/go-sdk/examples/v0/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/examples/v0/internal/time.go
+++ b/seed/go-sdk/examples/v0/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/time.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/time.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/time.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/time.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/extends/internal/time.go
+++ b/seed/go-sdk/extends/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/extends/internal/time.go
+++ b/seed/go-sdk/extends/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/extra-properties/internal/time.go
+++ b/seed/go-sdk/extra-properties/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/extra-properties/internal/time.go
+++ b/seed/go-sdk/extra-properties/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/file-download/internal/time.go
+++ b/seed/go-sdk/file-download/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/file-download/internal/time.go
+++ b/seed/go-sdk/file-download/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/file-upload-openapi/internal/time.go
+++ b/seed/go-sdk/file-upload-openapi/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/file-upload-openapi/internal/time.go
+++ b/seed/go-sdk/file-upload-openapi/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/file-upload/no-custom-config/internal/time.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/file-upload/no-custom-config/internal/time.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/file-upload/package-name/internal/time.go
+++ b/seed/go-sdk/file-upload/package-name/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/file-upload/package-name/internal/time.go
+++ b/seed/go-sdk/file-upload/package-name/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/file-upload/v0/internal/time.go
+++ b/seed/go-sdk/file-upload/v0/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/file-upload/v0/internal/time.go
+++ b/seed/go-sdk/file-upload/v0/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/folders/internal/time.go
+++ b/seed/go-sdk/folders/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/folders/internal/time.go
+++ b/seed/go-sdk/folders/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/time.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/time.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/time.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/time.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/go-content-type/internal/time.go
+++ b/seed/go-sdk/go-content-type/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/go-content-type/internal/time.go
+++ b/seed/go-sdk/go-content-type/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/go-optional-literal-alias/internal/time.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/go-optional-literal-alias/internal/time.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/time.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/time.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/header-auth-environment-variable/internal/time.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/header-auth-environment-variable/internal/time.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/header-auth/internal/time.go
+++ b/seed/go-sdk/header-auth/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/header-auth/internal/time.go
+++ b/seed/go-sdk/header-auth/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/http-head/internal/time.go
+++ b/seed/go-sdk/http-head/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/http-head/internal/time.go
+++ b/seed/go-sdk/http-head/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/idempotency-headers/internal/time.go
+++ b/seed/go-sdk/idempotency-headers/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/idempotency-headers/internal/time.go
+++ b/seed/go-sdk/idempotency-headers/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/imdb/no-custom-config/internal/time.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/imdb/no-custom-config/internal/time.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/time.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/time.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/inferred-auth-explicit/internal/time.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/inferred-auth-explicit/internal/time.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/inferred-auth-implicit/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/inferred-auth-implicit/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/license/internal/time.go
+++ b/seed/go-sdk/license/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/license/internal/time.go
+++ b/seed/go-sdk/license/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/literal/internal/time.go
+++ b/seed/go-sdk/literal/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/literal/internal/time.go
+++ b/seed/go-sdk/literal/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/mixed-case/default-values/internal/time.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/mixed-case/default-values/internal/time.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/time.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/time.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/mixed-file-directory/internal/time.go
+++ b/seed/go-sdk/mixed-file-directory/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/mixed-file-directory/internal/time.go
+++ b/seed/go-sdk/mixed-file-directory/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/multi-line-docs/internal/time.go
+++ b/seed/go-sdk/multi-line-docs/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/multi-line-docs/internal/time.go
+++ b/seed/go-sdk/multi-line-docs/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/multi-url-environment-no-default/internal/time.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/multi-url-environment-no-default/internal/time.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/multi-url-environment/internal/time.go
+++ b/seed/go-sdk/multi-url-environment/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/multi-url-environment/internal/time.go
+++ b/seed/go-sdk/multi-url-environment/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/multiple-request-bodies/internal/time.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/multiple-request-bodies/internal/time.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/no-environment/internal/time.go
+++ b/seed/go-sdk/no-environment/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/no-environment/internal/time.go
+++ b/seed/go-sdk/no-environment/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/no-retries/internal/time.go
+++ b/seed/go-sdk/no-retries/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/no-retries/internal/time.go
+++ b/seed/go-sdk/no-retries/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/nullable-allof-extends/internal/time.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/nullable-allof-extends/internal/time.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/nullable-optional/internal/time.go
+++ b/seed/go-sdk/nullable-optional/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/nullable-optional/internal/time.go
+++ b/seed/go-sdk/nullable-optional/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/time.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/time.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/nullable/internal/time.go
+++ b/seed/go-sdk/nullable/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/nullable/internal/time.go
+++ b/seed/go-sdk/nullable/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/oauth-client-credentials-default/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/oauth-client-credentials-default/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/oauth-client-credentials/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/oauth-client-credentials/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/object/internal/time.go
+++ b/seed/go-sdk/object/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/object/internal/time.go
+++ b/seed/go-sdk/object/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/objects-with-imports/internal/time.go
+++ b/seed/go-sdk/objects-with-imports/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/objects-with-imports/internal/time.go
+++ b/seed/go-sdk/objects-with-imports/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/optional/internal/time.go
+++ b/seed/go-sdk/optional/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/optional/internal/time.go
+++ b/seed/go-sdk/optional/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/package-yml/no-custom-config/internal/time.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/package-yml/no-custom-config/internal/time.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/pagination-uri-path/internal/time.go
+++ b/seed/go-sdk/pagination-uri-path/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/pagination-uri-path/internal/time.go
+++ b/seed/go-sdk/pagination-uri-path/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/pagination/internal/time.go
+++ b/seed/go-sdk/pagination/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/pagination/internal/time.go
+++ b/seed/go-sdk/pagination/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/time.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/time.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/path-parameters/package-name/internal/time.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/path-parameters/package-name/internal/time.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/path-parameters/v0/internal/time.go
+++ b/seed/go-sdk/path-parameters/v0/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/path-parameters/v0/internal/time.go
+++ b/seed/go-sdk/path-parameters/v0/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/plain-text/internal/time.go
+++ b/seed/go-sdk/plain-text/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/plain-text/internal/time.go
+++ b/seed/go-sdk/plain-text/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/property-access/internal/time.go
+++ b/seed/go-sdk/property-access/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/property-access/internal/time.go
+++ b/seed/go-sdk/property-access/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/public-object/internal/time.go
+++ b/seed/go-sdk/public-object/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/public-object/internal/time.go
+++ b/seed/go-sdk/public-object/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/time.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/time.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/query-parameters-openapi/internal/time.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/query-parameters-openapi/internal/time.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/query-parameters/internal/time.go
+++ b/seed/go-sdk/query-parameters/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/query-parameters/internal/time.go
+++ b/seed/go-sdk/query-parameters/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/required-nullable/internal/time.go
+++ b/seed/go-sdk/required-nullable/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/required-nullable/internal/time.go
+++ b/seed/go-sdk/required-nullable/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/reserved-keywords/internal/time.go
+++ b/seed/go-sdk/reserved-keywords/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/reserved-keywords/internal/time.go
+++ b/seed/go-sdk/reserved-keywords/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/response-property/internal/time.go
+++ b/seed/go-sdk/response-property/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/response-property/internal/time.go
+++ b/seed/go-sdk/response-property/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/server-url-templating/internal/time.go
+++ b/seed/go-sdk/server-url-templating/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/server-url-templating/internal/time.go
+++ b/seed/go-sdk/server-url-templating/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/simple-api/internal/time.go
+++ b/seed/go-sdk/simple-api/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/simple-api/internal/time.go
+++ b/seed/go-sdk/simple-api/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/simple-fhir/internal/time.go
+++ b/seed/go-sdk/simple-fhir/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/simple-fhir/internal/time.go
+++ b/seed/go-sdk/simple-fhir/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/single-url-environment-default/internal/time.go
+++ b/seed/go-sdk/single-url-environment-default/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/single-url-environment-default/internal/time.go
+++ b/seed/go-sdk/single-url-environment-default/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/single-url-environment-no-default/internal/time.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/single-url-environment-no-default/internal/time.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/streaming/internal/time.go
+++ b/seed/go-sdk/streaming/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/streaming/internal/time.go
+++ b/seed/go-sdk/streaming/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/time.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/time.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/time.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/time.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/unions-with-local-date/internal/time.go
+++ b/seed/go-sdk/unions-with-local-date/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/unions-with-local-date/internal/time.go
+++ b/seed/go-sdk/unions-with-local-date/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/unions/package-name/internal/time.go
+++ b/seed/go-sdk/unions/package-name/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/unions/package-name/internal/time.go
+++ b/seed/go-sdk/unions/package-name/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/unions/v0/internal/time.go
+++ b/seed/go-sdk/unions/v0/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/unions/v0/internal/time.go
+++ b/seed/go-sdk/unions/v0/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/unknown/internal/time.go
+++ b/seed/go-sdk/unknown/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/unknown/internal/time.go
+++ b/seed/go-sdk/unknown/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/url-form-encoded/internal/time.go
+++ b/seed/go-sdk/url-form-encoded/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/url-form-encoded/internal/time.go
+++ b/seed/go-sdk/url-form-encoded/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/validation/internal/time.go
+++ b/seed/go-sdk/validation/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/validation/internal/time.go
+++ b/seed/go-sdk/validation/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/variables/internal/time.go
+++ b/seed/go-sdk/variables/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/variables/internal/time.go
+++ b/seed/go-sdk/variables/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/version-no-default/internal/time.go
+++ b/seed/go-sdk/version-no-default/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/version-no-default/internal/time.go
+++ b/seed/go-sdk/version-no-default/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/version/internal/time.go
+++ b/seed/go-sdk/version/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/version/internal/time.go
+++ b/seed/go-sdk/version/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/webhook-audience/internal/time.go
+++ b/seed/go-sdk/webhook-audience/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/webhook-audience/internal/time.go
+++ b/seed/go-sdk/webhook-audience/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/webhooks/internal/time.go
+++ b/seed/go-sdk/webhooks/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/webhooks/internal/time.go
+++ b/seed/go-sdk/webhooks/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/websocket-bearer-auth/internal/time.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/websocket-bearer-auth/internal/time.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/websocket-inferred-auth/internal/time.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/websocket-inferred-auth/internal/time.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/seed/go-sdk/websocket/internal/time.go
+++ b/seed/go-sdk/websocket/internal/time.go
@@ -127,9 +127,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Attempt RFC3339 first, then fall back to the common ISO8601
+	// variant without a timezone (e.g. "2006-01-02T15:04:05").
 	parsedTime, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
+		if err != nil {
+			return err
+		}
 	}
 
 	*d = DateTime{t: &parsedTime}

--- a/seed/go-sdk/websocket/internal/time.go
+++ b/seed/go-sdk/websocket/internal/time.go
@@ -63,13 +63,33 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	parsedTime, err := time.Parse(dateFormat, raw)
-	if err != nil {
-		return err
+	// Try multiple layouts: date-only first, then datetime with and
+	// without timezone so that downstream datetime values gracefully
+	// degrade to a date.
+	layouts := []string{
+		dateFormat,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
 	}
 
-	*d = Date{t: &parsedTime}
-	return nil
+	for i, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if i == 2 {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			// Truncate to date (midnight UTC).
+			year, month, day := parsedTime.Date()
+			normalized := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			*d = Date{t: &normalized}
+			return nil
+		}
+	}
+
+	return &json.UnmarshalTypeError{
+		Value: "invalid date format: " + raw,
+	}
 }
 
 // DateTime wraps time.Time and adapts its JSON representation
@@ -118,7 +138,7 @@ func (d *DateTime) MarshalJSON() ([]byte, error) {
 	if d == nil || d.t == nil {
 		return nil, nil
 	}
-	return json.Marshal(d.t.Format(time.RFC3339))
+	return json.Marshal(d.t.Format(time.RFC3339Nano))
 }
 
 func (d *DateTime) UnmarshalJSON(data []byte) error {
@@ -127,16 +147,27 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Attempt RFC3339 first, then fall back to the common ISO8601
-	// variant without a timezone (e.g. "2006-01-02T15:04:05").
-	parsedTime, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
-		if err != nil {
-			return err
+	// Try RFC3339 (with timezone) first, then common ISO 8601 variants
+	// without a timezone suffix. Fractional seconds are handled by both
+	// the millisecond and nanosecond layouts.
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+	}
+
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, raw)
+		if err == nil {
+			if layout != time.RFC3339Nano {
+				// No timezone in the layout — assume UTC.
+				parsedTime = parsedTime.UTC()
+			}
+			*d = DateTime{t: &parsedTime}
+			return nil
 		}
 	}
 
-	*d = DateTime{t: &parsedTime}
-	return nil
+	return &json.UnmarshalTypeError{
+		Value: "invalid datetime format: " + raw,
+	}
 }

--- a/test-definitions/fern/apis/exhaustive/definition/endpoints/object.yml
+++ b/test-definitions/fern/apis/exhaustive/definition/endpoints/object.yml
@@ -74,6 +74,24 @@ service:
               unknown:
                 "\\$ref": "https://example.com/schema"
 
+    getAndReturnWithDatetimeAlias:
+      docs: |
+        Tests that datetime alias fields are properly serialized/deserialized
+        using custom datetime helpers (e.g. internal.DateTime in Go).
+      path: /get-and-return-with-datetime-alias
+      method: POST
+      request: objects.ObjectWithDatetimeAlias
+      response: objects.ObjectWithDatetimeAlias
+      examples:
+        - name: DatetimeAliasExample
+          request:
+            datetime: "2024-01-15T09:30:00Z"
+            datetimeAlias: "2024-01-15T09:30:00Z"
+          response:
+            body:
+              datetime: "2024-01-15T09:30:00Z"
+              datetimeAlias: "2024-01-15T09:30:00Z"
+
     getAndReturnWithDatetimeLikeString:
       docs: |
         Tests that string fields containing datetime-like values are NOT reformatted.

--- a/test-definitions/fern/apis/exhaustive/definition/types/object.yml
+++ b/test-definitions/fern/apis/exhaustive/definition/types/object.yml
@@ -54,6 +54,28 @@ types:
         type: datetime
         docs: An actual datetime field for comparison
 
+  DatetimeAlias:
+    docs: An alias for datetime that should be treated identically to datetime for serialization.
+    type: datetime
+
+  ObjectWithDatetimeAlias:
+    docs: |
+      Tests that datetime alias fields use custom datetime serialization helpers
+      (e.g. internal.DateTime in Go) rather than default serialization.
+    properties:
+      datetime:
+        type: datetime
+        docs: A direct datetime field for comparison
+      datetimeAlias:
+        type: DatetimeAlias
+        docs: A datetime alias field that should serialize identically to datetime
+      optionalDatetime:
+        type: optional<datetime>
+        docs: An optional datetime field
+      optionalDatetimeAlias:
+        type: optional<DatetimeAlias>
+        docs: An optional datetime alias field
+
   ObjectWithUnknownField:
     docs: |
       Tests that unknown/any values containing backslashes in map keys


### PR DESCRIPTION
## Description

Refs: Branch `jsklan/datetime-alias-go-marshaling` (test fixture reproduction)

Fixes Go SDK generator failing to apply custom `internal.DateTime` / `internal.Date` serialization helpers to fields whose type is an **alias** of `datetime` or `date`. When a Fern definition uses `DatetimeAlias: type: datetime` and a field references that alias, the generator previously fell through to default `time.Time` JSON handling because `maybeDateProperty` / `maybeDate` / `maybeFormatStructTag` only checked `valueType.Primitive` and never resolved named type aliases.

**Link to Devin session:** https://app.devin.ai/sessions/af530901c9f7446d9fc28e132dcb7710  
**Requested by:** @jsklan

## Changes Made

### 1. Alias resolution in `maybeDateProperty` / `maybeDate` / `maybeFormatStructTag` (`generators/go/internal/generator/model.go`)
- All three functions now accept a `types map[TypeId]*TypeDeclaration` parameter
- When `valueType.Named` is set, the functions look up the type declaration and recursively resolve through `Shape.Alias.AliasOf` — the same pattern used by `isLiteralType`, `isOptionalType`, and `maybeIterableType` elsewhere in the codebase
- All 8 call sites updated to pass the appropriate types map (`t.writer.types` or `c.types`)
- `maybeFormatStructTag` fix ensures date alias fields get the `format:"date"` struct tag for correct URL/query-parameter encoding

### 2. Multi-layout datetime parsing in `internal/time.go` (`generators/go/.../model/internal/time.go`)
Inspired by [a customer's `.fernignore`d override](https://app.devin.ai/sessions/af530901c9f7446d9fc28e132dcb7710), both `Date` and `DateTime` unmarshalers now try multiple layouts rather than a single strict format:

- **`DateTime.UnmarshalJSON`**: tries `time.RFC3339Nano` first, then falls back to `"2006-01-02T15:04:05.999999999"` (ISO 8601 without timezone). Timezone-less values are normalized to UTC.
- **`DateTime.MarshalJSON`**: changed from `time.RFC3339` → `time.RFC3339Nano` to preserve sub-second precision.
- **`Date.UnmarshalJSON`**: tries `dateFormat` (`"2006-01-02"`), then `time.RFC3339Nano`, then the timezone-less ISO 8601 layout. All parsed values are truncated to midnight UTC.
- Error returns now use `json.UnmarshalTypeError` with descriptive messages instead of raw `time.Parse` errors.

### 3. Exhaustive fixture additions (`test-definitions/fern/apis/exhaustive/`)
- Added `DatetimeAlias` type alias and `ObjectWithDatetimeAlias` object type with both direct and aliased datetime fields (required + optional)
- Added `getAndReturnWithDatetimeAlias` endpoint with example data
- Added JSON schema snapshots for the two new types

### 4. Seed output + versions.yml
- Regenerated all 122 go-sdk seed fixtures containing `internal/time.go`
- Added v1.27.0 changelog entry
- **Note:** The exhaustive fixture's go-sdk generation is broken due to pre-existing wire test issues (already in `allowedFailures`), so no exhaustive seed output could be generated to demonstrate the alias fix in snapshot form

## Testing
- [x] Go generator compiles (`go build ./...`)
- [x] `object` fixture: seed test passes
- [x] `nullable` fixture: seed test passes
- [x] All 122 go-sdk seed `internal/time.go` files updated
- [x] JSON schema snapshots generated for new exhaustive types
- [ ] Exhaustive fixture: cannot generate due to pre-existing wire test crash (unrelated to this PR)
- [ ] No unit tests added for the alias resolution logic itself

## ⚠️ Review Checklist
- [ ] **MarshalJSON behavior change**: `DateTime.MarshalJSON` now outputs `time.RFC3339Nano` (e.g. `2024-01-15T09:30:00.123456789Z`) instead of `time.RFC3339` (e.g. `2024-01-15T09:30:00Z`). This adds sub-second precision to all datetime outputs. Verify this doesn't break APIs expecting whole-second timestamps.
- [ ] **Date.UnmarshalJSON leniency**: Date fields now accept full datetime strings (e.g. `2024-01-15T09:30:00Z`) and truncate to date (`2024-01-15`). Verify this is desirable vs. strict validation that rejects datetime-formatted values for date-typed fields.
- [ ] **Timezone-less datetime handling**: Timestamps without timezone (e.g. `2024-01-15T09:30:00`) are normalized to UTC. Verify this is the intended behavior vs. local time or explicit rejection.
- [ ] **Alias resolution logic**: Verify the pattern matches other recursive alias resolution in the codebase (e.g. `isLiteralType`).
- [ ] **maybeFormatStructTag completeness**: The fix ensures date alias fields in URL/query parameters serialize correctly. Verify no other struct-tag-related functions need similar updates.
- [ ] **Circular alias risk**: Alias resolution recurses without a depth limit. Should be safe (IR validation prevents cycles), but worth noting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
