### PR TITLE
feat(internal): add zod schemas for docs.yml types

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -43,7 +43,8 @@
     "yazl",
     "diff",
     "@open-rpc/meta-schema",
-    "readable-stream"
+    "readable-stream",
+    "zod-to-json-schema"
   ],
   "ignore": ["node_modules/**", "**/dist/**", "**/lib/**", "**/generated/**", "**/docker/**", "**/__test__/**"]
 }

--- a/packages/cli/configuration/package.json
+++ b/packages/cli/configuration/package.json
@@ -43,6 +43,7 @@
     "@fern-api/configs": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod-to-json-schema": "^3.25.1"
   }
 }

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -2,19 +2,19 @@ import { z } from "zod";
 
 // ===== Simple type aliases =====
 
-const TabId = z.string();
+export const TabId = z.string();
 
-const ChangelogFolderRelativePath = z.string();
+export const ChangelogFolderRelativePath = z.string();
 
-const AudienceId = z.string();
+export const AudienceId = z.string();
 
-const RoleId = z.string();
+export const RoleId = z.string();
 
-const LibraryName = z.string();
+export const LibraryName = z.string();
 
 // ===== Enums =====
 
-const ProgrammingLanguage = z.enum([
+export const ProgrammingLanguage = z.enum([
     "typescript",
     "javascript",
     "python",
@@ -34,53 +34,84 @@ const ProgrammingLanguage = z.enum([
     "js"
 ]);
 
-const Language = z.enum(["en", "es", "fr", "de", "it", "pt", "ja", "zh", "ko", "el", "no", "pl", "ru", "sv", "tr"]);
+export const Language = z.enum([
+    "en",
+    "es",
+    "fr",
+    "de",
+    "it",
+    "pt",
+    "ja",
+    "zh",
+    "ko",
+    "el",
+    "no",
+    "pl",
+    "ru",
+    "sv",
+    "tr"
+]);
 
-const PageActionOption = z.enum(["copy-page", "view-as-markdown", "ask-ai", "chatgpt", "claude", "cursor", "vscode"]);
+export const PageActionOption = z.enum([
+    "copy-page",
+    "view-as-markdown",
+    "ask-ai",
+    "chatgpt",
+    "claude",
+    "cursor",
+    "vscode"
+]);
 
-const AIChatLocation = z.enum(["docs", "slack", "discord"]);
+export const AIChatLocation = z.enum(["docs", "slack", "discord"]);
 
-const AIChatModel = z.enum(["claude-3.7", "claude-4", "command-a"]);
+export const AIChatModel = z.enum(["claude-3.7", "claude-4", "command-a"]);
 
-const EditThisPageLaunch = z.enum(["github", "dashboard"]);
+export const EditThisPageLaunch = z.enum(["github", "dashboard"]);
 
-const Availability = z.enum(["stable", "generally-available", "in-development", "pre-release", "deprecated", "beta"]);
+export const Availability = z.enum([
+    "stable",
+    "generally-available",
+    "in-development",
+    "pre-release",
+    "deprecated",
+    "beta"
+]);
 
-const VersionAvailability = z.enum(["deprecated", "ga", "stable", "beta"]);
+export const VersionAvailability = z.enum(["deprecated", "ga", "stable", "beta"]);
 
-const TitleSource = z.enum(["frontmatter", "filename"]);
+export const TitleSource = z.enum(["frontmatter", "filename"]);
 
-const LibraryLanguage = z.enum(["python", "cpp"]);
+export const LibraryLanguage = z.enum(["python", "cpp"]);
 
-const FontStyle = z.enum(["normal", "italic"]);
+export const FontStyle = z.enum(["normal", "italic"]);
 
-const FontDisplay = z.enum(["auto", "block", "swap", "fallback", "optional"]);
+export const FontDisplay = z.enum(["auto", "block", "swap", "fallback", "optional"]);
 
-const SearchbarPlacement = z.enum(["header", "header-tabs", "sidebar"]);
+export const SearchbarPlacement = z.enum(["header", "header-tabs", "sidebar"]);
 
-const TabsPlacement = z.enum(["header", "sidebar"]);
+export const TabsPlacement = z.enum(["header", "sidebar"]);
 
-const SwitcherPlacement = z.enum(["header", "sidebar"]);
+export const SwitcherPlacement = z.enum(["header", "sidebar"]);
 
-const ContentAlignment = z.enum(["center", "left"]);
+export const ContentAlignment = z.enum(["center", "left"]);
 
-const HeaderPosition = z.enum(["fixed", "static"]);
+export const HeaderPosition = z.enum(["fixed", "static"]);
 
-const ProductSwitcherThemeConfig = z.enum(["default", "toggle"]);
+export const ProductSwitcherThemeConfig = z.enum(["default", "toggle"]);
 
-const LanguageSwitcherThemeConfig = z.enum(["default", "minimal"]);
+export const LanguageSwitcherThemeConfig = z.enum(["default", "minimal"]);
 
-const FooterNavThemeConfig = z.enum(["default", "minimal"]);
+export const FooterNavThemeConfig = z.enum(["default", "minimal"]);
 
-const TabsThemeConfig = z.enum(["default", "bubble"]);
+export const TabsThemeConfig = z.enum(["default", "bubble"]);
 
-const BodyThemeConfig = z.enum(["default", "canvas"]);
+export const BodyThemeConfig = z.enum(["default", "canvas"]);
 
-const SidebarThemeConfig = z.enum(["default", "minimal"]);
+export const SidebarThemeConfig = z.enum(["default", "minimal"]);
 
-const PageActionsThemeConfig = z.enum(["default", "toolbar"]);
+export const PageActionsThemeConfig = z.enum(["default", "toolbar"]);
 
-const HttpSnippetLanguage = z.enum([
+export const HttpSnippetLanguage = z.enum([
     "curl",
     "csharp",
     "go",
@@ -93,92 +124,92 @@ const HttpSnippetLanguage = z.enum([
     "typescript"
 ]);
 
-const Target = z.enum(["_blank", "_self", "_parent", "_top"]);
+export const Target = z.enum(["_blank", "_self", "_parent", "_top"]);
 
-const TwitterCardSetting = z.enum(["summary", "summary_large_image", "app", "player"]);
+export const TwitterCardSetting = z.enum(["summary", "summary_large_image", "app", "player"]);
 
-const JsScriptStrategy = z.enum(["beforeInteractive", "afterInteractive", "lazyOnload"]);
+export const JsScriptStrategy = z.enum(["beforeInteractive", "afterInteractive", "lazyOnload"]);
 
 // ===== Simple undiscriminated unions =====
 
-const FontWeight = z.union([z.string(), z.number().int()]);
+export const FontWeight = z.union([z.string(), z.number().int()]);
 
-const ColorThemedConfig = z.object({
+export const ColorThemedConfig = z.object({
     dark: z.string().optional(),
     light: z.string().optional()
 });
 
-const ColorConfig = z.union([z.string(), ColorThemedConfig]);
+export const ColorConfig = z.union([z.string(), ColorThemedConfig]);
 
-const Audience = z.union([AudienceId, z.array(AudienceId)]);
+export const Audience = z.union([AudienceId, z.array(AudienceId)]);
 
-const Role = z.union([RoleId, z.array(RoleId)]);
+export const Role = z.union([RoleId, z.array(RoleId)]);
 
-const CustomDomain = z.union([z.string(), z.array(z.string())]);
+export const CustomDomain = z.union([z.string(), z.array(z.string())]);
 
-const HttpSnippetsConfig = z.union([z.boolean(), z.array(HttpSnippetLanguage)]);
+export const HttpSnippetsConfig = z.union([z.boolean(), z.array(HttpSnippetLanguage)]);
 
-const BackgroundImageThemedConfig = z.object({
+export const BackgroundImageThemedConfig = z.object({
     dark: z.string().optional(),
     light: z.string().optional()
 });
 
-const BackgroundImageConfiguration = z.union([z.string(), BackgroundImageThemedConfig]);
+export const BackgroundImageConfiguration = z.union([z.string(), BackgroundImageThemedConfig]);
 
-const CssConfig = z.union([z.string(), z.array(z.string())]);
+export const CssConfig = z.union([z.string(), z.array(z.string())]);
 
 // ===== Base/mixin schemas =====
 
-const WithPermissions = z.object({
+export const WithPermissions = z.object({
     viewers: Role.optional(),
     orphaned: z.boolean().optional()
 });
 
-const FeatureFlag = z.object({
+export const FeatureFlag = z.object({
     flag: z.string(),
     "fallback-value": z.unknown().optional(),
     match: z.unknown().optional()
 });
 
-const FeatureFlagConfiguration = z.union([z.string(), FeatureFlag, z.array(FeatureFlag)]);
+export const FeatureFlagConfiguration = z.union([z.string(), FeatureFlag, z.array(FeatureFlag)]);
 
-const WithFeatureFlags = z.object({
+export const WithFeatureFlags = z.object({
     "feature-flag": FeatureFlagConfiguration.optional()
 });
 
-const WithViewers = z.object({
+export const WithViewers = z.object({
     viewers: Role.optional()
 });
 
 // ===== Analytics schemas =====
 
-const SegmentConfig = z.object({
+export const SegmentConfig = z.object({
     "write-key": z.string()
 });
 
-const FullStoryAnalyticsConfig = z.object({
+export const FullStoryAnalyticsConfig = z.object({
     "org-id": z.string()
 });
 
-const IntercomConfig = z.object({
+export const IntercomConfig = z.object({
     "app-id": z.string(),
     "api-base": z.string().optional()
 });
 
-const PostHogConfig = z.object({
+export const PostHogConfig = z.object({
     "api-key": z.string(),
     endpoint: z.string().optional()
 });
 
-const GTMConfig = z.object({
+export const GTMConfig = z.object({
     "container-id": z.string()
 });
 
-const GoogleAnalytics4Config = z.object({
+export const GoogleAnalytics4Config = z.object({
     "measurement-id": z.string()
 });
 
-const AnalyticsConfig = z.object({
+export const AnalyticsConfig = z.object({
     segment: SegmentConfig.optional(),
     fullstory: FullStoryAnalyticsConfig.optional(),
     intercom: IntercomConfig.optional(),
@@ -189,19 +220,19 @@ const AnalyticsConfig = z.object({
 
 // ===== AI schemas =====
 
-const AiExamplesConfig = z.object({
+export const AiExamplesConfig = z.object({
     enabled: z.boolean().optional(),
     style: z.string().optional()
 });
 
-const AIChatWebsiteDatasource = z.object({
+export const AIChatWebsiteDatasource = z.object({
     url: z.string(),
     title: z.string().optional()
 });
 
-const AIChatDatasource = AIChatWebsiteDatasource;
+export const AIChatDatasource = AIChatWebsiteDatasource;
 
-const AIChatConfig = z.object({
+export const AIChatConfig = z.object({
     model: AIChatModel.optional(),
     "system-prompt": z.string().optional(),
     location: z.array(AIChatLocation).optional(),
@@ -210,15 +241,15 @@ const AIChatConfig = z.object({
 
 // ===== Font schemas =====
 
-const FontConfigVariant = z.object({
+export const FontConfigVariant = z.object({
     path: z.string(),
     weight: FontWeight.optional(),
     style: FontStyle.optional()
 });
 
-const FontConfigPath = z.union([z.string(), FontConfigVariant]);
+export const FontConfigPath = z.union([z.string(), FontConfigVariant]);
 
-const FontConfig = z.object({
+export const FontConfig = z.object({
     name: z.string().optional(),
     path: z.string().optional(),
     weight: FontWeight.optional(),
@@ -231,7 +262,7 @@ const FontConfig = z.object({
 
 // ===== Typography =====
 
-const DocsTypographyConfig = z.object({
+export const DocsTypographyConfig = z.object({
     headingsFont: FontConfig.optional(),
     bodyFont: FontConfig.optional(),
     codeFont: FontConfig.optional()
@@ -239,7 +270,7 @@ const DocsTypographyConfig = z.object({
 
 // ===== Theme schemas =====
 
-const ThemeConfig = z.object({
+export const ThemeConfig = z.object({
     sidebar: SidebarThemeConfig.optional(),
     body: BodyThemeConfig.optional(),
     tabs: TabsThemeConfig.optional(),
@@ -251,7 +282,7 @@ const ThemeConfig = z.object({
 
 // ===== Layout schemas =====
 
-const LayoutConfig = z.object({
+export const LayoutConfig = z.object({
     "page-width": z.string().optional(),
     "content-width": z.string().optional(),
     "sidebar-width": z.string().optional(),
@@ -268,7 +299,7 @@ const LayoutConfig = z.object({
 
 // ===== Settings =====
 
-const DocsSettingsConfig = z.object({
+export const DocsSettingsConfig = z.object({
     "search-text": z.string().optional(),
     "disable-search": z.boolean().optional(),
     "dark-mode-code": z.boolean().optional(),
@@ -285,7 +316,7 @@ const DocsSettingsConfig = z.object({
 
 // ===== Colors =====
 
-const ColorsConfiguration = z.object({
+export const ColorsConfiguration = z.object({
     "accent-primary": ColorConfig.optional(),
     accentPrimary: ColorConfig.optional(),
     background: ColorConfig.optional(),
@@ -309,7 +340,7 @@ const ColorsConfiguration = z.object({
 
 // ===== Page actions =====
 
-const CustomPageAction = z.object({
+export const CustomPageAction = z.object({
     title: z.string(),
     subtitle: z.string().optional(),
     url: z.string(),
@@ -317,7 +348,7 @@ const CustomPageAction = z.object({
     default: z.boolean().optional()
 });
 
-const PageActionOptions = z.object({
+export const PageActionOptions = z.object({
     "copy-page": z.boolean().optional(),
     "view-as-markdown": z.boolean().optional(),
     "ask-ai": z.boolean().optional(),
@@ -328,28 +359,28 @@ const PageActionOptions = z.object({
     custom: z.array(CustomPageAction).optional()
 });
 
-const PageActionsConfig = z.object({
+export const PageActionsConfig = z.object({
     default: PageActionOption.optional(),
     options: PageActionOptions.optional()
 });
 
 // ===== Edit this page =====
 
-const GithubEditThisPageConfig = z.object({
+export const GithubEditThisPageConfig = z.object({
     host: z.string().optional(),
     owner: z.string(),
     repo: z.string(),
     branch: z.string().optional()
 });
 
-const EditThisPageConfig = z.object({
+export const EditThisPageConfig = z.object({
     github: GithubEditThisPageConfig.optional(),
     launch: EditThisPageLaunch.optional()
 });
 
 // ===== Docs Instance =====
 
-const DocsInstance = z.object({
+export const DocsInstance = z.object({
     url: z.string(),
     "custom-domain": CustomDomain.optional(),
     private: z.boolean().optional(),
@@ -359,7 +390,7 @@ const DocsInstance = z.object({
 
 // ===== Logo =====
 
-const LogoConfiguration = z.object({
+export const LogoConfiguration = z.object({
     dark: z.string().optional(),
     light: z.string().optional(),
     height: z.number().optional(),
@@ -369,7 +400,7 @@ const LogoConfiguration = z.object({
 
 // ===== Link =====
 
-const LinkConfiguration = z.object({
+export const LinkConfiguration = z.object({
     link: z.string(),
     href: z.string(),
     icon: z.string().optional(),
@@ -378,14 +409,14 @@ const LinkConfiguration = z.object({
 
 // ===== Snippets =====
 
-const VersionedSnippetLanguageConfiguration = z.object({
+export const VersionedSnippetLanguageConfiguration = z.object({
     version: z.string(),
     package: z.string()
 });
 
-const SnippetLanguageConfiguration = z.union([z.string(), VersionedSnippetLanguageConfiguration]);
+export const SnippetLanguageConfiguration = z.union([z.string(), VersionedSnippetLanguageConfiguration]);
 
-const SnippetsConfiguration = z.object({
+export const SnippetsConfiguration = z.object({
     python: SnippetLanguageConfiguration.optional(),
     typescript: SnippetLanguageConfiguration.optional(),
     go: SnippetLanguageConfiguration.optional(),
@@ -399,11 +430,11 @@ const SnippetsConfiguration = z.object({
 
 // ===== Playground =====
 
-const PlaygroundButtonSettings = z.object({
+export const PlaygroundButtonSettings = z.object({
     href: z.string().optional()
 });
 
-const PlaygroundSettings = z.object({
+export const PlaygroundSettings = z.object({
     hidden: z.boolean().optional(),
     environments: z.array(z.string()).optional(),
     button: PlaygroundButtonSettings.optional(),
@@ -413,13 +444,13 @@ const PlaygroundSettings = z.object({
 
 // ===== Announcement =====
 
-const AnnouncementConfig = z.object({
+export const AnnouncementConfig = z.object({
     message: z.string()
 });
 
 // ===== Navbar =====
 
-const NavbarLinkConfig = WithViewers.merge(
+export const NavbarLinkConfig = WithViewers.merge(
     z.object({
         href: z.string().optional(),
         target: Target.optional(),
@@ -431,16 +462,16 @@ const NavbarLinkConfig = WithViewers.merge(
     })
 );
 
-const NavbarGithubConfigWithOptions = WithViewers.merge(
+export const NavbarGithubConfigWithOptions = WithViewers.merge(
     z.object({
         url: z.string(),
         target: Target.optional()
     })
 );
 
-const NavbarGithubConfig = z.union([z.string(), NavbarGithubConfigWithOptions]);
+export const NavbarGithubConfig = z.union([z.string(), NavbarGithubConfigWithOptions]);
 
-const NavbarDropdownConfig = WithViewers.merge(
+export const NavbarDropdownConfig = WithViewers.merge(
     z.object({
         links: z.array(NavbarLinkConfig),
         text: z.string().optional(),
@@ -450,7 +481,7 @@ const NavbarDropdownConfig = WithViewers.merge(
     })
 );
 
-const NavbarLink = z.union([
+export const NavbarLink = z.union([
     NavbarLinkConfig.merge(z.object({ type: z.literal("filled") })),
     NavbarLinkConfig.merge(z.object({ type: z.literal("outlined") })),
     NavbarLinkConfig.merge(z.object({ type: z.literal("minimal") })),
@@ -462,7 +493,7 @@ const NavbarLink = z.union([
 
 // ===== Footer links =====
 
-const FooterLinksConfig = z.object({
+export const FooterLinksConfig = z.object({
     github: z.string().optional(),
     twitter: z.string().optional(),
     x: z.string().optional(),
@@ -479,25 +510,25 @@ const FooterLinksConfig = z.object({
 
 // ===== JS Config =====
 
-const JsFileConfigSettings = z.object({
+export const JsFileConfigSettings = z.object({
     path: z.string(),
     strategy: JsScriptStrategy.optional()
 });
 
-const JsFileConfig = z.union([z.string(), JsFileConfigSettings]);
+export const JsFileConfig = z.union([z.string(), JsFileConfigSettings]);
 
-const JsRemoteConfig = z.object({
+export const JsRemoteConfig = z.object({
     url: z.string(),
     strategy: JsScriptStrategy.optional()
 });
 
-const JsConfigOptions = z.union([JsRemoteConfig, JsFileConfig]);
+export const JsConfigOptions = z.union([JsRemoteConfig, JsFileConfig]);
 
-const JsConfig = z.union([JsConfigOptions, z.array(JsConfigOptions)]);
+export const JsConfig = z.union([JsConfigOptions, z.array(JsConfigOptions)]);
 
 // ===== Metadata =====
 
-const MetadataConfig = z.object({
+export const MetadataConfig = z.object({
     "og:site_name": z.string().optional(),
     "og:title": z.string().optional(),
     "og:description": z.string().optional(),
@@ -519,7 +550,7 @@ const MetadataConfig = z.object({
 
 // ===== Redirects =====
 
-const RedirectConfig = z.object({
+export const RedirectConfig = z.object({
     source: z.string(),
     destination: z.string(),
     permanent: z.boolean().optional()
@@ -527,13 +558,13 @@ const RedirectConfig = z.object({
 
 // ===== Integrations =====
 
-const IntegrationsConfig = z.object({
+export const IntegrationsConfig = z.object({
     intercom: z.string().optional()
 });
 
 // ===== Experimental =====
 
-const ExperimentalConfig = z.object({
+export const ExperimentalConfig = z.object({
     "mdx-components": z.array(z.string()).optional(),
     "disable-stream-toggle": z.boolean().optional(),
     "openapi-parser-v2": z.boolean().optional(),
@@ -547,22 +578,22 @@ const ExperimentalConfig = z.object({
 
 // ===== Library schemas =====
 
-const GitLibraryInputSchema = z.object({
+export const GitLibraryInputSchema = z.object({
     git: z.string(),
     subpath: z.string().optional()
 });
 
-const PathLibraryInputSchema = z.object({
+export const PathLibraryInputSchema = z.object({
     path: z.string()
 });
 
-const LibraryInputConfiguration = z.union([GitLibraryInputSchema, PathLibraryInputSchema]);
+export const LibraryInputConfiguration = z.union([GitLibraryInputSchema, PathLibraryInputSchema]);
 
-const LibraryOutputConfiguration = z.object({
+export const LibraryOutputConfiguration = z.object({
     path: z.string()
 });
 
-const LibraryConfiguration = z.object({
+export const LibraryConfiguration = z.object({
     input: LibraryInputConfiguration,
     output: LibraryOutputConfiguration,
     lang: LibraryLanguage
@@ -570,7 +601,7 @@ const LibraryConfiguration = z.object({
 
 // ===== Page Configuration =====
 
-const PageConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+export const PageConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         page: z.string(),
         path: z.string(),
@@ -584,7 +615,7 @@ const PageConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
 
 // ===== Changelog Configuration =====
 
-const ChangelogConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+export const ChangelogConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         changelog: ChangelogFolderRelativePath,
         title: z.string().optional(),
@@ -596,7 +627,7 @@ const ChangelogConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
 
 // ===== Library Reference Configuration =====
 
-const LibraryReferenceConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+export const LibraryReferenceConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         library: LibraryName,
         title: z.string().optional(),
@@ -606,7 +637,7 @@ const LibraryReferenceConfiguration = WithPermissions.merge(WithFeatureFlags).me
 
 // ===== Folder Configuration =====
 
-const FolderConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+export const FolderConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         folder: z.string(),
         title: z.string().optional(),
@@ -624,7 +655,7 @@ const FolderConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
 
 // ===== Recursive types: ApiReferenceLayoutItem =====
 
-const ApiReferenceEndpointConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+export const ApiReferenceEndpointConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         endpoint: z.string(),
         title: z.string().optional(),
@@ -636,7 +667,7 @@ const ApiReferenceEndpointConfiguration = WithPermissions.merge(WithFeatureFlags
     })
 );
 
-const ApiReferenceOperationConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+export const ApiReferenceOperationConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         operation: z.string(),
         title: z.string().optional(),
@@ -647,7 +678,7 @@ const ApiReferenceOperationConfiguration = WithPermissions.merge(WithFeatureFlag
 );
 
 // Use z.lazy for recursive ApiReferenceLayoutItem
-const ApiReferenceLayoutItem: z.ZodType<unknown> = z.lazy(() =>
+export const ApiReferenceLayoutItem: z.ZodType<unknown> = z.lazy(() =>
     z.union([
         z.string(),
         z.record(z.string(), ApiReferencePackageConfiguration),
@@ -659,7 +690,7 @@ const ApiReferenceLayoutItem: z.ZodType<unknown> = z.lazy(() =>
     ])
 );
 
-const ApiReferenceSectionConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+export const ApiReferenceSectionConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         section: z.string(),
         "referenced-packages": z.array(z.string()).optional(),
@@ -676,7 +707,7 @@ const ApiReferenceSectionConfiguration = WithPermissions.merge(WithFeatureFlags)
     })
 );
 
-const ApiReferencePackageConfigurationWithOptions = WithPermissions.merge(WithFeatureFlags).merge(
+export const ApiReferencePackageConfigurationWithOptions = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         title: z.string().optional(),
         summary: z.string().optional(),
@@ -690,13 +721,13 @@ const ApiReferencePackageConfigurationWithOptions = WithPermissions.merge(WithFe
     })
 );
 
-const ApiReferencePackageConfiguration: z.ZodType<unknown> = z.lazy(() =>
+export const ApiReferencePackageConfiguration: z.ZodType<unknown> = z.lazy(() =>
     z.union([z.array(ApiReferenceLayoutItem), ApiReferencePackageConfigurationWithOptions])
 );
 
 // ===== API Reference Configuration =====
 
-const ApiReferenceConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+export const ApiReferenceConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         api: z.string(),
         "api-name": z.string().optional(),
@@ -724,7 +755,7 @@ const ApiReferenceConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
 // ===== Recursive types: NavigationItem =====
 
 // Use z.lazy for recursive NavigationItem
-const NavigationItem: z.ZodType<unknown> = z.lazy(() =>
+export const NavigationItem: z.ZodType<unknown> = z.lazy(() =>
     z.union([
         PageConfiguration,
         SectionConfiguration,
@@ -736,7 +767,7 @@ const NavigationItem: z.ZodType<unknown> = z.lazy(() =>
     ])
 );
 
-const SectionConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+export const SectionConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         section: z.string(),
         path: z.string().optional(),
@@ -754,9 +785,9 @@ const SectionConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
 
 // ===== Navigation schemas =====
 
-const UntabbedNavigationConfig = z.array(NavigationItem);
+export const UntabbedNavigationConfig = z.array(NavigationItem);
 
-const TabVariant = WithPermissions.merge(WithFeatureFlags).merge(
+export const TabVariant = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         title: z.string(),
         subtitle: z.string().optional(),
@@ -769,25 +800,25 @@ const TabVariant = WithPermissions.merge(WithFeatureFlags).merge(
     })
 );
 
-const TabbedNavigationItemWithLayout = z.object({
+export const TabbedNavigationItemWithLayout = z.object({
     tab: TabId,
     layout: z.array(NavigationItem).optional()
 });
 
-const TabbedNavigationItemWithVariants = z.object({
+export const TabbedNavigationItemWithVariants = z.object({
     tab: TabId,
     variants: z.array(TabVariant)
 });
 
-const TabbedNavigationItem = z.union([TabbedNavigationItemWithLayout, TabbedNavigationItemWithVariants]);
+export const TabbedNavigationItem = z.union([TabbedNavigationItemWithLayout, TabbedNavigationItemWithVariants]);
 
-const TabbedNavigationConfig = z.array(TabbedNavigationItem);
+export const TabbedNavigationConfig = z.array(TabbedNavigationItem);
 
-const NavigationConfig = z.union([UntabbedNavigationConfig, TabbedNavigationConfig]);
+export const NavigationConfig = z.union([UntabbedNavigationConfig, TabbedNavigationConfig]);
 
 // ===== Tab Config =====
 
-const TabConfig = WithPermissions.merge(WithFeatureFlags).merge(
+export const TabConfig = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         "display-name": z.string(),
         icon: z.string().optional(),
@@ -802,7 +833,7 @@ const TabConfig = WithPermissions.merge(WithFeatureFlags).merge(
 
 // ===== Version Config =====
 
-const VersionConfig = WithPermissions.merge(WithFeatureFlags).merge(
+export const VersionConfig = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         "display-name": z.string(),
         path: z.string(),
@@ -814,7 +845,7 @@ const VersionConfig = WithPermissions.merge(WithFeatureFlags).merge(
     })
 );
 
-const VersionFileConfig = z.object({
+export const VersionFileConfig = z.object({
     tabs: z.record(TabId, TabConfig).optional(),
     "landing-page": PageConfiguration.optional(),
     navigation: NavigationConfig
@@ -822,7 +853,7 @@ const VersionFileConfig = z.object({
 
 // ===== Product schemas =====
 
-const ProductConfigBase = WithPermissions.merge(WithFeatureFlags).merge(
+export const ProductConfigBase = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         "display-name": z.string(),
         subtitle: z.string().optional(),
@@ -833,7 +864,7 @@ const ProductConfigBase = WithPermissions.merge(WithFeatureFlags).merge(
     })
 );
 
-const InternalProduct = ProductConfigBase.merge(
+export const InternalProduct = ProductConfigBase.merge(
     z.object({
         path: z.string(),
         slug: z.string().optional(),
@@ -841,16 +872,16 @@ const InternalProduct = ProductConfigBase.merge(
     })
 );
 
-const ExternalProduct = ProductConfigBase.merge(
+export const ExternalProduct = ProductConfigBase.merge(
     z.object({
         href: z.string(),
         target: Target.optional()
     })
 );
 
-const ProductConfig = z.union([InternalProduct, ExternalProduct]);
+export const ProductConfig = z.union([InternalProduct, ExternalProduct]);
 
-const RelativeProductPath = WithPermissions.merge(WithFeatureFlags).merge(
+export const RelativeProductPath = WithPermissions.merge(WithFeatureFlags).merge(
     z.object({
         "display-name": z.string(),
         path: z.string(),
@@ -858,13 +889,13 @@ const RelativeProductPath = WithPermissions.merge(WithFeatureFlags).merge(
     })
 );
 
-const AbsoluteProductPath = z.object({
+export const AbsoluteProductPath = z.object({
     href: z.string()
 });
 
-const ProductPath = z.union([RelativeProductPath, AbsoluteProductPath]);
+export const ProductPath = z.union([RelativeProductPath, AbsoluteProductPath]);
 
-const ProductFileConfig = z.object({
+export const ProductFileConfig = z.object({
     tabs: z.record(TabId, TabConfig).optional(),
     "landing-page": PageConfiguration.optional(),
     navigation: NavigationConfig
@@ -872,7 +903,7 @@ const ProductFileConfig = z.object({
 
 // ===== Main DocsConfiguration =====
 
-const DocsConfiguration = z.object({
+export const DocsConfiguration = z.object({
     instances: z.array(DocsInstance),
     title: z.string().optional(),
     libraries: z.record(LibraryName, LibraryConfiguration).optional(),
@@ -909,139 +940,3 @@ const DocsConfiguration = z.object({
     header: z.string().optional(),
     footer: z.string().optional()
 });
-
-// Suppress unused variable warnings. These schemas are not exported intentionally.
-// They will be exported in a future PR to replace the existing SDK-generated schemas.
-void TabId;
-void ChangelogFolderRelativePath;
-void AudienceId;
-void RoleId;
-void LibraryName;
-void ProgrammingLanguage;
-void Language;
-void PageActionOption;
-void AIChatLocation;
-void AIChatModel;
-void EditThisPageLaunch;
-void Availability;
-void VersionAvailability;
-void TitleSource;
-void LibraryLanguage;
-void FontStyle;
-void FontDisplay;
-void SearchbarPlacement;
-void TabsPlacement;
-void SwitcherPlacement;
-void ContentAlignment;
-void HeaderPosition;
-void ProductSwitcherThemeConfig;
-void LanguageSwitcherThemeConfig;
-void FooterNavThemeConfig;
-void TabsThemeConfig;
-void BodyThemeConfig;
-void SidebarThemeConfig;
-void PageActionsThemeConfig;
-void HttpSnippetLanguage;
-void Target;
-void TwitterCardSetting;
-void JsScriptStrategy;
-void FontWeight;
-void ColorThemedConfig;
-void ColorConfig;
-void Audience;
-void Role;
-void CustomDomain;
-void HttpSnippetsConfig;
-void BackgroundImageThemedConfig;
-void BackgroundImageConfiguration;
-void CssConfig;
-void WithPermissions;
-void FeatureFlag;
-void FeatureFlagConfiguration;
-void WithFeatureFlags;
-void WithViewers;
-void SegmentConfig;
-void FullStoryAnalyticsConfig;
-void IntercomConfig;
-void PostHogConfig;
-void GTMConfig;
-void GoogleAnalytics4Config;
-void AnalyticsConfig;
-void AiExamplesConfig;
-void AIChatWebsiteDatasource;
-void AIChatDatasource;
-void AIChatConfig;
-void FontConfigVariant;
-void FontConfigPath;
-void FontConfig;
-void DocsTypographyConfig;
-void ThemeConfig;
-void LayoutConfig;
-void DocsSettingsConfig;
-void ColorsConfiguration;
-void CustomPageAction;
-void PageActionOptions;
-void PageActionsConfig;
-void GithubEditThisPageConfig;
-void EditThisPageConfig;
-void DocsInstance;
-void LogoConfiguration;
-void LinkConfiguration;
-void VersionedSnippetLanguageConfiguration;
-void SnippetLanguageConfiguration;
-void SnippetsConfiguration;
-void PlaygroundButtonSettings;
-void PlaygroundSettings;
-void AnnouncementConfig;
-void NavbarLinkConfig;
-void NavbarGithubConfigWithOptions;
-void NavbarGithubConfig;
-void NavbarDropdownConfig;
-void NavbarLink;
-void FooterLinksConfig;
-void JsFileConfigSettings;
-void JsFileConfig;
-void JsRemoteConfig;
-void JsConfigOptions;
-void JsConfig;
-void MetadataConfig;
-void RedirectConfig;
-void IntegrationsConfig;
-void ExperimentalConfig;
-void GitLibraryInputSchema;
-void PathLibraryInputSchema;
-void LibraryInputConfiguration;
-void LibraryOutputConfiguration;
-void LibraryConfiguration;
-void PageConfiguration;
-void ChangelogConfiguration;
-void LibraryReferenceConfiguration;
-void FolderConfiguration;
-void ApiReferenceEndpointConfiguration;
-void ApiReferenceOperationConfiguration;
-void ApiReferenceLayoutItem;
-void ApiReferenceSectionConfiguration;
-void ApiReferencePackageConfigurationWithOptions;
-void ApiReferencePackageConfiguration;
-void ApiReferenceConfiguration;
-void NavigationItem;
-void SectionConfiguration;
-void UntabbedNavigationConfig;
-void TabVariant;
-void TabbedNavigationItemWithLayout;
-void TabbedNavigationItemWithVariants;
-void TabbedNavigationItem;
-void TabbedNavigationConfig;
-void NavigationConfig;
-void TabConfig;
-void VersionConfig;
-void VersionFileConfig;
-void ProductConfigBase;
-void InternalProduct;
-void ExternalProduct;
-void ProductConfig;
-void RelativeProductPath;
-void AbsoluteProductPath;
-void ProductPath;
-void ProductFileConfig;
-void DocsConfiguration;

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -1,0 +1,1047 @@
+import { z } from "zod";
+
+// ===== Simple type aliases =====
+
+const TabId = z.string();
+
+const ChangelogFolderRelativePath = z.string();
+
+const AudienceId = z.string();
+
+const RoleId = z.string();
+
+const LibraryName = z.string();
+
+// ===== Enums =====
+
+const ProgrammingLanguage = z.enum([
+    "typescript",
+    "javascript",
+    "python",
+    "java",
+    "go",
+    "ruby",
+    "csharp",
+    "php",
+    "swift",
+    "rust",
+    "nodets",
+    "nodejs",
+    "dotnet",
+    "curl",
+    "jvm",
+    "ts",
+    "js"
+]);
+
+const Language = z.enum(["en", "es", "fr", "de", "it", "pt", "ja", "zh", "ko", "el", "no", "pl", "ru", "sv", "tr"]);
+
+const PageActionOption = z.enum(["copy-page", "view-as-markdown", "ask-ai", "chatgpt", "claude", "cursor", "vscode"]);
+
+const AIChatLocation = z.enum(["docs", "slack", "discord"]);
+
+const AIChatModel = z.enum(["claude-3.7", "claude-4", "command-a"]);
+
+const EditThisPageLaunch = z.enum(["github", "dashboard"]);
+
+const Availability = z.enum(["stable", "generally-available", "in-development", "pre-release", "deprecated", "beta"]);
+
+const VersionAvailability = z.enum(["deprecated", "ga", "stable", "beta"]);
+
+const TitleSource = z.enum(["frontmatter", "filename"]);
+
+const LibraryLanguage = z.enum(["python", "cpp"]);
+
+const FontStyle = z.enum(["normal", "italic"]);
+
+const FontDisplay = z.enum(["auto", "block", "swap", "fallback", "optional"]);
+
+const SearchbarPlacement = z.enum(["header", "header-tabs", "sidebar"]);
+
+const TabsPlacement = z.enum(["header", "sidebar"]);
+
+const SwitcherPlacement = z.enum(["header", "sidebar"]);
+
+const ContentAlignment = z.enum(["center", "left"]);
+
+const HeaderPosition = z.enum(["fixed", "static"]);
+
+const ProductSwitcherThemeConfig = z.enum(["default", "toggle"]);
+
+const LanguageSwitcherThemeConfig = z.enum(["default", "minimal"]);
+
+const FooterNavThemeConfig = z.enum(["default", "minimal"]);
+
+const TabsThemeConfig = z.enum(["default", "bubble"]);
+
+const BodyThemeConfig = z.enum(["default", "canvas"]);
+
+const SidebarThemeConfig = z.enum(["default", "minimal"]);
+
+const PageActionsThemeConfig = z.enum(["default", "toolbar"]);
+
+const HttpSnippetLanguage = z.enum([
+    "curl",
+    "csharp",
+    "go",
+    "java",
+    "javascript",
+    "php",
+    "python",
+    "ruby",
+    "swift",
+    "typescript"
+]);
+
+const Target = z.enum(["_blank", "_self", "_parent", "_top"]);
+
+const TwitterCardSetting = z.enum(["summary", "summary_large_image", "app", "player"]);
+
+const JsScriptStrategy = z.enum(["beforeInteractive", "afterInteractive", "lazyOnload"]);
+
+// ===== Simple undiscriminated unions =====
+
+const FontWeight = z.union([z.string(), z.number().int()]);
+
+const ColorThemedConfig = z.object({
+    dark: z.string().optional(),
+    light: z.string().optional()
+});
+
+const ColorConfig = z.union([z.string(), ColorThemedConfig]);
+
+const Audience = z.union([AudienceId, z.array(AudienceId)]);
+
+const Role = z.union([RoleId, z.array(RoleId)]);
+
+const CustomDomain = z.union([z.string(), z.array(z.string())]);
+
+const HttpSnippetsConfig = z.union([z.boolean(), z.array(HttpSnippetLanguage)]);
+
+const BackgroundImageThemedConfig = z.object({
+    dark: z.string().optional(),
+    light: z.string().optional()
+});
+
+const BackgroundImageConfiguration = z.union([z.string(), BackgroundImageThemedConfig]);
+
+const CssConfig = z.union([z.string(), z.array(z.string())]);
+
+// ===== Base/mixin schemas =====
+
+const WithPermissions = z.object({
+    viewers: Role.optional(),
+    orphaned: z.boolean().optional()
+});
+
+const FeatureFlag = z.object({
+    flag: z.string(),
+    "fallback-value": z.unknown().optional(),
+    match: z.unknown().optional()
+});
+
+const FeatureFlagConfiguration = z.union([z.string(), FeatureFlag, z.array(FeatureFlag)]);
+
+const WithFeatureFlags = z.object({
+    "feature-flag": FeatureFlagConfiguration.optional()
+});
+
+const WithViewers = z.object({
+    viewers: Role.optional()
+});
+
+// ===== Analytics schemas =====
+
+const SegmentConfig = z.object({
+    "write-key": z.string()
+});
+
+const FullStoryAnalyticsConfig = z.object({
+    "org-id": z.string()
+});
+
+const IntercomConfig = z.object({
+    "app-id": z.string(),
+    "api-base": z.string().optional()
+});
+
+const PostHogConfig = z.object({
+    "api-key": z.string(),
+    endpoint: z.string().optional()
+});
+
+const GTMConfig = z.object({
+    "container-id": z.string()
+});
+
+const GoogleAnalytics4Config = z.object({
+    "measurement-id": z.string()
+});
+
+const AnalyticsConfig = z.object({
+    segment: SegmentConfig.optional(),
+    fullstory: FullStoryAnalyticsConfig.optional(),
+    intercom: IntercomConfig.optional(),
+    posthog: PostHogConfig.optional(),
+    gtm: GTMConfig.optional(),
+    ga4: GoogleAnalytics4Config.optional()
+});
+
+// ===== AI schemas =====
+
+const AiExamplesConfig = z.object({
+    enabled: z.boolean().optional(),
+    style: z.string().optional()
+});
+
+const AIChatWebsiteDatasource = z.object({
+    url: z.string(),
+    title: z.string().optional()
+});
+
+const AIChatDatasource = AIChatWebsiteDatasource;
+
+const AIChatConfig = z.object({
+    model: AIChatModel.optional(),
+    "system-prompt": z.string().optional(),
+    location: z.array(AIChatLocation).optional(),
+    datasources: z.array(AIChatDatasource).optional()
+});
+
+// ===== Font schemas =====
+
+const FontConfigVariant = z.object({
+    path: z.string(),
+    weight: FontWeight.optional(),
+    style: FontStyle.optional()
+});
+
+const FontConfigPath = z.union([z.string(), FontConfigVariant]);
+
+const FontConfig = z.object({
+    name: z.string().optional(),
+    path: z.string().optional(),
+    weight: FontWeight.optional(),
+    style: FontStyle.optional(),
+    paths: z.array(FontConfigPath).optional(),
+    display: FontDisplay.optional(),
+    fallback: z.array(z.string()).optional(),
+    "font-variation-settings": z.string().optional()
+});
+
+// ===== Typography =====
+
+const DocsTypographyConfig = z.object({
+    headingsFont: FontConfig.optional(),
+    bodyFont: FontConfig.optional(),
+    codeFont: FontConfig.optional()
+});
+
+// ===== Theme schemas =====
+
+const ThemeConfig = z.object({
+    sidebar: SidebarThemeConfig.optional(),
+    body: BodyThemeConfig.optional(),
+    tabs: TabsThemeConfig.optional(),
+    "page-actions": PageActionsThemeConfig.optional(),
+    "footer-nav": FooterNavThemeConfig.optional(),
+    "language-switcher": LanguageSwitcherThemeConfig.optional(),
+    "product-switcher": ProductSwitcherThemeConfig.optional()
+});
+
+// ===== Layout schemas =====
+
+const LayoutConfig = z.object({
+    "page-width": z.string().optional(),
+    "content-width": z.string().optional(),
+    "sidebar-width": z.string().optional(),
+    "header-height": z.string().optional(),
+    "searchbar-placement": SearchbarPlacement.optional(),
+    "tabs-placement": TabsPlacement.optional(),
+    "switcher-placement": SwitcherPlacement.optional(),
+    "content-alignment": ContentAlignment.optional(),
+    "header-position": HeaderPosition.optional(),
+    "disable-header": z.boolean().optional(),
+    "hide-nav-links": z.boolean().optional(),
+    "hide-feedback": z.boolean().optional()
+});
+
+// ===== Settings =====
+
+const DocsSettingsConfig = z.object({
+    "search-text": z.string().optional(),
+    "disable-search": z.boolean().optional(),
+    "dark-mode-code": z.boolean().optional(),
+    "default-search-filters": z.boolean().optional(),
+    "http-snippets": HttpSnippetsConfig.optional(),
+    "hide-404-page": z.boolean().optional(),
+    "use-javascript-as-typescript": z.boolean().optional(),
+    "disable-explorer-proxy": z.boolean().optional(),
+    "disable-analytics": z.boolean().optional(),
+    language: Language.optional(),
+    "folder-title-source": TitleSource.optional(),
+    "substitute-env-vars": z.boolean().optional()
+});
+
+// ===== Colors =====
+
+const ColorsConfiguration = z.object({
+    "accent-primary": ColorConfig.optional(),
+    accentPrimary: ColorConfig.optional(),
+    background: ColorConfig.optional(),
+    border: ColorConfig.optional(),
+    "sidebar-background": ColorConfig.optional(),
+    "header-background": ColorConfig.optional(),
+    "card-background": ColorConfig.optional(),
+    "accent-1": ColorConfig.optional(),
+    "accent-2": ColorConfig.optional(),
+    "accent-3": ColorConfig.optional(),
+    "accent-4": ColorConfig.optional(),
+    "accent-5": ColorConfig.optional(),
+    "accent-6": ColorConfig.optional(),
+    "accent-7": ColorConfig.optional(),
+    "accent-8": ColorConfig.optional(),
+    "accent-9": ColorConfig.optional(),
+    "accent-10": ColorConfig.optional(),
+    "accent-11": ColorConfig.optional(),
+    "accent-12": ColorConfig.optional()
+});
+
+// ===== Page actions =====
+
+const CustomPageAction = z.object({
+    title: z.string(),
+    subtitle: z.string().optional(),
+    url: z.string(),
+    icon: z.string().optional(),
+    default: z.boolean().optional()
+});
+
+const PageActionOptions = z.object({
+    "copy-page": z.boolean().optional(),
+    "view-as-markdown": z.boolean().optional(),
+    "ask-ai": z.boolean().optional(),
+    chatgpt: z.boolean().optional(),
+    claude: z.boolean().optional(),
+    cursor: z.boolean().optional(),
+    vscode: z.boolean().optional(),
+    custom: z.array(CustomPageAction).optional()
+});
+
+const PageActionsConfig = z.object({
+    default: PageActionOption.optional(),
+    options: PageActionOptions.optional()
+});
+
+// ===== Edit this page =====
+
+const GithubEditThisPageConfig = z.object({
+    host: z.string().optional(),
+    owner: z.string(),
+    repo: z.string(),
+    branch: z.string().optional()
+});
+
+const EditThisPageConfig = z.object({
+    github: GithubEditThisPageConfig.optional(),
+    launch: EditThisPageLaunch.optional()
+});
+
+// ===== Docs Instance =====
+
+const DocsInstance = z.object({
+    url: z.string(),
+    "custom-domain": CustomDomain.optional(),
+    private: z.boolean().optional(),
+    "edit-this-page": EditThisPageConfig.optional(),
+    audiences: Audience.optional()
+});
+
+// ===== Logo =====
+
+const LogoConfiguration = z.object({
+    dark: z.string().optional(),
+    light: z.string().optional(),
+    height: z.number().optional(),
+    href: z.string().optional(),
+    "right-text": z.string().optional()
+});
+
+// ===== Link =====
+
+const LinkConfiguration = z.object({
+    link: z.string(),
+    href: z.string(),
+    icon: z.string().optional(),
+    target: Target.optional()
+});
+
+// ===== Snippets =====
+
+const VersionedSnippetLanguageConfiguration = z.object({
+    version: z.string(),
+    package: z.string()
+});
+
+const SnippetLanguageConfiguration = z.union([z.string(), VersionedSnippetLanguageConfiguration]);
+
+const SnippetsConfiguration = z.object({
+    python: SnippetLanguageConfiguration.optional(),
+    typescript: SnippetLanguageConfiguration.optional(),
+    go: SnippetLanguageConfiguration.optional(),
+    java: SnippetLanguageConfiguration.optional(),
+    ruby: SnippetLanguageConfiguration.optional(),
+    csharp: SnippetLanguageConfiguration.optional(),
+    php: SnippetLanguageConfiguration.optional(),
+    swift: SnippetLanguageConfiguration.optional(),
+    rust: SnippetLanguageConfiguration.optional()
+});
+
+// ===== Playground =====
+
+const PlaygroundButtonSettings = z.object({
+    href: z.string().optional()
+});
+
+const PlaygroundSettings = z.object({
+    hidden: z.boolean().optional(),
+    environments: z.array(z.string()).optional(),
+    button: PlaygroundButtonSettings.optional(),
+    oauth: z.boolean().optional(),
+    "limit-websocket-messages-per-connection": z.number().int().optional()
+});
+
+// ===== Announcement =====
+
+const AnnouncementConfig = z.object({
+    message: z.string()
+});
+
+// ===== Navbar =====
+
+const NavbarLinkConfig = WithViewers.merge(
+    z.object({
+        href: z.string().optional(),
+        target: Target.optional(),
+        url: z.string().optional(),
+        text: z.string().optional(),
+        icon: z.string().optional(),
+        rightIcon: z.string().optional(),
+        rounded: z.boolean().optional()
+    })
+);
+
+const NavbarGithubConfigWithOptions = WithViewers.merge(
+    z.object({
+        url: z.string(),
+        target: Target.optional()
+    })
+);
+
+const NavbarGithubConfig = z.union([z.string(), NavbarGithubConfigWithOptions]);
+
+const NavbarDropdownConfig = WithViewers.merge(
+    z.object({
+        links: z.array(NavbarLinkConfig),
+        text: z.string().optional(),
+        icon: z.string().optional(),
+        rightIcon: z.string().optional(),
+        rounded: z.boolean().optional()
+    })
+);
+
+const NavbarLink = z.union([
+    NavbarLinkConfig.merge(z.object({ type: z.literal("filled") })),
+    NavbarLinkConfig.merge(z.object({ type: z.literal("outlined") })),
+    NavbarLinkConfig.merge(z.object({ type: z.literal("minimal") })),
+    z.object({ type: z.literal("github"), value: NavbarGithubConfig }),
+    NavbarDropdownConfig.merge(z.object({ type: z.literal("dropdown") })),
+    NavbarLinkConfig.merge(z.object({ type: z.literal("primary") })),
+    NavbarLinkConfig.merge(z.object({ type: z.literal("secondary") }))
+]);
+
+// ===== Footer links =====
+
+const FooterLinksConfig = z.object({
+    github: z.string().optional(),
+    twitter: z.string().optional(),
+    x: z.string().optional(),
+    linkedin: z.string().optional(),
+    youtube: z.string().optional(),
+    instagram: z.string().optional(),
+    facebook: z.string().optional(),
+    discord: z.string().optional(),
+    slack: z.string().optional(),
+    hackernews: z.string().optional(),
+    medium: z.string().optional(),
+    website: z.string().optional()
+});
+
+// ===== JS Config =====
+
+const JsFileConfigSettings = z.object({
+    path: z.string(),
+    strategy: JsScriptStrategy.optional()
+});
+
+const JsFileConfig = z.union([z.string(), JsFileConfigSettings]);
+
+const JsRemoteConfig = z.object({
+    url: z.string(),
+    strategy: JsScriptStrategy.optional()
+});
+
+const JsConfigOptions = z.union([JsRemoteConfig, JsFileConfig]);
+
+const JsConfig = z.union([JsConfigOptions, z.array(JsConfigOptions)]);
+
+// ===== Metadata =====
+
+const MetadataConfig = z.object({
+    "og:site_name": z.string().optional(),
+    "og:title": z.string().optional(),
+    "og:description": z.string().optional(),
+    "og:url": z.string().optional(),
+    "og:image": z.string().optional(),
+    "og:image:width": z.number().optional(),
+    "og:image:height": z.number().optional(),
+    "og:locale": z.string().optional(),
+    "og:logo": z.string().optional(),
+    "twitter:title": z.string().optional(),
+    "twitter:description": z.string().optional(),
+    "twitter:handle": z.string().optional(),
+    "twitter:image": z.string().optional(),
+    "twitter:site": z.string().optional(),
+    "twitter:url": z.string().optional(),
+    "twitter:card": TwitterCardSetting.optional(),
+    "canonical-host": z.string().optional()
+});
+
+// ===== Redirects =====
+
+const RedirectConfig = z.object({
+    source: z.string(),
+    destination: z.string(),
+    permanent: z.boolean().optional()
+});
+
+// ===== Integrations =====
+
+const IntegrationsConfig = z.object({
+    intercom: z.string().optional()
+});
+
+// ===== Experimental =====
+
+const ExperimentalConfig = z.object({
+    "mdx-components": z.array(z.string()).optional(),
+    "disable-stream-toggle": z.boolean().optional(),
+    "openapi-parser-v2": z.boolean().optional(),
+    "openapi-parser-v3": z.boolean().optional(),
+    "dynamic-snippets": z.boolean().optional(),
+    "ai-examples": z.boolean().optional(),
+    "ai-example-style-instructions": z.string().optional(),
+    "exclude-apis": z.boolean().optional(),
+    "basepath-aware": z.boolean().optional()
+});
+
+// ===== Library schemas =====
+
+const GitLibraryInputSchema = z.object({
+    git: z.string(),
+    subpath: z.string().optional()
+});
+
+const PathLibraryInputSchema = z.object({
+    path: z.string()
+});
+
+const LibraryInputConfiguration = z.union([GitLibraryInputSchema, PathLibraryInputSchema]);
+
+const LibraryOutputConfiguration = z.object({
+    path: z.string()
+});
+
+const LibraryConfiguration = z.object({
+    input: LibraryInputConfiguration,
+    output: LibraryOutputConfiguration,
+    lang: LibraryLanguage
+});
+
+// ===== Page Configuration =====
+
+const PageConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        page: z.string(),
+        path: z.string(),
+        slug: z.string().optional(),
+        icon: z.string().optional(),
+        hidden: z.boolean().optional(),
+        noindex: z.boolean().optional(),
+        availability: Availability.optional()
+    })
+);
+
+// ===== Changelog Configuration =====
+
+const ChangelogConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        changelog: ChangelogFolderRelativePath,
+        title: z.string().optional(),
+        slug: z.string().optional(),
+        icon: z.string().optional(),
+        hidden: z.boolean().optional()
+    })
+);
+
+// ===== Library Reference Configuration =====
+
+const LibraryReferenceConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        library: LibraryName,
+        title: z.string().optional(),
+        slug: z.string().optional()
+    })
+);
+
+// ===== Folder Configuration =====
+
+const FolderConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        folder: z.string(),
+        title: z.string().optional(),
+        "title-source": TitleSource.optional(),
+        slug: z.string().optional(),
+        icon: z.string().optional(),
+        hidden: z.boolean().optional(),
+        "skip-slug": z.boolean().optional(),
+        collapsed: z.boolean().optional(),
+        collapsible: z.boolean().optional(),
+        "collapsed-by-default": z.boolean().optional(),
+        availability: Availability.optional()
+    })
+);
+
+// ===== Recursive types: ApiReferenceLayoutItem =====
+
+const ApiReferenceEndpointConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        endpoint: z.string(),
+        title: z.string().optional(),
+        slug: z.string().optional(),
+        icon: z.string().optional(),
+        hidden: z.boolean().optional(),
+        availability: Availability.optional(),
+        playground: PlaygroundSettings.optional()
+    })
+);
+
+const ApiReferenceOperationConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        operation: z.string(),
+        title: z.string().optional(),
+        slug: z.string().optional(),
+        hidden: z.boolean().optional(),
+        availability: Availability.optional()
+    })
+);
+
+// Use z.lazy for recursive ApiReferenceLayoutItem
+const ApiReferenceLayoutItem: z.ZodType<unknown> = z.lazy(() =>
+    z.union([
+        z.string(),
+        z.record(z.string(), ApiReferencePackageConfiguration),
+        ApiReferenceSectionConfiguration,
+        ApiReferenceEndpointConfiguration,
+        ApiReferenceOperationConfiguration,
+        PageConfiguration,
+        LinkConfiguration
+    ])
+);
+
+const ApiReferenceSectionConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        section: z.string(),
+        "referenced-packages": z.array(z.string()).optional(),
+        summary: z.string().optional(),
+        contents: z.array(ApiReferenceLayoutItem).optional(),
+        slug: z.string().optional(),
+        icon: z.string().optional(),
+        hidden: z.boolean().optional(),
+        "skip-slug": z.boolean().optional(),
+        collapsible: z.boolean().optional(),
+        "collapsed-by-default": z.boolean().optional(),
+        availability: Availability.optional(),
+        playground: PlaygroundSettings.optional()
+    })
+);
+
+const ApiReferencePackageConfigurationWithOptions = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        title: z.string().optional(),
+        summary: z.string().optional(),
+        contents: z.array(ApiReferenceLayoutItem).optional(),
+        availability: Availability.optional(),
+        slug: z.string().optional(),
+        icon: z.string().optional(),
+        hidden: z.boolean().optional(),
+        "skip-slug": z.boolean().optional(),
+        playground: PlaygroundSettings.optional()
+    })
+);
+
+const ApiReferencePackageConfiguration: z.ZodType<unknown> = z.lazy(() =>
+    z.union([z.array(ApiReferenceLayoutItem), ApiReferencePackageConfigurationWithOptions])
+);
+
+// ===== API Reference Configuration =====
+
+const ApiReferenceConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        api: z.string(),
+        "api-name": z.string().optional(),
+        openrpc: z.string().optional(),
+        audiences: Audience.optional(),
+        "display-errors": z.boolean().optional(),
+        "tag-description-pages": z.boolean().optional(),
+        snippets: SnippetsConfiguration.optional(),
+        postman: z.string().optional(),
+        summary: z.string().optional(),
+        layout: z.array(ApiReferenceLayoutItem).optional(),
+        collapsed: z.boolean().optional(),
+        icon: z.string().optional(),
+        slug: z.string().optional(),
+        hidden: z.boolean().optional(),
+        availability: Availability.optional(),
+        "skip-slug": z.boolean().optional(),
+        alphabetized: z.boolean().optional(),
+        flattened: z.boolean().optional(),
+        paginated: z.boolean().optional(),
+        playground: PlaygroundSettings.optional()
+    })
+);
+
+// ===== Recursive types: NavigationItem =====
+
+// Use z.lazy for recursive NavigationItem
+const NavigationItem: z.ZodType<unknown> = z.lazy(() =>
+    z.union([
+        PageConfiguration,
+        SectionConfiguration,
+        ApiReferenceConfiguration,
+        LibraryReferenceConfiguration,
+        LinkConfiguration,
+        ChangelogConfiguration,
+        FolderConfiguration
+    ])
+);
+
+const SectionConfiguration = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        section: z.string(),
+        path: z.string().optional(),
+        contents: z.array(NavigationItem),
+        collapsed: z.boolean().optional(),
+        collapsible: z.boolean().optional(),
+        "collapsed-by-default": z.boolean().optional(),
+        slug: z.string().optional(),
+        icon: z.string().optional(),
+        hidden: z.boolean().optional(),
+        "skip-slug": z.boolean().optional(),
+        availability: Availability.optional()
+    })
+);
+
+// ===== Navigation schemas =====
+
+const UntabbedNavigationConfig = z.array(NavigationItem);
+
+const TabVariant = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        title: z.string(),
+        subtitle: z.string().optional(),
+        icon: z.string().optional(),
+        layout: z.array(NavigationItem),
+        slug: z.string().optional(),
+        "skip-slug": z.boolean().optional(),
+        hidden: z.boolean().optional(),
+        default: z.boolean().optional()
+    })
+);
+
+const TabbedNavigationItemWithLayout = z.object({
+    tab: TabId,
+    layout: z.array(NavigationItem).optional()
+});
+
+const TabbedNavigationItemWithVariants = z.object({
+    tab: TabId,
+    variants: z.array(TabVariant)
+});
+
+const TabbedNavigationItem = z.union([TabbedNavigationItemWithLayout, TabbedNavigationItemWithVariants]);
+
+const TabbedNavigationConfig = z.array(TabbedNavigationItem);
+
+const NavigationConfig = z.union([UntabbedNavigationConfig, TabbedNavigationConfig]);
+
+// ===== Tab Config =====
+
+const TabConfig = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        "display-name": z.string(),
+        icon: z.string().optional(),
+        slug: z.string().optional(),
+        "skip-slug": z.boolean().optional(),
+        hidden: z.boolean().optional(),
+        href: z.string().optional(),
+        target: Target.optional(),
+        changelog: ChangelogFolderRelativePath.optional()
+    })
+);
+
+// ===== Version Config =====
+
+const VersionConfig = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        "display-name": z.string(),
+        path: z.string(),
+        slug: z.string().optional(),
+        availability: VersionAvailability.optional(),
+        audiences: Audience.optional(),
+        hidden: z.boolean().optional(),
+        announcement: AnnouncementConfig.optional()
+    })
+);
+
+const VersionFileConfig = z.object({
+    tabs: z.record(TabId, TabConfig).optional(),
+    "landing-page": PageConfiguration.optional(),
+    navigation: NavigationConfig
+});
+
+// ===== Product schemas =====
+
+const ProductConfigBase = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        "display-name": z.string(),
+        subtitle: z.string().optional(),
+        icon: z.string().optional(),
+        image: z.string().optional(),
+        versions: z.array(VersionConfig).optional(),
+        audiences: Audience.optional()
+    })
+);
+
+const InternalProduct = ProductConfigBase.merge(
+    z.object({
+        path: z.string(),
+        slug: z.string().optional(),
+        announcement: AnnouncementConfig.optional()
+    })
+);
+
+const ExternalProduct = ProductConfigBase.merge(
+    z.object({
+        href: z.string(),
+        target: Target.optional()
+    })
+);
+
+const ProductConfig = z.union([InternalProduct, ExternalProduct]);
+
+const RelativeProductPath = WithPermissions.merge(WithFeatureFlags).merge(
+    z.object({
+        "display-name": z.string(),
+        path: z.string(),
+        slug: z.string().optional()
+    })
+);
+
+const AbsoluteProductPath = z.object({
+    href: z.string()
+});
+
+const ProductPath = z.union([RelativeProductPath, AbsoluteProductPath]);
+
+const ProductFileConfig = z.object({
+    tabs: z.record(TabId, TabConfig).optional(),
+    "landing-page": PageConfiguration.optional(),
+    navigation: NavigationConfig
+});
+
+// ===== Main DocsConfiguration =====
+
+const DocsConfiguration = z.object({
+    instances: z.array(DocsInstance),
+    title: z.string().optional(),
+    libraries: z.record(LibraryName, LibraryConfiguration).optional(),
+    analytics: AnalyticsConfig.optional(),
+    announcement: AnnouncementConfig.optional(),
+    roles: z.array(RoleId).optional(),
+    tabs: z.record(TabId, TabConfig).optional(),
+    versions: z.array(VersionConfig).optional(),
+    products: z.array(ProductConfig).optional(),
+    "landing-page": PageConfiguration.optional(),
+    navigation: NavigationConfig.optional(),
+    "navbar-links": z.array(NavbarLink).optional(),
+    "footer-links": FooterLinksConfig.optional(),
+    "page-actions": PageActionsConfig.optional(),
+    experimental: ExperimentalConfig.optional(),
+    "default-language": ProgrammingLanguage.optional(),
+    languages: z.array(Language).optional(),
+    "ai-chat": AIChatConfig.optional(),
+    "ai-search": AIChatConfig.optional(),
+    "ai-examples": AiExamplesConfig.optional(),
+    metadata: MetadataConfig.optional(),
+    redirects: z.array(RedirectConfig).optional(),
+    logo: LogoConfiguration.optional(),
+    favicon: z.string().optional(),
+    "background-image": BackgroundImageConfiguration.optional(),
+    colors: ColorsConfiguration.optional(),
+    typography: DocsTypographyConfig.optional(),
+    layout: LayoutConfig.optional(),
+    settings: DocsSettingsConfig.optional(),
+    theme: ThemeConfig.optional(),
+    integrations: IntegrationsConfig.optional(),
+    css: CssConfig.optional(),
+    js: JsConfig.optional(),
+    header: z.string().optional(),
+    footer: z.string().optional()
+});
+
+// Suppress unused variable warnings. These schemas are not exported intentionally.
+// They will be exported in a future PR to replace the existing SDK-generated schemas.
+void TabId;
+void ChangelogFolderRelativePath;
+void AudienceId;
+void RoleId;
+void LibraryName;
+void ProgrammingLanguage;
+void Language;
+void PageActionOption;
+void AIChatLocation;
+void AIChatModel;
+void EditThisPageLaunch;
+void Availability;
+void VersionAvailability;
+void TitleSource;
+void LibraryLanguage;
+void FontStyle;
+void FontDisplay;
+void SearchbarPlacement;
+void TabsPlacement;
+void SwitcherPlacement;
+void ContentAlignment;
+void HeaderPosition;
+void ProductSwitcherThemeConfig;
+void LanguageSwitcherThemeConfig;
+void FooterNavThemeConfig;
+void TabsThemeConfig;
+void BodyThemeConfig;
+void SidebarThemeConfig;
+void PageActionsThemeConfig;
+void HttpSnippetLanguage;
+void Target;
+void TwitterCardSetting;
+void JsScriptStrategy;
+void FontWeight;
+void ColorThemedConfig;
+void ColorConfig;
+void Audience;
+void Role;
+void CustomDomain;
+void HttpSnippetsConfig;
+void BackgroundImageThemedConfig;
+void BackgroundImageConfiguration;
+void CssConfig;
+void WithPermissions;
+void FeatureFlag;
+void FeatureFlagConfiguration;
+void WithFeatureFlags;
+void WithViewers;
+void SegmentConfig;
+void FullStoryAnalyticsConfig;
+void IntercomConfig;
+void PostHogConfig;
+void GTMConfig;
+void GoogleAnalytics4Config;
+void AnalyticsConfig;
+void AiExamplesConfig;
+void AIChatWebsiteDatasource;
+void AIChatDatasource;
+void AIChatConfig;
+void FontConfigVariant;
+void FontConfigPath;
+void FontConfig;
+void DocsTypographyConfig;
+void ThemeConfig;
+void LayoutConfig;
+void DocsSettingsConfig;
+void ColorsConfiguration;
+void CustomPageAction;
+void PageActionOptions;
+void PageActionsConfig;
+void GithubEditThisPageConfig;
+void EditThisPageConfig;
+void DocsInstance;
+void LogoConfiguration;
+void LinkConfiguration;
+void VersionedSnippetLanguageConfiguration;
+void SnippetLanguageConfiguration;
+void SnippetsConfiguration;
+void PlaygroundButtonSettings;
+void PlaygroundSettings;
+void AnnouncementConfig;
+void NavbarLinkConfig;
+void NavbarGithubConfigWithOptions;
+void NavbarGithubConfig;
+void NavbarDropdownConfig;
+void NavbarLink;
+void FooterLinksConfig;
+void JsFileConfigSettings;
+void JsFileConfig;
+void JsRemoteConfig;
+void JsConfigOptions;
+void JsConfig;
+void MetadataConfig;
+void RedirectConfig;
+void IntegrationsConfig;
+void ExperimentalConfig;
+void GitLibraryInputSchema;
+void PathLibraryInputSchema;
+void LibraryInputConfiguration;
+void LibraryOutputConfiguration;
+void LibraryConfiguration;
+void PageConfiguration;
+void ChangelogConfiguration;
+void LibraryReferenceConfiguration;
+void FolderConfiguration;
+void ApiReferenceEndpointConfiguration;
+void ApiReferenceOperationConfiguration;
+void ApiReferenceLayoutItem;
+void ApiReferenceSectionConfiguration;
+void ApiReferencePackageConfigurationWithOptions;
+void ApiReferencePackageConfiguration;
+void ApiReferenceConfiguration;
+void NavigationItem;
+void SectionConfiguration;
+void UntabbedNavigationConfig;
+void TabVariant;
+void TabbedNavigationItemWithLayout;
+void TabbedNavigationItemWithVariants;
+void TabbedNavigationItem;
+void TabbedNavigationConfig;
+void NavigationConfig;
+void TabConfig;
+void VersionConfig;
+void VersionFileConfig;
+void ProductConfigBase;
+void InternalProduct;
+void ExternalProduct;
+void ProductConfig;
+void RelativeProductPath;
+void AbsoluteProductPath;
+void ProductPath;
+void ProductFileConfig;
+void DocsConfiguration;

--- a/packages/cli/configuration/src/docs-yml/__test__/DocsYmlSchemas.test.ts
+++ b/packages/cli/configuration/src/docs-yml/__test__/DocsYmlSchemas.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import { DocsConfiguration, ProductFileConfig, VersionFileConfig } from "../DocsYmlSchemas.js";
+
+describe("DocsYmlSchemas", () => {
+    it("should produce JSON Schema for DocsConfiguration", () => {
+        const jsonSchema = zodToJsonSchema(DocsConfiguration, "DocsConfiguration");
+        expect(jsonSchema).toBeDefined();
+        expect(jsonSchema.$ref).toBe("#/definitions/DocsConfiguration");
+        expect(jsonSchema.definitions).toBeDefined();
+        const definitions = jsonSchema.definitions ?? {};
+        expect(definitions["DocsConfiguration"]).toBeDefined();
+    });
+
+    it("should produce JSON Schema for VersionFileConfig", () => {
+        const jsonSchema = zodToJsonSchema(VersionFileConfig, "VersionFileConfig");
+        expect(jsonSchema).toBeDefined();
+        expect(jsonSchema.$ref).toBe("#/definitions/VersionFileConfig");
+        expect(jsonSchema.definitions).toBeDefined();
+        const definitions = jsonSchema.definitions ?? {};
+        expect(definitions["VersionFileConfig"]).toBeDefined();
+    });
+
+    it("should produce JSON Schema for ProductFileConfig", () => {
+        const jsonSchema = zodToJsonSchema(ProductFileConfig, "ProductFileConfig");
+        expect(jsonSchema).toBeDefined();
+        expect(jsonSchema.$ref).toBe("#/definitions/ProductFileConfig");
+        expect(jsonSchema.definitions).toBeDefined();
+        const definitions = jsonSchema.definitions ?? {};
+        expect(definitions["ProductFileConfig"]).toBeDefined();
+    });
+
+    it("DocsConfiguration JSON Schema should contain expected top-level properties", () => {
+        const jsonSchema = zodToJsonSchema(DocsConfiguration, "DocsConfiguration");
+        const definitions = jsonSchema.definitions ?? {};
+        const docsConfigDef = definitions["DocsConfiguration"] as Record<string, unknown>;
+        const properties = docsConfigDef["properties"] as Record<string, unknown>;
+        expect(properties).toBeDefined();
+        expect(properties["instances"]).toBeDefined();
+        expect(properties["title"]).toBeDefined();
+        expect(properties["navigation"]).toBeDefined();
+        expect(properties["navbar-links"]).toBeDefined();
+        expect(properties["colors"]).toBeDefined();
+        expect(properties["typography"]).toBeDefined();
+        expect(properties["layout"]).toBeDefined();
+        expect(properties["ai-search"]).toBeDefined();
+    });
+});

--- a/packages/cli/configuration/src/docs-yml/__test__/DocsYmlSchemas.test.ts
+++ b/packages/cli/configuration/src/docs-yml/__test__/DocsYmlSchemas.test.ts
@@ -5,35 +5,35 @@ import { DocsConfiguration, ProductFileConfig, VersionFileConfig } from "../Docs
 
 describe("DocsYmlSchemas", () => {
     it("should produce JSON Schema for DocsConfiguration", () => {
-        const jsonSchema = zodToJsonSchema(DocsConfiguration, "DocsConfiguration");
+        const jsonSchema = zodToJsonSchema(DocsConfiguration, "DocsConfiguration") as Record<string, unknown>;
         expect(jsonSchema).toBeDefined();
-        expect(jsonSchema.$ref).toBe("#/definitions/DocsConfiguration");
-        expect(jsonSchema.definitions).toBeDefined();
-        const definitions = jsonSchema.definitions ?? {};
+        expect(jsonSchema["$ref"]).toBe("#/definitions/DocsConfiguration");
+        expect(jsonSchema["definitions"]).toBeDefined();
+        const definitions = (jsonSchema["definitions"] ?? {}) as Record<string, unknown>;
         expect(definitions["DocsConfiguration"]).toBeDefined();
     });
 
     it("should produce JSON Schema for VersionFileConfig", () => {
-        const jsonSchema = zodToJsonSchema(VersionFileConfig, "VersionFileConfig");
+        const jsonSchema = zodToJsonSchema(VersionFileConfig, "VersionFileConfig") as Record<string, unknown>;
         expect(jsonSchema).toBeDefined();
-        expect(jsonSchema.$ref).toBe("#/definitions/VersionFileConfig");
-        expect(jsonSchema.definitions).toBeDefined();
-        const definitions = jsonSchema.definitions ?? {};
+        expect(jsonSchema["$ref"]).toBe("#/definitions/VersionFileConfig");
+        expect(jsonSchema["definitions"]).toBeDefined();
+        const definitions = (jsonSchema["definitions"] ?? {}) as Record<string, unknown>;
         expect(definitions["VersionFileConfig"]).toBeDefined();
     });
 
     it("should produce JSON Schema for ProductFileConfig", () => {
-        const jsonSchema = zodToJsonSchema(ProductFileConfig, "ProductFileConfig");
+        const jsonSchema = zodToJsonSchema(ProductFileConfig, "ProductFileConfig") as Record<string, unknown>;
         expect(jsonSchema).toBeDefined();
-        expect(jsonSchema.$ref).toBe("#/definitions/ProductFileConfig");
-        expect(jsonSchema.definitions).toBeDefined();
-        const definitions = jsonSchema.definitions ?? {};
+        expect(jsonSchema["$ref"]).toBe("#/definitions/ProductFileConfig");
+        expect(jsonSchema["definitions"]).toBeDefined();
+        const definitions = (jsonSchema["definitions"] ?? {}) as Record<string, unknown>;
         expect(definitions["ProductFileConfig"]).toBeDefined();
     });
 
     it("DocsConfiguration JSON Schema should contain expected top-level properties", () => {
-        const jsonSchema = zodToJsonSchema(DocsConfiguration, "DocsConfiguration");
-        const definitions = jsonSchema.definitions ?? {};
+        const jsonSchema = zodToJsonSchema(DocsConfiguration, "DocsConfiguration") as Record<string, unknown>;
+        const definitions = (jsonSchema["definitions"] ?? {}) as Record<string, unknown>;
         const docsConfigDef = definitions["DocsConfiguration"] as Record<string, unknown>;
         const properties = docsConfigDef["properties"] as Record<string, unknown>;
         expect(properties).toBeDefined();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5165,6 +5165,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@types/node@18.15.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.3.3)
+      zod-to-json-schema:
+        specifier: ^3.25.1
+        version: 3.25.1(zod@3.25.76)
 
   packages/cli/configuration-loader:
     dependencies:
@@ -14623,6 +14626,11 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -21963,6 +21971,10 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Description

Refs: Requested by @dsinghvi
[Link to Devin Session](https://app.devin.ai/sessions/b065ff00f30c4c5784eba7cdae135b6f)

Adds hand-written Zod schemas for every type in `fern/apis/docs-yml/definition/docs.yml` to the `configuration` package. Schemas are exported from the file but **not re-exported from the package index** — in a follow-up PR they will replace the existing SDK-generated schemas.

## Changes Made

- Added `packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts` containing ~130 exported Zod schemas matching all types from the docs.yml Fern Definition
- Uses `z.lazy()` for recursive types (`NavigationItem` ↔ `SectionConfiguration`, `ApiReferenceLayoutItem` ↔ `ApiReferenceSectionConfiguration` / `ApiReferencePackageConfiguration`)
- Uses `z.object().merge()` for types that use `extends` (e.g., `WithPermissions`, `WithFeatureFlags`, `ProductConfigBase`)
- Schema names match the Fern Definition type names exactly
- `AIChatDatasource` simplified to alias `AIChatWebsiteDatasource` since `z.union` requires ≥2 members
- Added `zod-to-json-schema` as a devDependency for test verification
- Added `DocsYmlSchemas.test.ts` that verifies JSON Schema can be produced from root types (`DocsConfiguration`, `VersionFileConfig`, `ProductFileConfig`) and validates expected top-level properties
- Added `zod-to-json-schema` to `knip.json` `ignoreDependencies` (knip's `ignore` pattern excludes `__test__/**`, so it can't see the test import)

## Human Review Checklist

- [ ] Cross-reference a sampling of property names/types against `fern/apis/docs-yml/definition/docs.yml` — property names use raw YAML keys (kebab-case for most, camelCase for `headingsFont`/`bodyFont`/`codeFont`/`rightIcon`). A mismatch here would cause silent validation failures at runtime.
- [ ] Verify the `NavbarLink` discriminated union translation — uses `z.union` with merged `type` literals; the `github` variant wraps `NavbarGithubConfig` in a `value` field to match the SDK serialization shape. This is a manual interpretation worth double-checking against the actual SDK behavior.
- [ ] Confirm recursive `z.lazy()` patterns are correct for `NavigationItem` and `ApiReferenceLayoutItem` — these are typed as `z.ZodType<unknown>` which loses inner type safety
- [ ] Sanity-check that no types from docs.yml were missed
- [ ] Verify optional vs. required status of fields matches the Fern Definition (all non-`required` fields should use `.optional()`)

## Testing

- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] `biome check` lint passes
- [x] `knip` depcheck passes
- [x] Unit tests pass — JSON Schema generation verified for `DocsConfiguration`, `VersionFileConfig`, `ProductFileConfig`