### PR TITLE
chore(cli): Improve check output format

### DIFF
--- a/packages/cli/cli-v2/src/__test__/ApiChecker.test.ts
+++ b/packages/cli/cli-v2/src/__test__/ApiChecker.test.ts
@@ -1,7 +1,6 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { NOOP_LOGGER } from "@fern-api/logger";
 import { join } from "path";
-import { Writable } from "stream";
 import { describe, expect, it } from "vitest";
 import { ApiChecker } from "../api/checker/ApiChecker.js";
 import { loadFernYml } from "../config/fern-yml/loadFernYml.js";
@@ -26,11 +25,9 @@ describe("ApiChecker", () => {
                 return;
             }
 
-            const { stream, getOutput } = createCaptureStream();
             const checker = new ApiChecker({
                 context: createTestContext({ cwd }),
-                cliVersion: "0.0.0",
-                stream
+                cliVersion: "0.0.0"
             });
 
             const checkResult = await checker.check({
@@ -41,7 +38,7 @@ describe("ApiChecker", () => {
             expect(checkResult.invalidApis.size).toBe(0);
             expect(checkResult.errorCount).toBe(0);
             expect(checkResult.warningCount).toBe(0);
-            expect(getOutput()).toBe("");
+            expect(checkResult.violations).toHaveLength(0);
         });
 
         it("checks only specified APIs when apiNames is provided", async () => {
@@ -55,11 +52,9 @@ describe("ApiChecker", () => {
                 return;
             }
 
-            const { stream } = createCaptureStream();
             const checker = new ApiChecker({
                 context: createTestContext({ cwd }),
-                cliVersion: "0.0.0",
-                stream
+                cliVersion: "0.0.0"
             });
 
             const checkResult = await checker.check({
@@ -75,11 +70,9 @@ describe("ApiChecker", () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
             const workspace = await loadWorkspace("simple-api");
 
-            const { stream } = createCaptureStream();
             const checker = new ApiChecker({
                 context: createTestContext({ cwd }),
-                cliVersion: "0.0.0",
-                stream
+                cliVersion: "0.0.0"
             });
 
             const checkResult = await checker.check({
@@ -95,11 +88,9 @@ describe("ApiChecker", () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
             const workspace = await loadWorkspace("simple-api");
 
-            const { stream, getOutput } = createCaptureStream();
             const checker = new ApiChecker({
                 context: createTestContext({ cwd }),
-                cliVersion: "0.0.0",
-                stream
+                cliVersion: "0.0.0"
             });
 
             const checkResult = await checker.check({
@@ -111,18 +102,16 @@ describe("ApiChecker", () => {
             expect(checkResult.invalidApis.size).toBe(0);
             expect(checkResult.errorCount).toBe(0);
             expect(checkResult.warningCount).toBe(0);
-            expect(getOutput()).toBe("");
+            expect(checkResult.violations).toHaveLength(0);
         });
 
         it("includes elapsed time in result", async () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
             const workspace = await loadWorkspace("simple-api");
 
-            const { stream } = createCaptureStream();
             const checker = new ApiChecker({
                 context: createTestContext({ cwd }),
-                cliVersion: "0.0.0",
-                stream
+                cliVersion: "0.0.0"
             });
 
             const checkResult = await checker.check({
@@ -133,24 +122,21 @@ describe("ApiChecker", () => {
         });
     });
 
-    describe("stream injection", () => {
-        it("writes output to injected stream", async () => {
+    describe("violations returned in result", () => {
+        it("returns empty violations for valid workspace", async () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
             const workspace = await loadWorkspace("simple-api");
 
-            const { stream, getOutput } = createCaptureStream();
             const checker = new ApiChecker({
                 context: createTestContext({ cwd }),
-                cliVersion: "0.0.0",
-                stream
+                cliVersion: "0.0.0"
             });
 
-            await checker.check({
+            const checkResult = await checker.check({
                 workspace
             });
 
-            // Valid API produces no output.
-            expect(getOutput()).toBe("");
+            expect(checkResult.violations).toHaveLength(0);
         });
     });
 
@@ -159,11 +145,9 @@ describe("ApiChecker", () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
             const workspace = await loadWorkspace("simple-api");
 
-            const { stream } = createCaptureStream();
             const checker = new ApiChecker({
                 context: createTestContext({ cwd }),
-                cliVersion: "0.0.0",
-                stream
+                cliVersion: "0.0.0"
             });
 
             const checkResult = await checker.check({
@@ -175,21 +159,3 @@ describe("ApiChecker", () => {
         });
     });
 });
-
-/**
- * Creates a writable stream that captures output for testing.
- */
-function createCaptureStream(): { stream: NodeJS.WriteStream; getOutput: () => string } {
-    let output = "";
-    const stream = new Writable({
-        write(chunk, _encoding, callback) {
-            output += chunk.toString();
-            callback();
-        }
-    }) as NodeJS.WriteStream;
-
-    return {
-        stream,
-        getOutput: () => output
-    };
-}

--- a/packages/cli/cli-v2/src/__test__/SdkChecker.test.ts
+++ b/packages/cli/cli-v2/src/__test__/SdkChecker.test.ts
@@ -4,14 +4,13 @@ import { randomUUID } from "crypto";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import { Writable } from "stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadFernYml } from "../config/fern-yml/loadFernYml.js";
 import { SdkChecker } from "../sdk/checker/SdkChecker.js";
 import { WorkspaceLoader } from "../workspace/WorkspaceLoader.js";
 import { FIXTURES_DIR } from "./utils/constants.js";
 import { createTestContext } from "./utils/createTestContext.js";
-import { loadWorkspaceWithFernYml } from "./utils/loadWorkspace.js";
+import { loadWorkspace } from "./utils/loadWorkspace.js";
 
 /** A version checker that always reports versions as valid. */
 const NOOP_VERSION_CHECKER: SdkChecker.VersionChecker = async () => ({ violation: undefined });
@@ -32,20 +31,18 @@ describe("SdkChecker", () => {
     describe("valid configuration", () => {
         it("returns no errors for valid SDK config", async () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
-            const { workspace, fernYml } = await loadWorkspaceWithFernYml("simple-api");
+            const workspace = await loadWorkspace("simple-api");
 
-            const { stream, getOutput } = createCaptureStream();
             const checker = new SdkChecker({
                 context: createTestContext({ cwd }),
-                stream,
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
-            const result = await checker.check({ workspace, fernYml });
+            const result = await checker.check({ workspace });
 
             expect(result.errorCount).toBe(0);
             expect(result.warningCount).toBe(0);
-            expect(getOutput()).toBe("");
+            expect(result.violations).toHaveLength(0);
         });
 
         it("returns empty result for workspace without SDKs", async () => {
@@ -61,26 +58,18 @@ api:
             );
             await writeMinimalOpenApi(testDir);
 
-            const fernYml = await loadFernYml({ cwd: testDir });
-            const loader = new WorkspaceLoader({ cwd: testDir, logger: NOOP_LOGGER });
-            const loadResult = await loader.load({ fernYml });
-            expect(loadResult.success).toBe(true);
-            if (!loadResult.success) {
-                return;
-            }
+            const workspace = await loadTempWorkspace(testDir);
 
-            const { stream, getOutput } = createCaptureStream();
             const checker = new SdkChecker({
                 context: createTestContext({ cwd: testDir }),
-                stream,
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
-            const result = await checker.check({ workspace: loadResult.workspace, fernYml });
+            const result = await checker.check({ workspace });
 
             expect(result.errorCount).toBe(0);
             expect(result.warningCount).toBe(0);
-            expect(getOutput()).toBe("");
+            expect(result.violations).toHaveLength(0);
         });
     });
 
@@ -107,32 +96,28 @@ sdks:
             );
             await writeMinimalOpenApi(testDir);
 
-            const { workspace, fernYml } = await loadTempWorkspace(testDir);
-            const { stream, getOutput } = createCaptureStream();
+            const workspace = await loadTempWorkspace(testDir);
             const checker = new SdkChecker({
                 context: createTestContext({ cwd: testDir }),
-                stream,
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
-            const result = await checker.check({ workspace, fernYml });
+            const result = await checker.check({ workspace });
 
             expect(result.errorCount).toBe(1);
-            expect(getOutput()).toContain("not referenced by any target");
+            expect(result.violations.some((v) => v.message.includes("not referenced by any target"))).toBe(true);
         });
 
         it("passes when defaultGroup is referenced by a target", async () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
-            const { workspace, fernYml } = await loadWorkspaceWithFernYml("simple-api");
+            const workspace = await loadWorkspace("simple-api");
 
-            const { stream } = createCaptureStream();
             const checker = new SdkChecker({
                 context: createTestContext({ cwd }),
-                stream,
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
-            const result = await checker.check({ workspace, fernYml });
+            const result = await checker.check({ workspace });
 
             expect(result.errorCount).toBe(0);
         });
@@ -159,41 +144,37 @@ sdks:
             );
             await writeMinimalOpenApi(testDir);
 
-            const { workspace, fernYml } = await loadTempWorkspace(testDir);
-            const { stream, getOutput } = createCaptureStream();
+            const workspace = await loadTempWorkspace(testDir);
             const checker = new SdkChecker({
                 context: createTestContext({ cwd: testDir }),
-                stream,
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
-            const result = await checker.check({ workspace, fernYml });
+            const result = await checker.check({ workspace });
 
             expect(result.errorCount).toBe(1);
-            expect(getOutput()).toContain("not defined");
+            expect(result.violations.some((v) => v.message.includes("not defined"))).toBe(true);
         });
     });
 
     describe("version validation", () => {
         it("includes elapsed time in result", async () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
-            const { workspace, fernYml } = await loadWorkspaceWithFernYml("simple-api");
+            const workspace = await loadWorkspace("simple-api");
 
-            const { stream } = createCaptureStream();
             const checker = new SdkChecker({
                 context: createTestContext({ cwd }),
-                stream,
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
-            const result = await checker.check({ workspace, fernYml });
+            const result = await checker.check({ workspace });
 
             expect(result.elapsedMillis).toBeGreaterThanOrEqual(0);
         });
     });
 
-    describe("display", () => {
-        it("writes violations with severity icon and file location", async () => {
+    describe("violations returned in result", () => {
+        it("returns violations with file location for invalid config", async () => {
             await writeFile(
                 join(testDir, "fern.yml"),
                 `
@@ -215,47 +196,40 @@ sdks:
             );
             await writeMinimalOpenApi(testDir);
 
-            const { workspace, fernYml } = await loadTempWorkspace(testDir);
-            const { stream, getOutput } = createCaptureStream();
+            const workspace = await loadTempWorkspace(testDir);
             const checker = new SdkChecker({
                 context: createTestContext({ cwd: testDir }),
-                stream,
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
-            await checker.check({ workspace, fernYml });
+            const result = await checker.check({ workspace });
 
-            const output = getOutput();
-            expect(output).toContain("not referenced by any target");
-            expect(output).toContain("fern.yml");
+            expect(result.violations.some((v) => v.message.includes("not referenced by any target"))).toBe(true);
+            expect(result.violations.some((v) => v.displayRelativeFilepath.includes("fern.yml"))).toBe(true);
         });
 
-        it("writes no output for valid workspace", async () => {
+        it("returns empty violations for valid workspace", async () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
-            const { workspace, fernYml } = await loadWorkspaceWithFernYml("simple-api");
+            const workspace = await loadWorkspace("simple-api");
 
-            const { stream, getOutput } = createCaptureStream();
             const checker = new SdkChecker({
                 context: createTestContext({ cwd }),
-                stream,
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
-            await checker.check({ workspace, fernYml });
+            const result = await checker.check({ workspace });
 
-            expect(getOutput()).toBe("");
+            expect(result.violations).toHaveLength(0);
         });
     });
 
     describe("registry unreachable", () => {
         it("warns when registry is unreachable", async () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
-            const { workspace, fernYml } = await loadWorkspaceWithFernYml("simple-api");
+            const workspace = await loadWorkspace("simple-api");
 
-            const { stream, getOutput } = createCaptureStream();
             const checker = new SdkChecker({
                 context: createTestContext({ cwd }),
-                stream,
                 versionChecker: async ({ target }) => ({
                     violation: {
                         severity: "warning",
@@ -266,26 +240,23 @@ sdks:
                 })
             });
 
-            const result = await checker.check({ workspace, fernYml });
+            const result = await checker.check({ workspace });
 
             // simple-api has 2 pinned targets (typescript + python), each gets a warning
             expect(result.warningCount).toBe(2);
-            expect(getOutput()).toContain("registry unreachable");
+            expect(result.violations.some((v) => v.message.includes("registry unreachable"))).toBe(true);
         });
     });
 });
 
-async function loadTempWorkspace(cwd: AbsoluteFilePath): Promise<{
-    workspace: import("../workspace/Workspace.js").Workspace;
-    fernYml: import("../config/fern-yml/FernYmlSchemaLoader.js").FernYmlSchemaLoader.Success;
-}> {
+async function loadTempWorkspace(cwd: AbsoluteFilePath): Promise<import("../workspace/Workspace.js").Workspace> {
     const fernYml = await loadFernYml({ cwd });
     const loader = new WorkspaceLoader({ cwd, logger: NOOP_LOGGER });
     const result = await loader.load({ fernYml });
     if (!result.success) {
         throw new Error(`Failed to load workspace: ${JSON.stringify(result.issues)}`);
     }
-    return { workspace: result.workspace, fernYml };
+    return result.workspace;
 }
 
 async function writeMinimalOpenApi(dir: AbsoluteFilePath): Promise<void> {
@@ -299,19 +270,4 @@ info:
 paths: {}
 `
     );
-}
-
-function createCaptureStream(): { stream: NodeJS.WriteStream; getOutput: () => string } {
-    let output = "";
-    const stream = new Writable({
-        write(chunk, _encoding, callback) {
-            output += chunk.toString();
-            callback();
-        }
-    }) as NodeJS.WriteStream;
-
-    return {
-        stream,
-        getOutput: () => output
-    };
 }

--- a/packages/cli/cli-v2/src/api/checker/ApiChecker.ts
+++ b/packages/cli/cli-v2/src/api/checker/ApiChecker.ts
@@ -1,26 +1,17 @@
 import { assertNever } from "@fern-api/core-utils";
-import type { NodePath } from "@fern-api/fern-definition-schema";
 import type { ValidationViolation } from "@fern-api/fern-definition-validator";
 import { AbsoluteFilePath, join, RelativeFilePath, relativize } from "@fern-api/fs-utils";
-import chalk from "chalk";
 import type { Context } from "../../context/Context.js";
-import { Colors, formatMessage, Icons } from "../../ui/format.js";
 import { Task } from "../../ui/Task.js";
 import type { Workspace } from "../../workspace/Workspace.js";
+import type { ApiDefinition } from "../config/ApiDefinition.js";
 import type { ApiSpecType } from "../config/ApiSpec.js";
+import type { AsyncApiSpec } from "../config/AsyncApiSpec.js";
+import { isAsyncApiSpec } from "../config/AsyncApiSpec.js";
 import { isFernSpec } from "../config/FernSpec.js";
+import type { OpenApiSpec } from "../config/OpenApiSpec.js";
+import { isOpenApiSpec } from "../config/OpenApiSpec.js";
 import { ApiDefinitionValidator } from "../validator/ApiDefinitionValidator.js";
-
-const INDENT = {
-    /** Base indent for file paths */
-    FILE_PATH: 2,
-    /** Indent for file paths when nested under API badge */
-    FILE_PATH_NESTED: 4,
-    /** Indent for location path relative to file (FILE_PATH + 2) */
-    LOCATION: 2,
-    /** Indent for violation message relative to file (FILE_PATH + 4) */
-    VIOLATION: 4
-} as const;
 
 export declare namespace ApiChecker {
     /**
@@ -33,6 +24,10 @@ export declare namespace ApiChecker {
         apiSpecType: ApiSpecType;
         /** File path relative to user's current working directory */
         displayRelativeFilepath: string;
+        /** The line number in the file */
+        line: number;
+        /** The column number in the file */
+        column: number;
     }
 
     export interface Config {
@@ -41,9 +36,6 @@ export declare namespace ApiChecker {
 
         /** CLI version for workspace metadata */
         cliVersion: string;
-
-        /** Output stream for writing results (defaults to process.stderr) */
-        stream?: NodeJS.WriteStream;
 
         /** The current task, if any */
         task?: Task;
@@ -55,6 +47,9 @@ export declare namespace ApiChecker {
 
         /** APIs that failed validation (have errors) */
         invalidApis: Set<string>;
+
+        /** Resolved violations to display */
+        violations: ApiChecker.ResolvedViolation[];
 
         /** Total error count */
         errorCount: number;
@@ -70,13 +65,11 @@ export declare namespace ApiChecker {
 export class ApiChecker {
     private readonly context: Context;
     private readonly cliVersion: string;
-    private readonly stream: NodeJS.WriteStream;
     private readonly task: Task | undefined;
 
     constructor(config: ApiChecker.Config) {
         this.context = config.context;
         this.cliVersion = config.cliVersion;
-        this.stream = config.stream ?? process.stderr;
         this.task = config.task;
     }
 
@@ -104,6 +97,7 @@ export class ApiChecker {
             return {
                 validApis,
                 invalidApis,
+                violations: [],
                 errorCount: 0,
                 warningCount: 0,
                 elapsedMillis: performance.now() - startTime
@@ -132,243 +126,141 @@ export class ApiChecker {
             }
 
             const apiSpecType: ApiSpecType = apiDefinition.specs.some(isFernSpec) ? "fern" : "openapi";
-            const resolvedViolations = this.resolveViolationPaths(
-                result.violations,
-                result.workspaceRoot,
+            const resolvedViolations = this.resolveViolationPaths({
+                workspaceRoot: result.workspaceRoot,
                 apiName,
-                apiSpecType
-            );
+                apiSpecType,
+                apiDefinition,
+                violations: result.violations
+            });
             allViolations.push(...resolvedViolations);
         }
 
         const dedupedViolations = this.deduplicateViolations(allViolations);
-
-        const { errorCount, warningCount } = this.countViolations(dedupedViolations);
-
-        const violationsToDisplay = strict
-            ? dedupedViolations
-            : dedupedViolations.filter((v) => v.severity === "fatal" || v.severity === "error");
-
-        const elapsedMillis = performance.now() - startTime;
-
-        // Only produce output if there are violations to display (i.e. no news is good news).
-        if (violationsToDisplay.length > 0) {
-            this.writeHeader();
-            this.displayViolations(violationsToDisplay);
-            this.writeSummary({
-                errorCount,
-                warningCount,
-                elapsedMillis,
-                strict
-            });
-        }
-
         return {
+            ...this.countViolations(dedupedViolations),
             validApis,
             invalidApis,
-            errorCount,
-            warningCount,
-            elapsedMillis
+            violations: strict
+                ? dedupedViolations
+                : dedupedViolations.filter((v) => v.severity === "fatal" || v.severity === "error"),
+            elapsedMillis: performance.now() - startTime
         };
     }
 
-    private writeHeader(): void {
-        this.stream.write("\n");
-        this.stream.write(`${Icons.info} ${chalk.bold(`Validate APIs`)}\n`);
-        this.stream.write("\n");
-    }
-
-    private writeSummary({
-        errorCount,
-        warningCount,
-        elapsedMillis,
-        strict
+    private resolveViolationPaths({
+        violations,
+        workspaceRoot,
+        apiName,
+        apiSpecType,
+        apiDefinition
     }: {
-        errorCount: number;
-        warningCount: number;
-        elapsedMillis: number;
-        strict: boolean;
-    }): void {
-        const durationStr = this.formatDuration(elapsedMillis);
-        const hasErrors = errorCount > 0;
-        const hasWarnings = warningCount > 0;
-
-        if (!hasErrors && !hasWarnings) {
-            this.stream.write(`${Icons.success} All checks passed ${chalk.dim(`(${durationStr})`)}\n`);
-            this.stream.write("\n");
-            return;
-        }
-
-        // In strict mode, warnings are treated as failures.
-        const isFailure = hasErrors || (strict && hasWarnings);
-        if (isFailure) {
-            const errorLabel = errorCount === 1 ? "error" : "errors";
-            const warningLabel = warningCount === 1 ? "warning" : "warnings";
-            this.stream.write(
-                `${Icons.error} Found ${errorCount} ${errorLabel} and ${warningCount} ${warningLabel} ${chalk.dim(`(${durationStr})`)}\n`
-            );
-            if (!strict && warningCount > 0) {
-                this.stream.write(chalk.dim("  Run 'fern check --strict' to treat warnings as errors\n"));
-            }
-            this.stream.write("\n");
-            return;
-        }
-
-        const warningLabel = warningCount === 1 ? "warning" : "warnings";
-        this.stream.write(
-            `${Icons.success} Checks passed with ${warningCount} ${warningLabel} ${chalk.dim(`(${durationStr})`)}\n`
-        );
-        this.stream.write(chalk.dim("  Run 'fern check --strict' to treat warnings as errors\n"));
-        this.stream.write("\n");
-    }
-
-    private resolveViolationPaths(
-        violations: ValidationViolation[],
-        workspaceRoot: AbsoluteFilePath,
-        apiName: string,
-        apiSpecType: ApiSpecType
-    ): ApiChecker.ResolvedViolation[] {
+        violations: ValidationViolation[];
+        workspaceRoot: AbsoluteFilePath;
+        apiName: string;
+        apiSpecType: ApiSpecType;
+        apiDefinition: ApiDefinition;
+    }): ApiChecker.ResolvedViolation[] {
         return violations.map((violation) => {
-            const absolutePath = join(workspaceRoot, RelativeFilePath.of(violation.relativeFilepath));
-            const displayRelativeFilepath = relativize(this.context.cwd, absolutePath);
+            const message = apiSpecType === "fern" ? violation.message : this.formatOssMessage(violation);
             return {
                 ...violation,
-                displayRelativeFilepath,
+                message,
+                displayRelativeFilepath: this.resolveDisplayPath({
+                    workspaceRoot,
+                    apiDefinition,
+                    apiSpecType,
+                    violation
+                }),
                 apiSpecType,
-                apiName
+                apiName,
+
+                // We don't actually surface valuable line/column information yet, but
+                // this at least points to the correct file.
+                line: 1,
+                column: 1
             };
         });
     }
 
-    private displayViolations(violations: ApiChecker.ResolvedViolation[]): void {
-        if (violations.length === 0) {
-            return;
+    /**
+     * Format a violation message for non-Fern (OSS) specs.
+     *
+     * Prepends a human-readable node path so users can locate the endpoint,
+     * then strips synthetic file paths from the body of the message.
+     */
+    private formatOssMessage(violation: ValidationViolation): string {
+        const strippedMessage = this.stripSyntheticFilePaths(violation.message);
+        const nodePathPrefix = this.formatNodePath(violation.nodePath);
+        if (nodePathPrefix.length === 0) {
+            return strippedMessage;
         }
-
-        // Group violations by API.
-        const byApi = this.groupViolationsBy(violations, (v) => v.apiName);
-        const sortedApis = Array.from(byApi.keys()).sort();
-
-        // Only show API badges when there are multiple APIs.
-        const showApiBadge = sortedApis.length > 1;
-
-        for (const apiName of sortedApis) {
-            const apiViolations = byApi.get(apiName);
-            if (apiViolations == null || apiViolations.length === 0) {
-                continue;
-            }
-
-            if (showApiBadge) {
-                this.stream.write(`${" ".repeat(INDENT.FILE_PATH)}${chalk.bold(`[${apiName}]`)}\n`);
-            }
-
-            // Group violations by file, then by location within file.
-            const byFile = this.groupViolationsBy(apiViolations, (v) => v.displayRelativeFilepath);
-            const sortedFiles = Array.from(byFile.keys()).sort();
-            const baseIndent = showApiBadge ? INDENT.FILE_PATH_NESTED : INDENT.FILE_PATH;
-
-            for (const filePath of sortedFiles) {
-                const fileViolations = byFile.get(filePath);
-                if (fileViolations == null || fileViolations.length === 0) {
-                    continue;
-                }
-
-                // Only display the file header for Fern definitions where the path
-                // corresponds to a real file on disk.
-                const firstFileViolation = fileViolations[0];
-                if (firstFileViolation != null && firstFileViolation.apiSpecType === "fern") {
-                    this.stream.write(`${" ".repeat(baseIndent)}${chalk.underline(filePath)}\n`);
-                }
-
-                // Group by location within the file.
-                const byLocation = this.groupViolationsBy(fileViolations, (v) => this.getLocationKey(v.nodePath));
-                const sortedLocations = Array.from(byLocation.keys()).sort();
-
-                for (const locationKey of sortedLocations) {
-                    const locationViolations = byLocation.get(locationKey);
-                    if (locationViolations == null || locationViolations.length === 0) {
-                        continue;
-                    }
-
-                    const firstViolation = locationViolations[0];
-                    if (firstViolation != null && firstViolation.nodePath.length > 0) {
-                        const locationPath = this.formatNodePath(firstViolation.nodePath);
-                        this.stream.write(`${" ".repeat(baseIndent + INDENT.LOCATION)}${chalk.dim(locationPath)}\n`);
-                    }
-
-                    for (const violation of locationViolations) {
-                        const { icon, colorFn } = this.getSeverityStyle(violation.severity);
-                        const message =
-                            violation.apiSpecType === "fern"
-                                ? violation.message
-                                : this.stripSyntheticFilePaths(violation.message);
-                        const formatted = formatMessage({
-                            message,
-                            colorFn,
-                            icon,
-                            indent: baseIndent + INDENT.VIOLATION,
-                            continuationIndent: 2
-                        });
-                        this.stream.write(`${formatted}\n`);
-                    }
-                }
-            }
-
-            this.stream.write("\n");
-        }
+        return `${nodePathPrefix} - ${strippedMessage}`;
     }
 
-    private groupViolationsBy<K extends string>(
-        violations: ApiChecker.ResolvedViolation[],
-        keyFn: (v: ApiChecker.ResolvedViolation) => K
-    ): Map<K, ApiChecker.ResolvedViolation[]> {
-        const grouped = new Map<K, ApiChecker.ResolvedViolation[]>();
-        for (const violation of violations) {
-            const key = keyFn(violation);
-            const existing = grouped.get(key) ?? [];
-            existing.push(violation);
-            grouped.set(key, existing);
-        }
-        return grouped;
-    }
-
-    private getLocationKey(nodePath: NodePath): string {
-        return nodePath
-            .map((item) => {
-                if (typeof item === "string") {
-                    return item;
-                }
-                return item.arrayIndex != null ? `${item.key}[${item.arrayIndex}]` : item.key;
-            })
-            .join(".");
-    }
-
-    private formatNodePath(nodePath: NodePath): string {
+    /**
+     * Formats a NodePath into a readable string like "endpoints -> getUser".
+     *
+     * Skips the leading "service" segment since it's implicit.
+     */
+    private formatNodePath(nodePath: ValidationViolation["nodePath"]): string {
         const parts: string[] = [];
         for (const item of nodePath) {
             if (typeof item === "string") {
                 parts.push(item);
             } else {
-                const indexSuffix = item.arrayIndex != null ? `[${item.arrayIndex}]` : "";
-                parts.push(`${item.key}${indexSuffix}`);
+                parts.push(item.key);
             }
         }
-        return parts.join(" > ");
+        // Drop the leading "service" — it's noise for OSS specs.
+        if (parts[0] === "service") {
+            parts.shift();
+        }
+        return parts.join(" -> ");
     }
 
-    private getSeverityStyle(severity: ValidationViolation["severity"]): {
-        icon: string;
-        colorFn: (text: string) => string;
-    } {
-        switch (severity) {
-            case "fatal":
-            case "error":
-                return { icon: Icons.error, colorFn: Colors.error };
-            case "warning":
-                return { icon: Icons.warning, colorFn: Colors.warning };
-            default:
-                assertNever(severity);
+    private resolveDisplayPath({
+        workspaceRoot,
+        apiDefinition,
+        apiSpecType,
+        violation
+    }: {
+        workspaceRoot: AbsoluteFilePath;
+        apiDefinition: ApiDefinition;
+        apiSpecType: ApiSpecType;
+        violation: ValidationViolation;
+    }): string {
+        if (apiSpecType === "fern") {
+            const absolutePath = join(workspaceRoot, RelativeFilePath.of(violation.relativeFilepath));
+            return relativize(this.context.cwd, absolutePath);
         }
+        return this.resolveOssDisplayPath(apiDefinition, violation);
+    }
+
+    private resolveOssDisplayPath(apiDefinition: ApiDefinition, violation: ValidationViolation): string {
+        const ossSpecs = apiDefinition.specs.filter(
+            (s): s is OpenApiSpec | AsyncApiSpec => isOpenApiSpec(s) || isAsyncApiSpec(s)
+        );
+        if (ossSpecs.length === 0) {
+            return violation.relativeFilepath;
+        }
+        // For multi-spec with namespaces, try matching by namespace.
+        if (ossSpecs.length > 1) {
+            for (const spec of ossSpecs) {
+                const namespace = isOpenApiSpec(spec) ? spec.namespace : spec.namespace;
+                if (namespace != null && violation.relativeFilepath.startsWith(namespace)) {
+                    const filePath = isOpenApiSpec(spec) ? spec.openapi : spec.asyncapi;
+                    return relativize(this.context.cwd, filePath);
+                }
+            }
+        }
+        // Default to first OSS spec.
+        const firstSpec = ossSpecs[0];
+        if (firstSpec == null) {
+            return violation.relativeFilepath;
+        }
+        const filePath = isOpenApiSpec(firstSpec) ? firstSpec.openapi : firstSpec.asyncapi;
+        return relativize(this.context.cwd, filePath);
     }
 
     private deduplicateViolations(violations: ApiChecker.ResolvedViolation[]): ApiChecker.ResolvedViolation[] {
@@ -415,16 +307,5 @@ export class ApiChecker {
         }
 
         return { errorCount, warningCount };
-    }
-
-    private formatDuration(ms: number): string {
-        if (ms < 1000) {
-            return `${Math.round(ms)}ms`;
-        }
-        return `${(ms / 1000).toFixed(1)}s`;
-    }
-
-    private maybePluralApis(apis: string[]): string {
-        return apis.length === 1 ? "API" : "APIs";
     }
 }

--- a/packages/cli/cli-v2/src/commands/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/check/command.ts
@@ -1,14 +1,12 @@
 import chalk from "chalk";
 import type { Argv } from "yargs";
 import { ApiChecker } from "../../api/checker/ApiChecker.js";
-import { FernYmlSchemaLoader } from "../../config/fern-yml/FernYmlSchemaLoader.js";
 import type { Context } from "../../context/Context.js";
 import type { GlobalArgs } from "../../context/GlobalArgs.js";
 import { CliError } from "../../errors/CliError.js";
 import { SdkChecker } from "../../sdk/checker/SdkChecker.js";
 import { Icons } from "../../ui/format.js";
 import type { Workspace } from "../../workspace/Workspace.js";
-import { WorkspaceLoader } from "../../workspace/WorkspaceLoader.js";
 import { command } from "../_internal/command.js";
 
 export declare namespace CheckCommand {
@@ -22,17 +20,11 @@ export declare namespace CheckCommand {
 
 export class CheckCommand {
     public async handle(context: Context, args: CheckCommand.Args): Promise<void> {
-        const schemaLoader = new FernYmlSchemaLoader({ cwd: context.cwd });
-        const fernYml = await schemaLoader.loadOrThrow();
-
-        context.telemetry.tag({ org: fernYml.data.org });
-
-        const loader = new WorkspaceLoader({ cwd: context.cwd, logger: context.stderr });
-        const workspace = await loader.loadOrThrow({ fernYml });
+        const workspace = await context.loadWorkspaceOrThrow();
 
         this.validateArgs(args, workspace);
 
-        const { totalErrors, totalWarnings } = await this.runChecks({ context, workspace, fernYml });
+        const { totalErrors, totalWarnings } = await this.runChecks({ context, workspace });
 
         // Fail if there are errors, or if strict mode and there are warnings.
         if (totalErrors > 0 || (args.strict && totalWarnings > 0)) {
@@ -50,29 +42,45 @@ export class CheckCommand {
 
     private async runChecks({
         context,
-        workspace,
-        fernYml
+        workspace
     }: {
         context: Context;
         workspace: Workspace;
-        fernYml: FernYmlSchemaLoader.Success;
     }): Promise<{ totalErrors: number; totalWarnings: number }> {
+        const violations: (ApiChecker.ResolvedViolation | SdkChecker.ResolvedViolation)[] = [];
+
         const apiChecker = new ApiChecker({
             context,
             cliVersion: workspace.cliVersion
         });
-        const apiCheckResult = await apiChecker.check({
-            workspace
-        });
+        const apiCheckResult = await apiChecker.check({ workspace });
+        if (apiCheckResult.violations.length > 0) {
+            violations.push(...apiCheckResult.violations);
+        }
 
         const sdkChecker = new SdkChecker({ context });
-        const sdkCheckResult = await sdkChecker.check({ workspace, fernYml });
+        const sdkCheckResult = await sdkChecker.check({ workspace });
+        if (sdkCheckResult.violations.length > 0) {
+            violations.push(...sdkCheckResult.violations);
+        }
+
+        if (violations.length > 0) {
+            this.displayViolations(violations);
+        }
 
         return {
             totalErrors:
                 (apiCheckResult.invalidApis.size > 0 ? apiCheckResult.errorCount : 0) + sdkCheckResult.errorCount,
             totalWarnings: apiCheckResult.warningCount + sdkCheckResult.warningCount
         };
+    }
+
+    private displayViolations(
+        violations: Array<{ displayRelativeFilepath: string; line: number; column: number; message: string }>
+    ): void {
+        for (const v of violations) {
+            process.stderr.write(`${chalk.red(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`);
+        }
     }
 
     private validateArgs(args: CheckCommand.Args, workspace: Workspace): void {

--- a/packages/cli/cli-v2/src/commands/sdk/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/add/command.ts
@@ -6,7 +6,6 @@ import inquirer from "inquirer";
 import type { Argv } from "yargs";
 import { FERN_YML_FILENAME } from "../../../config/fern-yml/constants.js";
 import { FernYmlEditor } from "../../../config/fern-yml/FernYmlEditor.js";
-import { FernYmlSchemaLoader } from "../../../config/fern-yml/FernYmlSchemaLoader.js";
 import type { Context } from "../../../context/Context.js";
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { CliError } from "../../../errors/CliError.js";
@@ -41,8 +40,6 @@ export declare namespace AddCommand {
 
 export class AddCommand {
     public async handle(context: Context, args: AddCommand.Args): Promise<void> {
-        const schemaLoader = new FernYmlSchemaLoader({ cwd: context.cwd });
-        const fernYml = await schemaLoader.loadOrThrow();
         const workspace = await context.loadWorkspaceOrThrow();
 
         const fernYmlPath = workspace.absoluteFilePath;
@@ -53,7 +50,7 @@ export class AddCommand {
         }
 
         const sdkChecker = new SdkChecker({ context });
-        const sdkCheckResult = await sdkChecker.check({ workspace, fernYml });
+        const sdkCheckResult = await sdkChecker.check({ workspace });
         if (sdkCheckResult.errorCount > 0) {
             throw CliError.exit();
         }

--- a/packages/cli/cli-v2/src/commands/sdk/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/check/command.ts
@@ -1,12 +1,10 @@
 import chalk from "chalk";
 import type { Argv } from "yargs";
-import { FernYmlSchemaLoader } from "../../../config/fern-yml/FernYmlSchemaLoader.js";
 import type { Context } from "../../../context/Context.js";
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { CliError } from "../../../errors/CliError.js";
 import { SdkChecker } from "../../../sdk/checker/SdkChecker.js";
 import { Icons } from "../../../ui/format.js";
-import { WorkspaceLoader } from "../../../workspace/WorkspaceLoader.js";
 import { command } from "../../_internal/command.js";
 
 export declare namespace CheckCommand {
@@ -18,16 +16,18 @@ export declare namespace CheckCommand {
 
 export class CheckCommand {
     public async handle(context: Context, args: CheckCommand.Args): Promise<void> {
-        const schemaLoader = new FernYmlSchemaLoader({ cwd: context.cwd });
-        const fernYml = await schemaLoader.loadOrThrow();
-
-        context.telemetry.tag({ org: fernYml.data.org });
-
-        const loader = new WorkspaceLoader({ cwd: context.cwd, logger: context.stderr });
-        const workspace = await loader.loadOrThrow({ fernYml });
+        const workspace = await context.loadWorkspaceOrThrow();
 
         const checker = new SdkChecker({ context });
-        const result = await checker.check({ workspace, fernYml });
+        const result = await checker.check({ workspace });
+
+        if (result.violations.length > 0) {
+            for (const v of result.violations) {
+                process.stderr.write(
+                    `${chalk.red(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`
+                );
+            }
+        }
 
         if (result.errorCount > 0 || (args.strict && result.warningCount > 0)) {
             throw CliError.exit();

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -112,7 +112,7 @@ export class GenerateCommand {
         const targets = this.getTargets({
             workspace: workspaceWithOverrides,
             args,
-            groupName: args.group ?? workspaceWithOverrides.sdks?.defaultGroup
+            groupName: args.target != null ? undefined : (args.group ?? workspaceWithOverrides.sdks?.defaultGroup)
         });
 
         this.validateArgs({ workspace: workspaceWithOverrides, args, targets });

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -4,6 +4,7 @@ import type { ContainerRunner } from "@fern-api/core-utils";
 import { assertNever } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, resolve } from "@fern-api/fs-utils";
 import { ValidationIssue } from "@fern-api/yaml-loader";
+import chalk from "chalk";
 import { readdir } from "fs/promises";
 import inquirer from "inquirer";
 import yaml from "js-yaml";
@@ -11,7 +12,6 @@ import type { Argv } from "yargs";
 import { ApiChecker } from "../../../api/checker/ApiChecker.js";
 import type { ApiDefinition } from "../../../api/config/ApiDefinition.js";
 import { ApiSpecResolver } from "../../../api/resolver/ApiSpecResolver.js";
-import { FernYmlSchemaLoader } from "../../../config/fern-yml/FernYmlSchemaLoader.js";
 import { GENERATE_COMMAND_TIMEOUT_MS } from "../../../constants.js";
 import type { Context } from "../../../context/Context.js";
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
@@ -196,13 +196,25 @@ export class GenerateCommand {
             workspace,
             apiNames: apisToCheck
         });
+        if (checkResult.violations.length > 0) {
+            for (const v of checkResult.violations) {
+                process.stderr.write(
+                    `${chalk.red(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`
+                );
+            }
+        }
 
         // Check that the SDK configurations are valid (when fern.yml exists).
-        const schemaLoader = new FernYmlSchemaLoader({ cwd: context.cwd });
-        const fernYmlResult = await schemaLoader.load();
-        if (fernYmlResult.type === "success") {
+        if (workspace.fernYml != null) {
             const sdkChecker = new SdkChecker({ context });
-            const sdkCheckResult = await sdkChecker.check({ workspace, fernYml: fernYmlResult });
+            const sdkCheckResult = await sdkChecker.check({ workspace });
+            if (sdkCheckResult.violations.length > 0) {
+                for (const v of sdkCheckResult.violations) {
+                    process.stderr.write(
+                        `${chalk.red(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`
+                    );
+                }
+            }
             if (sdkCheckResult.errorCount > 0) {
                 throw CliError.exit();
             }

--- a/packages/cli/cli-v2/src/commands/sdk/update/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/update/command.ts
@@ -3,7 +3,6 @@ import inquirer from "inquirer";
 import type { Argv } from "yargs";
 import { FERN_YML_FILENAME } from "../../../config/fern-yml/constants.js";
 import { FernYmlEditor } from "../../../config/fern-yml/FernYmlEditor.js";
-import { FernYmlSchemaLoader } from "../../../config/fern-yml/FernYmlSchemaLoader.js";
 import type { Context } from "../../../context/Context.js";
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { CliError } from "../../../errors/CliError.js";
@@ -31,8 +30,6 @@ export declare namespace UpdateCommand {
 
 export class UpdateCommand {
     public async handle(context: Context, args: UpdateCommand.Args): Promise<void> {
-        const schemaLoader = new FernYmlSchemaLoader({ cwd: context.cwd });
-        const fernYml = await schemaLoader.loadOrThrow();
         const workspace = await context.loadWorkspaceOrThrow();
 
         const fernYmlPath = workspace.absoluteFilePath;
@@ -43,7 +40,7 @@ export class UpdateCommand {
         }
 
         const sdkChecker = new SdkChecker({ context });
-        const sdkCheckResult = await sdkChecker.check({ workspace, fernYml });
+        const sdkCheckResult = await sdkChecker.check({ workspace });
         if (sdkCheckResult.errorCount > 0) {
             throw CliError.exit();
         }

--- a/packages/cli/cli-v2/src/sdk/checker/SdkChecker.ts
+++ b/packages/cli/cli-v2/src/sdk/checker/SdkChecker.ts
@@ -1,10 +1,7 @@
 import { type ValidationViolation } from "@fern-api/fern-definition-validator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { FernRegistryClient as GeneratorsClient } from "@fern-fern/generators-sdk";
-import chalk from "chalk";
-import type { FernYmlSchemaLoader } from "../../config/fern-yml/FernYmlSchemaLoader.js";
 import type { Context } from "../../context/Context.js";
-import { Colors, Icons } from "../../ui/format.js";
 import type { Workspace } from "../../workspace/Workspace.js";
 import { getGeneratorIdFromImage } from "../config/converter/getGeneratorIdFromImage.js";
 import type { SdkConfig } from "../config/SdkConfig.js";
@@ -13,18 +10,27 @@ import type { Target } from "../config/Target.js";
 export declare namespace SdkChecker {
     export type VersionChecker = (args: { target: Target }) => Promise<{ violation: ValidationViolation | undefined }>;
 
+    export interface ResolvedViolation extends ValidationViolation {
+        /** File path relative to user's current working directory */
+        displayRelativeFilepath: string;
+        /** The line number in the file */
+        line: number;
+        /** The column number in the file */
+        column: number;
+    }
+
     export interface Config {
         /** The CLI context */
         context: Context;
-
-        /** Output stream for writing results (defaults to process.stderr) */
-        stream?: NodeJS.WriteStream;
 
         /** Override version checking (defaults to registry lookup). Useful for testing. */
         versionChecker?: VersionChecker;
     }
 
     export interface Result {
+        /** Resolved violations to display */
+        violations: SdkChecker.ResolvedViolation[];
+
         /** Total error count */
         errorCount: number;
 
@@ -37,29 +43,23 @@ export declare namespace SdkChecker {
 }
 
 export class SdkChecker {
-    private readonly stream: NodeJS.WriteStream;
     private readonly versionChecker: SdkChecker.VersionChecker;
 
     constructor(config: SdkChecker.Config) {
-        this.stream = config.stream ?? process.stderr;
         this.versionChecker = config.versionChecker ?? ((args) => this.checkVersionExists(args));
     }
 
     /**
      * Check SDK configuration in the workspace and display results.
      */
-    public async check({
-        workspace,
-        fernYml
-    }: {
-        workspace: Workspace;
-        fernYml: FernYmlSchemaLoader.Success;
-    }): Promise<SdkChecker.Result> {
+    public async check({ workspace }: { workspace: Workspace }): Promise<SdkChecker.Result> {
         const startTime = performance.now();
-        const violations: ValidationViolation[] = [];
+        const violations: SdkChecker.ResolvedViolation[] = [];
 
-        if (workspace.sdks == null) {
+        const fernYml = workspace.fernYml;
+        if (workspace.sdks == null || fernYml == null) {
             return {
+                violations: [],
                 errorCount: 0,
                 warningCount: 0,
                 elapsedMillis: performance.now() - startTime
@@ -75,11 +75,8 @@ export class SdkChecker {
         this.validateEmptyVersions({ sdks, violations });
         await this.validateVersions({ sdks, violations });
 
-        if (violations.length > 0) {
-            this.displayViolations(violations);
-        }
-
         return {
+            violations,
             ...this.countViolations(violations),
             elapsedMillis: performance.now() - startTime
         };
@@ -97,14 +94,17 @@ export class SdkChecker {
         workspace: Workspace;
         sdks: SdkConfig;
         fernYmlRelativePath: RelativeFilePath;
-        violations: ValidationViolation[];
+        violations: SdkChecker.ResolvedViolation[];
     }): void {
         if (Object.keys(workspace.apis).length === 0) {
             violations.push({
                 severity: "error",
                 relativeFilepath: fernYmlRelativePath,
                 nodePath: ["sdks"],
-                message: "SDKs are configured but no APIs are defined"
+                message: "SDKs are configured but no APIs are defined",
+                displayRelativeFilepath: fernYmlRelativePath,
+                line: 1,
+                column: 1
             });
         }
     }
@@ -119,7 +119,7 @@ export class SdkChecker {
     }: {
         workspace: Workspace;
         sdks: SdkConfig;
-        violations: ValidationViolation[];
+        violations: SdkChecker.ResolvedViolation[];
     }): void {
         for (const target of sdks.targets) {
             if (workspace.apis[target.api] == null) {
@@ -127,7 +127,10 @@ export class SdkChecker {
                     severity: "error",
                     relativeFilepath: target.sourceLocation.relativeFilePath,
                     nodePath: ["sdks", "targets", target.name, "api"],
-                    message: `API '${target.api}' is not defined`
+                    message: `API '${target.api}' is not defined`,
+                    displayRelativeFilepath: target.sourceLocation.relativeFilePath,
+                    line: target.sourceLocation.line,
+                    column: target.sourceLocation.column
                 });
             }
         }
@@ -143,7 +146,7 @@ export class SdkChecker {
     }: {
         sdks: SdkConfig;
         fernYmlRelativePath: RelativeFilePath;
-        violations: ValidationViolation[];
+        violations: SdkChecker.ResolvedViolation[];
     }): void {
         const defaultGroup = sdks.defaultGroup;
         if (defaultGroup == null) {
@@ -153,11 +156,15 @@ export class SdkChecker {
             (target) => target.groups != null && target.groups.includes(defaultGroup)
         );
         if (!isReferenced) {
+            const location = sdks.defaultGroupLocation;
             violations.push({
                 severity: "error",
-                relativeFilepath: fernYmlRelativePath,
+                relativeFilepath: location?.relativeFilePath ?? fernYmlRelativePath,
                 nodePath: ["sdks", "defaultGroup"],
-                message: `Default group '${defaultGroup}' is not referenced by any target`
+                message: `Default group '${defaultGroup}' is not referenced by any target`,
+                displayRelativeFilepath: location?.relativeFilePath ?? fernYmlRelativePath,
+                line: location?.line ?? 1,
+                column: location?.column ?? 1
             });
         }
     }
@@ -165,14 +172,23 @@ export class SdkChecker {
     /**
      * Checks if a target has an empty version string.
      */
-    private validateEmptyVersions({ sdks, violations }: { sdks: SdkConfig; violations: ValidationViolation[] }): void {
+    private validateEmptyVersions({
+        sdks,
+        violations
+    }: {
+        sdks: SdkConfig;
+        violations: SdkChecker.ResolvedViolation[];
+    }): void {
         for (const target of sdks.targets) {
             if (target.version.length === 0) {
                 violations.push({
                     severity: "error",
                     relativeFilepath: target.sourceLocation.relativeFilePath,
                     nodePath: ["sdks", "targets", target.name, "version"],
-                    message: "Version must not be empty"
+                    message: "Version must not be empty",
+                    displayRelativeFilepath: target.sourceLocation.relativeFilePath,
+                    line: target.sourceLocation.line,
+                    column: target.sourceLocation.column
                 });
             }
         }
@@ -186,12 +202,22 @@ export class SdkChecker {
         violations
     }: {
         sdks: SdkConfig;
-        violations: ValidationViolation[];
+        violations: SdkChecker.ResolvedViolation[];
     }): Promise<void> {
-        const results = await Promise.all(sdks.targets.map((target) => this.versionChecker({ target })));
+        const results = await Promise.all(
+            sdks.targets.map(async (target) => {
+                const result = await this.versionChecker({ target });
+                return { target, violation: result.violation };
+            })
+        );
         for (const result of results) {
             if (result.violation != null) {
-                violations.push(result.violation);
+                violations.push({
+                    ...result.violation,
+                    displayRelativeFilepath: result.target.sourceLocation.relativeFilePath,
+                    line: result.target.sourceLocation.line,
+                    column: result.target.sourceLocation.column
+                });
             }
         }
     }
@@ -235,32 +261,7 @@ export class SdkChecker {
         }
     }
 
-    /**
-     * Writes each violation to the output stream.
-     */
-    private displayViolations(violations: ValidationViolation[]): void {
-        for (const violation of violations) {
-            const { icon, colorFn } = this.getSeverityStyle(violation.severity);
-            const filepath = chalk.dim(String(violation.relativeFilepath));
-            this.stream.write(`  ${icon} ${filepath}  ${colorFn(violation.message)}\n`);
-        }
-        this.stream.write("\n");
-    }
-
-    private getSeverityStyle(severity: ValidationViolation["severity"]): {
-        icon: string;
-        colorFn: (text: string) => string;
-    } {
-        switch (severity) {
-            case "fatal":
-            case "error":
-                return { icon: Icons.error, colorFn: Colors.error };
-            case "warning":
-                return { icon: Icons.warning, colorFn: Colors.warning };
-        }
-    }
-
-    private countViolations(violations: ValidationViolation[]): { errorCount: number; warningCount: number } {
+    private countViolations(violations: SdkChecker.ResolvedViolation[]): { errorCount: number; warningCount: number } {
         let errorCount = 0;
         let warningCount = 0;
 

--- a/packages/cli/cli-v2/src/sdk/config/SdkConfig.ts
+++ b/packages/cli/cli-v2/src/sdk/config/SdkConfig.ts
@@ -1,3 +1,4 @@
+import type { SourceLocation } from "@fern-api/source";
 import type { Target } from "./Target.js";
 
 /**
@@ -8,6 +9,8 @@ export interface SdkConfig {
     org: string;
     /** The default group to generate, if any */
     defaultGroup?: string;
+    /** Source location of the defaultGroup field in fern.yml */
+    defaultGroupLocation?: SourceLocation;
     /** SDK targets to generate */
     targets: Target[];
 }

--- a/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
+++ b/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
@@ -62,6 +62,7 @@ export class SdkConfigConverter {
         const config: SdkConfig = {
             org: fernYml.data.org,
             defaultGroup: sdks.defaultGroup,
+            defaultGroupLocation: sourced.defaultGroup?.$loc,
             targets: this.convertTargets({
                 targetsConfig: sdks.targets,
                 sourced: sourced.targets

--- a/packages/cli/cli-v2/src/workspace/Workspace.ts
+++ b/packages/cli/cli-v2/src/workspace/Workspace.ts
@@ -1,6 +1,7 @@
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { AiConfig } from "../ai/config/AiConfig.js";
 import type { ApiDefinition } from "../api/config/ApiDefinition.js";
+import type { FernYmlSchemaLoader } from "../config/fern-yml/FernYmlSchemaLoader.js";
 import type { DocsConfig } from "../docs/config/DocsConfig.js";
 import type { SdkConfig } from "../sdk/config/SdkConfig.js";
 
@@ -14,6 +15,8 @@ import type { SdkConfig } from "../sdk/config/SdkConfig.js";
 export interface Workspace {
     /** Absolute path to fern.yml. Optional for flag-based workspace construction. */
     absoluteFilePath?: AbsoluteFilePath;
+    /** The parsed fern.yml schema. Optional for flag-based workspace construction. */
+    fernYml?: FernYmlSchemaLoader.Success;
     ai?: AiConfig;
     apis: Record<string, ApiDefinition>;
     cliVersion: string;

--- a/packages/cli/cli-v2/src/workspace/WorkspaceLoader.ts
+++ b/packages/cli/cli-v2/src/workspace/WorkspaceLoader.ts
@@ -74,11 +74,12 @@ export class WorkspaceLoader {
             success: true,
             workspace: {
                 absoluteFilePath: fernYml.absoluteFilePath,
+                fernYml,
                 ai,
                 apis,
-                org: fernYml.data.org,
                 cliVersion,
                 docs,
+                org: fernYml.data.org,
                 sdks
             }
         };


### PR DESCRIPTION
## Description

We now use a more standardized format for all `fern check` rules and point to the underlying source.

```sh
$ fern check
openapi/openapi.yml:1:1: endpoints -> listPets - Path parameter is unreferenced in endpoint: limit.
fern.yml:7:17: Default group 'example' is not referenced by any target
fern.yml:12:7: Version '5.0.0' does not exist for generator 'python'
```

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
