### PR TITLE
chore(csharp): Remove unused using System.Text.Json.Serialization from StringEnum.cs

### DIFF
--- a/generators/csharp/base/src/asIs/StringEnum.Template.cs
+++ b/generators/csharp/base/src/asIs/StringEnum.Template.cs
@@ -1,5 +1,3 @@
-using global::System.Text.Json.Serialization;
-
 namespace <%= namespace%>;
 
 public interface IStringEnum : IEquatable<string>

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.0.11
+  changelogEntry:
+    - summary: |
+        Remove unused `using System.Text.Json.Serialization` import from `StringEnum.cs`.
+      type: chore
+  createdAt: "2026-03-03"
+  irVersion: 62
+
 - version: 0.0.10
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.23.4
+  changelogEntry:
+    - summary: |
+        Remove unused `using System.Text.Json.Serialization` import from `StringEnum.cs`.
+      type: chore
+  createdAt: "2026-03-03"
+  irVersion: 62
+
 - version: 2.23.3
   changelogEntry:
     - summary: |

--- a/seed/csharp-model/accept-header/src/SeedAccept/Core/StringEnum.cs
+++ b/seed/csharp-model/accept-header/src/SeedAccept/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedAccept.Core;
 

--- a/seed/csharp-model/accept-header/src/SeedAccept/Core/StringEnum.cs
+++ b/seed/csharp-model/accept-header/src/SeedAccept/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedAccept.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/alias-extends/src/SeedAliasExtends/Core/StringEnum.cs
+++ b/seed/csharp-model/alias-extends/src/SeedAliasExtends/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedAliasExtends.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/alias-extends/src/SeedAliasExtends/Core/StringEnum.cs
+++ b/seed/csharp-model/alias-extends/src/SeedAliasExtends/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedAliasExtends.Core;
 

--- a/seed/csharp-model/alias/src/SeedAlias/Core/StringEnum.cs
+++ b/seed/csharp-model/alias/src/SeedAlias/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedAlias.Core;
 

--- a/seed/csharp-model/alias/src/SeedAlias/Core/StringEnum.cs
+++ b/seed/csharp-model/alias/src/SeedAlias/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedAlias.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/any-auth/src/SeedAnyAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/any-auth/src/SeedAnyAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedAnyAuth.Core;
 

--- a/seed/csharp-model/any-auth/src/SeedAnyAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/any-auth/src/SeedAnyAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedAnyAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnum.cs
+++ b/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApiWideBasePath.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnum.cs
+++ b/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApiWideBasePath.Core;
 

--- a/seed/csharp-model/audiences/src/SeedAudiences/Core/StringEnum.cs
+++ b/seed/csharp-model/audiences/src/SeedAudiences/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedAudiences.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/audiences/src/SeedAudiences/Core/StringEnum.cs
+++ b/seed/csharp-model/audiences/src/SeedAudiences/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedAudiences.Core;
 

--- a/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnum.cs
+++ b/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedBasicAuthEnvironmentVariables.Core;
 

--- a/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnum.cs
+++ b/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedBasicAuthEnvironmentVariables.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/basic-auth/src/SeedBasicAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/basic-auth/src/SeedBasicAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedBasicAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/basic-auth/src/SeedBasicAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/basic-auth/src/SeedBasicAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedBasicAuth.Core;
 

--- a/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnum.cs
+++ b/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedBearerTokenEnvironmentVariable.Core;
 

--- a/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnum.cs
+++ b/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedBearerTokenEnvironmentVariable.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/bytes-download/src/SeedBytesDownload/Core/StringEnum.cs
+++ b/seed/csharp-model/bytes-download/src/SeedBytesDownload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedBytesDownload.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/bytes-download/src/SeedBytesDownload/Core/StringEnum.cs
+++ b/seed/csharp-model/bytes-download/src/SeedBytesDownload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedBytesDownload.Core;
 

--- a/seed/csharp-model/bytes-upload/src/SeedBytesUpload/Core/StringEnum.cs
+++ b/seed/csharp-model/bytes-upload/src/SeedBytesUpload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedBytesUpload.Core;
 

--- a/seed/csharp-model/bytes-upload/src/SeedBytesUpload/Core/StringEnum.cs
+++ b/seed/csharp-model/bytes-upload/src/SeedBytesUpload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedBytesUpload.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/circular-references-advanced/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/circular-references-advanced/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/circular-references-advanced/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/circular-references-advanced/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/circular-references/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/circular-references/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/circular-references/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/circular-references/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/client-side-params/src/SeedClientSideParams/Core/StringEnum.cs
+++ b/seed/csharp-model/client-side-params/src/SeedClientSideParams/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedClientSideParams.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/client-side-params/src/SeedClientSideParams/Core/StringEnum.cs
+++ b/seed/csharp-model/client-side-params/src/SeedClientSideParams/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedClientSideParams.Core;
 

