### PR TITLE
fix(ci): fix cli-release workflow running when no new version exists

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Determine if prerelease
         id: check_prerelease
-        if: steps.get_version.outputs.HAS_NEW_VERSION
+        if: steps.get_version.outputs.HAS_NEW_VERSION == 'true'
         run: |
           if [[ "${{ steps.get_version.outputs.VERSION }}" == *"rc"* ]]; then
             echo "IS_PRERELEASE=true" >> $GITHUB_OUTPUT
@@ -70,7 +70,7 @@ jobs:
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
-        if: steps.get_version.outputs.HAS_NEW_VERSION
+        if: steps.get_version.outputs.HAS_NEW_VERSION == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.get_version.outputs.VERSION }}
@@ -79,5 +79,5 @@ jobs:
           prerelease: ${{ steps.check_prerelease.outputs.IS_PRERELEASE }}
 
       - name: Display Release URL
-        if: steps.get_version.outputs.HAS_NEW_VERSION
+        if: steps.get_version.outputs.HAS_NEW_VERSION == 'true'
         run: echo "Release created at ${{ steps.create_release.outputs.url }}"


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/actions/runs/22670233482/job/65712114172

Fixes the `Release CLI` workflow failing with `⚠️ GitHub Releases requires a tag` when `versions.yml` is pushed to main without an actual new version.

[Link to Devin Session](https://app.devin.ai/sessions/849a37bede934eaea7b018b205a039f2)
Requested by: @davidkonigsberg

## Changes Made

The root cause: GitHub Actions step `if:` conditions treat **any non-empty string** as truthy — including the string `"false"`. The workflow sets `HAS_NEW_VERSION=false` as an output when no new version is detected, but the downstream steps use bare `if: steps.get_version.outputs.HAS_NEW_VERSION`, which evaluates to `true` for the string `"false"`.

This causes `softprops/action-gh-release` to run with an empty `tag_name`, producing the error.

- Changed all three `if:` guards from `steps.get_version.outputs.HAS_NEW_VERSION` to `steps.get_version.outputs.HAS_NEW_VERSION == 'true'` (explicit string comparison)
  - `Determine if prerelease` step
  - `Create Release` step
  - `Display Release URL` step

## Review Checklist

- [ ] Confirm the three changed conditions are the correct guards for release-only steps
- [ ] Consider whether other workflows in this repo have the same truthy-string bug pattern

## Testing

- No unit tests applicable (workflow YAML change)
- Verified by reading the [failing job logs](https://github.com/fern-api/fern/actions/runs/22670233482/job/65712114172) which confirm `HAS_NEW_VERSION` was set to `"false"` but the release step still executed