### PR TITLE
feat(cli): unconfuse OpenAPI and AsyncAPI servers for `x-fern-server-name`

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -299,7 +299,8 @@ export function buildEndpoint({
                 convertedEndpoint.url = defaultServer;
             }
         } else {
-            convertedEndpoint.url = serverOverride.name ?? undefined;
+            const urlId = serverOverride.url != null ? context.getUrlId(serverOverride.url) : undefined;
+            convertedEndpoint.url = urlId ?? serverOverride.name ?? undefined;
         }
     }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEnvironments.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEnvironments.ts
@@ -578,6 +578,9 @@ export function buildEnvironments(context: OpenApiIrConverterContext): void {
                             : isRawMultipleBaseUrlsEnvironment(schema)
                               ? Object.values(schema.urls)[0]
                               : (schema["default-url"] ?? schema.url);
+                    if (baseUrl != null) {
+                        context.setUrlId(baseUrl, DEFAULT_URL_NAME);
+                    }
                     context.builder.addEnvironment({
                         name,
                         schema: {
@@ -603,6 +606,9 @@ export function buildEnvironments(context: OpenApiIrConverterContext): void {
                             : isRawMultipleBaseUrlsEnvironment(schema)
                               ? Object.values(schema.urls)[0]
                               : (schema["default-url"] ?? schema.url);
+                    if (baseUrl != null) {
+                        context.setUrlId(baseUrl, DEFAULT_URL_NAME);
+                    }
                     context.builder.addEnvironment({
                         name,
                         schema: {
@@ -661,6 +667,10 @@ export function buildEnvironments(context: OpenApiIrConverterContext): void {
 
             const hasTemplateData = Object.keys(multiUrlTemplates).length > 0 || Object.keys(multiVariables).length > 0;
 
+            if (topLevelServerUrl != null) {
+                context.setUrlId(topLevelServerUrl, DEFAULT_URL_NAME);
+            }
+
             const multiUrlSchema: RawSchemas.MultipleBaseUrlsEnvironmentSchema = {
                 urls: {
                     ...{ [DEFAULT_URL_NAME]: topLevelServerUrl ?? "" },
@@ -716,6 +726,8 @@ export function buildEnvironments(context: OpenApiIrConverterContext): void {
                         continue; // Skip if no base URL
                     }
 
+                    context.setUrlId(baseUrl, DEFAULT_URL_NAME);
+
                     const envSuffix = baseUrl.match(/[-]([a-z0-9]+)\./i)?.[1]?.toLowerCase() || "production";
 
                     const urls: Record<string, string> = {
@@ -767,6 +779,9 @@ export function buildEnvironments(context: OpenApiIrConverterContext): void {
                                 : isRawMultipleBaseUrlsEnvironment(schema)
                                   ? Object.values(schema.urls)[0]
                                   : (schema["default-url"] ?? schema.url);
+                        if (baseUrl != null) {
+                            context.setUrlId(baseUrl, DEFAULT_URL_NAME);
+                        }
                         context.builder.addEnvironment({
                             name,
                             schema: {

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.2.1
+  changelogEntry:
+    - summary: |
+        Fix REST HTTP clients incorrectly using WebSocket environment URLs in
+        multi-URL environments with both OpenAPI and AsyncAPI servers.
+      type: fix
+  createdAt: "2026-03-03"
+  irVersion: 65
+
 - version: 4.2.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
When path-level servers shared an `x-fern-server-name` with an AsyncAPI server (e.g. "Production"), REST endpoints resolved to the WebSocket URL (`wss://`) instead of the HTTP URL (`https://`). Endpoint server URLs are now mapped through the environment URL ID system, which is how channels already worked.

## Changes Made
Small changes to `buildEndpoint.ts` in the `openapi-ir-to-fern` parser.

## Testing
Manually checked for Deepgram.
- [X] Unit tests added/updated
- [X] Manual testing completed