--- a/seed/csharp-model/content-type/src/SeedContentTypes/Core/StringEnum.cs
+++ b/seed/csharp-model/content-type/src/SeedContentTypes/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedContentTypes.Core;
 

--- a/seed/csharp-model/content-type/src/SeedContentTypes/Core/StringEnum.cs
+++ b/seed/csharp-model/content-type/src/SeedContentTypes/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedContentTypes.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnum.cs
+++ b/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCrossPackageTypeNames.Core;
 

--- a/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnum.cs
+++ b/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCrossPackageTypeNames.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/csharp-grpc-proto/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-grpc-proto/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/csharp-grpc-proto/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-grpc-proto/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCsharpNamespaceCollision.Core;
 

--- a/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCsharpNamespaceCollision.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCsharpNamespaceConflict.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCsharpNamespaceConflict.Core;
 

--- a/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCsharpReadonlyRequest.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCsharpReadonlyRequest.Core;
 

--- a/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCsharpSystemCollision.Core;
 

--- a/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCsharpSystemCollision.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCsharpXmlEntities.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/Core/StringEnum.cs
+++ b/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCsharpXmlEntities.Core;
 

--- a/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnum.cs
+++ b/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedDollarStringExamples.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnum.cs
+++ b/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedDollarStringExamples.Core;
 

--- a/seed/csharp-model/empty-clients/src/SeedEmptyClients/Core/StringEnum.cs
+++ b/seed/csharp-model/empty-clients/src/SeedEmptyClients/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedEmptyClients.Core;
 

--- a/seed/csharp-model/empty-clients/src/SeedEmptyClients/Core/StringEnum.cs
+++ b/seed/csharp-model/empty-clients/src/SeedEmptyClients/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedEmptyClients.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedEndpointSecurityAuth.Core;
 

--- a/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedEndpointSecurityAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnum.cs
+++ b/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedEnum.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnum.cs
+++ b/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedEnum.Core;
 

--- a/seed/csharp-model/error-property/src/SeedErrorProperty/Core/StringEnum.cs
+++ b/seed/csharp-model/error-property/src/SeedErrorProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedErrorProperty.Core;
 

--- a/seed/csharp-model/error-property/src/SeedErrorProperty/Core/StringEnum.cs
+++ b/seed/csharp-model/error-property/src/SeedErrorProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedErrorProperty.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/errors/src/SeedErrors/Core/StringEnum.cs
+++ b/seed/csharp-model/errors/src/SeedErrors/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedErrors.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/errors/src/SeedErrors/Core/StringEnum.cs
+++ b/seed/csharp-model/errors/src/SeedErrors/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedErrors.Core;
 

--- a/seed/csharp-model/examples/src/SeedExamples/Core/StringEnum.cs
+++ b/seed/csharp-model/examples/src/SeedExamples/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExamples.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/examples/src/SeedExamples/Core/StringEnum.cs
+++ b/seed/csharp-model/examples/src/SeedExamples/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExamples.Core;
 

--- a/seed/csharp-model/exhaustive/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-model/exhaustive/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExhaustive.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/exhaustive/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-model/exhaustive/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExhaustive.Core;
 

--- a/seed/csharp-model/extends/src/SeedExtends/Core/StringEnum.cs
+++ b/seed/csharp-model/extends/src/SeedExtends/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExtends.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/extends/src/SeedExtends/Core/StringEnum.cs
+++ b/seed/csharp-model/extends/src/SeedExtends/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExtends.Core;
 

--- a/seed/csharp-model/extra-properties/src/SeedExtraProperties/Core/StringEnum.cs
+++ b/seed/csharp-model/extra-properties/src/SeedExtraProperties/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExtraProperties.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/extra-properties/src/SeedExtraProperties/Core/StringEnum.cs
+++ b/seed/csharp-model/extra-properties/src/SeedExtraProperties/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExtraProperties.Core;
 

--- a/seed/csharp-model/file-download/src/SeedFileDownload/Core/StringEnum.cs
+++ b/seed/csharp-model/file-download/src/SeedFileDownload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedFileDownload.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/file-download/src/SeedFileDownload/Core/StringEnum.cs
+++ b/seed/csharp-model/file-download/src/SeedFileDownload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedFileDownload.Core;
 

--- a/seed/csharp-model/file-upload-openapi/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/file-upload-openapi/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/file-upload-openapi/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/file-upload-openapi/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/file-upload/src/SeedFileUpload/Core/StringEnum.cs
+++ b/seed/csharp-model/file-upload/src/SeedFileUpload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedFileUpload.Core;
 

