### PR TITLE
feat(java): add `custom-interceptors` config for OkHttp interceptor support

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/JavaSdkCustomConfig.java
@@ -95,6 +95,17 @@ public interface JavaSdkCustomConfig extends ICustomConfig {
         return false;
     }
 
+    /**
+     * If true, expose an {@code addInterceptor(Interceptor)} method on the client builder
+     * that allows SDK users to add custom OkHttp interceptors (e.g., for PKCV client validation).
+     * The interceptors are applied to the OkHttpClient when building the client.
+     */
+    @Value.Default
+    @JsonProperty("custom-interceptors")
+    default Boolean customInterceptors() {
+        return false;
+    }
+
     static ImmutableJavaSdkCustomConfig.Builder builder() {
         return ImmutableJavaSdkCustomConfig.builder();
     }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -81,6 +81,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 
 public abstract class AbstractRootClientGenerator extends AbstractFileGenerator {
@@ -596,6 +597,27 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                 .addStatement(isExtensible ? "return self()" : "return this")
                 .build());
 
+        // Add interceptors field and addInterceptor method when custom-interceptors is enabled
+        if (clientGeneratorContext.getCustomConfig().customInterceptors()) {
+            clientBuilder.addField(FieldSpec.builder(
+                            ParameterizedTypeName.get(ClassName.get(List.class), ClassName.get(Interceptor.class)),
+                            "interceptors")
+                    .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                    .initializer("new $T<>()", ArrayList.class)
+                    .build());
+
+            clientBuilder.addMethod(MethodSpec.methodBuilder("addInterceptor")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addJavadoc("Add a custom OkHttp interceptor to the client.\n"
+                            + "Interceptors are applied to the OkHttpClient when the client is built.\n"
+                            + "This can be used for custom request signing, logging, or other request/response modifications.\n")
+                    .returns(isExtensible ? TypeVariableName.get("T") : builderName)
+                    .addParameter(Interceptor.class, "interceptor")
+                    .addStatement("this.interceptors.add(interceptor)")
+                    .addStatement(isExtensible ? "return self()" : "return this")
+                    .build());
+        }
+
         clientBuilder.addField(FieldSpec.builder(
                         ParameterizedTypeName.get(
                                 ClassName.get(Optional.class),
@@ -735,7 +757,14 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
         }
 
         buildClientOptionsMethodBuilder
-                .addStatement("setHttpClient(builder)")
+                .addStatement("setHttpClient(builder)");
+
+        // Add setInterceptors call when custom-interceptors is enabled
+        if (clientGeneratorContext.getCustomConfig().customInterceptors()) {
+            buildClientOptionsMethodBuilder.addStatement("setInterceptors(builder)");
+        }
+
+        buildClientOptionsMethodBuilder
                 .addStatement("setTimeouts(builder)")
                 .addStatement("setRetries(builder)")
                 .addStatement("setLogging(builder)")
@@ -949,6 +978,22 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                 .endControlFlow()
                 .build();
         clientBuilder.addMethod(setHttpClientMethod);
+
+        // Add setInterceptors method when custom-interceptors is enabled
+        if (clientGeneratorContext.getCustomConfig().customInterceptors()) {
+            MethodSpec setInterceptorsMethod = MethodSpec.methodBuilder("setInterceptors")
+                    .addModifiers(Modifier.PROTECTED)
+                    .addParameter(generatedClientOptions.builderClassName(), "builder")
+                    .addJavadoc("Sets the custom OkHttp interceptors.\n"
+                            + "Override this method to add or modify custom interceptors.\n"
+                            + "\n"
+                            + "@param builder The ClientOptions.Builder to configure")
+                    .beginControlFlow("for ($T interceptor : this.interceptors)", Interceptor.class)
+                    .addStatement("builder.addInterceptor(interceptor)")
+                    .endControlFlow()
+                    .build();
+            clientBuilder.addMethod(setInterceptorsMethod);
+        }
 
         MethodSpec setLoggingMethod = MethodSpec.methodBuilder("setLogging")
                 .addModifiers(Modifier.PROTECTED)

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
@@ -43,6 +43,7 @@ import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 
 public final class ClientOptionsGenerator extends AbstractFileGenerator {
@@ -672,6 +674,17 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                     .build());
         }
 
+        // Add interceptors list field when custom-interceptors is enabled
+        if (clientGeneratorContext.getCustomConfig().customInterceptors()) {
+            builder.addField(FieldSpec.builder(
+                            ParameterizedTypeName.get(ClassName.get(List.class), ClassName.get(Interceptor.class)),
+                            "interceptors",
+                            Modifier.PRIVATE,
+                            Modifier.FINAL)
+                    .initializer("new $T<>()", ArrayList.class)
+                    .build());
+        }
+
         builder.addFields(variableFields.values())
                 .addFields(apiPathParamFields.values())
                 .addMethod(getEnvironmentBuilder())
@@ -710,6 +723,20 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                         .addStatement("this.$L = $L", OKHTTP_CLIENT_FIELD.name, OKHTTP_CLIENT_FIELD.name)
                         .addStatement("return this")
                         .build());
