### PR TITLE
fix(cli): handle non-file-path custom license strings in generators.yml

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.3.5
+  changelogEntry:
+    - summary: |
+        Fix `generators.yml` loading crash when a custom license value is a literal
+        name or text string rather than a file path. Previously, the CLI unconditionally
+        tried to read the `custom` license value as a file, causing an ENOENT error that
+        blocked all generators in the same config. Now the CLI checks if the path exists
+        first and falls back to treating the value as literal license content.
+      type: fix
+  createdAt: "2026-03-04"
+  irVersion: 65
+
 - version: 4.3.4
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -1,6 +1,6 @@
 import { generatorsYml } from "@fern-api/configuration";
 import { assertNever } from "@fern-api/core-utils";
-import { AbsoluteFilePath, dirname, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, doesPathExist, dirname, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { parseRepository } from "@fern-api/github";
 import { TaskContext } from "@fern-api/task-context";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
@@ -936,9 +936,15 @@ async function getGithubLicense({
         AbsoluteFilePath.of(path.dirname(absolutePathToGeneratorsConfiguration)),
         RelativeFilePath.of(githubLicense.custom)
     );
-    const licenseContent = await readFile(absolutePathToLicense);
+    if (await doesPathExist(absolutePathToLicense)) {
+        const licenseContent = await readFile(absolutePathToLicense);
+        return FernFiddle.GithubLicense.custom({
+            contents: licenseContent.toString()
+        });
+    }
+    // If the custom value is not a valid file path, treat it as literal license content
     return FernFiddle.GithubLicense.custom({
-        contents: licenseContent.toString()
+        contents: githubLicense.custom
     });
 }
 

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -1,6 +1,6 @@
 import { generatorsYml } from "@fern-api/configuration";
 import { assertNever } from "@fern-api/core-utils";
-import { AbsoluteFilePath, doesPathExist, dirname, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, dirname, doesPathExist, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { parseRepository } from "@fern-api/github";
 import { TaskContext } from "@fern-api/task-context";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";

--- a/test-definitions/fern/apis/exhaustive/generators.yml
+++ b/test-definitions/fern/apis/exhaustive/generators.yml
@@ -22,3 +22,5 @@ groups:
           mode: push
           uri: fern-api/go-sdk-tests
           branch: exhaustive
+          license:
+            custom: Custom License Name


### PR DESCRIPTION
## Description

Refs: Customer report (Anduril) — go-sdk generation fails when `generators.yml` contains a custom license that is a literal name/string rather than a file path.

**Requested by:** @jsklan
**Devin Session:** https://app.devin.ai/sessions/3d6daf57732e474cb484dab4d8ee37bb

The `getGithubLicense` function in `convertGeneratorsConfiguration.ts` unconditionally calls `readFile` on the `custom` license value, assuming it's always a file path. When the value is a literal license name (e.g., `"Anduril Lattice Software Development Kit License Agreement"`), this crashes with `ENOENT`, preventing **all** generators in that `generators.yml` from running — not just the one with the problematic license.

## Changes Made

- Added a `license: { custom: "Custom License Name" }` entry to the exhaustive fixture's `generators.yml` for the go-sdk group, which reproduces the ENOENT crash
- Fixed `getGithubLicense` in `convertGeneratorsConfiguration.ts` to check if the custom license path exists before reading it; falls back to treating the value as literal license content if the file is not found
- Added `doesPathExist` import from `@fern-api/fs-utils`
- Added changelog entry in `versions.yml` (CLI v4.3.5)

> **Note:** No COMMIT 3 with updated fixture output because the go-sdk exhaustive fixture has pre-existing allowed generation failures (unrelated wire-test mapping issues). The important thing is that it no longer crashes during configuration loading.

## Testing

- [x] Confirmed bug reproduces: `pnpm seed:local test --generator go-sdk --fixture exhaustive` crashes with `ENOENT: no such file or directory, open '.../Custom License Name'`
- [x] Confirmed bug reproduces against customer fixture: `pnpm seed:local run --generator go-sdk --path <customer-api>` crashes with the same error
- [x] Confirmed fix works: exhaustive fixture no longer crashes (generation proceeds, expected failures are unrelated)
- [x] Confirmed fix works against customer fixture: `pnpm seed:local run --generator go-sdk --path <customer-api>` succeeds past config loading
- [x] `pnpm run check` (biome) passes locally

## ⚠️ Human Review Checklist

- [ ] **Silent fallback behavior**: The fix treats any `custom` license value whose resolved path doesn't exist as literal license content. This means a **typo in an actual file path** (e.g., `custom: ../../LISENCE`) would silently use the string `"../../LISENCE"` as the license content instead of erroring. Verify this tradeoff is acceptable, or consider whether a warning log should be emitted when falling back.