### PR TITLE
fix(cli): respect skip-slug on sections with overview page

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.2.1
+  changelogEntry:
+    - summary: |
+        Fix `skip-slug` being ignored on sections with an intro article (`path`).
+        When a section had both `skip-slug: true` and a `path` pointing to an
+        overview page with a frontmatter slug, the frontmatter slug took precedence
+        and the section's slug was not skipped. Now `skip-slug` is respected
+        regardless of whether the section has an overview page.
+      type: fix
+  createdAt: "2026-03-03"
+  irVersion: 65
+
 - version: 4.2.0
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -1857,9 +1857,10 @@ export class DocsDefinitionResolver {
         const id = this.#idgen.get(pageId ?? `${prefix}/section`);
         const slug = parentSlug.apply({
             urlSlug: item.slug ?? kebabCase(item.title),
-            fullSlug: item.overviewAbsolutePath
-                ? this.markdownFilesToFullSlugs.get(item.overviewAbsolutePath)?.split("/")
-                : undefined,
+            fullSlug:
+                item.overviewAbsolutePath && !item.skipUrlSlug
+                    ? this.markdownFilesToFullSlugs.get(item.overviewAbsolutePath)?.split("/")
+                    : undefined,
             skipUrlSlug: item.skipUrlSlug
         });
         const noindex =


### PR DESCRIPTION
## Description

Fixes `skip-slug: true` being ignored when a section also has an intro article via `path`.

Reported by a customer: a section like this was producing `/applications/apache-c-intro/apache-changelog` instead of `/applications/apache-changelog`:

```yaml
- section: Apache - C Module
  skip-slug: true
  path: ../docs/pages/.../apache-c-intro.mdx
  contents:
    - changelog: ...
      slug: apache-changelog
```

**Link to Devin session:** https://app.devin.ai/sessions/b2e7eddc061345d186ce0476140e1295
**Requested by:** @jon-fern

## Changes Made

- In `toSectionNode`, skip passing `fullSlug` to `SlugGenerator.apply()` when `skipUrlSlug` is true. Previously, `fullSlug` (derived from the overview page's frontmatter slug) took priority over `skipUrlSlug` inside `SlugGenerator.apply()`, causing the section slug to be included despite `skip-slug: true`.
- Added CLI `versions.yml` entry for 4.2.1.

Companion PR in fern-platform (defense-in-depth fix to `SlugGenerator.apply()` itself): pending.

## Testing

- [ ] Unit tests added/updated (tests added in companion fern-platform PR for `SlugGenerator.apply()`)
- [x] Lint passes (`pnpm run check`)

## Review Checklist

- [ ] Verify that when `skipUrlSlug=true` with an overview page, the section's own page and its children correctly inherit the parent slug without the section segment
- [ ] Confirm no edge case where `fullSlug` from frontmatter should still override `skipUrlSlug`