### PR TITLE
fix(cli): ensure fern add never resolves outdated generator versions

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.3.1
+  changelogEntry:
+    - summary: |
+        Fix `fern add` resolving outdated generator versions when FDR returns a
+        version older than the hardcoded fallback. This could happen when the dev
+        CLI (version 0.0.0) queries FDR, which returns an old version incompatible
+        with CLI v4. The resolved version is now guaranteed to be at least as new
+        as the hardcoded fallback version shipped with the CLI.
+      type: fix
+  createdAt: "2026-03-04"
+  irVersion: 65
+
 - version: 4.3.0
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/generators-yml/addGenerator.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/addGenerator.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_GROUP_GENERATORS_CONFIG_KEY, generatorsYml } from "@fern-api/configuration";
 import { TaskContext } from "@fern-api/task-context";
+import semver from "semver";
 
 import { GENERATOR_INVOCATIONS } from "./generatorInvocations.js";
 import {
@@ -43,17 +44,26 @@ export async function addGenerator({
             ) {
                 context.failAndThrow(`${generatorName} is already installed in group ${groupName}.`);
             }
+            const latestVersion = await getLatestGeneratorVersion({
+                cliVersion,
+                generatorName: normalizedGeneratorName,
+                context,
+                channel: undefined
+            });
+
+            // Use the latest version from FDR if it's newer than the hardcoded fallback,
+            // otherwise use the hardcoded version. This ensures we never add a generator
+            // version that's older than what the current CLI is known to support (e.g.
+            // when the dev CLI version 0.0.0 causes FDR to return an outdated version).
+            const version =
+                latestVersion != null && semver.valid(latestVersion) && semver.gt(latestVersion, invocation.version)
+                    ? latestVersion
+                    : invocation.version;
+
             group.generators.push({
                 name: shorthandGeneratorName,
                 ...invocation,
-                // Fall back to the hardcoded version if a "latest" does not yet exist
-                version:
-                    (await getLatestGeneratorVersion({
-                        cliVersion,
-                        generatorName: normalizedGeneratorName,
-                        context,
-                        channel: undefined
-                    })) ?? invocation.version
+                version
             });
         }
     });


### PR DESCRIPTION
## Description

Fixes the `live-test-dev` CI failure that has been broken on `main` since CLI v4 was released (commit `dffefd4f3a61`, ~30 consecutive failing runs).

**Root cause**: `live-test.sh` runs `fern add fern-java-sdk` using the dev CLI (version `0.0.0`). The dev CLI queries the dev FDR registry with `cliVersion: "0.0.0"`, which returns `fern-java-sdk@2.2.0` as the "latest compatible" version. However, CLI v4 severed IR versions 1–52 and requires `fern-java-sdk >= 2.5.0`. When `fern generate` runs, the IR migration rejects version 2.2.0 with: `fernapi/fern-java-sdk@2.2.0 is not compatible with CLI v4.x.x+`.

**Link to Devin session**: https://app.devin.ai/sessions/a6ed2ea21dd84760a745500954fde066
**Requested by**: @davidkonigsberg

## Changes Made

- **`addGenerator.ts`**: Changed version resolution to use `max(fdrVersion, hardcodedFallback)` instead of `fdrVersion ?? hardcodedFallback`. The hardcoded fallback in `GENERATOR_INVOCATIONS` is maintained by the Fern team and is always compatible with the CLI it ships with, so it serves as a safe floor.
- **`versions.yml`**: Added changelog entry for v4.3.1.

## Testing

- [x] `pnpm run check` (biome lint) passes locally
- [ ] No unit tests added for the new version comparison logic — **reviewer should consider whether tests are needed**

## Review Checklist

- [ ] Verify `semver.gt` handles edge cases correctly — some generators in `GENERATOR_INVOCATIONS` may have pre-release versions (e.g., `0.18.4` is fine, but worth checking). `semver.valid()` guard is included.
- [ ] Confirm this doesn't silently override FDR in production: in prod, FDR should always return a version ≥ the hardcoded fallback. If FDR ever intentionally returns an older version (e.g., for rollback), this logic would ignore it.
- [ ] Consider whether the same fix should apply to the `fern upgrade` / `fern generator upgrade` path, which also queries FDR with `cliVersion`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
