### PR TITLE
fix(java): convert RFC 2822 dates in mock response body before MockWebServer serves them

### DIFF
--- a/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestMethodBuilder.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestMethodBuilder.ts
@@ -80,8 +80,16 @@ export class TestMethodBuilder {
             }
 
             const expectedRequestJson = testExample.request.body;
-            const expectedResponseJson = testExample.response.body;
+            const rawResponseJson = testExample.response.body;
             const responseStatusCode = testExample.response.statusCode;
+
+            // Convert RFC 2822 dates to ISO 8601 in the response JSON BEFORE using it for both
+            // the mock response body (served by MockWebServer) and the expected response assertion.
+            // Jackson's JavaTimeModule expects ISO 8601 for OffsetDateTime fields typed as "dateTime";
+            // RFC 2822 dates would cause DateTimeParseException during deserialization.
+            const expectedResponseJson = rawResponseJson
+                ? (this.convertRfc2822DatesToIso8601(rawResponseJson) as typeof rawResponseJson)
+                : rawResponseJson;
 
             const mockResponseBody = expectedResponseJson
                 ? JSON.stringify(expectedResponseJson)
@@ -212,36 +220,15 @@ export class TestMethodBuilder {
                 } else {
                     writer.writeLine("String actualResponseJson = objectMapper.writeValueAsString(response);");
 
-                    // Convert RFC 2822 dates to ISO 8601 Z format in expected response.
-                    // The mock response can contain RFC 2822 dates (the SDK's Rfc2822DateTimeDeserializer handles them),
-                    // but after deserialization and re-serialization, Jackson outputs ISO 8601 with Z for UTC.
-                    const normalizedResponseJson = this.convertRfc2822DatesToIso8601(expectedResponseJson);
-                    const responseWasNormalized =
-                        JSON.stringify(normalizedResponseJson) !== JSON.stringify(expectedResponseJson);
-
-                    // Use the same resource file that was registered for mock setup, or inline for small payloads
-                    if (responseResourcePath && this.resourceWriter && this.currentTestClassName) {
-                        if (responseWasNormalized) {
-                            // Response had RFC 2822 dates that were converted — write a separate normalized resource
-                            const normalizedResourcePath = this.resourceWriter.registerResource(
-                                this.currentTestClassName,
-                                testMethodName,
-                                "expected_response",
-                                normalizedResponseJson
-                            );
-                            writer.addImport(`${this.context.getRootPackageName()}.TestResources`);
-                            writer.writeLine(
-                                `String expectedResponseBody = TestResources.loadResource("${normalizedResourcePath}");`
-                            );
-                        } else {
-                            // No date conversion needed — reuse the original mock response resource
-                            writer.addImport(`${this.context.getRootPackageName()}.TestResources`);
-                            writer.writeLine(
-                                `String expectedResponseBody = TestResources.loadResource("${responseResourcePath}");`
-                            );
-                        }
+                    // RFC 2822 dates are already converted to ISO 8601 upfront (before mock response registration),
+                    // so the response resource file and expected response use the same normalized data.
+                    if (responseResourcePath) {
+                        writer.addImport(`${this.context.getRootPackageName()}.TestResources`);
+                        writer.writeLine(
+                            `String expectedResponseBody = TestResources.loadResource("${responseResourcePath}");`
+                        );
                     } else {
-                        this.jsonValidator.formatMultilineJson(writer, "expectedResponseBody", normalizedResponseJson);
+                        this.jsonValidator.formatMultilineJson(writer, "expectedResponseBody", expectedResponseJson);
                     }
 
                     writer.writeLine("JsonNode actualResponseNode = objectMapper.readTree(actualResponseJson);");

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.40.8
+  changelogEntry:
+    - summary: |
+        Fix wire test generation to convert RFC 2822 dates to ISO 8601 in both
+        the mock response body (served by MockWebServer) and the expected response
+        assertion. Previously, only the expected response was converted, leaving
+        RFC 2822 dates in the mock response which caused `DateTimeParseException`
+        during Jackson deserialization for fields typed as `dateTime` (not
+        `dateTimeRfc2822`). The conversion now happens upfront so a single
+        normalized resource file is shared by both mock setup and validation.
+      type: fix
+  createdAt: "2026-03-03"
+  irVersion: 65
+
 - version: 3.40.7
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Follows up on #13087 and #13093 to fix remaining wire test failures (140 `DateTimeParseException` errors) in the regenerated Twilio Java SDK.

The wire test generator's `convertRfc2822DatesToIso8601()` was only applied to the **expected response assertion**, not to the **mock response body** served by MockWebServer. When Jackson deserializes the mock response, fields typed as `dateTime` (not `dateTimeRfc2822`) use the standard ISO 8601 parser—causing `DateTimeParseException` on RFC 2822 date strings like `"Thu, 30 Jul 2015 20:00:00 +0000"`.

## Changes Made

- Moved RFC 2822 → ISO 8601 date conversion **upfront** in `TestMethodBuilder.ts`, before the response JSON is used for either mock setup or assertion validation
- Removed the redundant second conversion and the conditional `expected_response` resource file logic—a single normalized resource file now serves both mock response and expected response
- Added version `3.40.8` changelog entry

## Testing

- [x] `pnpm run check` (biome) passes
- [x] Seed test `pagination-uri-path` passes with zero diff
- [x] Seed test `pagination` passes with zero diff
- [ ] Full Twilio SDK regeneration + `./gradlew test` (requires publishing v3.40.8 and re-triggering generation)

## ⚠️ Review Checklist

1. **`as typeof rawResponseJson` cast** (line 91): `convertRfc2822DatesToIso8601` returns `unknown`, cast back to the original type. Safe because the function preserves structure and only modifies string values, but worth verifying.
2. **Mock response no longer contains RFC 2822 dates**: The SDK's `Rfc2822DateTimeDeserializer` can handle both RFC 2822 and ISO 8601, so serving ISO 8601 from MockWebServer is fine. But confirm no test logic depends on the mock response retaining RFC 2822 format.
3. **String-based date detection**: The regex matches any value that is exactly an RFC 2822 date (`^...$` anchored). Non-date fields with values that happen to match the pattern would be incorrectly converted—low risk in practice but worth noting.

---

Link to Devin session: https://app.devin.ai/sessions/528c2dcb23b242778cd7c271abde0ae5
Requested by: @iamnamananand996