### PR TITLE
fix(generator-cli): clean replay PRs with local conflict resolution

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -14,7 +14,7 @@ import {
 } from "@fern-api/configuration-loader";
 import { ContainerRunner, haveSameNullishness, undefinedIfNullish, undefinedIfSomeNullish } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, doesPathExist, isURL, resolve } from "@fern-api/fs-utils";
-import { formatBootstrapSummary, replayInit } from "@fern-api/generator-cli";
+import { formatBootstrapSummary, replayInit, replayResolve } from "@fern-api/generator-cli";
 import {
     initializeAPI,
     initializeDocs,
@@ -2049,6 +2049,7 @@ function addReplayCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
         describe: false, // hidden from --help
         builder: (yargs) => {
             addReplayInitCommand(yargs, cliContext);
+            addReplayResolveCommand(yargs, cliContext);
             return yargs;
         },
         handler: () => {
@@ -2149,6 +2150,78 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
                 cliContext.failAndThrow(
                     `Failed to initialize Replay: ${error instanceof Error ? error.message : String(error)}`
                 );
+            }
+        }
+    );
+}
+
+function addReplayResolveCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
+    cli.command(
+        "resolve [directory]",
+        false, // hidden from --help
+        (yargs) =>
+            yargs
+                .positional("directory", {
+                    type: "string",
+                    default: ".",
+                    description: "SDK directory containing .fern/replay.lock"
+                })
+                .option("no-check-markers", {
+                    type: "boolean",
+                    default: false,
+                    description: "Skip checking for remaining conflict markers before committing"
+                }),
+        async (argv) => {
+            await cliContext.instrumentPostHogEvent({
+                command: "fern replay resolve"
+            });
+
+            const outputDir = resolve(cwd(), argv.directory ?? ".");
+
+            try {
+                const result = await replayResolve({
+                    outputDir,
+                    checkMarkers: !argv.noCheckMarkers
+                });
+
+                switch (result.phase) {
+                    case "applied":
+                        cliContext.logger.info(
+                            `Applied ${result.patchesApplied} unresolved patch(es) to your working tree.`
+                        );
+                        if (result.unresolvedFiles && result.unresolvedFiles.length > 0) {
+                            cliContext.logger.info(`\nFiles with conflict markers:`);
+                            for (const file of result.unresolvedFiles) {
+                                cliContext.logger.info(`  ${file}`);
+                            }
+                            cliContext.logger.info(
+                                `\nResolve the conflicts in your editor, then run \`fern replay resolve\` again to finalize.`
+                            );
+                        }
+                        break;
+                    case "committed":
+                        cliContext.logger.info(
+                            `Resolved ${result.patchesResolved} patch(es) and committed. Push when ready.`
+                        );
+                        break;
+                    case "nothing-to-resolve":
+                        cliContext.logger.info("No unresolved patches found.");
+                        break;
+                    default:
+                        if (!result.success) {
+                            if (result.reason === "unresolved-conflicts" && result.unresolvedFiles) {
+                                cliContext.logger.warn(`Some files still have conflict markers:`);
+                                for (const file of result.unresolvedFiles) {
+                                    cliContext.logger.warn(`  ${file}`);
+                                }
+                                cliContext.logger.warn(`Resolve them first, then run \`fern replay resolve\` again.`);
+                            } else {
+                                cliContext.failAndThrow(`Resolve failed: ${result.reason ?? "unknown error"}`);
+                            }
+                        }
+                }
+            } catch (error) {
+                cliContext.failAndThrow(`Failed to resolve: ${error instanceof Error ? error.message : String(error)}`);
             }
         }
     );

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.1.1
+  changelogEntry:
+    - summary: |
+        Add CLI subcommand for resolving customization conflicts on SDK generation PR branches.
+      type: fix
+  createdAt: "2026-03-02"
+  irVersion: 65
+
 - version: 4.1.0
   changelogEntry:
     - summary: |

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -23,7 +23,7 @@
   },
   "files": ["bin", "dist", "lib"],
   "dependencies": {
-    "@fern-api/replay": "^0.6.2",
+    "@fern-api/replay": "^0.7.0",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/generator-cli/src/api.ts
+++ b/packages/generator-cli/src/api.ts
@@ -34,4 +34,9 @@ export {
     type ReplayInitResult,
     replayInit
 } from "./replay/replay-init.js";
+export {
+    type ReplayResolveParams,
+    type ResolveResult,
+    replayResolve
+} from "./replay/replay-resolve.js";
 export { type ReplayRunParams, type ReplayRunResult, replayRun } from "./replay/replay-run.js";

--- a/packages/generator-cli/src/pipeline/github/createReplayBranch.ts
+++ b/packages/generator-cli/src/pipeline/github/createReplayBranch.ts
@@ -10,69 +10,32 @@ export async function createReplayBranch(
         | {
               previousGenerationSha: string;
               currentGenerationSha: string;
-              hasConflicts: boolean;
-              baseBranchHead?: string;
           }
         | undefined,
     logger: PipelineLogger
 ): Promise<string | undefined> {
-    if (replayConflictInfo?.hasConflicts) {
-        // Parent must be previousGenerationSha to create a divergent fork in history.
-        // GitHub computes merge base = previousGen, then shows real 3-way diff between
-        // main's path (previousGen → mainHEAD) and the branch (previousGen → synthetic).
-        // Using baseBranchHead (= main HEAD) would make the branch linear, showing
-        // conflict markers as plain text instead of real merge conflicts.
-        const parentSha = replayConflictInfo.previousGenerationSha;
-        // Use baseBranchHead for lockfile restore — it's on main's lineage and has the
-        // correct lockfile state (pre-replay). Fall back to previousGenerationSha.
-        const lockfileRestoreSha = replayConflictInfo.baseBranchHead ?? replayConflictInfo.previousGenerationSha;
-
-        logger.debug(`Creating divergent PR branch with generation tree (parent: ${parentSha.substring(0, 7)})`);
-
-        // Use the pure generation tree — NOT HEAD's tree (which has conflict markers as text).
-        // With the generation tree parented off previousGenerationSha, GitHub computes a real
-        // 3-way merge: base=previousGen, main=previousGen+user edits, PR=newGen. Files where
-        // both sides diverged show as real merge conflicts in the PR "Files changed" view.
-        const genTreeHash = await repository.getCommitTreeHash(replayConflictInfo.currentGenerationSha);
-        const syntheticCommitSha = await repository.commitTree(
-            genTreeHash,
-            parentSha,
-            `[fern-generated] ${commitMessage ?? "Update SDK"}`
-        );
-
-        await repository.createBranchFromCommit(branchName, syntheticCommitSha);
-
-        // Restore the lockfile from the base branch so it matches main.
-        // The HEAD tree has a replay-updated lockfile which would cause a spurious
-        // lockfile conflict in the PR. Main's lockfile is the source of truth.
-        try {
-            await repository.restoreFilesFromCommit(lockfileRestoreSha, ".fern/replay.lock");
-            await repository.commitAllChanges(`[fern-generated] ${commitMessage ?? "Update SDK"}`);
-        } catch (error) {
-            logger.debug(
-                `Could not restore lockfile from base branch: ${error instanceof Error ? error.message : String(error)}`
-            );
-        }
-
-        return syntheticCommitSha;
-    } else if (replayConflictInfo != null) {
-        const parentSha = replayConflictInfo.previousGenerationSha;
-
-        logger.debug(`Creating linear PR branch from HEAD (no conflicts)`);
-
-        await repository.createBranchFromHead(branchName);
-
-        const genTreeHash = await repository.getCommitTreeHash(replayConflictInfo.currentGenerationSha);
-        const tagCommitSha = await repository.commitTree(
-            genTreeHash,
-            parentSha,
-            `[fern-generated] ${commitMessage ?? "Update SDK"}`
-        );
-
-        return tagCommitSha;
-    } else {
+    if (replayConflictInfo == null) {
         // No previous generation info — use existing linear behavior
         await repository.createBranchFromHead(branchName);
         return undefined;
     }
+
+    const parentSha = replayConflictInfo.previousGenerationSha;
+
+    // Always create a linear branch from HEAD — the code is clean.
+    // The lockfile stays as-is: it has the latest generation, current_generation,
+    // and any status: unresolved markers so `fern replay resolve` works on the branch.
+    await repository.createBranchFromHead(branchName);
+
+    // Tag commit: pure generation tree + previousGenerationSha as parent.
+    // Not used as branch content — only pushed as the fern-generation-base tag
+    // so that the next run's sync detection works.
+    const genTreeHash = await repository.getCommitTreeHash(replayConflictInfo.currentGenerationSha);
+    const tagCommitSha = await repository.commitTree(
+        genTreeHash,
+        parentSha,
+        `[fern-generated] ${commitMessage ?? "Update SDK"}`
+    );
+
+    return tagCommitSha;
 }

--- a/packages/generator-cli/src/pipeline/index.ts
+++ b/packages/generator-cli/src/pipeline/index.ts
@@ -2,7 +2,6 @@ export { consolePipelineLogger, type PipelineLogger } from "./PipelineLogger";
 export { PostGenerationPipeline } from "./PostGenerationPipeline";
 export { formatReplayPrBody, logReplaySummary } from "./replay-summary";
 export type {
-    ConflictInfo,
     FernignoreStepConfig,
     FernignoreStepResult,
     GithubStepConfig,

--- a/packages/generator-cli/src/pipeline/replay-summary.ts
+++ b/packages/generator-cli/src/pipeline/replay-summary.ts
@@ -10,21 +10,21 @@ export function formatConflictReason(reason: string | undefined): string {
         case "same-line-edit":
             return "The new generation changed the same lines you edited";
         case "new-file-both":
-            return "You and the generator both created this file";
+            return "Both the generator and your customization created this file";
         case "base-generation-mismatch":
-            return "The generated code changed significantly around your edit";
+            return "This customization was from a previous generation";
         case "patch-apply-failed":
-            return "Your change could not be applied to the new generated code";
+            return "The customization could not be applied to the new code";
         default:
             return "Your edit overlaps with changes in the new generation";
     }
 }
 
-export function patchDescription(detail: { patchMessage: string; files: Array<{ file: string }> }): string {
+export function patchDescription(detail: { patchMessage: string; files: string[] }): string {
     if (detail.patchMessage && detail.patchMessage !== "update") {
         return detail.patchMessage;
     }
-    const firstFile = detail.files[0]?.file;
+    const firstFile = detail.files[0];
     return firstFile != null ? `changes in ${firstFile}` : "customization";
 }
 
@@ -35,11 +35,11 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
 
     const applied = result.patchesApplied ?? 0;
     const absorbed = result.patchesAbsorbed ?? 0;
-    const conflicts = result.patchesWithConflicts ?? 0;
+    const unresolvedCount = result.unresolvedPatches?.length ?? 0;
     const preserved = applied - absorbed;
 
     logger.debug(
-        `Replay: flow=${result.flow}, detected=${result.patchesDetected ?? 0}, applied=${applied}, absorbed=${absorbed}, conflicts=${conflicts}`
+        `Replay: flow=${result.flow}, detected=${result.patchesDetected ?? 0}, applied=${applied}, absorbed=${absorbed}, unresolved=${unresolvedCount}`
     );
 
     if (preserved > 0) {
@@ -49,14 +49,17 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
         logger.info(`Replay: customizations now part of generated code`);
     }
 
-    if (conflicts > 0) {
-        const totalFiles = (result.conflictDetails ?? []).reduce((sum, d) => sum + d.files.length, 0);
-        logger.warn(
-            `Replay: ${plural(totalFiles, "file")} ${totalFiles === 1 ? "has" : "have"} merge conflicts — resolve in the PR or locally`
+    if (unresolvedCount > 0) {
+        const totalFiles = (result.unresolvedPatches ?? []).reduce(
+            (sum, patch) => sum + patch.conflictDetails.length,
+            0
         );
-        for (const detail of result.conflictDetails ?? []) {
-            logger.warn(`  "${patchDescription(detail)}":`);
-            for (const file of detail.files) {
+        logger.warn(
+            `Replay: ${plural(totalFiles, "file")} ${totalFiles === 1 ? "has" : "have"} unresolved conflicts — resolve via \`fern replay resolve\``
+        );
+        for (const patch of result.unresolvedPatches ?? []) {
+            logger.warn(`  "${patchDescription(patch)}":`);
+            for (const file of patch.conflictDetails) {
                 logger.warn(`    ${file.file} — ${formatConflictReason(file.conflictReason)}`);
             }
         }
@@ -69,7 +72,7 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
 
 export function formatReplayPrBody(
     result: ReplayStepResult | undefined,
-    options?: { branchName?: string }
+    options?: { branchName?: string; repoUri?: string }
 ): string | undefined {
     if (result == null || !result.executed) {
         return undefined;
@@ -77,70 +80,68 @@ export function formatReplayPrBody(
 
     const applied = result.patchesApplied ?? 0;
     const absorbed = result.patchesAbsorbed ?? 0;
-    const conflicts = result.patchesWithConflicts ?? 0;
+    const unresolvedPatches = result.unresolvedPatches ?? [];
+    const hasUnresolved = unresolvedPatches.length > 0;
     const preserved = applied - absorbed;
 
-    if (preserved === 0 && conflicts === 0) {
+    if (preserved === 0 && !hasUnresolved) {
         return undefined;
     }
 
     const parts: string[] = [];
 
-    if (preserved > 0 && conflicts === 0) {
+    if (preserved > 0 && !hasUnresolved) {
         parts.push(`\u2705 Customizations automatically preserved in this update.`);
     } else if (preserved > 0) {
+        const totalFiles = unresolvedPatches.reduce((sum, patch) => sum + patch.conflictDetails.length, 0);
         parts.push(
-            `\u2705 Customizations automatically preserved, but ${plural(conflicts, "file")} ${conflicts === 1 ? "needs" : "need"} your attention.`
+            `\u2705 Customizations automatically preserved, but ${plural(totalFiles, "file")} ${totalFiles === 1 ? "needs" : "need"} your attention.`
         );
     }
 
-    // Conflict detail
-    if (conflicts > 0) {
-        const allFiles = (result.conflictDetails ?? []).flatMap((d) => d.files);
-        const totalFiles = allFiles.length;
+    if (hasUnresolved) {
+        const totalFiles = unresolvedPatches.reduce((sum, patch) => sum + patch.conflictDetails.length, 0);
 
-        parts.push(`\n### \u26a0\ufe0f Action required: ${plural(totalFiles, "file")} with customization conflicts\n`);
+        parts.push(`\n### Action required: ${plural(totalFiles, "file")} with unresolved customization conflicts\n`);
         parts.push(
-            `You previously customized ${totalFiles === 1 ? "a file" : "files"} in this SDK. This generation changed the same code, so your ${totalFiles === 1 ? "edit" : "edits"} couldn't be applied automatically.\n`
-        );
-        parts.push(
-            `> \u26a0\ufe0f **Label guide:** In GitHub's conflict editor, \`<<<<<<< HEAD\` ("Accept current") = new generated code. \`>>>>>>> main\` ("Accept incoming") = your customization.\n`
+            `The new generation changed code you previously customized. Non-conflicting customizations have been applied automatically. The following files need manual resolution:\n`
         );
 
         parts.push(`| File | Your customization | Why it conflicted |`);
         parts.push(`|------|-------------------|-------------------|`);
-        for (const detail of result.conflictDetails ?? []) {
-            const description = patchDescription(detail);
-            for (const f of detail.files) {
-                parts.push(`| \`${f.file}\` | ${description} | ${formatConflictReason(f.conflictReason)} |`);
+        for (const patch of unresolvedPatches) {
+            const description = patchDescription(patch);
+            for (const file of patch.conflictDetails) {
+                parts.push(`| \`${file.file}\` | ${description} | ${formatConflictReason(file.conflictReason)} |`);
             }
         }
 
         const branch = options?.branchName ?? "<branch-name>";
-        parts.push(`\n#### How to fix\n`);
+        const repoUri = options?.repoUri;
+        const repoName = repoUri?.split("/").pop() ?? "<repo>";
 
-        parts.push(`**Option A: Resolve in GitHub (recommended for simple conflicts)**\n`);
-        parts.push(`1. Click the **Resolve conflicts** button below`);
-        parts.push(`2. For each file, choose which code to keep:`);
-        parts.push(`   - \`<<<<<<< HEAD\` / "Accept current changes" = **new generated code**`);
-        parts.push(`   - \`>>>>>>> main\` / "Accept incoming changes" = **your customization**`);
-        parts.push(`   - Or manually combine both, then delete the conflict markers`);
-        parts.push(`3. Click **Mark as resolved** for each file, then **Commit merge**\n`);
-
-        parts.push(`**Option B: Resolve locally**\n`);
-        parts.push(`1. Fetch and check out this branch:`);
+        parts.push(`\n#### How to resolve\n`);
+        parts.push(`1. Check out this branch:`);
         parts.push(`   \`\`\`sh`);
-        parts.push(`   git fetch origin && git checkout ${branch}`);
+        parts.push(`   git fetch origin && git checkout -b ${branch} origin/${branch}`);
         parts.push(`   \`\`\``);
-        parts.push(`2. Merge the base branch and resolve conflicts in your editor:`);
-        parts.push(`   \`\`\`sh`);
-        parts.push(`   git merge origin/main`);
-        parts.push(`   \`\`\``);
-        parts.push(`3. Commit and push:`);
-        parts.push(`   \`\`\`sh`);
-        parts.push(`   git add -A && git commit -m "resolve conflicts" && git push`);
-        parts.push(`   \`\`\`\n`);
-        parts.push(`Your resolved changes will be remembered on future SDK generations.`);
+        if (repoUri != null) {
+            parts.push(`   Or if you don't have the repo cloned:`);
+            parts.push(`   \`\`\`sh`);
+            parts.push(
+                `   git clone https://github.com/${repoUri}.git && cd ${repoName} && git checkout -b ${branch} origin/${branch}`
+            );
+            parts.push(`   \`\`\``);
+        }
+        parts.push(`2. Run: \`fern replay resolve\``);
+        parts.push(`3. Open the conflicting files in your editor — you'll see standard merge conflict markers`);
+        parts.push(`4. Resolve using your editor's merge tools (VS Code, IntelliJ, etc.)`);
+        parts.push(`5. Run: \`fern replay resolve\` again to finalize`);
+        parts.push(`6. Push your changes\n`);
+        parts.push(`Your resolved customizations will be remembered on future SDK generations.`);
+        parts.push(
+            `If you merge this PR without resolving, your unresolved customizations will conflict again on the next generation.`
+        );
     }
 
     return parts.join("\n");

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -3,7 +3,6 @@ import { Octokit } from "@octokit/rest";
 import { access, writeFile } from "fs/promises";
 import { join } from "path";
 import { createReplayBranch } from "../github/createReplayBranch";
-import type { ExistingPullRequest } from "../github/findExistingUpdatablePR";
 import { findExistingUpdatablePR } from "../github/findExistingUpdatablePR";
 import { parseCommitMessageForPR } from "../github/parseCommitMessage";
 import type { PipelineLogger } from "../PipelineLogger";
@@ -86,8 +85,6 @@ export class GithubStep extends BaseStep {
             | {
                   previousGenerationSha: string;
                   currentGenerationSha: string;
-                  hasConflicts: boolean;
-                  baseBranchHead?: string;
               }
             | undefined,
         replayResult: ReplayStepResult | undefined
@@ -178,19 +175,9 @@ export class GithubStep extends BaseStep {
             }
         }
 
-        // Runs after push so head SHA is available on remote
-        if (!this.config.previewMode) {
-            const headSha = await repository.getHeadSha();
-            await this.postReplayConflictStatus(octokit, owner, repo, headSha, replayConflictInfo, replayResult);
-
-            if (isUpdatingExistingPR && existingPR != null) {
-                await this.togglePrDraftState(octokit, existingPR, replayConflictInfo);
-            }
-        }
-
         const finalCommitMessage = this.config.commitMessage ?? "SDK Generation";
         const { prTitle, prBody } = parseCommitMessageForPR(finalCommitMessage);
-        const replaySection = formatReplayPrBody(replayResult, { branchName: prBranch });
+        const replaySection = formatReplayPrBody(replayResult, { branchName: prBranch, repoUri: this.config.uri });
         const enrichedBody = replaySection != null ? prBody + "\n\n---\n\n" + replaySection : prBody;
 
         if (isUpdatingExistingPR && existingPR != null) {
@@ -215,7 +202,6 @@ export class GithubStep extends BaseStep {
         } else {
             const head = `${owner}:${prBranch}`;
 
-            const hasConflicts = replayConflictInfo?.hasConflicts === true;
             try {
                 const { data: pullRequest } = await octokit.pulls.create({
                     owner,
@@ -223,8 +209,7 @@ export class GithubStep extends BaseStep {
                     title: prTitle,
                     body: enrichedBody,
                     head,
-                    base: baseBranch,
-                    draft: hasConflicts
+                    base: baseBranch
                 });
 
                 this.logger.info(`Created pull request: ${pullRequest.html_url}`);
@@ -238,23 +223,6 @@ export class GithubStep extends BaseStep {
                     throw error;
                 }
             }
-        }
-
-        if (
-            !this.config.previewMode &&
-            result.prNumber != null &&
-            replayConflictInfo?.hasConflicts === true &&
-            replayResult != null
-        ) {
-            await this.postWebEditorFallbackComment(
-                octokit,
-                owner,
-                repo,
-                result.prNumber,
-                prBranch,
-                baseBranch,
-                replayResult
-            );
         }
 
         return result;
@@ -312,273 +280,19 @@ export class GithubStep extends BaseStep {
         | {
               previousGenerationSha: string;
               currentGenerationSha: string;
-              hasConflicts: boolean;
-              baseBranchHead?: string;
           }
         | undefined {
         if (replayResult == null) {
             return undefined;
         }
-        const hasConflicts = (replayResult.patchesWithConflicts ?? 0) > 0;
         const previousGenerationSha = replayResult.previousGenerationSha;
         const currentGenerationSha = replayResult.currentGenerationSha;
         if (previousGenerationSha != null && currentGenerationSha != null) {
             return {
                 previousGenerationSha,
-                currentGenerationSha,
-                hasConflicts,
-                baseBranchHead: replayResult.baseBranchHead
+                currentGenerationSha
             };
         }
         return undefined;
     }
-
-    private async togglePrDraftState(
-        octokit: Octokit,
-        existingPR: ExistingPullRequest,
-        replayConflictInfo:
-            | {
-                  previousGenerationSha: string;
-                  currentGenerationSha: string;
-                  hasConflicts: boolean;
-                  baseBranchHead?: string;
-              }
-            | undefined
-    ): Promise<void> {
-        const hasConflicts = replayConflictInfo?.hasConflicts === true;
-
-        if (hasConflicts && !existingPR.isDraft) {
-            await this.convertPrToDraft(octokit, existingPR.nodeId, existingPR.number);
-        } else if (!hasConflicts && existingPR.isDraft) {
-            await this.markPrReady(octokit, existingPR.nodeId, existingPR.number);
-        }
-    }
-
-    private async convertPrToDraft(octokit: Octokit, nodeId: string, prNumber: number): Promise<void> {
-        try {
-            await octokit.graphql(
-                `mutation($id: ID!) {
-                    convertPullRequestToDraft(input: {pullRequestId: $id}) {
-                        pullRequest { isDraft }
-                    }
-                }`,
-                { id: nodeId }
-            );
-            this.logger.info(`Converted PR #${prNumber} to draft due to replay conflicts`);
-        } catch (error) {
-            this.logger.debug(
-                `Could not convert PR to draft: ${error instanceof Error ? error.message : String(error)}`
-            );
-        }
-    }
-
-    private async markPrReady(octokit: Octokit, nodeId: string, prNumber: number): Promise<void> {
-        try {
-            await octokit.graphql(
-                `mutation($id: ID!) {
-                    markPullRequestReadyForReview(input: {pullRequestId: $id}) {
-                        pullRequest { isDraft }
-                    }
-                }`,
-                { id: nodeId }
-            );
-            this.logger.info(`Marked PR #${prNumber} as ready (conflicts resolved)`);
-        } catch (error) {
-            this.logger.debug(`Could not mark PR as ready: ${error instanceof Error ? error.message : String(error)}`);
-        }
-    }
-
-    private async postReplayConflictStatus(
-        octokit: Octokit,
-        owner: string,
-        repo: string,
-        sha: string,
-        replayConflictInfo:
-            | {
-                  previousGenerationSha: string;
-                  currentGenerationSha: string;
-                  hasConflicts: boolean;
-                  baseBranchHead?: string;
-              }
-            | undefined,
-        replayResult: ReplayStepResult | undefined
-    ): Promise<void> {
-        if (replayResult == null || !replayResult.executed) {
-            return;
-        }
-
-        const hasConflicts = replayConflictInfo?.hasConflicts === true;
-        const conflictFileCount = (replayResult.conflictDetails ?? []).reduce(
-            (sum, detail) => sum + detail.files.length,
-            0
-        );
-        const sanitizedName = this.config.generatorName?.replace(/\//g, "--");
-        const context =
-            sanitizedName != null ? `fern / sdk customizations / ${sanitizedName}` : "fern / sdk customizations";
-
-        try {
-            await octokit.repos.createCommitStatus({
-                owner,
-                repo,
-                sha,
-                state: hasConflicts ? "failure" : "success",
-                context,
-                description: hasConflicts
-                    ? `${conflictFileCount} file(s) need manual conflict resolution — see PR description`
-                    : "All customizations applied"
-            });
-            this.logger.debug(`Posted ${hasConflicts ? "failing" : "passing"} commit status (${context})`);
-        } catch (error) {
-            this.logger.debug(
-                `Could not post commit status: ${error instanceof Error ? error.message : String(error)}`
-            );
-        }
-    }
-
-    private async postWebEditorFallbackComment(
-        octokit: Octokit,
-        owner: string,
-        repo: string,
-        prNumber: number,
-        branchName: string,
-        baseBranch: string,
-        replayResult: ReplayStepResult
-    ): Promise<void> {
-        try {
-            const webEditorLikelyDisabled = await this.isWebEditorLikelyDisabled(
-                octokit,
-                owner,
-                repo,
-                prNumber,
-                replayResult
-            );
-
-            if (!webEditorLikelyDisabled) {
-                this.logger.debug(`PR #${prNumber}: web conflict editor appears usable, skipping fallback comment`);
-                return;
-            }
-
-            const comment = buildWebEditorFallbackComment(branchName, baseBranch);
-            await octokit.issues.createComment({
-                owner,
-                repo,
-                issue_number: prNumber,
-                body: comment
-            });
-            this.logger.info(`Posted web-editor fallback comment on PR #${prNumber}`);
-        } catch (error) {
-            this.logger.debug(
-                `Could not post web-editor fallback comment: ${error instanceof Error ? error.message : String(error)}`
-            );
-        }
-    }
-
-    private async isWebEditorLikelyDisabled(
-        octokit: Octokit,
-        owner: string,
-        repo: string,
-        prNumber: number,
-        replayResult: ReplayStepResult
-    ): Promise<boolean> {
-        const conflictDetails = replayResult.conflictDetails ?? [];
-        const allConflictFiles = conflictDetails.flatMap((d) => d.files);
-        const totalConflictFiles = allConflictFiles.length;
-
-        const hasFileDeletionConflict = allConflictFiles.some((f) => {
-            const status = (f.status ?? "").toLowerCase();
-            const reason = (f.conflictReason ?? "").toLowerCase();
-            return status === "skipped" || reason.includes("delete") || reason.includes("removed");
-        });
-
-        if (hasFileDeletionConflict) {
-            this.logger.debug(`PR #${prNumber}: detected file deletion conflict, web editor likely disabled`);
-            return true;
-        }
-
-        if (totalConflictFiles >= WEB_EDITOR_FILE_THRESHOLD) {
-            this.logger.debug(
-                `PR #${prNumber}: ${totalConflictFiles} conflicting files exceeds threshold (${WEB_EDITOR_FILE_THRESHOLD}), web editor likely disabled`
-            );
-            return true;
-        }
-
-        const totalHunks = (replayResult.conflicts ?? []).reduce(
-            (sum, fileConflict) => sum + fileConflict.conflicts.length,
-            0
-        );
-        if (totalHunks >= WEB_EDITOR_HUNK_THRESHOLD) {
-            this.logger.debug(
-                `PR #${prNumber}: ${totalHunks} conflict hunks exceeds threshold (${WEB_EDITOR_HUNK_THRESHOLD}), web editor likely disabled`
-            );
-            return true;
-        }
-
-        const mergeableState = await this.pollMergeableState(octokit, owner, repo, prNumber);
-        if (mergeableState.mergeable === null) {
-            this.logger.debug(`PR #${prNumber}: mergeable state still null after polling, web editor likely disabled`);
-            return true;
-        }
-
-        return false;
-    }
-
-    private async pollMergeableState(
-        octokit: Octokit,
-        owner: string,
-        repo: string,
-        prNumber: number
-    ): Promise<{ mergeable: boolean | null; mergeableState: string }> {
-        for (let attempt = 0; attempt < MERGEABLE_POLL_MAX_ATTEMPTS; attempt++) {
-            const { data: pr } = await octokit.pulls.get({
-                owner,
-                repo,
-                pull_number: prNumber
-            });
-
-            if (pr.mergeable != null) {
-                return {
-                    mergeable: pr.mergeable,
-                    mergeableState: pr.mergeable_state
-                };
-            }
-
-            if (attempt < MERGEABLE_POLL_MAX_ATTEMPTS - 1) {
-                await sleep(MERGEABLE_POLL_DELAY_MS);
-            }
-        }
-
-        return { mergeable: null, mergeableState: "unknown" };
-    }
-}
-
-const WEB_EDITOR_FILE_THRESHOLD = 20;
-const WEB_EDITOR_HUNK_THRESHOLD = 50;
-const MERGEABLE_POLL_MAX_ATTEMPTS = 3;
-const MERGEABLE_POLL_DELAY_MS = 1500;
-
-function buildWebEditorFallbackComment(branchName: string, baseBranch: string): string {
-    const lines = [
-        `> **Note:** These conflicts may be too complex for GitHub's web editor. To resolve locally:`,
-        `>`,
-        `> 1. Check out this branch:`,
-        `>    \`\`\`sh`,
-        `>    git fetch origin && git checkout ${branchName}`,
-        `>    \`\`\``,
-        `> 2. Merge the base branch:`,
-        `>    \`\`\`sh`,
-        `>    git merge origin/${baseBranch}`,
-        `>    \`\`\``,
-        `> 3. Resolve conflicts in your editor (VS Code, IntelliJ, etc. have built-in merge tools)`,
-        `> 4. Commit and push:`,
-        `>    \`\`\`sh`,
-        `>    git add -A && git commit -m "resolve conflicts" && git push`,
-        `>    \`\`\``,
-        `>`,
-        `> **Label guide:** In your editor's merge view, "current" = new generated code, "incoming" = your customization.`
-    ];
-    return lines.join("\n");
-}
-
-function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
@@ -38,8 +38,7 @@ export class ReplayStep extends BaseStep {
                 flow: "first-generation",
                 patchesDetected: 0,
                 patchesApplied: 0,
-                patchesWithConflicts: 0,
-                conflicts: []
+                patchesWithConflicts: 0
             };
         }
 
@@ -58,23 +57,12 @@ export class ReplayStep extends BaseStep {
             patchesRepointed: report.patchesRepointed,
             patchesContentRebased: report.patchesContentRebased,
             patchesKeptAsUserOwned: report.patchesKeptAsUserOwned,
-            conflicts: report.conflicts.map((fileResult) => ({
-                filePath: fileResult.file,
-                conflicts:
-                    fileResult.conflicts?.map((conflict) => ({
-                        startLine: conflict.startLine,
-                        endLine: conflict.endLine,
-                        ours: conflict.ours,
-                        theirs: conflict.theirs
-                    })) ?? []
-            })),
-            conflictDetails: report.conflictDetails?.map((detail) => ({
-                patchId: detail.patchId,
-                patchMessage: detail.patchMessage,
-                reason: detail.reason,
-                files: detail.files.map((f) => ({
+            unresolvedPatches: report.unresolvedPatches?.map((info) => ({
+                patchId: info.patchId,
+                patchMessage: info.patchMessage,
+                files: info.files,
+                conflictDetails: info.conflictDetails.map((f) => ({
                     file: f.file,
-                    status: f.status,
                     conflictReason: f.conflictReason
                 }))
             })),

--- a/packages/generator-cli/src/pipeline/types.ts
+++ b/packages/generator-cli/src/pipeline/types.ts
@@ -52,8 +52,6 @@ export interface GithubStepConfig {
     replayConflictInfo?: {
         previousGenerationSha: string;
         currentGenerationSha: string;
-        hasConflicts: boolean;
-        baseBranchHead?: string;
     };
 }
 
@@ -80,28 +78,16 @@ export interface ReplayStepResult extends StepResult {
     previousGenerationSha?: string;
     currentGenerationSha?: string;
     baseBranchHead?: string;
-    conflicts?: ConflictInfo[];
-    conflictDetails?: Array<{
+    unresolvedPatches?: Array<{
         patchId: string;
         patchMessage: string;
-        reason?: string;
-        files: Array<{
+        files: string[];
+        conflictDetails: Array<{
             file: string;
-            status: string;
             conflictReason?: string;
         }>;
     }>;
     warnings?: string[];
-}
-
-export interface ConflictInfo {
-    filePath: string;
-    conflicts: Array<{
-        startLine: number;
-        endLine: number;
-        ours: string[];
-        theirs: string[];
-    }>;
 }
 
 export interface FernignoreStepResult extends StepResult {

--- a/packages/generator-cli/src/replay/replay-resolve.ts
+++ b/packages/generator-cli/src/replay/replay-resolve.ts
@@ -1,0 +1,16 @@
+import { type ResolveOptions, type ResolveResult, resolve } from "@fern-api/replay";
+
+export type { ResolveOptions, ResolveResult };
+
+export interface ReplayResolveParams {
+    /** Directory containing the SDK (where .fern/replay.lock lives) */
+    outputDir: string;
+    /** Check for remaining conflict markers before committing. Default: true */
+    checkMarkers?: boolean;
+}
+
+export async function replayResolve(params: ReplayResolveParams): Promise<ResolveResult> {
+    return resolve(params.outputDir, {
+        checkMarkers: params.checkMarkers
+    });
+}

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -2,6 +2,16 @@
 
 - changelogEntry:
     - summary: |
+        Clean PRs with local conflict resolution. Replay PRs are now always
+        linear from HEAD with clean code (no conflict markers committed).
+        When customizations conflict with new generated code, the PR body
+        includes instructions to run locally.
+      type: feat
+  createdAt: "2026-03-02"
+  version: 0.6.11
+
+- changelogEntry:
+    - summary: |
         Disable commit signing and skip hooks for the internal git commit in
         replay-init to avoid triggering prompts (e.g. Touch ID on macOS,
         1Password SSH agent).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7926,8 +7926,8 @@ importers:
   packages/generator-cli:
     dependencies:
       '@fern-api/replay':
-        specifier: ^0.6.2
-        version: 0.6.2
+        specifier: ^0.7.0
+        version: 0.7.0
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -9426,13 +9426,13 @@ packages:
   '@fern-api/logger@0.4.24-rc1':
     resolution: {integrity: sha512-yh0E2F3K3IPnJZcE4dv+u8I51iKgTgv/reinKo4K5YmYEG1iLtw5vBEYMOPkQmsYFPAKIh++OMB/6TrsahMWew==}
 
-  '@fern-api/replay@0.6.1':
-    resolution: {integrity: sha512-h3pRkz+i4IuWTR1usuRDNpCvk6Cv534VX76aXicE/L+u7ZcPbRAShNb08RLeFc9y3LeoEOK+s2JlvWqsvv1W/A==}
+  '@fern-api/replay@0.6.2':
+    resolution: {integrity: sha512-AECUgZRIqU1XJneDRWkIB3YBAqJ4NdHqQ9CVx10abotGUtiGeoyoXNov79y4SgSrbKF+77CpmdjxTnwauNlPdQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  '@fern-api/replay@0.6.2':
-    resolution: {integrity: sha512-AECUgZRIqU1XJneDRWkIB3YBAqJ4NdHqQ9CVx10abotGUtiGeoyoXNov79y4SgSrbKF+77CpmdjxTnwauNlPdQ==}
+  '@fern-api/replay@0.7.0':
+    resolution: {integrity: sha512-NJrnacvCtc8Uy/k056KKR/6/8WJvsPC7yf+cJHIQGWRe8MZRUnEDGC5k76NIuq6c3/YWrVJW0+jUbjOWNLw9jg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -15909,7 +15909,7 @@ snapshots:
 
   '@fern-api/generator-cli@0.6.4':
     dependencies:
-      '@fern-api/replay': 0.6.1
+      '@fern-api/replay': 0.6.2
       '@octokit/rest': 22.0.1
       es-toolkit: 1.44.0
       tmp-promise: 3.0.3
@@ -15921,7 +15921,7 @@ snapshots:
       '@fern-api/core-utils': 0.4.24-rc1
       chalk: 5.6.2
 
-  '@fern-api/replay@0.6.1':
+  '@fern-api/replay@0.6.2':
     dependencies:
       minimatch: 10.2.4
       node-diff3: 3.2.0
@@ -15930,7 +15930,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fern-api/replay@0.6.2':
+  '@fern-api/replay@0.7.0':
     dependencies:
       minimatch: 10.2.4
       node-diff3: 3.2.0


### PR DESCRIPTION
## Summary
- Replay PRs are now always linear from HEAD with clean code — no conflict markers are ever committed to PR branches
- When customizations conflict with new generated code, the PR body includes instructions to run `fern replay resolve` locally
- Adds `fern replay resolve` CLI subcommand (hidden, referenced only from PR body instructions)
- Removes draft PR toggling, commit status checks, divergent branch creation, and web editor fallback logic
- Bumps `@fern-api/replay` to `^0.7.0`

## What changed

**`generator-cli/src/pipeline/steps/GithubStep.ts`** — Major simplification (~585 → ~300 lines). Removed `togglePrDraftState`, `convertPrToDraft`, `markPrReady`, `postReplayConflictStatus`, `postWebEditorFallbackComment`, `isWebEditorLikelyDisabled`, `pollMergeableState`, and associated constants/helpers. PRs are always created ready for review.

**`generator-cli/src/pipeline/github/createReplayBranch.ts`** — Always creates linear branch from HEAD. Removed divergent branch path and lockfile restore (which was overwriting `status: unresolved` markers needed by `fern replay resolve`).

**`generator-cli/src/pipeline/replay-summary.ts`** — Rewrote PR body conflict section to use `unresolvedPatches` with `fern replay resolve` instructions including clone/checkout commands.

**`generator-cli/src/pipeline/types.ts`** — Added `unresolvedPatches` to `ReplayStepResult`, removed `conflicts`/`conflictDetails`/`ConflictInfo`. Simplified `replayConflictInfo` (removed `hasUnresolvedPatches`/`baseBranchHead`).

**`generator-cli/src/pipeline/steps/ReplayStep.ts`** — Maps `unresolvedPatches` from replay report, removed old conflict mappings.

**`generator-cli/src/replay/replay-resolve.ts`** (new) — Thin wrapper around `@fern-api/replay` resolve for CLI consumption.

**`cli/cli/src/cli.ts`** — Added `fern replay resolve [directory]` subcommand (hidden).

## Test plan
- [x] `pnpm compile` passes (generator-cli + cli)
- [x] All 83 generator-cli tests pass
- [ ] End-to-end: `fern generate` creates clean PR with resolve instructions when patches conflict
- [ ] End-to-end: `fern replay resolve` on PR branch applies patches → user resolves → second `fern replay resolve` commits
- [ ] End-to-end: next generation after resolved merge preserves customizations cleanly