### PR TITLE
fix(csharp): Fix incorrect MaxRetries doc comment and add missing readonly on sub-client fields

### DIFF
--- a/generators/csharp/base/src/asIs/test/RawClientTests/IdempotentHeadersTests.Template.cs
+++ b/generators/csharp/base/src/asIs/test/RawClientTests/IdempotentHeadersTests.Template.cs
@@ -56,7 +56,7 @@ public partial class IdempotentRequestOptions : IIdempotentRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/generators/csharp/sdk/src/options/BaseOptionsGenerator.ts
+++ b/generators/csharp/sdk/src/options/BaseOptionsGenerator.ts
@@ -87,7 +87,7 @@ export class BaseOptionsGenerator extends WithGeneration {
             init: true,
             type: optional ? type.asOptional() : type,
             initializer: includeInitializer ? this.csharp.codeblock("2") : undefined,
-            summary: "The http client used to make requests."
+            summary: "The max number of retries to attempt."
         });
     }
 

--- a/generators/csharp/sdk/src/subpackage-client/SubPackageClientGenerator.ts
+++ b/generators/csharp/sdk/src/subpackage-client/SubPackageClientGenerator.ts
@@ -84,14 +84,16 @@ export class SubPackageClientGenerator extends FileGenerator<CSharpFile, SdkGene
         class_.addField({
             origin: this.members.client,
             access: ast.Access.Private,
-            type: this.Types.RawClient
+            type: this.Types.RawClient,
+            readonly: true
         });
 
         if (this.grpcClientInfo != null) {
             class_.addField({
                 origin: this.members.grpcClient,
                 access: ast.Access.Private,
-                type: this.Types.RawGrpcClient
+                type: this.Types.RawGrpcClient,
+                readonly: true
             });
 
             class_.addField({

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -7,6 +7,12 @@
         "The http client used to make requests." (copy-paste from `HttpClient`)
         and now correctly reads "The max number of retries to attempt."
       type: fix
+    - summary: |
+        Add missing `readonly` modifier to `_client` field in generated sub-clients.
+        The root client already had `private readonly RawClient _client` but sub-clients
+        only had `private RawClient _client`, despite the field being assigned once in
+        the constructor and never reassigned.
+      type: fix
   createdAt: "2026-03-03"
   irVersion: 62
 

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.23.2
+  changelogEntry:
+    - summary: |
+        Fix incorrect XML doc comment on `MaxRetries` property in `ClientOptions`,
+        `RequestOptions`, and `IRequestOptions`. The summary previously read
+        "The http client used to make requests." (copy-paste from `HttpClient`)
+        and now correctly reads "The max number of retries to attempt."
+      type: fix
+  createdAt: "2026-03-03"
+  irVersion: 62
+
 - version: 2.23.1
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Service/ServiceClient.cs
@@ -5,7 +5,7 @@ namespace SeedAccept;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedAnyAuth;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/User/UserClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedAnyAuth;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Service/ServiceClient.cs
@@ -4,7 +4,7 @@ namespace SeedApiWideBasePath;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderA/FolderAClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderA/FolderAClient.cs
@@ -4,7 +4,7 @@ namespace SeedAudiences.FolderA;
 
 public partial class FolderAClient : IFolderAClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal FolderAClient(RawClient client)
     {

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderA/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderA/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedAudiences.FolderA;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/FolderDClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/FolderDClient.cs
@@ -4,7 +4,7 @@ namespace SeedAudiences.FolderD;
 
 public partial class FolderDClient : IFolderDClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal FolderDClient(RawClient client)
     {

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedAudiences.FolderD;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Foo/FooClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Foo/FooClient.cs
@@ -5,7 +5,7 @@ namespace SeedAudiences;
 
 public partial class FooClient : IFooClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal FooClient(RawClient client)
     {

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/BasicAuth/BasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/BasicAuth/BasicAuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedBasicAuthEnvironmentVariables;
 
 public partial class BasicAuthClient : IBasicAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal BasicAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/BasicAuth/BasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/BasicAuth/BasicAuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedBasicAuth;
 
 public partial class BasicAuthClient : IBasicAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal BasicAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Service/ServiceClient.cs
@@ -5,7 +5,7 @@ namespace SeedBearerTokenEnvironmentVariable;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Service/ServiceClient.cs
@@ -4,7 +4,7 @@ namespace SeedBytesDownload;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Service/ServiceClient.cs
@@ -4,7 +4,7 @@ namespace SeedBytesUpload;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Service/ServiceClient.cs
@@ -5,7 +5,7 @@ namespace SeedClientSideParams;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Service/ServiceClient.cs
@@ -4,7 +4,7 @@ namespace SeedContentTypes;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/FolderAClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/FolderAClient.cs
@@ -4,7 +4,7 @@ namespace SeedCrossPackageTypeNames.FolderA;
 
 public partial class FolderAClient : IFolderAClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal FolderAClient(RawClient client)
     {

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedCrossPackageTypeNames.FolderA;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/FolderDClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/FolderDClient.cs
@@ -4,7 +4,7 @@ namespace SeedCrossPackageTypeNames.FolderD;
 
 public partial class FolderDClient : IFolderDClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal FolderDClient(RawClient client)
     {

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedCrossPackageTypeNames.FolderD;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Foo/FooClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Foo/FooClient.cs
@@ -5,7 +5,7 @@ namespace SeedCrossPackageTypeNames;
 
 public partial class FooClient : IFooClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal FooClient(RawClient client)
     {

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/Public/ClientOptions.cs
@@ -50,7 +50,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Dataservice/DataserviceClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Dataservice/DataserviceClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class DataserviceClient : IDataserviceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal DataserviceClient(RawClient client)
     {

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Dataservice/DataserviceClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Dataservice/DataserviceClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class DataserviceClient : IDataserviceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal DataserviceClient(RawClient client)
     {

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Dataservice/DataserviceClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Dataservice/DataserviceClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class DataserviceClient : IDataserviceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal DataserviceClient(RawClient client)
     {

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Dataservice/DataserviceClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Dataservice/DataserviceClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class DataserviceClient : IDataserviceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal DataserviceClient(RawClient client)
     {

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/System/SystemClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/System/SystemClient.cs
@@ -5,7 +5,7 @@ namespace SeedCsharpNamespaceCollision.System;
 
 public partial class SystemClient : ISystemClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SystemClient(RawClient client)
     {

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Tasktest/TasktestClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Tasktest/TasktestClient.cs
@@ -4,7 +4,7 @@ namespace SeedCsharpNamespaceConflict;
 
 public partial class TasktestClient : ITasktestClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal TasktestClient(RawClient client)
     {

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedEndpointSecurityAuth;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/User/UserClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedEndpointSecurityAuth;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Headers/HeadersClient.cs
@@ -4,7 +4,7 @@ namespace SeedEnum;
 
 public partial class HeadersClient : IHeadersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HeadersClient(RawClient client)
     {

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
@@ -4,7 +4,7 @@ namespace SeedEnum;
 
 public partial class InlinedRequestClient : IInlinedRequestClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlinedRequestClient(RawClient client)
     {

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
@@ -4,7 +4,7 @@ namespace SeedEnum;
 
 public partial class MultipartFormClient : IMultipartFormClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal MultipartFormClient(RawClient client)
     {

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/PathParam/PathParamClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/PathParam/PathParamClient.cs
@@ -5,7 +5,7 @@ namespace SeedEnum;
 
 public partial class PathParamClient : IPathParamClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PathParamClient(RawClient client)
     {

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/QueryParam/QueryParamClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/QueryParam/QueryParamClient.cs
@@ -4,7 +4,7 @@ namespace SeedEnum;
 
 public partial class QueryParamClient : IQueryParamClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal QueryParamClient(RawClient client)
     {

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Headers/HeadersClient.cs
@@ -4,7 +4,7 @@ namespace SeedEnum;
 
 public partial class HeadersClient : IHeadersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HeadersClient(RawClient client)
     {

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
@@ -4,7 +4,7 @@ namespace SeedEnum;
 
 public partial class InlinedRequestClient : IInlinedRequestClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlinedRequestClient(RawClient client)
     {

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
@@ -4,7 +4,7 @@ namespace SeedEnum;
 
 public partial class MultipartFormClient : IMultipartFormClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal MultipartFormClient(RawClient client)
     {

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/PathParam/PathParamClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/PathParam/PathParamClient.cs
@@ -5,7 +5,7 @@ namespace SeedEnum;
 
 public partial class PathParamClient : IPathParamClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PathParamClient(RawClient client)
     {

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/QueryParam/QueryParamClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/QueryParam/QueryParamClient.cs
@@ -4,7 +4,7 @@ namespace SeedEnum;
 
 public partial class QueryParamClient : IQueryParamClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal QueryParamClient(RawClient client)
     {

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/PropertyBasedError/PropertyBasedErrorClient.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/PropertyBasedError/PropertyBasedErrorClient.cs
@@ -5,7 +5,7 @@ namespace SeedErrorProperty;
 
 public partial class PropertyBasedErrorClient : IPropertyBasedErrorClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PropertyBasedErrorClient(RawClient client)
     {

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/errors/src/SeedErrors/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Simple/SimpleClient.cs
@@ -5,7 +5,7 @@ namespace SeedErrors;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/FileClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/FileClient.cs
@@ -5,7 +5,7 @@ namespace SeedExamples.File_;
 
 public partial class FileClient : IFileClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal FileClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/NotificationClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/NotificationClient.cs
@@ -4,7 +4,7 @@ namespace SeedExamples.File_.Notification;
 
 public partial class NotificationClient : INotificationClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NotificationClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedExamples.File_.Notification;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedExamples.File_;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/HealthClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/HealthClient.cs
@@ -4,7 +4,7 @@ namespace SeedExamples.Health;
 
 public partial class HealthClient : IHealthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HealthClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedExamples.Health;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Service/ServiceClient.cs
@@ -5,7 +5,7 @@ namespace SeedExamples;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/FileClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/FileClient.cs
@@ -5,7 +5,7 @@ namespace SeedExamples.File_;
 
 public partial class FileClient : IFileClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal FileClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/NotificationClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/NotificationClient.cs
@@ -4,7 +4,7 @@ namespace SeedExamples.File_.Notification;
 
 public partial class NotificationClient : INotificationClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NotificationClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedExamples.File_.Notification;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedExamples.File_;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/HealthClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/HealthClient.cs
@@ -4,7 +4,7 @@ namespace SeedExamples.Health;
 
 public partial class HealthClient : IHealthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HealthClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedExamples.Health;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Service/ServiceClient.cs
@@ -5,7 +5,7 @@ namespace SeedExamples;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -8,7 +8,7 @@ namespace SeedExhaustive.Endpoints.Container;
 
 public partial class ContainerClient : IContainerClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ContainerClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints.ContentType;
 
 public partial class ContentTypeClient : IContentTypeClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ContentTypeClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/EndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/EndpointsClient.cs
@@ -12,7 +12,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class EndpointsClient : IEndpointsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EndpointsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints.Enum;
 
 public partial class EnumClient : IEnumClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EnumClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints.HttpMethods;
 
 public partial class HttpMethodsClient : IHttpMethodsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HttpMethodsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints.Object;
 
 public partial class ObjectClient : IObjectClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ObjectClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints.Pagination;
 
 public partial class PaginationClient : IPaginationClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PaginationClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints.Params;
 
 public partial class ParamsClient : IParamsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ParamsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints.Primitive;
 
 public partial class PrimitiveClient : IPrimitiveClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PrimitiveClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints.Put;
 
 public partial class PutClient : IPutClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PutClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints.Union;
 
 public partial class UnionClient : IUnionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnionClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints.Urls;
 
 public partial class UrlsClient : IUrlsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UrlsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -8,7 +8,7 @@ namespace SeedExhaustive.InlinedRequests;
 
 public partial class InlinedRequestsClient : IInlinedRequestsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlinedRequestsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.NoAuth;
 
 public partial class NoAuthClient : INoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.NoReqBody;
 
 public partial class NoReqBodyClient : INoReqBodyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NoReqBodyClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -5,7 +5,7 @@ namespace SeedExhaustive.ReqWithHeaders;
 
 public partial class ReqWithHeadersClient : IReqWithHeadersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ReqWithHeadersClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -50,7 +50,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -8,7 +8,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ContainerClient : IContainerClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ContainerClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ContentTypeClient : IContentTypeClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ContentTypeClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/EndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/EndpointsClient.cs
@@ -4,7 +4,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class EndpointsClient : IEndpointsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EndpointsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class EnumClient : IEnumClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EnumClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class HttpMethodsClient : IHttpMethodsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HttpMethodsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ObjectClient : IObjectClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ObjectClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PaginationClient : IPaginationClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PaginationClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ParamsClient : IParamsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ParamsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PrimitiveClient : IPrimitiveClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PrimitiveClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PutClient : IPutClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PutClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class UnionClient : IUnionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnionClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class UrlsClient : IUrlsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UrlsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive;
 
 public partial class InlinedRequestsClient : IInlinedRequestsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlinedRequestsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedExhaustive;
 
 public partial class NoAuthClient : INoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive;
 
 public partial class NoReqBodyClient : INoReqBodyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NoReqBodyClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -4,7 +4,7 @@ namespace SeedExhaustive;
 
 public partial class ReqWithHeadersClient : IReqWithHeadersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ReqWithHeadersClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -8,7 +8,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ContainerClient : IContainerClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ContainerClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ContentTypeClient : IContentTypeClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ContentTypeClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/EndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/EndpointsClient.cs
@@ -4,7 +4,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class EndpointsClient : IEndpointsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EndpointsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class EnumClient : IEnumClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EnumClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class HttpMethodsClient : IHttpMethodsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HttpMethodsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ObjectClient : IObjectClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ObjectClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PaginationClient : IPaginationClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PaginationClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ParamsClient : IParamsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ParamsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PrimitiveClient : IPrimitiveClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PrimitiveClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PutClient : IPutClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PutClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class UnionClient : IUnionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnionClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class UrlsClient : IUrlsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UrlsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive;
 
 public partial class InlinedRequestsClient : IInlinedRequestsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlinedRequestsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedExhaustive;
 
 public partial class NoAuthClient : INoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive;
 
 public partial class NoReqBodyClient : INoReqBodyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NoReqBodyClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -4,7 +4,7 @@ namespace SeedExhaustive;
 
 public partial class ReqWithHeadersClient : IReqWithHeadersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ReqWithHeadersClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -43,7 +43,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Public/RequestOptions.cs
@@ -38,7 +38,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -8,7 +8,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ContainerClient : IContainerClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ContainerClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -5,7 +5,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ContentTypeClient : IContentTypeClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ContentTypeClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/EndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/EndpointsClient.cs
@@ -4,7 +4,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class EndpointsClient : IEndpointsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EndpointsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class EnumClient : IEnumClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EnumClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class HttpMethodsClient : IHttpMethodsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HttpMethodsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ObjectClient : IObjectClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ObjectClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PaginationClient : IPaginationClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PaginationClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ParamsClient : IParamsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ParamsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PrimitiveClient : IPrimitiveClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PrimitiveClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PutClient : IPutClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PutClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class UnionClient : IUnionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnionClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class UrlsClient : IUrlsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UrlsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive;
 
 public partial class InlinedRequestsClient : IInlinedRequestsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlinedRequestsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedExhaustive;
 
 public partial class NoAuthClient : INoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive;
 
 public partial class NoReqBodyClient : INoReqBodyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NoReqBodyClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -4,7 +4,7 @@ namespace SeedExhaustive;
 
 public partial class ReqWithHeadersClient : IReqWithHeadersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ReqWithHeadersClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -8,7 +8,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ContainerClient : IContainerClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ContainerClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ContentTypeClient : IContentTypeClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ContentTypeClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/EndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/EndpointsClient.cs
@@ -4,7 +4,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class EndpointsClient : IEndpointsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EndpointsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class EnumClient : IEnumClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EnumClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class HttpMethodsClient : IHttpMethodsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HttpMethodsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ObjectClient : IObjectClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ObjectClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PaginationClient : IPaginationClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PaginationClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class ParamsClient : IParamsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ParamsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PrimitiveClient : IPrimitiveClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PrimitiveClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class PutClient : IPutClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PutClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -7,7 +7,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class UnionClient : IUnionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnionClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive.Endpoints;
 
 public partial class UrlsClient : IUrlsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UrlsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive;
 
 public partial class InlinedRequestsClient : IInlinedRequestsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlinedRequestsClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedExhaustive;
 
 public partial class NoAuthClient : INoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -6,7 +6,7 @@ namespace SeedExhaustive;
 
 public partial class NoReqBodyClient : INoReqBodyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NoReqBodyClient(RawClient client)
     {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -4,7 +4,7 @@ namespace SeedExhaustive;
 
 public partial class ReqWithHeadersClient : IReqWithHeadersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ReqWithHeadersClient(RawClient client)
     {

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/User/UserClient.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedExtraProperties;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Service/ServiceClient.cs
@@ -4,7 +4,7 @@ namespace SeedFileDownload;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/FileUploadExample/FileUploadExampleClient.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/FileUploadExample/FileUploadExampleClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class FileUploadExampleClient : IFileUploadExampleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal FileUploadExampleClient(RawClient client)
     {

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Service/ServiceClient.cs
@@ -5,7 +5,7 @@ namespace SeedFileUpload;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/folders/src/SeedApi/A/AClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/A/AClient.cs
@@ -6,7 +6,7 @@ namespace SeedApi.A;
 
 public partial class AClient : IAClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AClient(RawClient client)
     {

--- a/seed/csharp-sdk/folders/src/SeedApi/A/B/BClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/A/B/BClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi.A.B;
 
 public partial class BClient : IBClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal BClient(RawClient client)
     {

--- a/seed/csharp-sdk/folders/src/SeedApi/A/C/CClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/A/C/CClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi.A.C;
 
 public partial class CClient : ICClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal CClient(RawClient client)
     {

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/folders/src/SeedApi/Folder/FolderClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Folder/FolderClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi.Folder;
 
 public partial class FolderClient : IFolderClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal FolderClient(RawClient client)
     {

--- a/seed/csharp-sdk/folders/src/SeedApi/Folder/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Folder/Service/ServiceClient.cs
@@ -6,7 +6,7 @@ namespace SeedApi.Folder;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Service/ServiceClient.cs
@@ -5,7 +5,7 @@ namespace SeedHeaderTokenEnvironmentVariable;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Service/ServiceClient.cs
@@ -5,7 +5,7 @@ namespace SeedHeaderToken;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/User/UserClient.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/User/UserClient.cs
@@ -6,7 +6,7 @@ namespace SeedHttpHead;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Core/RawClientTests/IdempotentHeadersTests.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Core/RawClientTests/IdempotentHeadersTests.cs
@@ -55,7 +55,7 @@ public partial class IdempotentRequestOptions : IIdempotentRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/Public/IdempotentRequestOptions.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/Public/IdempotentRequestOptions.cs
@@ -40,7 +40,7 @@ public partial class IdempotentRequestOptions : IIdempotentRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Payment/PaymentClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Payment/PaymentClient.cs
@@ -5,7 +5,7 @@ namespace SeedIdempotencyHeaders;
 
 public partial class PaymentClient : IPaymentClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PaymentClient(RawClient client)
     {

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Imdb/ImdbClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class ImdbClient : IImdbClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ImdbClient(RawClient client)
     {

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Imdb/ImdbClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class ImdbClient : IImdbClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ImdbClient(RawClient client)
     {

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Imdb/ImdbClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class ImdbClient : IImdbClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ImdbClient(RawClient client)
     {

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/Public/ClientOptions.cs
@@ -50,7 +50,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Imdb/ImdbClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class ImdbClient : IImdbClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ImdbClient(RawClient client)
     {

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Imdb/ImdbClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class ImdbClient : IImdbClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ImdbClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthExplicit;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthExplicit.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthExplicit.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthExplicit.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthExplicit.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthExplicit;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicitApiKey;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicitApiKey.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicitApiKey.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicitApiKey.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicitApiKey.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicitApiKey;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicitNoExpiry;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicitNoExpiry.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicitNoExpiry.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicitNoExpiry.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicitNoExpiry.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicitNoExpiry;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicit;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicit.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicit.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicit.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicit.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicit;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicit;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicit.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicit.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedInferredAuthImplicit.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicit.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedInferredAuthImplicit;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Headers/HeadersClient.cs
@@ -5,7 +5,7 @@ namespace SeedLiteral;
 
 public partial class HeadersClient : IHeadersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HeadersClient(RawClient client)
     {

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Inlined/InlinedClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Inlined/InlinedClient.cs
@@ -5,7 +5,7 @@ namespace SeedLiteral;
 
 public partial class InlinedClient : IInlinedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlinedClient(RawClient client)
     {

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Path/PathClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Path/PathClient.cs
@@ -5,7 +5,7 @@ namespace SeedLiteral;
 
 public partial class PathClient : IPathClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PathClient(RawClient client)
     {

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Query/QueryClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Query/QueryClient.cs
@@ -5,7 +5,7 @@ namespace SeedLiteral;
 
 public partial class QueryClient : IQueryClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal QueryClient(RawClient client)
     {

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Reference/ReferenceClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Reference/ReferenceClient.cs
@@ -5,7 +5,7 @@ namespace SeedLiteral;
 
 public partial class ReferenceClient : IReferenceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ReferenceClient(RawClient client)
     {

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Headers/HeadersClient.cs
@@ -5,7 +5,7 @@ namespace SeedLiteral;
 
 public partial class HeadersClient : IHeadersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HeadersClient(RawClient client)
     {

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Inlined/InlinedClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Inlined/InlinedClient.cs
@@ -5,7 +5,7 @@ namespace SeedLiteral;
 
 public partial class InlinedClient : IInlinedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlinedClient(RawClient client)
     {

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Path/PathClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Path/PathClient.cs
@@ -5,7 +5,7 @@ namespace SeedLiteral;
 
 public partial class PathClient : IPathClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PathClient(RawClient client)
     {

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Query/QueryClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Query/QueryClient.cs
@@ -5,7 +5,7 @@ namespace SeedLiteral;
 
 public partial class QueryClient : IQueryClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal QueryClient(RawClient client)
     {

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Reference/ReferenceClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Reference/ReferenceClient.cs
@@ -5,7 +5,7 @@ namespace SeedLiteral;
 
 public partial class ReferenceClient : IReferenceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ReferenceClient(RawClient client)
     {

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Service/ServiceClient.cs
@@ -5,7 +5,7 @@ namespace SeedMixedCase;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Organization/OrganizationClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Organization/OrganizationClient.cs
@@ -5,7 +5,7 @@ namespace SeedMixedFileDirectory;
 
 public partial class OrganizationClient : IOrganizationClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal OrganizationClient(RawClient client)
     {

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/EventsClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/EventsClient.cs
@@ -7,7 +7,7 @@ namespace SeedMixedFileDirectory.User_;
 
 public partial class EventsClient : IEventsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EventsClient(RawClient client)
     {

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/Metadata/MetadataClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/Metadata/MetadataClient.cs
@@ -6,7 +6,7 @@ namespace SeedMixedFileDirectory.User_.Events;
 
 public partial class MetadataClient : IMetadataClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal MetadataClient(RawClient client)
     {

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/UserClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/UserClient.cs
@@ -6,7 +6,7 @@ namespace SeedMixedFileDirectory;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/User/UserClient.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedMultiLineDocs;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Ec2/Ec2Client.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Ec2/Ec2Client.cs
@@ -4,7 +4,7 @@ namespace SeedMultiUrlEnvironmentNoDefault;
 
 public partial class Ec2Client : IEc2Client
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal Ec2Client(RawClient client)
     {

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/S3/S3Client.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/S3/S3Client.cs
@@ -5,7 +5,7 @@ namespace SeedMultiUrlEnvironmentNoDefault;
 
 public partial class S3Client : IS3Client
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal S3Client(RawClient client)
     {

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Ec2/Ec2Client.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Ec2/Ec2Client.cs
@@ -4,7 +4,7 @@ namespace SeedMultiUrlEnvironment;
 
 public partial class Ec2Client : IEc2Client
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal Ec2Client(RawClient client)
     {

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/S3/S3Client.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/S3/S3Client.cs
@@ -5,7 +5,7 @@ namespace SeedMultiUrlEnvironment;
 
 public partial class S3Client : IS3Client
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal S3Client(RawClient client)
     {

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Ec2/Ec2Client.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Ec2/Ec2Client.cs
@@ -4,7 +4,7 @@ namespace SeedMultiUrlEnvironment;
 
 public partial class Ec2Client : IEc2Client
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal Ec2Client(RawClient client)
     {

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/S3/S3Client.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/S3/S3Client.cs
@@ -5,7 +5,7 @@ namespace SeedMultiUrlEnvironment;
 
 public partial class S3Client : IS3Client
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal S3Client(RawClient client)
     {

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Dummy/DummyClient.cs
@@ -5,7 +5,7 @@ namespace SeedNoEnvironment;
 
 public partial class DummyClient : IDummyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal DummyClient(RawClient client)
     {

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Retries/RetriesClient.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Retries/RetriesClient.cs
@@ -5,7 +5,7 @@ namespace SeedNoRetries;
 
 public partial class RetriesClient : IRetriesClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal RetriesClient(RawClient client)
     {

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
@@ -5,7 +5,7 @@ namespace SeedNullableOptional;
 
 public partial class NullableOptionalClient : INullableOptionalClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NullableOptionalClient(RawClient client)
     {

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
@@ -5,7 +5,7 @@ namespace SeedNullableOptional;
 
 public partial class NullableOptionalClient : INullableOptionalClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NullableOptionalClient(RawClient client)
     {

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/TestGroup/TestGroupClient.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/TestGroup/TestGroupClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial class TestGroupClient : ITestGroupClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal TestGroupClient(RawClient client)
     {

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Nullable/NullableClient.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Nullable/NullableClient.cs
@@ -5,7 +5,7 @@ namespace SeedNullable;
 
 public partial class NullableClient : INullableClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NullableClient(RawClient client)
     {

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Nullable/NullableClient.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Nullable/NullableClient.cs
@@ -5,7 +5,7 @@ namespace SeedNullable;
 
 public partial class NullableClient : INullableClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NullableClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsDefault;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsDefault.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsDefault.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsDefault.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsDefault.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsDefault;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsEnvironmentVariables;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsEnvironmentVariables.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsEnvironmentVariables.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsEnvironmentVariables.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsEnvironmentVariables.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsEnvironmentVariables;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsMandatoryAuth;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsMandatoryAuth.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsMandatoryAuth.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsMandatoryAuth;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -6,7 +6,7 @@ namespace SeedOauthClientCredentials.Auth;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsReference;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsReference;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsWithVariables;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsWithVariables.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsWithVariables.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentialsWithVariables.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsWithVariables.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Service/ServiceClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsWithVariables;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsWithVariables;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
@@ -50,7 +50,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/NestedClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial class NestedClient : INestedClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial class ApiClient : IApiClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ApiClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial class NestedNoAuthClient : INestedNoAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal NestedNoAuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentials;
 
 public partial class SimpleClient : ISimpleClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SimpleClient(RawClient client)
     {

--- a/seed/csharp-sdk/object/src/SeedObject/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/object/src/SeedObject/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/object/src/SeedObject/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Optional/OptionalClient.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Optional/OptionalClient.cs
@@ -5,7 +5,7 @@ namespace SeedObjectsWithImports;
 
 public partial class OptionalClient : IOptionalClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal OptionalClient(RawClient client)
     {

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Optional/OptionalClient.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Optional/OptionalClient.cs
@@ -5,7 +5,7 @@ namespace SeedObjectsWithImports;
 
 public partial class OptionalClient : IOptionalClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal OptionalClient(RawClient client)
     {

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Service/ServiceClient.cs
@@ -4,7 +4,7 @@ namespace SeedPackageYml;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Users/UsersClient.cs
@@ -4,7 +4,7 @@ namespace SeedPagination;
 
 public partial class UsersClient : IUsersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UsersClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Users/UsersClient.cs
@@ -5,7 +5,7 @@ namespace SeedPaginationUriPath;
 
 public partial class UsersClient : IUsersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UsersClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Complex/ComplexClient.cs
@@ -5,7 +5,7 @@ namespace SeedPagination;
 
 public partial class ComplexClient : IComplexClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ComplexClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Public/ClientOptions.cs
@@ -50,7 +50,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -6,7 +6,7 @@ namespace SeedPagination.InlineUsers;
 
 public partial class InlineUsersClient_ : IInlineUsersClient_
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlineUsersClient_(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsersClient.cs
@@ -4,7 +4,7 @@ namespace SeedPagination.InlineUsers;
 
 public partial class InlineUsersClient : IInlineUsersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlineUsersClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Users/UsersClient.cs
@@ -5,7 +5,7 @@ namespace SeedPagination;
 
 public partial class UsersClient : IUsersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UsersClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Complex/ComplexClient.cs
@@ -5,7 +5,7 @@ namespace SeedPagination;
 
 public partial class ComplexClient : IComplexClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ComplexClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -6,7 +6,7 @@ namespace SeedPagination.InlineUsers;
 
 public partial class InlineUsersClient_ : IInlineUsersClient_
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlineUsersClient_(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsersClient.cs
@@ -4,7 +4,7 @@ namespace SeedPagination.InlineUsers;
 
 public partial class InlineUsersClient : IInlineUsersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlineUsersClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Users/UsersClient.cs
@@ -5,7 +5,7 @@ namespace SeedPagination;
 
 public partial class UsersClient : IUsersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UsersClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Complex/ComplexClient.cs
@@ -5,7 +5,7 @@ namespace SeedPagination;
 
 public partial class ComplexClient : IComplexClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ComplexClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -6,7 +6,7 @@ namespace SeedPagination.InlineUsers;
 
 public partial class InlineUsersClient_ : IInlineUsersClient_
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlineUsersClient_(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsersClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsersClient.cs
@@ -4,7 +4,7 @@ namespace SeedPagination.InlineUsers;
 
 public partial class InlineUsersClient : IInlineUsersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal InlineUsersClient(RawClient client)
     {

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Users/UsersClient.cs
@@ -5,7 +5,7 @@ namespace SeedPagination;
 
 public partial class UsersClient : IUsersClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UsersClient(RawClient client)
     {

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Organizations/OrganizationsClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Organizations/OrganizationsClient.cs
@@ -5,7 +5,7 @@ namespace SeedPathParameters;
 
 public partial class OrganizationsClient : IOrganizationsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal OrganizationsClient(RawClient client)
     {

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedPathParameters;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Organizations/OrganizationsClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Organizations/OrganizationsClient.cs
@@ -5,7 +5,7 @@ namespace SeedPathParameters;
 
 public partial class OrganizationsClient : IOrganizationsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal OrganizationsClient(RawClient client)
     {

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedPathParameters;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Service/ServiceClient.cs
@@ -4,7 +4,7 @@ namespace SeedPlainText;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Service/ServiceClient.cs
@@ -4,7 +4,7 @@ namespace SeedPublicObject;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedQueryParameters;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedRequestParameters;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedRequestParameters;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Package/PackageClient.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Package/PackageClient.cs
@@ -4,7 +4,7 @@ namespace SeedNurseryApi;
 
 public partial class PackageClient : IPackageClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PackageClient(RawClient client)
     {

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Service/ServiceClient.cs
@@ -5,7 +5,7 @@ namespace SeedResponseProperty;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Completions/CompletionsClient.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Completions/CompletionsClient.cs
@@ -5,7 +5,7 @@ namespace SeedServerSentEvents;
 
 public partial class CompletionsClient : ICompletionsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal CompletionsClient(RawClient client)
     {

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Completions/CompletionsClient.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Completions/CompletionsClient.cs
@@ -5,7 +5,7 @@ namespace SeedServerSentEvents;
 
 public partial class CompletionsClient : ICompletionsClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal CompletionsClient(RawClient client)
     {

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/User/UserClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedSimpleApi;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/User/UserClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedSimpleApi;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/User/UserClient.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedSimpleApi;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Dummy/DummyClient.cs
@@ -5,7 +5,7 @@ namespace SeedSingleUrlEnvironmentDefault;
 
 public partial class DummyClient : IDummyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal DummyClient(RawClient client)
     {

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Dummy/DummyClient.cs
@@ -5,7 +5,7 @@ namespace SeedSingleUrlEnvironmentNoDefault;
 
 public partial class DummyClient : IDummyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal DummyClient(RawClient client)
     {

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Dummy/DummyClient.cs
@@ -4,7 +4,7 @@ namespace SeedStreaming;
 
 public partial class DummyClient : IDummyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal DummyClient(RawClient client)
     {

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Dummy/DummyClient.cs
@@ -5,7 +5,7 @@ namespace SeedStreaming;
 
 public partial class DummyClient : IDummyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal DummyClient(RawClient client)
     {

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Dummy/DummyClient.cs
@@ -5,7 +5,7 @@ namespace SeedStreaming;
 
 public partial class DummyClient : IDummyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal DummyClient(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/Admin/AdminClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Admin/AdminClient.cs
@@ -4,7 +4,7 @@ namespace SeedTrace;
 
 public partial class AdminClient : IAdminClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AdminClient(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/IRequestOptions.cs
@@ -40,7 +40,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/Public/ClientOptions.cs
@@ -48,7 +48,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/Public/RequestOptions.cs
@@ -43,7 +43,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/trace/src/SeedTrace/Homepage/HomepageClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Homepage/HomepageClient.cs
@@ -5,7 +5,7 @@ namespace SeedTrace;
 
 public partial class HomepageClient : IHomepageClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal HomepageClient(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/Migration/MigrationClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Migration/MigrationClient.cs
@@ -5,7 +5,7 @@ namespace SeedTrace;
 
 public partial class MigrationClient : IMigrationClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal MigrationClient(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/Playlist/PlaylistClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Playlist/PlaylistClient.cs
@@ -5,7 +5,7 @@ namespace SeedTrace;
 
 public partial class PlaylistClient : IPlaylistClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal PlaylistClient(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/Problem/ProblemClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Problem/ProblemClient.cs
@@ -5,7 +5,7 @@ namespace SeedTrace;
 
 public partial class ProblemClient : IProblemClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ProblemClient(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/Submission/SubmissionClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Submission/SubmissionClient.cs
@@ -5,7 +5,7 @@ namespace SeedTrace;
 
 public partial class SubmissionClient : ISubmissionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SubmissionClient(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/Sysprop/SyspropClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Sysprop/SyspropClient.cs
@@ -5,7 +5,7 @@ namespace SeedTrace;
 
 public partial class SyspropClient : ISyspropClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal SyspropClient(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/V2/Problem/ProblemClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/V2/Problem/ProblemClient.cs
@@ -6,7 +6,7 @@ namespace SeedTrace.V2;
 
 public partial class ProblemClient : IProblemClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ProblemClient(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/V2/V2Client.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/V2/V2Client.cs
@@ -6,7 +6,7 @@ namespace SeedTrace.V2;
 
 public partial class V2Client : IV2Client
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal V2Client(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/V2/V3/Problem/ProblemClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/V2/V3/Problem/ProblemClient.cs
@@ -6,7 +6,7 @@ namespace SeedTrace.V2.V3;
 
 public partial class ProblemClient : IProblemClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ProblemClient(RawClient client)
     {

--- a/seed/csharp-sdk/trace/src/SeedTrace/V2/V3/V3Client.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/V2/V3/V3Client.cs
@@ -4,7 +4,7 @@ namespace SeedTrace.V2.V3;
 
 public partial class V3Client : IV3Client
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal V3Client(RawClient client)
     {

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
@@ -6,7 +6,7 @@ namespace SeedUndiscriminatedUnions;
 
 public partial class UnionClient : IUnionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnionClient(RawClient client)
     {

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
@@ -5,7 +5,7 @@ namespace SeedUndiscriminatedUnions;
 
 public partial class UnionClient : IUnionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnionClient(RawClient client)
     {

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Bigunion/BigunionClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Bigunion/BigunionClient.cs
@@ -5,7 +5,7 @@ namespace SeedUnions;
 
 public partial class BigunionClient : IBigunionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal BigunionClient(RawClient client)
     {

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Types/TypesClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Types/TypesClient.cs
@@ -5,7 +5,7 @@ namespace SeedUnions;
 
 public partial class TypesClient : ITypesClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal TypesClient(RawClient client)
     {

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Union/UnionClient.cs
@@ -5,7 +5,7 @@ namespace SeedUnions;
 
 public partial class UnionClient : IUnionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnionClient(RawClient client)
     {

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Bigunion/BigunionClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Bigunion/BigunionClient.cs
@@ -5,7 +5,7 @@ namespace SeedUnions;
 
 public partial class BigunionClient : IBigunionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal BigunionClient(RawClient client)
     {

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Union/UnionClient.cs
@@ -5,7 +5,7 @@ namespace SeedUnions;
 
 public partial class UnionClient : IUnionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnionClient(RawClient client)
     {

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Bigunion/BigunionClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Bigunion/BigunionClient.cs
@@ -5,7 +5,7 @@ namespace SeedUnions;
 
 public partial class BigunionClient : IBigunionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal BigunionClient(RawClient client)
     {

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Union/UnionClient.cs
@@ -5,7 +5,7 @@ namespace SeedUnions;
 
 public partial class UnionClient : IUnionClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnionClient(RawClient client)
     {

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Unknown/UnknownClient.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Unknown/UnknownClient.cs
@@ -5,7 +5,7 @@ namespace SeedUnknownAsAny;
 
 public partial class UnknownClient : IUnknownClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UnknownClient(RawClient client)
     {

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/variables/src/SeedVariables/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Service/ServiceClient.cs
@@ -4,7 +4,7 @@ namespace SeedVariables;
 
 public partial class ServiceClient : IServiceClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal ServiceClient(RawClient client)
     {

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/User/UserClient.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedVersion;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/version/src/SeedVersion/User/UserClient.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/User/UserClient.cs
@@ -5,7 +5,7 @@ namespace SeedVersion;
 
 public partial class UserClient : IUserClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal UserClient(RawClient client)
     {

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Auth/AuthClient.cs
@@ -5,7 +5,7 @@ namespace SeedWebsocketAuth;
 
 public partial class AuthClient : IAuthClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal AuthClient(RawClient client)
     {

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/IRequestOptions.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/IRequestOptions.cs
@@ -37,7 +37,7 @@ internal interface IRequestOptions
     }
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/Public/ClientOptions.cs
@@ -45,7 +45,7 @@ public partial class ClientOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/Public/RequestOptions.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/Public/RequestOptions.cs
@@ -40,7 +40,7 @@ public partial class RequestOptions : IRequestOptions
     } = [];
 
     /// <summary>
-    /// The http client used to make requests.
+    /// The max number of retries to attempt.
     /// </summary>
     public int? MaxRetries { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyClient.cs
@@ -4,7 +4,7 @@ namespace SeedWebsocket.Empty;
 
 public partial class EmptyClient : IEmptyClient
 {
-    private RawClient _client;
+    private readonly RawClient _client;
 
     internal EmptyClient(RawClient client)
     {


### PR DESCRIPTION
## Description

Refs: Code smell analysis of the generated C# SDK

Two code quality fixes for the generated C# SDK:

1. **Incorrect XML doc comment on `MaxRetries`**: The `MaxRetries` property in `ClientOptions`, `RequestOptions`, and `IRequestOptions` had a copy-paste error — its summary read *"The http client used to make requests."* (which belongs to the `HttpClient` property). Corrected to *"The max number of retries to attempt."*

2. **Missing `readonly` on `_client` field in sub-clients**: The root client correctly declared `private readonly RawClient _client`, but all generated sub-clients only had `private RawClient _client` despite the field being assigned once in the constructor and never reassigned. Also applied to the `_grpc` field in sub-clients.

## Changes Made

### Generator source
- `BaseOptionsGenerator.ts`: Fixed `summary` string in `getMaxRetriesField`
- `SubPackageClientGenerator.ts`: Added `readonly: true` to `_client` and `_grpc` field declarations

### Template
- `IdempotentHeadersTests.Template.cs`: Fixed the same wrong comment on the `MaxRetries` property

### Seed snapshots
- Updated 434 files for the XML doc comment fix (`IRequestOptions.cs`, `ClientOptions.cs`, `RequestOptions.cs`)
- Updated 325 sub-client files for the `readonly` fix

### Changelog
- `versions.yml`: Added version `2.23.2` with both fixes

## Important for review

- Seed files were updated via **context-aware `sed`** / direct string replacement rather than full seed regeneration (Docker unavailable in dev environment). CI seed tests will validate snapshot correctness.
- For the doc comment fix: only replaced when the comment was followed within 2 lines by `MaxRetries`, preserving the correct comment on `HttpClient`.
- No logic changes — purely doc comment + access modifier fixes.

### Human review checklist
- [ ] Verify CI seed snapshot tests pass (confirms sed replacements match generator output)
- [ ] Spot-check a few sub-client files to confirm `private readonly RawClient _client;` is correct

## Testing

- [x] TypeScript compilation passes (`pnpm turbo run compile --filter @fern-api/fern-csharp-sdk`)
- [ ] Seed test regeneration (CI will validate snapshot correctness)

---

[Link to Devin Session](https://app.devin.ai/sessions/c85c5622c77c4ec889cc41ac626942e7)
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