--- a/seed/csharp-model/file-upload/src/SeedFileUpload/Core/StringEnum.cs
+++ b/seed/csharp-model/file-upload/src/SeedFileUpload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedFileUpload.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/folders/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/folders/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/folders/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/folders/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnum.cs
+++ b/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedHeaderTokenEnvironmentVariable.Core;
 

--- a/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnum.cs
+++ b/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedHeaderTokenEnvironmentVariable.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/header-auth/src/SeedHeaderToken/Core/StringEnum.cs
+++ b/seed/csharp-model/header-auth/src/SeedHeaderToken/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedHeaderToken.Core;
 

--- a/seed/csharp-model/header-auth/src/SeedHeaderToken/Core/StringEnum.cs
+++ b/seed/csharp-model/header-auth/src/SeedHeaderToken/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedHeaderToken.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/http-head/src/SeedHttpHead/Core/StringEnum.cs
+++ b/seed/csharp-model/http-head/src/SeedHttpHead/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedHttpHead.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/http-head/src/SeedHttpHead/Core/StringEnum.cs
+++ b/seed/csharp-model/http-head/src/SeedHttpHead/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedHttpHead.Core;
 

--- a/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnum.cs
+++ b/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedIdempotencyHeaders.Core;
 

--- a/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnum.cs
+++ b/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedIdempotencyHeaders.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/imdb/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/imdb/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/imdb/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/imdb/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnum.cs
+++ b/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedInferredAuthExplicit.Core;
 

--- a/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnum.cs
+++ b/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedInferredAuthExplicit.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnum.cs
+++ b/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedInferredAuthImplicitApiKey.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnum.cs
+++ b/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedInferredAuthImplicitApiKey.Core;
 

--- a/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnum.cs
+++ b/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedInferredAuthImplicitNoExpiry.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnum.cs
+++ b/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedInferredAuthImplicitNoExpiry.Core;
 

--- a/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnum.cs
+++ b/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedInferredAuthImplicit.Core;
 

--- a/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnum.cs
+++ b/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedInferredAuthImplicit.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnum.cs
+++ b/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedInferredAuthImplicit.Core;
 

--- a/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnum.cs
+++ b/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedInferredAuthImplicit.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/license/src/SeedLicense/Core/StringEnum.cs
+++ b/seed/csharp-model/license/src/SeedLicense/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedLicense.Core;
 

--- a/seed/csharp-model/license/src/SeedLicense/Core/StringEnum.cs
+++ b/seed/csharp-model/license/src/SeedLicense/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedLicense.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/literal/src/SeedLiteral/Core/StringEnum.cs
+++ b/seed/csharp-model/literal/src/SeedLiteral/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedLiteral.Core;
 

--- a/seed/csharp-model/literal/src/SeedLiteral/Core/StringEnum.cs
+++ b/seed/csharp-model/literal/src/SeedLiteral/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedLiteral.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/Core/StringEnum.cs
+++ b/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedLiteralsUnions.Core;
 

--- a/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/Core/StringEnum.cs
+++ b/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedLiteralsUnions.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/mixed-case/src/SeedMixedCase/Core/StringEnum.cs
+++ b/seed/csharp-model/mixed-case/src/SeedMixedCase/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMixedCase.Core;
 

--- a/seed/csharp-model/mixed-case/src/SeedMixedCase/Core/StringEnum.cs
+++ b/seed/csharp-model/mixed-case/src/SeedMixedCase/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMixedCase.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnum.cs
+++ b/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMixedFileDirectory.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnum.cs
+++ b/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMixedFileDirectory.Core;
 

--- a/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnum.cs
+++ b/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMultiLineDocs.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnum.cs
+++ b/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMultiLineDocs.Core;
 

--- a/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnum.cs
+++ b/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMultiUrlEnvironmentNoDefault.Core;
 

--- a/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnum.cs
+++ b/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMultiUrlEnvironmentNoDefault.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
+++ b/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMultiUrlEnvironment.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
+++ b/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMultiUrlEnvironment.Core;
 

--- a/seed/csharp-model/multiple-request-bodies/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/multiple-request-bodies/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/multiple-request-bodies/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/multiple-request-bodies/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/no-environment/src/SeedNoEnvironment/Core/StringEnum.cs
+++ b/seed/csharp-model/no-environment/src/SeedNoEnvironment/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNoEnvironment.Core;
 

--- a/seed/csharp-model/no-environment/src/SeedNoEnvironment/Core/StringEnum.cs
+++ b/seed/csharp-model/no-environment/src/SeedNoEnvironment/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNoEnvironment.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/no-retries/src/SeedNoRetries/Core/StringEnum.cs
+++ b/seed/csharp-model/no-retries/src/SeedNoRetries/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNoRetries.Core;
 