+
+        // Add addInterceptor method when custom-interceptors is enabled
+        if (clientGeneratorContext.getCustomConfig().customInterceptors()) {
+            builder.addMethod(MethodSpec.methodBuilder("addInterceptor")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addJavadoc("Add a custom OkHttp interceptor to the client.\n"
+                            + "Interceptors are applied to the OkHttpClient when the client is built.\n"
+                            + "This can be used for custom request signing, logging, or other request/response modifications.\n")
+                    .returns(builderClassName)
+                    .addParameter(Interceptor.class, "interceptor")
+                    .addStatement("this.interceptors.add(interceptor)")
+                    .addStatement("return this")
+                    .build());
+        }
 
         // Only add webSocketFactory method to builder if WebSocket channels are present
         if (webSocketFactoryField != null) {
@@ -1158,8 +1185,17 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                         OKHTTP_CLIENT_FIELD.name + "Builder",
                         clientGeneratorContext.getPoetClassNameFactory().getLoggingInterceptorClassName(),
                         "logger")
-                .addCode("\n")
-                .addStatement("this.$L = $L.build()", OKHTTP_CLIENT_FIELD.name, OKHTTP_CLIENT_FIELD.name + "Builder")
+                .addCode("\n");
+
+        // Apply custom interceptors when custom-interceptors is enabled
+        if (clientGeneratorContext.getCustomConfig().customInterceptors()) {
+            builder.beginControlFlow("for ($T interceptor : this.interceptors)", Interceptor.class)
+                    .addStatement("$L.addInterceptor(interceptor)", OKHTTP_CLIENT_FIELD.name + "Builder")
+                    .endControlFlow()
+                    .addCode("\n");
+        }
+
+        builder.addStatement("this.$L = $L.build()", OKHTTP_CLIENT_FIELD.name, OKHTTP_CLIENT_FIELD.name + "Builder")
                 .addStatement(
                         "this.$L = $T.of($L.callTimeoutMillis() / 1000)",
                         TIMEOUT_FIELD.name,

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.41.0
+  changelogEntry:
+    - summary: |
+        Add `custom-interceptors` configuration option for the Java SDK generator.
+        When enabled (`custom-interceptors: true` in `generators.yml`), the generated
+        client builder exposes an `addInterceptor(Interceptor)` method that allows SDK
+        users to add custom OkHttp interceptors. Interceptors are applied to the
+        OkHttpClient when the client is built. This enables use cases like PKCV (Public
+        Key Client Validation), custom request signing, and other HTTP-level
+        customizations via custom code protected by `.fernignore`.
+      type: feat
+  createdAt: "2026-03-03"
+  irVersion: 65
+
 - version: 3.40.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: PKCV (Public Key Client Validation) support for Java SDK — mirrors the `custom_transport` pattern already implemented for the Python SDK generator.

Link to Devin Session: https://app.devin.ai/sessions/e3775c91fce24285a086c0685d7742a8
Requested by: @iamnamananand996

## Changes Made

Adds a new `custom-interceptors` configuration option to the Java SDK generator. When set to `true` in `generators.yml`, the generated SDK client builder exposes an `addInterceptor(Interceptor)` method, allowing SDK consumers to attach custom OkHttp interceptors (e.g., for PKCV request signing). Interceptors are applied to the `OkHttpClient` at build time.

**Files changed:**

- **`JavaSdkCustomConfig.java`** — New `custom-interceptors` boolean config field (defaults to `false`)
- **`ClientOptionsGenerator.java`** — When enabled: adds `interceptors` list field + `addInterceptor()` builder method to `ClientOptions.Builder`; applies interceptors to `OkHttpClient.Builder` during `build()`
- **`AbstractRootClientGenerator.java`** — When enabled: adds `interceptors` list field + `addInterceptor()` method on the root client builder; adds `setInterceptors()` protected method that forwards interceptors to `ClientOptions.Builder`
- **`versions.yml`** — Changelog entry for `3.41.0`

## Testing

- [x] Java generator compiles (`./gradlew :sdk:compileJava` passes)
- [x] `pnpm run check` (biome lint) passes
- [ ] **No seed test fixture added** — no snapshot test exercises `custom-interceptors: true`
- [ ] No end-to-end test validating the generated SDK code compiles and works when the flag is enabled

## Human Review Checklist

- **Interceptor duplication risk**: Both `AbstractRootClientGenerator` (root builder) and `ClientOptionsGenerator` (`ClientOptions.Builder`) each maintain their own `interceptors` list and `addInterceptor()` method. The root builder forwards via `setInterceptors()` → `builder.addInterceptor()`. Verify these two levels don't cause double-application of interceptors.
- **Interceptor ordering**: Custom interceptors are applied *after* the logging interceptor in `ClientOptions.Builder.build()`. Confirm this ordering is intentional/acceptable.
- **Scope vs. Python pattern**: Python's PKCV support included both `custom_transport` and `import_paths`. This PR only adds the interceptor equivalent — `import_paths` is not included (Java doesn't have the same auto-import mechanism). Confirm this is sufficient for the PKCV use case.
- **Missing test fixture**: No seed test exercises the new config flag. Consider whether a `java-custom-interceptors` fixture should be added to validate generated code.