### PR TITLE
fix(java): fix form-urlencoded serialization for objects and dates in wire tests

### DIFF
--- a/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestMethodBuilder.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestMethodBuilder.ts
@@ -289,10 +289,23 @@ export class TestMethodBuilder {
             return `[${value.join(", ")}]`;
         }
         if (typeof value === "object" && value !== null) {
-            // Java serializes objects as JSON strings
-            return JSON.stringify(value);
+            // Java's Map.toString() produces "{key1=value1, key2=value2}"
+            const entries = Object.entries(value);
+            return `{${entries.map(([k, v]) => `${k}=${v}`).join(", ")}}`;
+        }
+        if (typeof value === "string") {
+            return this.normalizeIso8601ForJava(value);
         }
         return String(value);
+    }
+
+    /**
+     * Normalizes ISO 8601 date strings to match Java's OffsetDateTime.toString() output.
+     * Java drops zero seconds (e.g. "2015-07-30T20:00:00Z" → "2015-07-30T20:00Z").
+     */
+    private normalizeIso8601ForJava(value: string): string {
+        // Match ISO 8601 with zero seconds: "2015-07-30T20:00:00Z" or "2015-07-30T20:00:00+00:00"
+        return value.replace(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}):00(Z|[+-]\d{2}:\d{2})$/, "$1$2");
     }
 
     /**

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.40.9
+  changelogEntry:
+    - summary: |
+        Fix wire test generation for form-urlencoded request bodies: objects
+        now serialize as Java's `Map.toString()` format (`{key=value}`) instead
+        of JSON (`{"key":"value"}`), and ISO 8601 dates with zero seconds drop
+        the `:00` to match Java's `OffsetDateTime.toString()` output (e.g.
+        `2015-07-30T20:00Z` instead of `2015-07-30T20:00:00Z`).
+      type: fix
+  createdAt: "2026-03-03"
+  irVersion: 65
+
 - version: 3.40.8
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Follows up on #13097 and #13087 to fix the last 3 wire test failures in the regenerated Twilio Java SDK (`fern-bot/2026-03-03T20-20Z` branch, generator v3.40.8).

Two mismatches in `formValueToString()` caused assertion failures when comparing the expected request body against what the Java SDK actually sends:

1. **Objects**: Generator used `JSON.stringify` → `{"key":"value"}`, but Java SDK uses `Map.toString()` → `{key=value}`
2. **Dates with zero seconds**: Generator kept `:00` seconds (e.g. `2015-07-30T20:00:00Z`), but Java's `OffsetDateTime.toString()` drops them → `2015-07-30T20:00Z`

## Changes Made

- Changed object serialization in `formValueToString` from `JSON.stringify(value)` to Java's `Map.toString()` format (`{key1=value1, key2=value2}`)
- Added `normalizeIso8601ForJava()` to strip `:00` seconds from ISO 8601 dates, matching `OffsetDateTime.toString()` behavior
- String values in form bodies now pass through `normalizeIso8601ForJava` before URL-encoding
- Added version `3.40.9` changelog entry

## Testing

- [x] `pnpm run check` (biome) passes
- [x] Seed test `pagination-uri-path` passes with zero diff
- [x] Seed test `url-form-encoded` passes with zero diff
- [ ] Full Twilio SDK regeneration (requires publishing v3.40.9)

## Review Checklist

1. **Flat object serialization only**: The `Map.toString()` implementation (`{k=v}`) doesn't recurse into nested objects — a nested map would produce `{key=[object Object]}`. Verify this is acceptable for form-urlencoded bodies (nested maps are uncommon here, and the Twilio SDK only sends flat maps).
2. **`normalizeIso8601ForJava` applies to all string form values**: Any string matching `YYYY-MM-DDTHH:MM:00Z` will have `:00` stripped. The `^...$` anchors prevent partial matches, but a non-date string that is exactly an ISO 8601 timestamp with zero seconds would be modified.
3. **No seed fixture exercises these paths**: Existing seed tests don't contain objects or dates in form-urlencoded bodies, so the new logic is only validated by the Twilio SDK failure analysis, not by automated seed snapshots.

---

Link to Devin session: https://app.devin.ai/sessions/528c2dcb23b242778cd7c271abde0ae5
Requested by: @iamnamananand996