--- a/seed/csharp-model/no-retries/src/SeedNoRetries/Core/StringEnum.cs
+++ b/seed/csharp-model/no-retries/src/SeedNoRetries/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNoRetries.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/nullable-allof-extends/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/nullable-allof-extends/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/nullable-allof-extends/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/nullable-allof-extends/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/nullable-optional/src/SeedNullableOptional/Core/StringEnum.cs
+++ b/seed/csharp-model/nullable-optional/src/SeedNullableOptional/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNullableOptional.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/nullable-optional/src/SeedNullableOptional/Core/StringEnum.cs
+++ b/seed/csharp-model/nullable-optional/src/SeedNullableOptional/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNullableOptional.Core;
 

--- a/seed/csharp-model/nullable-request-body/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/nullable-request-body/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/nullable-request-body/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/nullable-request-body/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/nullable/src/SeedNullable/Core/StringEnum.cs
+++ b/seed/csharp-model/nullable/src/SeedNullable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNullable.Core;
 

--- a/seed/csharp-model/nullable/src/SeedNullable/Core/StringEnum.cs
+++ b/seed/csharp-model/nullable/src/SeedNullable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNullable.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentials.Core;
 

--- a/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentials.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentialsDefault.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentialsDefault.Core;
 

--- a/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentialsEnvironmentVariables.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentialsEnvironmentVariables.Core;
 

--- a/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentialsMandatoryAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentialsMandatoryAuth.Core;
 

--- a/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentials.Core;
 

--- a/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentials.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentialsReference.Core;
 

--- a/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentialsReference.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentialsWithVariables.Core;
 

--- a/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentialsWithVariables.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentials.Core;
 

--- a/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentials.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/object/src/SeedObject/Core/StringEnum.cs
+++ b/seed/csharp-model/object/src/SeedObject/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedObject.Core;
 

--- a/seed/csharp-model/object/src/SeedObject/Core/StringEnum.cs
+++ b/seed/csharp-model/object/src/SeedObject/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedObject.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnum.cs
+++ b/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedObjectsWithImports.Core;
 

--- a/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnum.cs
+++ b/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedObjectsWithImports.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/optional/src/SeedObjectsWithImports/Core/StringEnum.cs
+++ b/seed/csharp-model/optional/src/SeedObjectsWithImports/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedObjectsWithImports.Core;
 

--- a/seed/csharp-model/optional/src/SeedObjectsWithImports/Core/StringEnum.cs
+++ b/seed/csharp-model/optional/src/SeedObjectsWithImports/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedObjectsWithImports.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/package-yml/src/SeedPackageYml/Core/StringEnum.cs
+++ b/seed/csharp-model/package-yml/src/SeedPackageYml/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPackageYml.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/package-yml/src/SeedPackageYml/Core/StringEnum.cs
+++ b/seed/csharp-model/package-yml/src/SeedPackageYml/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPackageYml.Core;
 

--- a/seed/csharp-model/pagination-custom/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-model/pagination-custom/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPagination.Core;
 

--- a/seed/csharp-model/pagination-custom/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-model/pagination-custom/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPagination.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnum.cs
+++ b/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPaginationUriPath.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnum.cs
+++ b/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPaginationUriPath.Core;
 

--- a/seed/csharp-model/pagination/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-model/pagination/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPagination.Core;
 

--- a/seed/csharp-model/pagination/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-model/pagination/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPagination.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/path-parameters/src/SeedPathParameters/Core/StringEnum.cs
+++ b/seed/csharp-model/path-parameters/src/SeedPathParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPathParameters.Core;
 

--- a/seed/csharp-model/path-parameters/src/SeedPathParameters/Core/StringEnum.cs
+++ b/seed/csharp-model/path-parameters/src/SeedPathParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPathParameters.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/plain-text/src/SeedPlainText/Core/StringEnum.cs
+++ b/seed/csharp-model/plain-text/src/SeedPlainText/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPlainText.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/plain-text/src/SeedPlainText/Core/StringEnum.cs
+++ b/seed/csharp-model/plain-text/src/SeedPlainText/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPlainText.Core;
 

--- a/seed/csharp-model/property-access/src/SeedPropertyAccess/Core/StringEnum.cs
+++ b/seed/csharp-model/property-access/src/SeedPropertyAccess/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPropertyAccess.Core;
 

--- a/seed/csharp-model/property-access/src/SeedPropertyAccess/Core/StringEnum.cs
+++ b/seed/csharp-model/property-access/src/SeedPropertyAccess/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPropertyAccess.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/public-object/src/SeedPublicObject/Core/StringEnum.cs
+++ b/seed/csharp-model/public-object/src/SeedPublicObject/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPublicObject.Core;
 

