### PR TITLE
fix(typescript): safename in certain union member names

### DIFF
--- a/generators/typescript/model/type-generator/src/union/ParsedSingleUnionTypeForUnion.ts
+++ b/generators/typescript/model/type-generator/src/union/ParsedSingleUnionTypeForUnion.ts
@@ -79,7 +79,7 @@ export class ParsedSingleUnionTypeForUnion<Context extends BaseContext> extends 
     }
 
     public getTypeName(): string {
-        return sanitizeIdentifier(this.singleUnionTypeFromUnion.discriminantValue.name.pascalCase.unsafeName);
+        return sanitizeIdentifier(this.singleUnionTypeFromUnion.discriminantValue.name.pascalCase.safeName);
     }
 
     public needsRequestResponse(context: Context): { request: boolean; response: boolean } {

--- a/generators/typescript/model/union-schema-generator/src/AbstractRawSingleUnionType.ts
+++ b/generators/typescript/model/union-schema-generator/src/AbstractRawSingleUnionType.ts
@@ -26,7 +26,7 @@ export abstract class AbstractRawSingleUnionType<Context> implements RawSingleUn
 
     public generateInterface(context: Context): OptionalKind<InterfaceDeclarationStructure> {
         return {
-            name: sanitizeIdentifier(this.discriminantValueWithAllCasings.name.pascalCase.unsafeName),
+            name: sanitizeIdentifier(this.discriminantValueWithAllCasings.name.pascalCase.safeName),
             extends: this.getExtends(context).map(getTextOfTsNode),
             properties: [
                 {

--- a/generators/typescript/sdk/endpoint-error-union-generator/src/error/ParsedSingleUnionTypeForError.ts
+++ b/generators/typescript/sdk/endpoint-error-union-generator/src/error/ParsedSingleUnionTypeForError.ts
@@ -62,7 +62,7 @@ export class ParsedSingleUnionTypeForError extends AbstractKnownSingleUnionType<
     }
 
     public getTypeName(): string {
-        return sanitizeIdentifier(this.errorDeclaration.discriminantValue.name.pascalCase.unsafeName);
+        return sanitizeIdentifier(this.errorDeclaration.discriminantValue.name.pascalCase.safeName);
     }
 
     public getDiscriminantValue(): string | number {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.53.4
+  changelogEntry:
+    - summary: |
+        Fix union member interfaces shadowing built-in TypeScript types like `Date` and `Error`.
+        Union variants such as `date` generated `export interface Date` inside the union namespace,
+        which shadowed the global `Date` type and caused compile errors when other variants
+        referenced it. Interface names now use `safeName` (e.g., `Date_`, `Error_`) to avoid
+        collisions with reserved identifiers.
+      type: fix
+  createdAt: "2026-03-04"
+  irVersion: 65
+
 - version: 3.53.3
   changelogEntry:
     - summary: |

--- a/seed/ts-express/trace/no-custom-config/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-express/trace/no-custom-config/api/resources/problem/types/CreateProblemResponse.ts
@@ -2,7 +2,7 @@
 
 import type * as SeedTrace from "../../../index";
 
-export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error;
+export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error_;
 
 export namespace CreateProblemResponse {
     export interface Success {
@@ -10,7 +10,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error {
+    export interface Error_ {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-express/trace/no-custom-config/serialization/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-express/trace/no-custom-config/serialization/resources/problem/types/CreateProblemResponse.ts
@@ -22,14 +22,14 @@ export const CreateProblemResponse: core.serialization.Schema<
     });
 
 export declare namespace CreateProblemResponse {
-    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error;
+    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error_;
 
     export interface Success {
         type: "success";
         value: serializers.ProblemId.Raw;
     }
 
-    export interface Error {
+    export interface Error_ {
         type: "error";
         value: serializers.CreateProblemError.Raw;
     }

--- a/seed/ts-express/trace/no-zurg-trace/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-express/trace/no-zurg-trace/api/resources/problem/types/CreateProblemResponse.ts
@@ -2,7 +2,7 @@
 
 import type * as SeedTrace from "../../../index";
 
-export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error;
+export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error_;
 
 export namespace CreateProblemResponse {
     export interface Success {
@@ -10,7 +10,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error {
+    export interface Error_ {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-express/unions-with-local-date/api/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-express/unions-with-local-date/api/resources/types/types/UnionWithOptionalTime.ts
@@ -27,10 +27,10 @@ import type * as SeedUnions from "../../../index";
  *         value: undefined
  *     }
  */
-export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date | SeedUnions.UnionWithOptionalTime.Datetime;
+export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date_ | SeedUnions.UnionWithOptionalTime.Datetime;
 
 export namespace UnionWithOptionalTime {
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value?: string;
     }

--- a/seed/ts-express/unions-with-local-date/api/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-express/unions-with-local-date/api/resources/types/types/UnionWithTime.ts
@@ -23,7 +23,7 @@ import type * as SeedUnions from "../../../index";
  */
 export type UnionWithTime =
     | SeedUnions.UnionWithTime.Value
-    | SeedUnions.UnionWithTime.Date
+    | SeedUnions.UnionWithTime.Date_
     | SeedUnions.UnionWithTime.Datetime;
 
 export namespace UnionWithTime {
@@ -32,7 +32,7 @@ export namespace UnionWithTime {
         value: number;
     }
 
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value: string;
     }

--- a/seed/ts-express/unions-with-local-date/serialization/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-express/unions-with-local-date/serialization/resources/types/types/UnionWithOptionalTime.ts
@@ -22,9 +22,9 @@ export const UnionWithOptionalTime: core.serialization.Schema<
     });
 
 export declare namespace UnionWithOptionalTime {
-    export type Raw = UnionWithOptionalTime.Date | UnionWithOptionalTime.Datetime;
+    export type Raw = UnionWithOptionalTime.Date_ | UnionWithOptionalTime.Datetime;
 
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value?: string | null;
     }

--- a/seed/ts-express/unions-with-local-date/serialization/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-express/unions-with-local-date/serialization/resources/types/types/UnionWithTime.ts
@@ -23,14 +23,14 @@ export const UnionWithTime: core.serialization.Schema<serializers.UnionWithTime.
         });
 
 export declare namespace UnionWithTime {
-    export type Raw = UnionWithTime.Value | UnionWithTime.Date | UnionWithTime.Datetime;
+    export type Raw = UnionWithTime.Value | UnionWithTime.Date_ | UnionWithTime.Datetime;
 
     export interface Value {
         type: "value";
         value: number;
     }
 
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value: string;
     }

--- a/seed/ts-express/unions/api/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-express/unions/api/resources/types/types/UnionWithOptionalTime.ts
@@ -27,10 +27,10 @@ import type * as SeedUnions from "../../../index";
  *         value: undefined
  *     }
  */
-export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date | SeedUnions.UnionWithOptionalTime.Datetime;
+export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date_ | SeedUnions.UnionWithOptionalTime.Datetime;
 
 export namespace UnionWithOptionalTime {
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value?: string;
     }

--- a/seed/ts-express/unions/api/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-express/unions/api/resources/types/types/UnionWithTime.ts
@@ -23,7 +23,7 @@ import type * as SeedUnions from "../../../index";
  */
 export type UnionWithTime =
     | SeedUnions.UnionWithTime.Value
-    | SeedUnions.UnionWithTime.Date
+    | SeedUnions.UnionWithTime.Date_
     | SeedUnions.UnionWithTime.Datetime;
 
 export namespace UnionWithTime {
@@ -32,7 +32,7 @@ export namespace UnionWithTime {
         value: number;
     }
 
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value: string;
     }

--- a/seed/ts-express/unions/serialization/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-express/unions/serialization/resources/types/types/UnionWithOptionalTime.ts
@@ -22,9 +22,9 @@ export const UnionWithOptionalTime: core.serialization.Schema<
     });
 
 export declare namespace UnionWithOptionalTime {
-    export type Raw = UnionWithOptionalTime.Date | UnionWithOptionalTime.Datetime;
+    export type Raw = UnionWithOptionalTime.Date_ | UnionWithOptionalTime.Datetime;
 
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value?: string | null;
     }

--- a/seed/ts-express/unions/serialization/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-express/unions/serialization/resources/types/types/UnionWithTime.ts
@@ -23,14 +23,14 @@ export const UnionWithTime: core.serialization.Schema<serializers.UnionWithTime.
         });
 
 export declare namespace UnionWithTime {
-    export type Raw = UnionWithTime.Value | UnionWithTime.Date | UnionWithTime.Datetime;
+    export type Raw = UnionWithTime.Value | UnionWithTime.Date_ | UnionWithTime.Datetime;
 
     export interface Value {
         type: "value";
         value: number;
     }
 
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value: string;
     }

--- a/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/types/StreamEvent.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/types/StreamEvent.ts
@@ -2,14 +2,14 @@
 
 import type * as SeedServerSentEvents from "../../../index.js";
 
-export type StreamEvent = SeedServerSentEvents.StreamEvent.Completion | SeedServerSentEvents.StreamEvent.Error;
+export type StreamEvent = SeedServerSentEvents.StreamEvent.Completion | SeedServerSentEvents.StreamEvent.Error_;
 
 export namespace StreamEvent {
     export interface Completion extends SeedServerSentEvents.CompletionEvent {
         event: "completion";
     }
 
-    export interface Error extends SeedServerSentEvents.ErrorEvent {
+    export interface Error_ extends SeedServerSentEvents.ErrorEvent {
         event: "error";
     }
 }

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/problem/types/CreateProblemResponse.ts
@@ -4,7 +4,7 @@ import type * as SeedTrace from "../../../index.js";
 
 export type CreateProblemResponse =
     | SeedTrace.CreateProblemResponse.Success
-    | SeedTrace.CreateProblemResponse.Error
+    | SeedTrace.CreateProblemResponse.Error_
     | SeedTrace.CreateProblemResponse._Unknown;
 
 export namespace CreateProblemResponse {
@@ -13,7 +13,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error {
+    export interface Error_ {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/problem/types/CreateProblemResponse.ts
@@ -2,7 +2,7 @@
 
 import type * as SeedTrace from "../../../index.js";
 
-export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error;
+export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error_;
 
 export namespace CreateProblemResponse {
     export interface Success {
@@ -10,7 +10,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error {
+    export interface Error_ {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/problem/types/CreateProblemResponse.ts
@@ -2,7 +2,7 @@
 
 import type * as SeedTrace from "../../../index.js";
 
-export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error;
+export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error_;
 
 export namespace CreateProblemResponse {
     export interface Success {
@@ -10,7 +10,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error {
+    export interface Error_ {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-sdk/trace/serde-no-throwing/src/serialization/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/serialization/resources/problem/types/CreateProblemResponse.ts
@@ -24,14 +24,14 @@ export const CreateProblemResponse: core.serialization.Schema<
     });
 
 export declare namespace CreateProblemResponse {
-    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error;
+    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error_;
 
     export interface Success {
         type: "success";
         value: ProblemId.Raw;
     }
 
-    export interface Error {
+    export interface Error_ {
         type: "error";
         value: CreateProblemError.Raw;
     }

--- a/seed/ts-sdk/trace/serde/src/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/problem/types/CreateProblemResponse.ts
@@ -2,7 +2,7 @@
 
 import type * as SeedTrace from "../../../index.js";
 
-export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error;
+export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error_;
 
 export namespace CreateProblemResponse {
     export interface Success {
@@ -10,7 +10,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error {
+    export interface Error_ {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-sdk/trace/serde/src/serialization/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/serde/src/serialization/resources/problem/types/CreateProblemResponse.ts
@@ -24,14 +24,14 @@ export const CreateProblemResponse: core.serialization.Schema<
     });
 
 export declare namespace CreateProblemResponse {
-    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error;
+    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error_;
 
     export interface Success {
         type: "success";
         value: ProblemId.Raw;
     }
 
-    export interface Error {
+    export interface Error_ {
         type: "error";
         value: CreateProblemError.Raw;
     }

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/types/types/UnionWithOptionalTime.ts
@@ -27,10 +27,10 @@ import type * as SeedUnions from "../../../index.js";
  *         value: undefined
  *     }
  */
-export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date | SeedUnions.UnionWithOptionalTime.Datetime;
+export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date_ | SeedUnions.UnionWithOptionalTime.Datetime;
 
 export namespace UnionWithOptionalTime {
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value?: string;
     }

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/types/types/UnionWithTime.ts
@@ -23,7 +23,7 @@ import type * as SeedUnions from "../../../index.js";
  */
 export type UnionWithTime =
     | SeedUnions.UnionWithTime.Value
-    | SeedUnions.UnionWithTime.Date
+    | SeedUnions.UnionWithTime.Date_
     | SeedUnions.UnionWithTime.Datetime;
 
 export namespace UnionWithTime {
@@ -32,7 +32,7 @@ export namespace UnionWithTime {
         value: number;
     }
 
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value: string;
     }

--- a/seed/ts-sdk/unions/src/api/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-sdk/unions/src/api/resources/types/types/UnionWithOptionalTime.ts
@@ -27,10 +27,10 @@ import type * as SeedUnions from "../../../index.js";
  *         value: undefined
  *     }
  */
-export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date | SeedUnions.UnionWithOptionalTime.Datetime;
+export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date_ | SeedUnions.UnionWithOptionalTime.Datetime;
 
 export namespace UnionWithOptionalTime {
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value?: string;
     }

--- a/seed/ts-sdk/unions/src/api/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-sdk/unions/src/api/resources/types/types/UnionWithTime.ts
@@ -23,7 +23,7 @@ import type * as SeedUnions from "../../../index.js";
  */
 export type UnionWithTime =
     | SeedUnions.UnionWithTime.Value
-    | SeedUnions.UnionWithTime.Date
+    | SeedUnions.UnionWithTime.Date_
     | SeedUnions.UnionWithTime.Datetime;
 
 export namespace UnionWithTime {
@@ -32,7 +32,7 @@ export namespace UnionWithTime {
         value: number;
     }
 
-    export interface Date {
+    export interface Date_ {
         type: "date";
         value: string;
     }


### PR DESCRIPTION
## Description
Union members would be sanitized, but still based off the `unsafeName`, which could cause problems if they accidentally shadowed certain global types like `Date` and `Error`. Now they use `safeName`.

## Changes Made
Three-liner in certain TypeScript union generators.

## Testing
Regenerated seed; fixes Candid.
- [X] Unit tests added/updated
- [X] Manual testing completed
