### PR TITLE
chore(internal): update posthog-node to ^5.26.2

### DIFF
--- a/packages/cli/posthog-manager/package.json
+++ b/packages/cli/posthog-manager/package.json
@@ -36,7 +36,7 @@
     "@fern-api/core": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
-    "posthog-node": "^5.14.0",
+    "posthog-node": "^5.26.2",
     "uuid": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6740,8 +6740,8 @@ importers:
         specifier: workspace:*
         version: link:../task-context
       posthog-node:
-        specifier: ^5.14.0
-        version: 5.24.7
+        specifier: ^5.26.2
+        version: 5.26.2
       uuid:
         specifier: 'catalog:'
         version: 9.0.1
@@ -10060,6 +10060,9 @@ packages:
   '@posthog/core@1.17.0':
     resolution: {integrity: sha512-8pDNL+/u9ojzXloA5wILVDXBCV5daJ7w2ipCALQlEEZmL752cCKhRpbyiHn3tjKXh3Hy6aOboJneYa1JdlVHrQ==}
 
+  '@posthog/core@1.23.2':
+    resolution: {integrity: sha512-zTDdda9NuSHrnwSOfFMxX/pyXiycF4jtU1kTr8DL61dHhV+7LF6XF1ndRZZTuaGGbfbb/GJYkEsjEX9SXfNZeQ==}
+
   '@puppeteer/browsers@2.11.2':
     resolution: {integrity: sha512-GBY0+2lI9fDrjgb5dFL9+enKXqyOPok9PXg/69NVkjW3bikbK9RQrNrI3qccQXmDNN7ln4j/yL89Qgvj/tfqrw==}
     engines: {node: '>=18'}
@@ -13296,6 +13299,10 @@ packages:
 
   posthog-node@5.24.7:
     resolution: {integrity: sha512-IJ0Zj+v+eg/JQMZ75n0Hcp4NzuQzWcZjqFjcUQs6RhW2l5FiQIq09sKJMleXX33hYxD6sfjFsDTqugJlgeAohg==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+
+  posthog-node@5.26.2:
+    resolution: {integrity: sha512-fAivzhkhwsZiq6b3YdMYQ5av4Zo5ggV5BC9Uwr5id5N6y0o4OCOTYlKg3O+O+I6SvbbZNYIUZIjgQMWz2yIMkw==}
     engines: {node: ^20.20.0 || >=22.22.0}
 
   prelude-ls@1.2.1:
@@ -16651,6 +16658,10 @@ snapshots:
       config-chain: 1.1.13
 
   '@posthog/core@1.17.0':
+    dependencies:
+      cross-spawn: 7.0.5
+
+  '@posthog/core@1.23.2':
     dependencies:
       cross-spawn: 7.0.5
 
@@ -20321,6 +20332,10 @@ snapshots:
   posthog-node@5.24.7:
     dependencies:
       '@posthog/core': 1.17.0
+
+  posthog-node@5.26.2:
+    dependencies:
+      '@posthog/core': 1.23.2
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
## Description

Refs: PostHog SDK Doctor flagged all current SDK versions as outdated.

Updates `posthog-node` dependency in `@fern-api/posthog-manager` from `^5.14.0` to `^5.26.2` (latest available per PostHog's SDK Doctor).

This is part of a cross-org effort to update PostHog SDKs across all fern-api repositories, with a separate PR per repo.

## Changes Made

- Bumped `posthog-node` version in `packages/cli/posthog-manager/package.json` (`^5.14.0` → `^5.26.2`)
- Regenerated `pnpm-lock.yaml` (resolved version: `5.24.7` → `5.26.2`; transitive dep `@posthog/core`: `1.17.0` → `1.23.2`)

## Testing

- [x] CI passes — no breaking API changes in the new version (no code changes needed — same major version, semver-compatible bump)

## Human Review Checklist

- [x] Verify CI passes — the lockfile has been regenerated and no breaking changes surfaced
- [ ] Spot-check [posthog-node changelog](https://github.com/PostHog/posthog-js-lite/releases) for any deprecations of APIs used in `posthog-manager`

[Link to Devin Session](https://app.devin.ai/sessions/a993b7ee26a048dc8ddb3a060e0e5961)
Requested by: @dannysheridan