### PR TITLE
fix(cli): strip file: prefix from frontmatter image fileIds

### DIFF
--- a/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
+++ b/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
@@ -978,17 +978,23 @@ function visitFrontmatterImages(
             // realtime validation, this also assumes there can be other stuff in the object, but we only care about the valid keys
             if (typeof value === "object") {
                 if (value.type === "fileId") {
+                    const mapped = mapImage(value.value);
+                    // Strip the "file:" prefix if present, since frontmatter FileIdOrUrl
+                    // stores raw fileIds (the "file:" prefix is only for inline markdown images)
+                    const fileId = stripFilePrefix(mapped);
                     data[key] = {
                         type: "fileId",
-                        value: CjsFdrSdk.FileId(mapImage(value.value) ?? value.value)
+                        value: CjsFdrSdk.FileId(fileId ?? value.value)
                     };
                 }
             } else if (typeof value === "string") {
                 const mappedImage = mapImage(value);
-                data[key] = mappedImage
+                // Strip the "file:" prefix if present for the same reason as above
+                const fileId = stripFilePrefix(mappedImage);
+                data[key] = fileId
                     ? {
                           type: "fileId",
-                          value: CjsFdrSdk.FileId(mappedImage)
+                          value: CjsFdrSdk.FileId(fileId)
                       }
                     : {
                           type: "url",
@@ -998,6 +1004,13 @@ function visitFrontmatterImages(
             // else do nothing
         }
     }
+}
+
+function stripFilePrefix(value: string | undefined): string | undefined {
+    if (value == null) {
+        return undefined;
+    }
+    return value.startsWith("file:") ? value.slice(5) : value;
 }
 
 const LogoOverrideFrontmatterSchema = z.union([
@@ -1013,10 +1026,12 @@ export function convertImageToFileIdOrUrl(
     mapImage: (image: string | undefined) => string | undefined
 ): DocsV1Write.FileIdOrUrl {
     const mappedImage = mapImage(value);
-    return mappedImage
+    // Strip the "file:" prefix if present, since FileIdOrUrl stores raw fileIds
+    const fileId = stripFilePrefix(mappedImage);
+    return fileId
         ? {
               type: "fileId",
-              value: CjsFdrSdk.FileId(mappedImage)
+              value: CjsFdrSdk.FileId(fileId)
           }
         : {
               type: "url",


### PR DESCRIPTION
## Description

Refs: Discovered while debugging missing `og:image` meta tags on deployed Fern docs sites.

Frontmatter image fields (`og:image`, `twitter:image`, `image`, `og:logo`) with local file paths have been silently broken on the **app router** rendering path since `visitFrontmatterImages` was introduced in July 2024 (#4156). The CLI stores file IDs with a `file:` prefix (e.g., `file:ed218567-...`) in frontmatter `FileIdOrUrl` objects, but the rendering code looks up `files[image.value]` using raw UUIDs as keys — so the lookup always returns `undefined` and the meta tag is silently dropped.

## Changes Made

- Added `stripFilePrefix` helper to remove the `file:` prefix when present
- Applied it in `visitFrontmatterImages` (both the object/fileId and string code paths)
- Applied it in `convertImageToFileIdOrUrl` (used by `replaceFrontmatterImagesforLogo`)

The `file:` prefix is only meant for inline markdown image URLs — not for `FileIdOrUrl` values stored in frontmatter YAML. This fix ensures frontmatter stores raw file IDs that the rendering code can resolve correctly.

- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- [ ] Unit tests added/updated — **No tests added.** The existing test suite does not cover frontmatter image fileId round-tripping. Worth adding a test that verifies `visitFrontmatterImages` produces raw fileIds (without `file:` prefix) when called from `replaceImagePathsAndUrls`.
- [x] Manual testing completed — Verified the deployed page at `plant0.usefern.com` has the frontmatter data with `file:` prefix causing the lookup failure.

## ⚠️ Key Review Points

1. **Page router backward compat**: The page router's `with-seo.ts` has a workaround that *expects* the `file:` prefix and strips it via `fileId.value.split(":")[1]`. After this fix, new deploys will store raw UUIDs, so `split(":")[1]` returns `undefined` and the page router path silently drops the image. If any sites still use the page router, this is a regression. (User confirmed all sites use app router.)
2. **Already-deployed data**: Sites deployed with the old CLI have `file:`-prefixed values stored in FDR. A companion defensive fix on the rendering/platform side is needed to handle both old and new formats.
3. **No tests**: The fix is straightforward but untested — a unit test for `visitFrontmatterImages` with a `mapImage` that returns `file:${id}` would increase confidence.

---

- Requested by: @Ryan-Amirthan
- [Link to Devin Session](https://app.devin.ai/sessions/2fcbee18ce0b406fba94bd65d4f4f0d5)