--- a/seed/csharp-model/public-object/src/SeedPublicObject/Core/StringEnum.cs
+++ b/seed/csharp-model/public-object/src/SeedPublicObject/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPublicObject.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/query-parameters-openapi/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/query-parameters-openapi/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/query-parameters-openapi/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/query-parameters-openapi/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/query-parameters/src/SeedQueryParameters/Core/StringEnum.cs
+++ b/seed/csharp-model/query-parameters/src/SeedQueryParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedQueryParameters.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/query-parameters/src/SeedQueryParameters/Core/StringEnum.cs
+++ b/seed/csharp-model/query-parameters/src/SeedQueryParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedQueryParameters.Core;
 

--- a/seed/csharp-model/request-parameters/src/SeedRequestParameters/Core/StringEnum.cs
+++ b/seed/csharp-model/request-parameters/src/SeedRequestParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedRequestParameters.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/request-parameters/src/SeedRequestParameters/Core/StringEnum.cs
+++ b/seed/csharp-model/request-parameters/src/SeedRequestParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedRequestParameters.Core;
 

--- a/seed/csharp-model/required-nullable/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/required-nullable/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/required-nullable/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/required-nullable/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/Core/StringEnum.cs
+++ b/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNurseryApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/Core/StringEnum.cs
+++ b/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNurseryApi.Core;
 

--- a/seed/csharp-model/response-property/src/SeedResponseProperty/Core/StringEnum.cs
+++ b/seed/csharp-model/response-property/src/SeedResponseProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedResponseProperty.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/response-property/src/SeedResponseProperty/Core/StringEnum.cs
+++ b/seed/csharp-model/response-property/src/SeedResponseProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedResponseProperty.Core;
 

--- a/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnum.cs
+++ b/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedServerSentEvents.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnum.cs
+++ b/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedServerSentEvents.Core;
 

--- a/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/Core/StringEnum.cs
+++ b/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedServerSentEvents.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/Core/StringEnum.cs
+++ b/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedServerSentEvents.Core;
 

--- a/seed/csharp-model/server-url-templating/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/server-url-templating/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/server-url-templating/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/server-url-templating/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/simple-api/src/SeedSimpleApi/Core/StringEnum.cs
+++ b/seed/csharp-model/simple-api/src/SeedSimpleApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedSimpleApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/simple-api/src/SeedSimpleApi/Core/StringEnum.cs
+++ b/seed/csharp-model/simple-api/src/SeedSimpleApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedSimpleApi.Core;
 

--- a/seed/csharp-model/simple-fhir/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/simple-fhir/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/simple-fhir/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/simple-fhir/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnum.cs
+++ b/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedSingleUrlEnvironmentDefault.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnum.cs
+++ b/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedSingleUrlEnvironmentDefault.Core;
 

--- a/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnum.cs
+++ b/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedSingleUrlEnvironmentNoDefault.Core;
 

--- a/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnum.cs
+++ b/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedSingleUrlEnvironmentNoDefault.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/streaming-parameter/src/SeedStreaming/Core/StringEnum.cs
+++ b/seed/csharp-model/streaming-parameter/src/SeedStreaming/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedStreaming.Core;
 

--- a/seed/csharp-model/streaming-parameter/src/SeedStreaming/Core/StringEnum.cs
+++ b/seed/csharp-model/streaming-parameter/src/SeedStreaming/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedStreaming.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/streaming/src/SeedStreaming/Core/StringEnum.cs
+++ b/seed/csharp-model/streaming/src/SeedStreaming/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedStreaming.Core;
 

--- a/seed/csharp-model/streaming/src/SeedStreaming/Core/StringEnum.cs
+++ b/seed/csharp-model/streaming/src/SeedStreaming/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedStreaming.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/trace/src/SeedTrace/Core/StringEnum.cs
+++ b/seed/csharp-model/trace/src/SeedTrace/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedTrace.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/trace/src/SeedTrace/Core/StringEnum.cs
+++ b/seed/csharp-model/trace/src/SeedTrace/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedTrace.Core;
 

--- a/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnum.cs
+++ b/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUndiscriminatedUnionWithResponseProperty.Core;
 

--- a/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnum.cs
+++ b/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUndiscriminatedUnionWithResponseProperty.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
+++ b/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUndiscriminatedUnions.Core;
 

--- a/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
+++ b/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUndiscriminatedUnions.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/unions-with-local-date/src/SeedUnions/Core/StringEnum.cs
+++ b/seed/csharp-model/unions-with-local-date/src/SeedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUnions.Core;
 

--- a/seed/csharp-model/unions-with-local-date/src/SeedUnions/Core/StringEnum.cs
+++ b/seed/csharp-model/unions-with-local-date/src/SeedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUnions.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/unions/src/SeedUnions/Core/StringEnum.cs
+++ b/seed/csharp-model/unions/src/SeedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUnions.Core;
 

