### PR TITLE
fix(ci): skip git diff check and plumb allow-unexpected-failures in auto-update-seed

### DIFF
--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -37,8 +37,8 @@ runs:
         fixtures-to-run: ${{ inputs.fixtures-to-run }}
         job-index: ${{ strategy.job-index }}
         collect-metrics: false
-        allow-unexpected-failures: ${{ inputs.allow-unexpected-failures }}
         skip-scripts: ${{ inputs.skip-scripts }}
+        skip-git-diff-check: true
 
     # Add changes first to simplify git diff checks, no changes will NOT error here
     - name: Check for changes

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -37,6 +37,7 @@ runs:
         fixtures-to-run: ${{ inputs.fixtures-to-run }}
         job-index: ${{ strategy.job-index }}
         collect-metrics: false
+        allow-unexpected-failures: ${{ inputs.allow-unexpected-failures }}
         skip-scripts: ${{ inputs.skip-scripts }}
         skip-git-diff-check: true
 

--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -26,6 +26,10 @@ inputs:
     description: "JSON array of paths to exclude from determinism verification step, typically package manager/lock files"
     required: false
     default: '["seed/*/.mock/*"]'
+  allow-unexpected-failures:
+    description: "Whether to allow unexpected failures during seed generation"
+    required: false
+    default: "false"
   skip-git-diff-check:
     description: "Whether to skip the git diff check (used by auto-update-seed where changes are expected)"
     required: false
@@ -73,6 +77,7 @@ runs:
         generator-path: ${{ inputs.generator-path }}
         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
         skip-scripts: ${{ inputs.skip-scripts }}
+        allow-unexpected-failures: ${{ inputs.allow-unexpected-failures }}
 
     - name: Summarize Test Results
       if: always() && !cancelled()

--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -26,6 +26,10 @@ inputs:
     description: "JSON array of paths to exclude from determinism verification step, typically package manager/lock files"
     required: false
     default: '["seed/*/.mock/*"]'
+  skip-git-diff-check:
+    description: "Whether to skip the git diff check (used by auto-update-seed where changes are expected)"
+    required: false
+    default: "false"
 
 outputs:
   start_time:
@@ -105,7 +109,7 @@ runs:
 
     # Fail CI if seed produced changes to any git-tracked files (excluding known non-deterministic paths like .mock and lock files)
     - name: Ensure no pending git changes
-      if: always() && !cancelled()
+      if: always() && !cancelled() && inputs.skip-git-diff-check != 'true'
       shell: bash
       run: |
         # Parse JSON array and build exclude arguments


### PR DESCRIPTION
## Description

Fixes the `update-seed.yml` workflow which has been failing on every push to `main` since March 2, 2026.

Requested by: @davidkonigsberg
[Link to Devin Session](https://app.devin.ai/sessions/c543269ba4cd460aaa39b25b248f552e)

## Root Cause

The "Ensure no pending git changes" step was added to `run-seed-process` in #12992 for the seed CI workflow (`seed.yml`). However, `run-seed-process` is also called by `auto-update-seed` (used by `update-seed.yml`), where seed output changes are **expected** — the whole point of that workflow is to detect changes and open PRs with them.

When seed generation produces any diff (e.g., a transient `poetry.lock` update like `sqlalchemy 2.0.47 → 2.0.48`), the git diff check fails the job, which prevents the subsequent patch-creation and artifact-upload steps from running.

Additionally, `auto-update-seed` was passing `allow-unexpected-failures` to `run-seed-process`, but `run-seed-process` never declared this input and never forwarded it to `cached-seed`, so the flag was silently dropped.

## Changes Made

- Added `skip-git-diff-check` input to `run-seed-process` (default `"false"`) so the git diff step can be conditionally skipped
- Set `skip-git-diff-check: true` in `auto-update-seed` when calling `run-seed-process`
- Added `allow-unexpected-failures` input to `run-seed-process` (default `"false"`) and forwarded it to `cached-seed`, fixing a pre-existing bug where this flag was silently ignored in the `auto-update-seed` → `run-seed-process` → `cached-seed` chain

## Review Checklist

- [ ] Confirm `run-seed-process` now correctly forwards `allow-unexpected-failures` to `cached-seed` (which already supports it)
- [ ] Confirm no other callers of `run-seed-process` are affected (they use the defaults `"false"` for both new inputs)
- [ ] This can only be fully validated by a successful `update-seed.yml` run on `main` after merge

## Testing

- Reviewed 10+ consecutive failing runs of `update-seed.yml` — all fail on the same `python-sdk-seed-update` job at the "Ensure no pending git changes" step
- Confirmed last successful run was March 2 at 16:00 UTC, first failure was March 2 at 17:25 UTC
- No unit tests applicable (CI workflow-only change)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
