### PR TITLE
fix(cli): support repository-based GitHub configs in replay init

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -2111,9 +2111,11 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
             }
 
             if (githubRepo == null || token == null) {
-                return cliContext.failAndThrow(
-                    "Missing required github config. Either use --group to read from generators.yml, or provide --github and --token directly."
-                );
+                const hint =
+                    githubRepo != null
+                        ? "Repository found but no token. Pass --token or set GITHUB_TOKEN environment variable."
+                        : "Either use --group to read from generators.yml, or provide --github and --token directly.";
+                return cliContext.failAndThrow(`Missing required github config. ${hint}`);
             }
 
             cliContext.logger.info(`Initializing Replay for: ${githubRepo}`);

--- a/packages/cli/cli/src/resolveGroupGithubConfig.ts
+++ b/packages/cli/cli/src/resolveGroupGithubConfig.ts
@@ -5,7 +5,7 @@ import { loadProjectAndRegisterWorkspacesWithContext } from "./cliCommons.js";
 
 export interface ResolvedGithubConfig {
     githubRepo: string;
-    token: string;
+    token: string | undefined;
     mode: "push" | "pull-request";
     branch: string | undefined;
 }
@@ -36,28 +36,48 @@ export async function resolveGroupGithubConfig(
         return cliContext.failAndThrow(`Group "${groupName}" not found. Available groups: ${available}`);
     }
 
-    const generatorWithGithub = group.generators.find((g) => g.raw?.github != null && isGithubSelfhosted(g.raw.github));
-
-    if (generatorWithGithub?.raw?.github == null || !isGithubSelfhosted(generatorWithGithub.raw.github)) {
-        return cliContext.failAndThrow(
-            `No generator in group "${groupName}" has a self-hosted github configuration (uri + token).`
-        );
-    }
-
     const resolveEnv = <T>(value: T): T =>
         replaceEnvVariables(value, {
             onError: (message) => cliContext.failAndThrow(message)
         });
-    const githubConfig = resolveEnv(generatorWithGithub.raw.github);
 
-    cliContext.logger.info(
-        `Using github config from group "${groupName}" generator "${generatorWithGithub.name}" (mode: ${githubConfig.mode ?? "pull-request"})`
+    // 1. Prefer self-hosted config (has uri + token)
+    const generatorWithSelfhosted = group.generators.find(
+        (g) => g.raw?.github != null && isGithubSelfhosted(g.raw.github)
     );
 
-    return {
-        githubRepo: githubConfig.uri,
-        token: githubConfig.token,
-        mode: githubConfig.mode === "push" ? "push" : "pull-request",
-        branch: githubConfig.branch
-    };
+    if (generatorWithSelfhosted?.raw?.github != null && isGithubSelfhosted(generatorWithSelfhosted.raw.github)) {
+        const githubConfig = resolveEnv(generatorWithSelfhosted.raw.github);
+        cliContext.logger.info(
+            `Using github config from group "${groupName}" generator "${generatorWithSelfhosted.name}" (mode: ${githubConfig.mode ?? "pull-request"})`
+        );
+        return {
+            githubRepo: githubConfig.uri,
+            token: githubConfig.token,
+            mode: githubConfig.mode === "push" ? "push" : "pull-request",
+            branch: githubConfig.branch
+        };
+    }
+
+    // 2. Fallback to repository-based config (pull-request, push, commit-and-release)
+    const generatorWithRepo = group.generators.find((g) => g.raw?.github != null && "repository" in g.raw.github);
+
+    if (generatorWithRepo?.raw?.github != null && "repository" in generatorWithRepo.raw.github) {
+        const githubConfig = resolveEnv(generatorWithRepo.raw.github);
+        const token = process.env.GITHUB_TOKEN;
+
+        cliContext.logger.info(
+            `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}"` +
+                (token != null ? ". Using GITHUB_TOKEN from environment." : ".")
+        );
+
+        return {
+            githubRepo: githubConfig.repository,
+            token,
+            mode: githubConfig.mode === "push" ? "push" : "pull-request",
+            branch: "branch" in githubConfig ? githubConfig.branch : undefined
+        };
+    }
+
+    return cliContext.failAndThrow(`No generator in group "${groupName}" has a github configuration.`);
 }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.3.4
+  changelogEntry:
+    - summary: |
+        Support repository-based GitHub configurations in `fern replay init`.
+        Previously, replay init required a self-hosted GitHub config with explicit
+        `uri` and `token` fields. Now it also accepts standard `repository`-based
+        configs (pull-request, push, commit-and-release modes) and reads the token
+        from the `GITHUB_TOKEN` environment variable or the `--token` CLI flag.
+      type: fix
+  createdAt: "2026-03-04"
+  irVersion: 65
+
 - version: 4.3.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Previously, `fern replay init --group` only accepted self-hosted GitHub
configurations (with explicit `uri` and `token` fields). Customers using
standard repository-based configs (e.g., `repository: owner/repo` with
`mode: pull-request`) would get an error.

Now resolveGroupGithubConfig falls back to repository-based configs when
no self-hosted config is found, reading the token from GITHUB_TOKEN env
var or the --token CLI flag.

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
