### PR TITLE
fix(java): handle URI and path pagination types in wire test generation

### DIFF
--- a/generators/java-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/java-v2/sdk/src/SdkGeneratorContext.ts
@@ -376,6 +376,13 @@ export class SdkGeneratorContext extends AbstractJavaGeneratorContext<SdkCustomC
             }
         } else if (pagination.type === "custom") {
             return undefined;
+        } else {
+            // Handle uri, path, and any future pagination types that have a results property
+            const paginationAny = pagination as unknown as { results?: FernIr.ResponseProperty };
+            const resultsProperty = paginationAny.results;
+            if (resultsProperty?.property?.valueType) {
+                return this.extractPaginationItemType(resultsProperty.property.valueType);
+            }
         }
         return undefined;
     }

--- a/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
@@ -238,8 +238,12 @@ export class JsonValidator {
         if (pagination.type === "cursor" || pagination.type === "offset") {
             // For now, return common patterns
             return "data";
+        } else if (pagination.type === "custom") {
+            return undefined;
+        } else {
+            // Handle uri, path, and any future pagination types
+            return "data";
         }
-        return undefined;
     }
 
     /**

--- a/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
@@ -238,12 +238,8 @@ export class JsonValidator {
         if (pagination.type === "cursor" || pagination.type === "offset") {
             // For now, return common patterns
             return "data";
-        } else if (pagination.type === "custom") {
-            return undefined;
-        } else {
-            // Handle uri, path, and any future pagination types
-            return "data";
         }
+        return undefined;
     }
 
     /**

--- a/generators/java-v2/sdk/src/sdk-wire-tests/validators/PaginationValidator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/validators/PaginationValidator.ts
@@ -69,6 +69,12 @@ export class PaginationValidator {
             return this.extractPath(endpoint.pagination.results);
         } else if (endpoint.pagination.type === "custom") {
             return undefined;
+        } else {
+            // Handle uri, path, and any future pagination types that have a results property
+            const paginationAny = endpoint.pagination as unknown as { results?: FernIr.ResponseProperty };
+            if (paginationAny.results) {
+                return this.extractPath(paginationAny.results);
+            }
         }
 
         return "data"; // Default fallback

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.40.5
+  changelogEntry:
+    - summary: |
+        Fix wire test generation for URI and path paginated endpoints. The generated
+        wire tests incorrectly used the raw response type (e.g. `ListMessagesResponse`)
+        instead of the paginated return type (`SyncPagingIterable<T>`) for endpoints
+        using URI or path-based pagination, causing compilation failures.
+      type: fix
+  createdAt: "2026-03-03"
+  irVersion: 65
+
 - version: 3.40.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: https://github.com/fern-demo/twilio-core-java-sdk/actions/runs/22601303103/job/65483692621?pr=60

Fixes wire test compilation failures for endpoints using URI or path-based pagination. The generated wire tests assigned the `.list()` return value to the raw response type (e.g. `ListMessagesResponse`) instead of the paginated return type (`SyncPagingIterable<T>`), causing `incompatible types` errors in downstream SDKs like `twilio-core-java-sdk`.

**Link to Devin Session:** https://app.devin.ai/sessions/528c2dcb23b242778cd7c271abde0ae5
**Requested by:** @iamnamananand996

## Changes Made

- **`SdkGeneratorContext.ts`**: Added `else` fallback in `getPaginationItemType()` to extract the pagination item type from `uri`, `path`, and any future pagination types that carry a `results` property. Uses `as unknown as` cast because the published `@fern-fern/ir-sdk@61.7.0` doesn't yet include `uri`/`path` in the `Pagination` discriminated union, even though they exist in the local IR definition.
- **`PaginationValidator.ts`**: Same pattern — added `else` fallback in `getPaginationResultsPath()` to extract the results path from uri/path pagination via cast.
- **`versions.yml`**: Bumped to `3.40.5` with fix changelog entry.

## ⚠️ Key Review Points

1. **Type casts (`as unknown as`)**: The `@fern-fern/ir-sdk@61.7.0` npm package only includes `cursor | offset | custom` in the `Pagination` union — `uri` and `path` are missing. TypeScript narrows to `never` in the `else` branch, so the cast is required. Once the IR SDK is republished with these types, the casts can be replaced with proper discriminant checks.
2. **Runtime shape assumption**: The `else` branch assumes uri/path pagination objects have a `results` property with the same `ResponseProperty` shape as cursor/offset. This matches the local IR definition (`UriPagination` and `PathPagination` both have `results: ResponseProperty`), but isn't enforced at compile time due to the cast.
3. **Seed test coverage gap**: The existing `pagination-uri-path` seed fixture doesn't generate wire tests, so the seed test passing with zero diff confirms no regressions but does not directly exercise the new code path. Full validation requires regenerating a SDK with wire tests enabled (e.g. `twilio-core-java-sdk`).

### Human Review Checklist
- [ ] Verify that `as unknown as { results?: FernIr.ResponseProperty }` is acceptable vs. bumping the `@fern-fern/ir-sdk` dependency to a version that includes `uri`/`path`.
- [ ] Confirm the `else` branch won't silently swallow errors for genuinely unknown future pagination types that may not have a `results` property.

## Testing

- [x] TypeScript compilation passes (`pnpm --filter @fern-api/java-sdk... compile`)
- [x] Lint passes (`pnpm run check`)
- [x] Seed test passes with zero diff (`pnpm seed test --generator java-sdk --fixture pagination-uri-path --skip-scripts`)
- [ ] Manual verification against `twilio-core-java-sdk` regeneration