--- a/seed/csharp-model/unions/src/SeedUnions/Core/StringEnum.cs
+++ b/seed/csharp-model/unions/src/SeedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUnions.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/unknown/src/SeedUnknownAsAny/Core/StringEnum.cs
+++ b/seed/csharp-model/unknown/src/SeedUnknownAsAny/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUnknownAsAny.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/unknown/src/SeedUnknownAsAny/Core/StringEnum.cs
+++ b/seed/csharp-model/unknown/src/SeedUnknownAsAny/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUnknownAsAny.Core;
 

--- a/seed/csharp-model/url-form-encoded/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/url-form-encoded/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/url-form-encoded/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/url-form-encoded/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/validation/src/SeedValidation/Core/StringEnum.cs
+++ b/seed/csharp-model/validation/src/SeedValidation/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedValidation.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/validation/src/SeedValidation/Core/StringEnum.cs
+++ b/seed/csharp-model/validation/src/SeedValidation/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedValidation.Core;
 

--- a/seed/csharp-model/variables/src/SeedVariables/Core/StringEnum.cs
+++ b/seed/csharp-model/variables/src/SeedVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedVariables.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/variables/src/SeedVariables/Core/StringEnum.cs
+++ b/seed/csharp-model/variables/src/SeedVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedVariables.Core;
 

--- a/seed/csharp-model/version-no-default/src/SeedVersion/Core/StringEnum.cs
+++ b/seed/csharp-model/version-no-default/src/SeedVersion/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedVersion.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/version-no-default/src/SeedVersion/Core/StringEnum.cs
+++ b/seed/csharp-model/version-no-default/src/SeedVersion/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedVersion.Core;
 

--- a/seed/csharp-model/version/src/SeedVersion/Core/StringEnum.cs
+++ b/seed/csharp-model/version/src/SeedVersion/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedVersion.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/version/src/SeedVersion/Core/StringEnum.cs
+++ b/seed/csharp-model/version/src/SeedVersion/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedVersion.Core;
 

--- a/seed/csharp-model/webhook-audience/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/webhook-audience/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/webhook-audience/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-model/webhook-audience/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-model/webhooks/src/SeedWebhooks/Core/StringEnum.cs
+++ b/seed/csharp-model/webhooks/src/SeedWebhooks/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedWebhooks.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/webhooks/src/SeedWebhooks/Core/StringEnum.cs
+++ b/seed/csharp-model/webhooks/src/SeedWebhooks/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedWebhooks.Core;
 

--- a/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedWebsocketBearerAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedWebsocketBearerAuth.Core;
 

--- a/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedWebsocketAuth.Core;
 

--- a/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnum.cs
+++ b/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedWebsocketAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-model/websocket/src/SeedWebsocket/Core/StringEnum.cs
+++ b/seed/csharp-model/websocket/src/SeedWebsocket/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedWebsocket.Core;
 

