### PR TITLE
fix(docs): strip .md/.mdx extensions from frontmatter slugs in DocsDefinitionResolver

### DIFF
--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -631,7 +631,8 @@ export class DocsDefinitionResolver {
             // Extract slug
             const slug = frontmatter.data.slug;
             if (typeof slug === "string" && slug.trim().length > 0) {
-                const trimmedSlug = slug.trim();
+                // Strip .md/.mdx extensions to prevent file extensions from leaking into navigation URLs
+                const trimmedSlug = slug.trim().replace(/\.(md|mdx)$/i, "");
                 if (isValidRelativeSlug(trimmedSlug)) {
                     this.markdownFilesToFullSlugs.set(absolutePath, trimmedSlug);
                 } else {


### PR DESCRIPTION
## Description

Refs: Companion PR: https://github.com/fern-api/fern-platform/pull/7842

Strips `.md`/`.mdx` file extensions from frontmatter `slug:` values at the CLI level to prevent file extensions from leaking into navigation URLs and causing 404s during version switching.

## Changes Made

- Added `.replace(/\.(md|mdx)$/i, "")` to the slug extraction in `extractAllFrontmatterData()` so that frontmatter slugs like `path/to/page.mdx` become `path/to/page` before entering the `markdownFilesToFullSlugs` map

This is part 2 of a 2-repo fix. The [companion PR in fern-platform](https://github.com/fern-api/fern-platform/pull/7842) adds the same stripping at the FDR write-to-DB conversion and V1 frontmatter parsing levels.

## Context

A customer reported 404s when using the version dropdown. The `fullSlug` field (sourced from frontmatter `slug:`) bypasses `kebabCase` sanitization and is used as-is in `SlugGenerator.apply()`. If a frontmatter slug ends with `.mdx`, it propagates into `slugMap` and `pointsTo`, causing the version switcher to navigate to URLs ending in `.mdx` which 404.

## Reviewer Checklist

- [ ] Verify regex `/\.(md|mdx)$/i` won't false-positive on legitimate slugs (requires a literal `.` before the extension — e.g. `using-cmd` is safe)
- [ ] Confirm stripping happens in the right order (after `trim()`, before `isValidRelativeSlug()`)
- [ ] Review companion PR https://github.com/fern-api/fern-platform/pull/7842

## Testing

- [x] Lint passes (`pnpm run check`)
- [ ] No unit tests added — this is a defensive no-op for well-formed slugs that only activates when a slug incorrectly ends with `.md`/`.mdx`

Link to Devin session: https://app.devin.ai/sessions/c41578e6b96a42959b02cd5a038b2957
Requested by: @sbawabe
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
