### PR TITLE
feat: added uv support for python sdk generator

### DIFF
--- a/generators/python/README.md
+++ b/generators/python/README.md
@@ -105,6 +105,35 @@ config:
     boto3: 1.28.15
 ```
 
+#### ✨ `package_manager`
+
+**Type:** `"poetry"` or `"uv"`
+
+**Default:** `"poetry"`
+
+Controls the format of the generated `pyproject.toml`. By default, the generator outputs
+a Poetry-compatible `pyproject.toml` with `[tool.poetry]` sections. Set to `"uv"` to generate
+a PEP 621 standard `pyproject.toml` compatible with [uv](https://docs.astral.sh/uv/).
+
+When using `"uv"`:
+- Dependencies use PEP 508 format under `[project.dependencies]`
+- Dev dependencies use PEP 735 `[dependency-groups]`
+- Build backend is `hatchling` instead of `poetry-core`
+- `poetry.lock` is not generated; use `uv sync` instead of `poetry install`
+
+```yaml
+config:
+  package_manager: uv
+```
+
+After generation, install and run with:
+
+```bash
+uv sync          # Install dependencies
+uv run pytest .  # Run tests
+uv run mypy .    # Type check
+```
+
 #### ✨ `pydantic_config.include_union_utils`
 
 **Type:** boolean

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -119,6 +119,10 @@ class AbstractGenerator(ABC):
         if generator_config.custom_config is not None and "import_paths" in generator_config.custom_config:
             import_paths = generator_config.custom_config.get("import_paths")
 
+        package_manager = "poetry"
+        if generator_config.custom_config is not None and "package_manager" in generator_config.custom_config:
+            package_manager = generator_config.custom_config.get("package_manager", "poetry")
+
         with Project(
             filepath=generator_config.output.path,
             relative_path_to_project=os.path.join(
@@ -146,6 +150,7 @@ class AbstractGenerator(ABC):
             generator_exec_wrapper=generator_exec_wrapper,
             mypy_exclude=mypy_exclude,
             import_paths=import_paths,
+            package_manager=package_manager,
         ) as project:
             self.run(
                 generator_exec_wrapper=generator_exec_wrapper,
@@ -191,11 +196,13 @@ class AbstractGenerator(ABC):
             publisher.run_ruff_check_fix("/fern/output", cwd="/")
             publisher.run_ruff_format("/fern/output", cwd="/")
         elif output_mode_union.type == "github":
-            publisher.run_poetry_lock()
+            if package_manager == "poetry":
+                publisher.run_poetry_lock()
             publisher.run_ruff_check_fix()
             publisher.run_ruff_format()
         elif output_mode_union.type == "publish":
-            publisher.run_poetry_lock()
+            if package_manager == "poetry":
+                publisher.run_poetry_lock()
             publisher.run_ruff_check_fix()
             publisher.run_ruff_format()
             publisher.publish_package(publish_config=output_mode_union)

--- a/generators/python/src/fern_python/codegen/project.py
+++ b/generators/python/src/fern_python/codegen/project.py
@@ -57,6 +57,7 @@ class Project:
         generator_exec_wrapper: Optional[GeneratorExecWrapper] = None,
         mypy_exclude: Optional[List[str]] = None,
         import_paths: Optional[List[str]] = None,
+        package_manager: str = "poetry",
     ) -> None:
         relative_path_to_project = relative_path_to_project.replace(".", "/")
 
@@ -110,6 +111,7 @@ class Project:
         self._enable_wire_tests = enable_wire_tests
         self._generator_exec_wrapper = generator_exec_wrapper
         self._mypy_exclude = mypy_exclude
+        self._package_manager = package_manager
 
     def get_module_path_for_imports(self) -> str:
         """
@@ -264,6 +266,7 @@ class Project:
                 enable_wire_tests=self._enable_wire_tests,
                 user_defined_toml=self._user_defined_toml,
                 mypy_exclude=self._mypy_exclude,
+                package_manager=self._package_manager,
             )
             py_project_toml.write()
 

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -46,8 +46,12 @@ class PyProjectToml:
         enable_wire_tests: bool = False,
         user_defined_toml: Optional[str] = None,
         mypy_exclude: Optional[List[str]] = None,
+        package_manager: str = "poetry",
     ):
         self._name = name
+        self._version = version
+        self._package = package
+        self._package_manager = package_manager
         self._poetry_block = PyProjectToml.PoetryBlock(
             name=name,
             version=version,
@@ -60,6 +64,9 @@ class PyProjectToml:
             github_output_mode=github_output_mode,
             license_=license_,
         )
+        self._pypi_metadata = pypi_metadata
+        self._github_output_mode = github_output_mode
+        self._license = license_
         self._dependency_manager = dependency_manager
         self._path = path
         self._python_version = python_version
@@ -69,6 +76,12 @@ class PyProjectToml:
         self._mypy_exclude = mypy_exclude
 
     def write(self) -> None:
+        if self._package_manager == "uv":
+            self._write_uv()
+        else:
+            self._write_poetry()
+
+    def _write_poetry(self) -> None:
         blocks: List[PyProjectToml.Block] = [
             self._poetry_block,
             PyProjectToml.DependenciesBlock(
@@ -94,8 +107,50 @@ dynamic = ["version"]
 [tool.poetry.extras]
 """
             for key, vals in self._extras.items():
-                stringified_vals = ", ".join([f'"{val}"' for val in vals])
+                stringified_vals = ", ".join([f'"{ val}"' for val in vals])
                 content += f"{key}=[{stringified_vals}]\n"
+
+        if self._user_defined_toml is not None:
+            content += "\n"
+            content += self._user_defined_toml
+
+        with open(os.path.join(self._path, "pyproject.toml"), "w") as f:
+            f.write(content)
+
+    def _write_uv(self) -> None:
+        blocks: List[PyProjectToml.Block] = [
+            PyProjectToml.ProjectBlock(
+                name=self._name,
+                version=self._version,
+                package=self._package,
+                classifiers=PyPIClassifierMetadataGenerator.create_classifiers(
+                    python_version=self._python_version,
+                    license_=self._license,
+                ),
+                python_version=self._python_version,
+                dependencies=self._dependency_manager.get_dependencies(),
+                pypi_metadata=self._pypi_metadata,
+                github_output_mode=self._github_output_mode,
+                license_=self._license,
+            ),
+            PyProjectToml.UvDependencyGroupsBlock(
+                dev_dependencies=self._dependency_manager.get_dev_dependencies(),
+                enable_wire_tests=self._enable_wire_tests,
+            ),
+            PyProjectToml.PluginConfigurationBlock(mypy_exclude=self._mypy_exclude),
+            PyProjectToml.HatchBuildSystemBlock(
+                package=self._package,
+            ),
+        ]
+        content = ""
+        for block in blocks:
+            content += block.to_string()
+
+        if len(self._extras) > 0:
+            content += "\n[project.optional-dependencies]\n"
+            for key, vals in self._extras.items():
+                stringified_vals = ", ".join([f'"{ val}"' for val in vals])
+                content += f"{key} = [{stringified_vals}]\n"
 
         if self._user_defined_toml is not None:
             content += "\n"
@@ -288,4 +343,222 @@ section-order = ["future", "standard-library", "third-party", "first-party"]
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+"""
+
+    @dataclass(frozen=True)
+    class ProjectBlock(Block):
+        """PEP 621 [project] block for uv-compatible pyproject.toml."""
+        name: str
+        version: Optional[str]
+        package: PyProjectTomlPackageConfig
+        classifiers: List[str]
+        python_version: str
+        dependencies: Set[Dependency]
+        pypi_metadata: Optional[PypiMetadata]
+        github_output_mode: Optional[GithubOutputMode]
+        license_: Optional[LicenseConfig]
+
+        def _convert_poetry_version_to_pep440(self, version: str) -> str:
+            """Convert Poetry version specifiers to PEP 440 format."""
+            version = version.strip()
+            if version.startswith("^"):
+                # ^X.Y.Z means >=X.Y.Z, <(X+1).0.0
+                base = version[1:]
+                parts = base.split(".")
+                major = int(parts[0])
+                if major == 0 and len(parts) > 1:
+                    minor = int(parts[1])
+                    return f">={base},<{major}.{minor + 1}.0"
+                return f">={base},<{major + 1}.0.0"
+            if version.startswith("~"):
+                # ~X.Y.Z means >=X.Y.Z, <X.(Y+1).0
+                base = version[1:]
+                parts = base.split(".")
+                major = int(parts[0])
+                minor = int(parts[1]) if len(parts) > 1 else 0
+                return f">={base},<{major}.{minor + 1}.0"
+            return version
+
+        def _python_version_to_requires_python(self, version: str) -> str:
+            """Convert Poetry python version to PEP 440 requires-python."""
+            return self._convert_poetry_version_to_pep440(version)
+
+        def to_string(self) -> str:
+            s = f'[project]\nname = "{self.name}"\n'
+            if self.version is not None:
+                s += f'version = "{self.version}"\n'
+
+            description = ""
+            authors: List[typing.Dict[str, str]] = []
+            keywords: List[str] = []
+            project_urls: List[str] = []
+
+            license_str = ""
+            if self.pypi_metadata is not None:
+                description = (
+                    self.pypi_metadata.description if self.pypi_metadata.description is not None else description
+                )
+                if self.pypi_metadata.authors is not None:
+                    authors = [
+                        {"name": author.name, "email": author.email}
+                        for author in self.pypi_metadata.authors
+                    ]
+                keywords = self.pypi_metadata.keywords if self.pypi_metadata.keywords is not None else keywords
+                if self.pypi_metadata.documentation_link is not None:
+                    project_urls.append(f'Documentation = "{self.pypi_metadata.documentation_link}"')
+                if self.pypi_metadata.homepage_link is not None:
+                    project_urls.append(f'Homepage = "{self.pypi_metadata.homepage_link}"')
+
+            if self.license_ is not None:
+                if self.license_.get_as_union().type == "basic":
+                    license_id = cast(BasicLicense, self.license_.get_as_union()).id
+                    if license_id == LicenseId.MIT:
+                        license_str = 'license = "MIT"\n'
+                    elif license_id == LicenseId.APACHE_2:
+                        license_str = 'license = "Apache-2.0"\n'
+
+            if self.github_output_mode is not None:
+                project_urls.append(f'Repository = "{self.github_output_mode.repo_url}"')
+
+            s += f'description = "{description}"\n'
+            s += 'readme = "README.md"\n'
+
+            if authors:
+                authors_str = json.dumps(authors, indent=4)
+                s += f'authors = {authors_str}\n'
+            else:
+                s += 'authors = []\n'
+
+            if keywords:
+                s += f'keywords = {json.dumps(keywords, indent=4)}\n'
+
+            s += license_str
+            s += f'classifiers = {json.dumps(self.classifiers, indent=4)}\n'
+
+            requires_python = self._python_version_to_requires_python(self.python_version)
+            s += f'requires-python = "{requires_python}"\n'
+
+            # Dependencies in PEP 508 format
+            deps_list: List[str] = []
+            for dep in sorted(self.dependencies, key=lambda d: d.name):
+                name = dep.name.replace(".", "-")
+                version = dep.version
+                compatibility = dep.compatibility
+                extras = dep.extras
+                extras_str = ""
+                if extras is not None:
+                    extras_str = "[" + ",".join(extras) + "]"
+
+                if compatibility == DependencyCompatibility.GREATER_THAN_OR_EQUAL:
+                    version_spec = f">={version}"
+                elif version.startswith(("^", "~")):
+                    version_spec = self._convert_poetry_version_to_pep440(version)
+                elif version.startswith((">=", "<=", "==", ">", "<")):
+                    version_spec = version
+                else:
+                    version_spec = f"=={version}"
+
+                dep_str = f"{name}{extras_str}{version_spec}"
+
+                if dep.python is not None:
+                    dep_str += f' ; python_version{dep.python}'
+
+                deps_list.append(dep_str)
+
+            s += 'dependencies = [\n'
+            for dep_str in deps_list:
+                s += f'    "{dep_str}",\n'
+            s += ']\n'
+
+            if project_urls:
+                s += '\n[project.urls]\n'
+                for url in project_urls:
+                    s += url + '\n'
+
+            s += '\n'
+            return s
+
+    @dataclass(frozen=True)
+    class UvDependencyGroupsBlock(Block):
+        """PEP 735 [dependency-groups] block for uv-compatible pyproject.toml."""
+        dev_dependencies: Set[Dependency]
+        enable_wire_tests: bool = False
+
+        def _convert_poetry_version_to_pep440(self, version: str) -> str:
+            """Convert Poetry version specifiers to PEP 440 format."""
+            version = version.strip()
+            if version.startswith("^"):
+                base = version[1:]
+                parts = base.split(".")
+                major = int(parts[0])
+                if major == 0 and len(parts) > 1:
+                    minor = int(parts[1])
+                    return f">={base},<{major}.{minor + 1}.0"
+                return f">={base},<{major + 1}.0.0"
+            if version.startswith("~"):
+                base = version[1:]
+                parts = base.split(".")
+                major = int(parts[0])
+                minor = int(parts[1]) if len(parts) > 1 else 0
+                return f">={base},<{major}.{minor + 1}.0"
+            return version
+
+        def _dep_to_pep508(self, dep: Dependency) -> str:
+            name = dep.name.replace(".", "-")
+            version = dep.version
+            compatibility = dep.compatibility
+            extras = dep.extras
+            extras_str = ""
+            if extras is not None:
+                extras_str = "[" + ",".join(extras) + "]"
+
+            if compatibility == DependencyCompatibility.GREATER_THAN_OR_EQUAL:
+                version_spec = f">={version}"
+            elif version.startswith(("^", "~")):
+                version_spec = self._convert_poetry_version_to_pep440(version)
+            elif version.startswith((">=", "<=", "==", ">", "<")):
+                version_spec = version
+            else:
+                version_spec = f"=={version}"
+
+            return f"{name}{extras_str}{version_spec}"
+
+        def to_string(self) -> str:
+            s = '[dependency-groups]\ndev = [\n'
+            # Default dev dependencies
+            s += '    "mypy==1.13.0",\n'
+            s += '    "pytest>=7.4.0,<8.0.0",\n'
+            s += '    "pytest-asyncio>=0.23.5,<1.0.0",\n'
+            s += '    "pytest-xdist>=3.6.1,<4.0.0",\n'
+            s += '    "python-dateutil>=2.9.0,<3.0.0",\n'
+            s += '    "types-python-dateutil>=2.9.0.20240316",\n'
+
+            if self.enable_wire_tests:
+                s += '    "requests>=2.31.0,<3.0.0",\n'
+                s += '    "types-requests>=2.31.0,<3.0.0",\n'
+
+            for dep in sorted(self.dev_dependencies, key=lambda d: d.name):
+                s += f'    "{self._dep_to_pep508(dep)}",\n'
+
+            s += ']\n'
+            return s
+
+    @dataclass(frozen=True)
+    class HatchBuildSystemBlock(Block):
+        """Hatchling build system block for uv-compatible pyproject.toml."""
+        package: PyProjectTomlPackageConfig
+
+        def to_string(self) -> str:
+            if self.package._from is not None:
+                packages_path = f"{self.package._from}/{self.package.include}"
+            else:
+                packages_path = self.package.include
+
+            return f"""
+[tool.hatch.build.targets.wheel]
+packages = ["{packages_path}"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 """

--- a/generators/python/src/fern_python/generators/sdk/custom_config.py
+++ b/generators/python/src/fern_python/generators/sdk/custom_config.py
@@ -163,6 +163,11 @@ class SDKCustomConfig(pydantic.BaseModel):
     # "page-index": offset increments by 1 each page.
     offset_semantics: Literal["item-index", "page-index"] = "item-index"
 
+    # Controls the package manager format for the generated pyproject.toml.
+    # "poetry" (default): Generates Poetry-compatible pyproject.toml with [tool.poetry] sections.
+    # "uv": Generates PEP 621 standard pyproject.toml with [project] sections, compatible with uv.
+    package_manager: Literal["poetry", "uv"] = "poetry"
+
     class Config:
         extra = pydantic.Extra.forbid
 

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -46,6 +46,12 @@ customFixtureConfig:
     use_typeddict_requests: true
   outputFolder: client-filename
 fixtures:
+  path-parameters:
+    - customConfig:
+        package_manager: uv
+      outputFolder: uv-package-manager
+    - customConfig: null
+      outputFolder: no-custom-config
   alias-extends:
     - customConfig: null
       outputFolder: no-custom-config


### PR DESCRIPTION
## Description
- Refs: https://github.com/fern-api/fern/issues/5673

## Changes Made
- Added package_manager config (uv, poetry)
- SDK generates pyproject.toml based on package manager
- Updated readme
- Updated python-sdk/seed.yml with custom config for uv package manager

## Testing
- [x] `pnpm seed test --generator python-sdk --fixture path-parameters --skip-scripts`
- [x] `cd seed/python-sdk/path-parameters/uv-package-manager`
- [x] `uv sync` && `uv run pytest -rP .`