--- a/seed/csharp-model/websocket/src/SeedWebsocket/Core/StringEnum.cs
+++ b/seed/csharp-model/websocket/src/SeedWebsocket/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedWebsocket.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/StringEnum.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedAccept.Core;
 

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/StringEnum.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedAccept.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/StringEnum.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedAliasExtends.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/StringEnum.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedAliasExtends.Core;
 

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/StringEnum.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedAlias.Core;
 

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/StringEnum.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedAlias.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedAnyAuth.Core;
 

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedAnyAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnum.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApiWideBasePath.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnum.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApiWideBasePath.Core;
 

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/StringEnum.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedAudiences.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/StringEnum.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedAudiences.Core;
 

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnum.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedBasicAuthEnvironmentVariables.Core;
 

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnum.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedBasicAuthEnvironmentVariables.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedBasicAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedBasicAuth.Core;
 

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnum.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedBearerTokenEnvironmentVariable.Core;
 

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnum.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedBearerTokenEnvironmentVariable.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/StringEnum.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedBytesDownload.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/StringEnum.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedBytesDownload.Core;
 

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/StringEnum.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedBytesUpload.Core;
 

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/StringEnum.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedBytesUpload.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/StringEnum.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedClientSideParams.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/StringEnum.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedClientSideParams.Core;
 

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/StringEnum.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedContentTypes.Core;
 

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/StringEnum.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedContentTypes.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnum.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCrossPackageTypeNames.Core;
 

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnum.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCrossPackageTypeNames.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCsharpNamespaceConflict.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCsharpNamespaceConflict.Core;
 

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCsharpReadonlyRequest.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCsharpReadonlyRequest.Core;
 

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCsharpSystemCollision.Core;
 

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCsharpSystemCollision.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedCsharpXmlEntities.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/StringEnum.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedCsharpXmlEntities.Core;
 

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnum.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedDollarStringExamples.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnum.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedDollarStringExamples.Core;
 

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/StringEnum.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedEmptyClients.Core;
 

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/StringEnum.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedEmptyClients.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedEndpointSecurityAuth.Core;
 

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedEndpointSecurityAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnum.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedEnum.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnum.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedEnum.Core;
 

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/StringEnum.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedErrorProperty.Core;
 

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/StringEnum.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedErrorProperty.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/StringEnum.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedErrors.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/StringEnum.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedErrors.Core;
 

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/StringEnum.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExamples.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/StringEnum.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExamples.Core;
 

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/StringEnum.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExamples.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/StringEnum.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExamples.Core;
 

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExhaustive.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExhaustive.Core;
 

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExhaustive.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExhaustive.Core;
 

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExhaustive.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExhaustive.Core;
 

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExhaustive.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExhaustive.Core;
 

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExhaustive.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/StringEnum.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExhaustive.Core;
 

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/StringEnum.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExtends.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/StringEnum.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExtends.Core;
 

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/StringEnum.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedExtraProperties.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/StringEnum.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedExtraProperties.Core;
 

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/StringEnum.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedFileDownload.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/StringEnum.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedFileDownload.Core;
 

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/StringEnum.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedFileUpload.Core;
 

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/StringEnum.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedFileUpload.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnum.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedHeaderTokenEnvironmentVariable.Core;
 

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnum.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedHeaderTokenEnvironmentVariable.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/StringEnum.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedHeaderToken.Core;
 

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/StringEnum.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedHeaderToken.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/StringEnum.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedHttpHead.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/StringEnum.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedHttpHead.Core;
 

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnum.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedIdempotencyHeaders.Core;
 

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnum.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedIdempotencyHeaders.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnum.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedInferredAuthExplicit.Core;
 

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnum.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedInferredAuthExplicit.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnum.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedInferredAuthImplicitApiKey.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnum.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedInferredAuthImplicitApiKey.Core;
 

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnum.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedInferredAuthImplicitNoExpiry.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnum.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedInferredAuthImplicitNoExpiry.Core;
 

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnum.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedInferredAuthImplicit.Core;
 

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnum.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedInferredAuthImplicit.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnum.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedInferredAuthImplicit.Core;
 

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnum.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedInferredAuthImplicit.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/StringEnum.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedLicense.Core;
 

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/StringEnum.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedLicense.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/StringEnum.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedLicense.Core;
 

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/StringEnum.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedLicense.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/StringEnum.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedLiteral.Core;
 

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/StringEnum.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedLiteral.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/StringEnum.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedLiteral.Core;
 

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/StringEnum.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedLiteral.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedLiteralsUnions.Core;
 

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedLiteralsUnions.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/StringEnum.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMixedCase.Core;
 

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/StringEnum.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMixedCase.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnum.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMixedFileDirectory.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnum.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMixedFileDirectory.Core;
 

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnum.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMultiLineDocs.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnum.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMultiLineDocs.Core;
 

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnum.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMultiUrlEnvironmentNoDefault.Core;
 

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnum.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMultiUrlEnvironmentNoDefault.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMultiUrlEnvironment.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMultiUrlEnvironment.Core;
 

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedMultiUrlEnvironment.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedMultiUrlEnvironment.Core;
 

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/StringEnum.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNoEnvironment.Core;
 

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/StringEnum.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNoEnvironment.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/StringEnum.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNoRetries.Core;
 

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/StringEnum.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNoRetries.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNullableOptional.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNullableOptional.Core;
 

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNullableOptional.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNullableOptional.Core;
 

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNullable.Core;
 

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNullable.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNullable.Core;
 

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/StringEnum.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNullable.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentials.Core;
 

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentials.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentialsDefault.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentialsDefault.Core;
 

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentialsEnvironmentVariables.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentialsEnvironmentVariables.Core;
 

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentialsMandatoryAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentialsMandatoryAuth.Core;
 

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentials.Core;
 

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentials.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentialsReference.Core;
 

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentialsReference.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentialsWithVariables.Core;
 

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentialsWithVariables.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentials.Core;
 

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentials.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedOauthClientCredentials.Core;
 

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/StringEnum.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedOauthClientCredentials.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/object/src/SeedObject/Core/StringEnum.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedObject.Core;
 

