### PR TITLE
fix(ci): fix branch regex to exclude JSON delimiters in test-remote-local

### DIFF
--- a/packages/seed/src/commands/test-remote-local/constants.ts
+++ b/packages/seed/src/commands/test-remote-local/constants.ts
@@ -127,7 +127,9 @@ export const LOCAL_BUILD_VERSION = "99.99.99";
 export const SEMVER_REGEX = /^\d+\.\d+\.\d+$/;
 
 // GitHub branch URL pattern in logs - flexible pattern to extract branch from any GitHub tree URL
-export const GITHUB_BRANCH_URL_REGEX = /https?:\/\/(?:www\.)?github\.com\/[^\/]+\/[^\/]+\/tree\/([^\s]+)/;
+// The capture group excludes " to avoid capturing trailing JSON when the URL is embedded in structured log output
+// e.g. ...tree/fern-bot/2026-03-03T20-32Z","prUrl":"..."
+export const GITHUB_BRANCH_URL_REGEX = /https?:\/\/(?:www\.)?github\.com\/[^\/]+\/[^\/]+\/tree\/([^\s"]+)/;
 
 // ============================================================================
 // Log Messages & Separators


### PR DESCRIPTION
## Description

Refs: https://github.com/fern-api/fern/actions/workflows/test-remote-vs-local-generation-parity.yml

Fixes the `test-remote-vs-local-generation-parity` CI workflow, which has been consistently failing since ~March 3rd.

**Root cause:** The `GITHUB_BRANCH_URL_REGEX` used to extract branch names from CLI logs captures `([^\s]+)` after `/tree/`, matching everything until whitespace. Remote generation now emits structured JSON logs where the branch URL is embedded without spaces:
```
...tree/fern-bot/2026-03-03T20-32Z","prUrl":"https://github.com/fern-api/empty/pull/8293","prNumber":8293}}}
```
This caused the regex to capture the branch name **plus** trailing JSON (`fern-bot/2026-03-03T20-32Z","prUrl":"..."`), which then failed the subsequent `git clone --branch`.

**Fix:** Add `"` to the regex exclusion set → `([^\s"]+)`. Git branch names cannot contain double-quote characters, so this is safe.

[Link to Devin Session](https://app.devin.ai/sessions/952c2133e6fb48818c7dd459923d4f74)
Requested by: @davidkonigsberg

## Changes Made
- Updated `GITHUB_BRANCH_URL_REGEX` in `packages/seed/src/commands/test-remote-local/constants.ts` to exclude `"` from the branch name capture group
- Added explanatory comments describing why the exclusion is needed

## Testing
- [ ] Unit tests added/updated — no unit tests added; this is a one-character regex fix in CI infrastructure
- [x] Verified via CI logs that the regex correctly extracts `fern-bot/2026-03-03T20-32Z` from both clean and JSON-embedded log lines
- [x] Lint check (`pnpm run check`) passes locally

## Review Checklist
- [ ] Confirm `"` cannot appear in valid git branch names (it cannot — git disallows it)
- [ ] Confirm the regex still correctly handles the clean (non-JSON) log format: `Pushed branch: https://github.com/.../tree/fern-bot/2026-03-03T20-32Z`