--- a/seed/csharp-sdk/object/src/SeedObject/Core/StringEnum.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedObject.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnum.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedObjectsWithImports.Core;
 

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnum.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedObjectsWithImports.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/StringEnum.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedObjectsWithImports.Core;
 

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/StringEnum.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedObjectsWithImports.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/StringEnum.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedObjectsWithImports.Core;
 

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/StringEnum.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedObjectsWithImports.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/StringEnum.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPackageYml.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/StringEnum.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPackageYml.Core;
 

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPagination.Core;
 

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPagination.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnum.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPaginationUriPath.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnum.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPaginationUriPath.Core;
 

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPagination.Core;
 

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPagination.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPagination.Core;
 

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPagination.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPagination.Core;
 

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/StringEnum.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPagination.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/StringEnum.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPathParameters.Core;
 

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/StringEnum.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPathParameters.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/StringEnum.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPathParameters.Core;
 

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/StringEnum.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPathParameters.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/StringEnum.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPlainText.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/StringEnum.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPlainText.Core;
 

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/StringEnum.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPropertyAccess.Core;
 

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/StringEnum.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPropertyAccess.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/StringEnum.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedPublicObject.Core;
 

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/StringEnum.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedPublicObject.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/StringEnum.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedQueryParameters.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/StringEnum.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedQueryParameters.Core;
 

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/StringEnum.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedRequestParameters.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/StringEnum.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedRequestParameters.Core;
 

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/StringEnum.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedRequestParameters.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/StringEnum.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedRequestParameters.Core;
 

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedNurseryApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedNurseryApi.Core;
 

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/StringEnum.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedResponseProperty.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/StringEnum.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedResponseProperty.Core;
 

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnum.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedServerSentEvents.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnum.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedServerSentEvents.Core;
 

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/StringEnum.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedServerSentEvents.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/StringEnum.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedServerSentEvents.Core;
 

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedSimpleApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedSimpleApi.Core;
 

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedSimpleApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedSimpleApi.Core;
 

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedSimpleApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedSimpleApi.Core;
 

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnum.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedSingleUrlEnvironmentDefault.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnum.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedSingleUrlEnvironmentDefault.Core;
 

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnum.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedSingleUrlEnvironmentNoDefault.Core;
 

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnum.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedSingleUrlEnvironmentNoDefault.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/StringEnum.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedStreaming.Core;
 

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/StringEnum.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedStreaming.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/StringEnum.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedStreaming.Core;
 

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/StringEnum.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedStreaming.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/StringEnum.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedStreaming.Core;
 

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/StringEnum.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedStreaming.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/StringEnum.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedTrace.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/StringEnum.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedTrace.Core;
 

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnum.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUndiscriminatedUnionWithResponseProperty.Core;
 

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnum.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUndiscriminatedUnionWithResponseProperty.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUndiscriminatedUnions.Core;
 

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUndiscriminatedUnions.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUndiscriminatedUnions.Core;
 

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUndiscriminatedUnions.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUnions.Core;
 

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUnions.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUnions.Core;
 

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUnions.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUnions.Core;
 

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/StringEnum.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUnions.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/StringEnum.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedUnknownAsAny.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/StringEnum.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedUnknownAsAny.Core;
 

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/StringEnum.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedValidation.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/StringEnum.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedValidation.Core;
 

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/StringEnum.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedVariables.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/StringEnum.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedVariables.Core;
 

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/StringEnum.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedVersion.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/StringEnum.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedVersion.Core;
 

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/StringEnum.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedVersion.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/StringEnum.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedVersion.Core;
 

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedApi.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/StringEnum.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedApi.Core;
 

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/StringEnum.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedWebhooks.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/StringEnum.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedWebhooks.Core;
 

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedWebsocketBearerAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedWebsocketBearerAuth.Core;
 

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedWebsocketAuth.Core;
 

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnum.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedWebsocketAuth.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/StringEnum.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedWebsocket.Core;
 

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/StringEnum.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedWebsocket.Core;
 
 public interface IStringEnum : IEquatable<string>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/StringEnum.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-using global::System.Text.Json.Serialization;
 
 namespace SeedWebsocket.Core;
 

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/StringEnum.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/StringEnum.cs
@@ -1,4 +1,3 @@
-
 namespace SeedWebsocket.Core;
 
 public interface IStringEnum : IEquatable<string>


### PR DESCRIPTION
## Description

Refs code smell #14 from C# SDK analysis.

Removes the unused `using global::System.Text.Json.Serialization;` import from the generated `StringEnum.cs` file. The `IStringEnum` interface only uses `IEquatable<string>` (from `System`), so `System.Text.Json.Serialization` was never needed.

[Link to Devin Session](https://app.devin.ai/sessions/c85c5622c77c4ec889cc41ac626942e7)
Requested by: @Swimburger

## Changes Made

- Removed the unused `using` directive from `generators/csharp/base/src/asIs/StringEnum.Template.cs`
- Updated 255 seed snapshot files across `seed/csharp-sdk/` (142 files) and `seed/csharp-model/` (113 files)
- Bumped `generators/csharp/sdk/versions.yml` → 2.23.4
- Bumped `generators/csharp/model/versions.yml` → 0.0.11

## Testing

- [ ] Seed snapshot tests (CI) confirm generated output matches expectations
- [ ] Manual verification that `IStringEnum` has no dependency on `System.Text.Json.Serialization`

## Human Review Checklist

- Verify version bump numbers (SDK 2.23.4, Model 0.0.11) are correct and don't conflict with any in-flight PRs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
