### PR TITLE
feat(cli): add `--retry-rate-limited` flag to `fern generate`

### DIFF
--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -126,7 +126,7 @@ export class LegacyRemoteGenerationRunner {
                 absolutePathToPreview,
                 whitelabel: undefined,
                 dynamicIrOnly: false,
-                handleTooManyRequests: false
+                retryRateLimited: false
             });
 
             if (this.isLocalGitCombo(args) && absolutePathToPreview != null) {

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -125,7 +125,8 @@ export class LegacyRemoteGenerationRunner {
                 fernignorePath: args.fernignorePath,
                 absolutePathToPreview,
                 whitelabel: undefined,
-                dynamicIrOnly: false
+                dynamicIrOnly: false,
+                handleTooManyRequests: false
             });
 
             if (this.isLocalGitCombo(args) && absolutePathToPreview != null) {

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -693,7 +693,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     hidden: true,
                     description: "Run replay after generation (use --no-replay to skip)"
                 })
-                .option("handle-too-many-requests", {
+                .option("retry-rate-limited", {
                     boolean: true,
                     default: false,
                     description:
@@ -760,7 +760,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     dynamicIrOnly: argv["dynamic-ir-only"],
                     outputDir: argv.output,
                     noReplay: !argv.replay,
-                    handleTooManyRequests: argv["handle-too-many-requests"]
+                    retryRateLimited: argv["retry-rate-limited"]
                 });
             }
             if (argv.docs != null) {
@@ -815,7 +815,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 dynamicIrOnly: argv["dynamic-ir-only"],
                 outputDir: argv.output,
                 noReplay: !argv.replay,
-                handleTooManyRequests: argv["handle-too-many-requests"]
+                retryRateLimited: argv["retry-rate-limited"]
             });
         }
     );

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -692,6 +692,12 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     default: true,
                     hidden: true,
                     description: "Run replay after generation (use --no-replay to skip)"
+                })
+                .option("handle-too-many-requests", {
+                    boolean: true,
+                    default: false,
+                    description:
+                        "Automatically retry with exponential backoff when receiving 429 Too Many Requests responses"
                 }),
         async (argv) => {
             if (argv.api != null && argv.docs != null) {
@@ -753,7 +759,8 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     fernignorePath: argv.fernignore,
                     dynamicIrOnly: argv["dynamic-ir-only"],
                     outputDir: argv.output,
-                    noReplay: !argv.replay
+                    noReplay: !argv.replay,
+                    handleTooManyRequests: argv["handle-too-many-requests"]
                 });
             }
             if (argv.docs != null) {
@@ -807,7 +814,8 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 fernignorePath: argv.fernignore,
                 dynamicIrOnly: argv["dynamic-ir-only"],
                 outputDir: argv.output,
-                noReplay: !argv.replay
+                noReplay: !argv.replay,
+                handleTooManyRequests: argv["handle-too-many-requests"]
             });
         }
     );

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -36,7 +36,7 @@ export async function generateWorkspace({
     fernignorePath,
     dynamicIrOnly,
     noReplay,
-    handleTooManyRequests
+    retryRateLimited
 }: {
     organization: string;
     workspace: AbstractAPIWorkspace<unknown>;
@@ -57,7 +57,7 @@ export async function generateWorkspace({
     fernignorePath: string | undefined;
     dynamicIrOnly: boolean;
     noReplay: boolean;
-    handleTooManyRequests: boolean;
+    retryRateLimited: boolean;
 }): Promise<void> {
     if (workspace.generatorsConfiguration == null) {
         context.logger.warn("This workspaces has no generators.yml");
@@ -156,7 +156,7 @@ export async function generateWorkspace({
                     fernignorePath,
                     dynamicIrOnly,
                     validateWorkspace: true,
-                    handleTooManyRequests
+                    retryRateLimited
                 });
             }
         })

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -35,7 +35,8 @@ export async function generateWorkspace({
     lfsOverride,
     fernignorePath,
     dynamicIrOnly,
-    noReplay
+    noReplay,
+    handleTooManyRequests
 }: {
     organization: string;
     workspace: AbstractAPIWorkspace<unknown>;
@@ -56,6 +57,7 @@ export async function generateWorkspace({
     fernignorePath: string | undefined;
     dynamicIrOnly: boolean;
     noReplay: boolean;
+    handleTooManyRequests: boolean;
 }): Promise<void> {
     if (workspace.generatorsConfiguration == null) {
         context.logger.warn("This workspaces has no generators.yml");
@@ -153,7 +155,8 @@ export async function generateWorkspace({
                     mode,
                     fernignorePath,
                     dynamicIrOnly,
-                    validateWorkspace: true
+                    validateWorkspace: true,
+                    handleTooManyRequests
                 });
             }
         })

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -35,7 +35,7 @@ export async function generateAPIWorkspaces({
     dynamicIrOnly,
     outputDir,
     noReplay,
-    handleTooManyRequests
+    retryRateLimited
 }: {
     project: Project;
     cliContext: CliContext;
@@ -55,7 +55,7 @@ export async function generateAPIWorkspaces({
     dynamicIrOnly: boolean;
     outputDir: string | undefined;
     noReplay: boolean;
-    handleTooManyRequests: boolean;
+    retryRateLimited: boolean;
 }): Promise<void> {
     let token: FernToken | undefined = undefined;
 
@@ -153,7 +153,7 @@ export async function generateAPIWorkspaces({
                     fernignorePath,
                     dynamicIrOnly,
                     noReplay,
-                    handleTooManyRequests
+                    retryRateLimited
                 });
             });
         })

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -34,7 +34,8 @@ export async function generateAPIWorkspaces({
     fernignorePath,
     dynamicIrOnly,
     outputDir,
-    noReplay
+    noReplay,
+    handleTooManyRequests
 }: {
     project: Project;
     cliContext: CliContext;
@@ -54,6 +55,7 @@ export async function generateAPIWorkspaces({
     dynamicIrOnly: boolean;
     outputDir: string | undefined;
     noReplay: boolean;
+    handleTooManyRequests: boolean;
 }): Promise<void> {
     let token: FernToken | undefined = undefined;
 
@@ -150,7 +152,8 @@ export async function generateAPIWorkspaces({
                     lfsOverride,
                     fernignorePath,
                     dynamicIrOnly,
-                    noReplay
+                    noReplay,
+                    handleTooManyRequests
                 });
             });
         })

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -3,9 +3,8 @@
   changelogEntry:
     - summary: |
         Add `--retry-rate-limited` flag to `fern generate` that automatically retries
-        with exponential backoff when receiving 429 Too Many Requests responses. When a
-        server provides a `Retry-After` header, that value is used; otherwise the CLI
-        falls back to exponential backoff with jitter. Retries up to 3 times.
+        with exponential backoff and jitter when receiving 429 Too Many Requests responses.
+        Retries up to 3 times (2s, 4s, 8s base delays, capped at 120s).
       type: feat
   createdAt: "2026-03-04"
   irVersion: 65

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 4.3.5
+- version: 4.4.0
   changelogEntry:
     - summary: |
         Add `--retry-rate-limited` flag to `fern generate` that automatically retries

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.3.5
+  changelogEntry:
+    - summary: |
+        Add `--retry-rate-limited` flag to `fern generate` that automatically retries
+        with exponential backoff when receiving 429 Too Many Requests responses. When a
+        server provides a `Retry-After` header, that value is used; otherwise the CLI
+        falls back to exponential backoff with jitter. Retries up to 3 times.
+      type: feat
+  createdAt: "2026-03-04"
+  irVersion: 65
+
 - version: 4.3.4
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi } from "vitest";
+import { TooManyRequestsError, retryWithRateLimit } from "../retryWithRateLimit.js";
+
+function createMockLogger() {
+    return {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn(),
+        trace: vi.fn()
+    };
+}
+
+describe("TooManyRequestsError", () => {
+    it("should be an instance of Error", () => {
+        const error = new TooManyRequestsError();
+        expect(error).toBeInstanceOf(Error);
+        expect(error).toBeInstanceOf(TooManyRequestsError);
+    });
+
+    it("should have the correct message", () => {
+        const error = new TooManyRequestsError();
+        expect(error.message).toBe("Received 429 Too Many Requests");
+    });
+
+    it("should store retryAfterSeconds when provided", () => {
+        const error = new TooManyRequestsError(30);
+        expect(error.retryAfterSeconds).toBe(30);
+    });
+
+    it("should have undefined retryAfterSeconds when not provided", () => {
+        const error = new TooManyRequestsError();
+        expect(error.retryAfterSeconds).toBeUndefined();
+    });
+});
+
+describe("retryWithRateLimit", () => {
+    const noDelay = async (_ms: number) => {
+        // no-op: skip delay in tests
+    };
+
+    it("should return the result when fn succeeds on first try", async () => {
+        const logger = createMockLogger();
+        const result = await retryWithRateLimit({
+            fn: async () => "success",
+            retryRateLimited: true,
+            logger,
+            onRateLimitedWithoutRetry: () => {
+                throw new Error("should not be called");
+            },
+            delayFn: noDelay
+        });
+        expect(result).toBe("success");
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("should call onRateLimitedWithoutRetry when retryRateLimited is false and 429 occurs", async () => {
+        const logger = createMockLogger();
+        const onRateLimited = vi.fn(() => {
+            throw new Error("Rate limited without retry");
+        });
+
+        await expect(
+            retryWithRateLimit({
+                fn: async () => {
+                    throw new TooManyRequestsError();
+                },
+                retryRateLimited: false,
+                logger,
+                onRateLimitedWithoutRetry: onRateLimited as () => never,
+                delayFn: noDelay
+            })
+        ).rejects.toThrow("Rate limited without retry");
+
+        expect(onRateLimited).toHaveBeenCalledOnce();
+    });
+
+    it("should rethrow non-429 errors when retryRateLimited is false", async () => {
+        const logger = createMockLogger();
+
+        await expect(
+            retryWithRateLimit({
+                fn: async () => {
+                    throw new Error("some other error");
+                },
+                retryRateLimited: false,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: noDelay
+            })
+        ).rejects.toThrow("some other error");
+    });
+
+    it("should retry up to 3 times on TooManyRequestsError and succeed", async () => {
+        const logger = createMockLogger();
+        let callCount = 0;
+
+        const result = await retryWithRateLimit({
+            fn: async () => {
+                callCount++;
+                if (callCount <= 2) {
+                    throw new TooManyRequestsError();
+                }
+                return "success after retries";
+            },
+            retryRateLimited: true,
+            logger,
+            onRateLimitedWithoutRetry: () => {
+                throw new Error("should not be called");
+            },
+            delayFn: noDelay
+        });
+
+        expect(result).toBe("success after retries");
+        expect(callCount).toBe(3);
+        expect(logger.warn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should throw after exhausting all 3 retries", async () => {
+        const logger = createMockLogger();
+        let callCount = 0;
+
+        await expect(
+            retryWithRateLimit({
+                fn: async () => {
+                    callCount++;
+                    throw new TooManyRequestsError();
+                },
+                retryRateLimited: true,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: noDelay
+            })
+        ).rejects.toThrow(TooManyRequestsError);
+
+        // 1 initial + 3 retries = 4 total calls
+        expect(callCount).toBe(4);
+        expect(logger.warn).toHaveBeenCalledTimes(3);
+    });
+
+    it("should rethrow non-429 errors immediately even when retryRateLimited is true", async () => {
+        const logger = createMockLogger();
+        let callCount = 0;
+
+        await expect(
+            retryWithRateLimit({
+                fn: async () => {
+                    callCount++;
+                    throw new Error("network error");
+                },
+                retryRateLimited: true,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: noDelay
+            })
+        ).rejects.toThrow("network error");
+
+        expect(callCount).toBe(1);
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("should use exponential backoff delays", async () => {
+        const logger = createMockLogger();
+        const delays: number[] = [];
+        let callCount = 0;
+
+        // Mock Math.random to return 0.5 (no jitter effect: 1 + (0.5 - 0.5) * 0.2 = 1.0)
+        const originalRandom = Math.random;
+        Math.random = () => 0.5;
+
+        try {
+            await retryWithRateLimit({
+                fn: async () => {
+                    callCount++;
+                    throw new TooManyRequestsError();
+                },
+                retryRateLimited: true,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: async (ms: number) => {
+                    delays.push(ms);
+                }
+            }).catch(() => {
+                // expected: exhausted retries
+            });
+        } finally {
+            Math.random = originalRandom;
+        }
+
+        // With Math.random = 0.5, jitter factor = 1.0 (no jitter)
+        // Attempt 0: 2000 * 2^0 = 2000ms
+        // Attempt 1: 2000 * 2^1 = 4000ms
+        // Attempt 2: 2000 * 2^2 = 8000ms
+        expect(delays).toEqual([2000, 4000, 8000]);
+    });
+
+    it("should use Retry-After value when provided", async () => {
+        const logger = createMockLogger();
+        const delays: number[] = [];
+        let callCount = 0;
+
+        // Mock Math.random to return 0.5 (no jitter effect)
+        const originalRandom = Math.random;
+        Math.random = () => 0.5;
+
+        try {
+            await retryWithRateLimit({
+                fn: async () => {
+                    callCount++;
+                    if (callCount <= 2) {
+                        throw new TooManyRequestsError(10); // Retry-After: 10 seconds
+                    }
+                    return "success";
+                },
+                retryRateLimited: true,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: async (ms: number) => {
+                    delays.push(ms);
+                }
+            });
+        } finally {
+            Math.random = originalRandom;
+        }
+
+        // Retry-After = 10s, with jitter factor 1.0 (Math.random = 0.5), delay = 10000ms
+        expect(delays).toEqual([10000, 10000]);
+    });
+
+    it("should apply jitter to delays", async () => {
+        const logger = createMockLogger();
+        const delays: number[] = [];
+
+        // Mock Math.random to return 0.0 (minimum jitter: 1 + (0.0 - 0.5) * 0.2 = 0.9)
+        const originalRandom = Math.random;
+        Math.random = () => 0.0;
+
+        try {
+            await retryWithRateLimit({
+                fn: async () => {
+                    throw new TooManyRequestsError();
+                },
+                retryRateLimited: true,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: async (ms: number) => {
+                    delays.push(ms);
+                }
+            }).catch(() => {
+                // expected: exhausted retries
+            });
+        } finally {
+            Math.random = originalRandom;
+        }
+
+        // With Math.random = 0.0, jitter = 1 + (0.0 - 0.5) * 0.2 = 0.9
+        // Attempt 0: round(2000 * 0.9) = 1800ms
+        // Attempt 1: round(4000 * 0.9) = 3600ms
+        // Attempt 2: round(8000 * 0.9) = 7200ms
+        expect(delays).toEqual([1800, 3600, 7200]);
+    });
+
+    it("should cap delay at max retry delay", async () => {
+        const logger = createMockLogger();
+        const delays: number[] = [];
+
+        // Mock Math.random to return 0.5 (no jitter)
+        const originalRandom = Math.random;
+        Math.random = () => 0.5;
+
+        try {
+            // Use a Retry-After value larger than max delay
+            await retryWithRateLimit({
+                fn: async () => {
+                    throw new TooManyRequestsError();
+                },
+                retryRateLimited: true,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: async (ms: number) => {
+                    delays.push(ms);
+                }
+            }).catch(() => {
+                // expected: exhausted retries
+            });
+        } finally {
+            Math.random = originalRandom;
+        }
+
+        // All delays should be <= 120000ms (max delay)
+        for (const delay of delays) {
+            expect(delay).toBeLessThanOrEqual(120000);
+        }
+    });
+
+    it("should include attempt count in warn messages", async () => {
+        const logger = createMockLogger();
+        let callCount = 0;
+
+        await retryWithRateLimit({
+            fn: async () => {
+                callCount++;
+                if (callCount <= 2) {
+                    throw new TooManyRequestsError();
+                }
+                return "success";
+            },
+            retryRateLimited: true,
+            logger,
+            onRateLimitedWithoutRetry: () => {
+                throw new Error("should not be called");
+            },
+            delayFn: noDelay
+        });
+
+        expect(logger.warn).toHaveBeenCalledTimes(2);
+        const firstCall = logger.warn.mock.calls[0]?.[0] as string;
+        const secondCall = logger.warn.mock.calls[1]?.[0] as string;
+        expect(firstCall).toContain("attempt 1/3");
+        expect(secondCall).toContain("attempt 2/3");
+    });
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { TooManyRequestsError, retryWithRateLimit } from "../retryWithRateLimit.js";
+import { describe, expect, it, vi } from "vitest";
+import { retryWithRateLimit, TooManyRequestsError } from "../retryWithRateLimit.js";
 
 function createMockLogger() {
     return {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
@@ -275,7 +275,7 @@ describe("retryWithRateLimit", () => {
         expect(delays).toEqual([1800, 3600, 7200]);
     });
 
-    it("should cap delay at max retry delay", async () => {
+    it("should cap exponential backoff delay at max retry delay", async () => {
         const logger = createMockLogger();
         const delays: number[] = [];
 
@@ -284,7 +284,6 @@ describe("retryWithRateLimit", () => {
         Math.random = () => 0.5;
 
         try {
-            // Use a Retry-After value larger than max delay
             await retryWithRateLimit({
                 fn: async () => {
                     throw new TooManyRequestsError();
@@ -308,6 +307,43 @@ describe("retryWithRateLimit", () => {
         for (const delay of delays) {
             expect(delay).toBeLessThanOrEqual(120000);
         }
+    });
+
+    it("should cap Retry-After delay at max retry delay", async () => {
+        const logger = createMockLogger();
+        const delays: number[] = [];
+
+        // Mock Math.random to return 0.5 (no jitter)
+        const originalRandom = Math.random;
+        Math.random = () => 0.5;
+
+        try {
+            await retryWithRateLimit({
+                fn: async () => {
+                    // Server says wait 600 seconds (10 minutes), should be capped at 120s
+                    throw new TooManyRequestsError(600);
+                },
+                retryRateLimited: true,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: async (ms: number) => {
+                    delays.push(ms);
+                }
+            }).catch(() => {
+                // expected: exhausted retries
+            });
+        } finally {
+            Math.random = originalRandom;
+        }
+
+        // All delays should be capped at 120000ms even though Retry-After was 600s
+        for (const delay of delays) {
+            expect(delay).toBeLessThanOrEqual(120000);
+        }
+        // Verify we actually hit the cap (600s * 1000 = 600000ms would be uncapped)
+        expect(delays[0]).toBe(120000);
     });
 
     it("should include attempt count in warn messages", async () => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
@@ -25,16 +25,6 @@ describe("TooManyRequestsError", () => {
         const error = new TooManyRequestsError();
         expect(error.message).toBe("Received 429 Too Many Requests");
     });
-
-    it("should store retryAfterSeconds when provided", () => {
-        const error = new TooManyRequestsError(30);
-        expect(error.retryAfterSeconds).toBe(30);
-    });
-
-    it("should have undefined retryAfterSeconds when not provided", () => {
-        const error = new TooManyRequestsError();
-        expect(error.retryAfterSeconds).toBeUndefined();
-    });
 });
 
 describe("retryWithRateLimit", () => {
@@ -205,41 +195,6 @@ describe("retryWithRateLimit", () => {
         expect(delays).toEqual([2000, 4000, 8000]);
     });
 
-    it("should use Retry-After value when provided", async () => {
-        const logger = createMockLogger();
-        const delays: number[] = [];
-        let callCount = 0;
-
-        // Mock Math.random to return 0.5 (no jitter effect)
-        const originalRandom = Math.random;
-        Math.random = () => 0.5;
-
-        try {
-            await retryWithRateLimit({
-                fn: async () => {
-                    callCount++;
-                    if (callCount <= 2) {
-                        throw new TooManyRequestsError(10); // Retry-After: 10 seconds
-                    }
-                    return "success";
-                },
-                retryRateLimited: true,
-                logger,
-                onRateLimitedWithoutRetry: () => {
-                    throw new Error("should not be called");
-                },
-                delayFn: async (ms: number) => {
-                    delays.push(ms);
-                }
-            });
-        } finally {
-            Math.random = originalRandom;
-        }
-
-        // Retry-After = 10s, with jitter factor 1.0 (Math.random = 0.5), delay = 10000ms
-        expect(delays).toEqual([10000, 10000]);
-    });
-
     it("should apply jitter to delays", async () => {
         const logger = createMockLogger();
         const delays: number[] = [];
@@ -307,43 +262,6 @@ describe("retryWithRateLimit", () => {
         for (const delay of delays) {
             expect(delay).toBeLessThanOrEqual(120000);
         }
-    });
-
-    it("should cap Retry-After delay at max retry delay", async () => {
-        const logger = createMockLogger();
-        const delays: number[] = [];
-
-        // Mock Math.random to return 0.5 (no jitter)
-        const originalRandom = Math.random;
-        Math.random = () => 0.5;
-
-        try {
-            await retryWithRateLimit({
-                fn: async () => {
-                    // Server says wait 600 seconds (10 minutes), should be capped at 120s
-                    throw new TooManyRequestsError(600);
-                },
-                retryRateLimited: true,
-                logger,
-                onRateLimitedWithoutRetry: () => {
-                    throw new Error("should not be called");
-                },
-                delayFn: async (ms: number) => {
-                    delays.push(ms);
-                }
-            }).catch(() => {
-                // expected: exhausted retries
-            });
-        } finally {
-            Math.random = originalRandom;
-        }
-
-        // All delays should be capped at 120000ms even though Retry-After was 600s
-        for (const delay of delays) {
-            expect(delay).toBeLessThanOrEqual(120000);
-        }
-        // Verify we actually hit the cap (600s * 1000 = 600000ms would be uncapped)
-        expect(delays[0]).toBe(120000);
     });
 
     it("should include attempt count in warn messages", async () => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -15,7 +15,7 @@ import FormData from "form-data";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 import urlJoin from "url-join";
-import { TooManyRequestsError, retryWithRateLimit } from "./retryWithRateLimit.js";
+import { retryWithRateLimit, TooManyRequestsError } from "./retryWithRateLimit.js";
 
 export async function createAndStartJob({
     projectConfig,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -17,6 +17,11 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 import urlJoin from "url-join";
 
+const TOO_MANY_REQUESTS_INITIAL_RETRY_DELAY_MS = 2_000;
+const TOO_MANY_REQUESTS_MAX_RETRY_DELAY_MS = 120_000;
+const TOO_MANY_REQUESTS_MAX_RETRIES = 5;
+const TOO_MANY_REQUESTS_JITTER_FACTOR = 0.2;
+
 export async function createAndStartJob({
     projectConfig,
     workspace,
@@ -30,7 +35,8 @@ export async function createAndStartJob({
     whitelabel,
     irVersionOverride,
     absolutePathToPreview,
-    fernignorePath
+    fernignorePath,
+    handleTooManyRequests
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     workspace: FernWorkspace;
@@ -45,6 +51,7 @@ export async function createAndStartJob({
     irVersionOverride: string | undefined;
     absolutePathToPreview: AbsoluteFilePath | undefined;
     fernignorePath: string | undefined;
+    handleTooManyRequests: boolean;
 }): Promise<FernFiddle.remoteGen.CreateJobResponse> {
     // Read fernignore file contents if path is provided
     let fernignoreContents: string | undefined;
@@ -56,7 +63,7 @@ export async function createAndStartJob({
         }
     }
 
-    const job = await createJob({
+    const job = await createJobWithOptionalRetry({
         projectConfig,
         workspace,
         organization,
@@ -67,10 +74,61 @@ export async function createAndStartJob({
         token,
         whitelabel,
         absolutePathToPreview,
-        fernignoreContents
+        fernignoreContents,
+        handleTooManyRequests
     });
     await startJob({ intermediateRepresentation, job, context, generatorInvocation, irVersionOverride });
     return job;
+}
+
+async function createJobWithOptionalRetry(
+    args: Parameters<typeof createJob>[0] & { handleTooManyRequests: boolean }
+): Promise<FernFiddle.remoteGen.CreateJobResponse> {
+    const { handleTooManyRequests, ...createJobArgs } = args;
+
+    if (!handleTooManyRequests) {
+        try {
+            return await createJob(createJobArgs);
+        } catch (error) {
+            if (error instanceof TooManyRequestsError) {
+                return args.context.failAndThrow(
+                    "Received 429 Too Many Requests. Re-run with --handle-too-many-requests to automatically retry."
+                );
+            }
+            throw error;
+        }
+    }
+
+    for (let attempt = 0; attempt <= TOO_MANY_REQUESTS_MAX_RETRIES; attempt++) {
+        try {
+            return await createJob(createJobArgs);
+        } catch (error) {
+            if (error instanceof TooManyRequestsError && attempt < TOO_MANY_REQUESTS_MAX_RETRIES) {
+                const baseDelay = Math.min(
+                    TOO_MANY_REQUESTS_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
+                    TOO_MANY_REQUESTS_MAX_RETRY_DELAY_MS
+                );
+                const jitter = 1 + (Math.random() - 0.5) * TOO_MANY_REQUESTS_JITTER_FACTOR;
+                const delay = Math.round(baseDelay * jitter);
+                args.context.logger.warn(
+                    `Received 429 Too Many Requests. Retrying in ${(delay / 1000).toFixed(1)}s (attempt ${attempt + 1}/${TOO_MANY_REQUESTS_MAX_RETRIES})...`
+                );
+                await new Promise((resolve) => setTimeout(resolve, delay));
+            } else {
+                throw error;
+            }
+        }
+    }
+
+    // Unreachable, but TypeScript needs this
+    return args.context.failAndThrow("Exceeded maximum retries for 429 Too Many Requests.");
+}
+
+class TooManyRequestsError extends Error {
+    constructor() {
+        super("Received 429 Too Many Requests");
+        Object.setPrototypeOf(this, TooManyRequestsError.prototype);
+    }
 }
 
 async function createJob({
@@ -125,7 +183,13 @@ async function createJob({
     });
 
     if (!createResponse.ok) {
-        return convertCreateJobError(createResponse.error as unknown as Fetcher.Error)._visit({
+        // Check for 429 Too Many Requests before processing the error through the visitor.
+        // This allows the retry wrapper to catch and retry on rate limiting.
+        const rawError = createResponse.error as unknown as Fetcher.Error;
+        if (rawError.reason === "status-code" && rawError.statusCode === 429) {
+            throw new TooManyRequestsError();
+        }
+        return convertCreateJobError(rawError)._visit({
             illegalApiNameError: () => {
                 return context.failAndThrow("API name is invalid: " + workspace.definition.rootApiFile.contents.name);
             },

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -103,7 +103,7 @@ async function createJobWithOptionalRetry(
             return await createJob(createJobArgs);
         } catch (error) {
             if (error instanceof TooManyRequestsError && attempt < RATE_LIMIT_MAX_RETRIES) {
-                const retryAfterSeconds = (error as TooManyRequestsError).retryAfterSeconds;
+                const retryAfterSeconds = error.retryAfterSeconds;
                 let delay: number;
                 if (retryAfterSeconds != null) {
                     // Use the server-provided Retry-After value with a small jitter

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -15,11 +15,7 @@ import FormData from "form-data";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 import urlJoin from "url-join";
-
-const RATE_LIMIT_INITIAL_RETRY_DELAY_MS = 2_000;
-const RATE_LIMIT_MAX_RETRY_DELAY_MS = 120_000;
-const RATE_LIMIT_MAX_RETRIES = 3;
-const RATE_LIMIT_JITTER_FACTOR = 0.2;
+import { TooManyRequestsError, retryWithRateLimit } from "./retryWithRateLimit.js";
 
 export async function createAndStartJob({
     projectConfig,
@@ -62,84 +58,30 @@ export async function createAndStartJob({
         }
     }
 
-    const job = await createJobWithOptionalRetry({
-        projectConfig,
-        workspace,
-        organization,
-        generatorInvocation,
-        version,
-        context,
-        shouldLogS3Url,
-        token,
-        whitelabel,
-        absolutePathToPreview,
-        fernignoreContents,
-        retryRateLimited
+    const job = await retryWithRateLimit({
+        fn: () =>
+            createJob({
+                projectConfig,
+                workspace,
+                organization,
+                generatorInvocation,
+                version,
+                context,
+                shouldLogS3Url,
+                token,
+                whitelabel,
+                absolutePathToPreview,
+                fernignoreContents
+            }),
+        retryRateLimited,
+        logger: context.logger,
+        onRateLimitedWithoutRetry: () =>
+            context.failAndThrow(
+                "Received 429 Too Many Requests. Re-run with --retry-rate-limited to automatically retry."
+            )
     });
     await startJob({ intermediateRepresentation, job, context, generatorInvocation, irVersionOverride });
     return job;
-}
-
-async function createJobWithOptionalRetry(
-    args: Parameters<typeof createJob>[0] & { retryRateLimited: boolean }
-): Promise<FernFiddle.remoteGen.CreateJobResponse> {
-    const { retryRateLimited, ...createJobArgs } = args;
-
-    if (!retryRateLimited) {
-        try {
-            return await createJob(createJobArgs);
-        } catch (error) {
-            if (error instanceof TooManyRequestsError) {
-                return args.context.failAndThrow(
-                    "Received 429 Too Many Requests. Re-run with --retry-rate-limited to automatically retry."
-                );
-            }
-            throw error;
-        }
-    }
-
-    for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
-        try {
-            return await createJob(createJobArgs);
-        } catch (error) {
-            if (error instanceof TooManyRequestsError && attempt < RATE_LIMIT_MAX_RETRIES) {
-                const retryAfterSeconds = error.retryAfterSeconds;
-                let delay: number;
-                if (retryAfterSeconds != null) {
-                    // Use the server-provided Retry-After value with a small jitter
-                    const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
-                    delay = Math.round(retryAfterSeconds * 1000 * jitter);
-                } else {
-                    // Fall back to exponential backoff with jitter
-                    const baseDelay = Math.min(
-                        RATE_LIMIT_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
-                        RATE_LIMIT_MAX_RETRY_DELAY_MS
-                    );
-                    const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
-                    delay = Math.round(baseDelay * jitter);
-                }
-                args.context.logger.warn(
-                    `Received 429 Too Many Requests. Retrying in ${(delay / 1000).toFixed(1)}s (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES})...`
-                );
-                await new Promise((resolve) => setTimeout(resolve, delay));
-            } else {
-                throw error;
-            }
-        }
-    }
-
-    // Unreachable, but TypeScript needs this
-    return args.context.failAndThrow("Exceeded maximum retries for 429 Too Many Requests.");
-}
-
-class TooManyRequestsError extends Error {
-    public readonly retryAfterSeconds: number | undefined;
-
-    constructor(retryAfterSeconds?: number) {
-        super("Received 429 Too Many Requests");
-        Object.setPrototypeOf(this, TooManyRequestsError.prototype);
-        this.retryAfterSeconds = retryAfterSeconds;
-    }
 }
 
 async function createJob({

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -16,10 +16,10 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 import urlJoin from "url-join";
 
-const TOO_MANY_REQUESTS_INITIAL_RETRY_DELAY_MS = 2_000;
-const TOO_MANY_REQUESTS_MAX_RETRY_DELAY_MS = 120_000;
-const TOO_MANY_REQUESTS_MAX_RETRIES = 5;
-const TOO_MANY_REQUESTS_JITTER_FACTOR = 0.2;
+const RATE_LIMIT_INITIAL_RETRY_DELAY_MS = 2_000;
+const RATE_LIMIT_MAX_RETRY_DELAY_MS = 120_000;
+const RATE_LIMIT_MAX_RETRIES = 3;
+const RATE_LIMIT_JITTER_FACTOR = 0.2;
 
 export async function createAndStartJob({
     projectConfig,
@@ -35,7 +35,7 @@ export async function createAndStartJob({
     irVersionOverride,
     absolutePathToPreview,
     fernignorePath,
-    handleTooManyRequests
+    retryRateLimited
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     workspace: FernWorkspace;
@@ -50,7 +50,7 @@ export async function createAndStartJob({
     irVersionOverride: string | undefined;
     absolutePathToPreview: AbsoluteFilePath | undefined;
     fernignorePath: string | undefined;
-    handleTooManyRequests: boolean;
+    retryRateLimited: boolean;
 }): Promise<FernFiddle.remoteGen.CreateJobResponse> {
     // Read fernignore file contents if path is provided
     let fernignoreContents: string | undefined;
@@ -74,43 +74,52 @@ export async function createAndStartJob({
         whitelabel,
         absolutePathToPreview,
         fernignoreContents,
-        handleTooManyRequests
+        retryRateLimited
     });
     await startJob({ intermediateRepresentation, job, context, generatorInvocation, irVersionOverride });
     return job;
 }
 
 async function createJobWithOptionalRetry(
-    args: Parameters<typeof createJob>[0] & { handleTooManyRequests: boolean }
+    args: Parameters<typeof createJob>[0] & { retryRateLimited: boolean }
 ): Promise<FernFiddle.remoteGen.CreateJobResponse> {
-    const { handleTooManyRequests, ...createJobArgs } = args;
+    const { retryRateLimited, ...createJobArgs } = args;
 
-    if (!handleTooManyRequests) {
+    if (!retryRateLimited) {
         try {
             return await createJob(createJobArgs);
         } catch (error) {
             if (error instanceof TooManyRequestsError) {
                 return args.context.failAndThrow(
-                    "Received 429 Too Many Requests. Re-run with --handle-too-many-requests to automatically retry."
+                    "Received 429 Too Many Requests. Re-run with --retry-rate-limited to automatically retry."
                 );
             }
             throw error;
         }
     }
 
-    for (let attempt = 0; attempt <= TOO_MANY_REQUESTS_MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
         try {
             return await createJob(createJobArgs);
         } catch (error) {
-            if (error instanceof TooManyRequestsError && attempt < TOO_MANY_REQUESTS_MAX_RETRIES) {
-                const baseDelay = Math.min(
-                    TOO_MANY_REQUESTS_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
-                    TOO_MANY_REQUESTS_MAX_RETRY_DELAY_MS
-                );
-                const jitter = 1 + (Math.random() - 0.5) * TOO_MANY_REQUESTS_JITTER_FACTOR;
-                const delay = Math.round(baseDelay * jitter);
+            if (error instanceof TooManyRequestsError && attempt < RATE_LIMIT_MAX_RETRIES) {
+                const retryAfterSeconds = (error as TooManyRequestsError).retryAfterSeconds;
+                let delay: number;
+                if (retryAfterSeconds != null) {
+                    // Use the server-provided Retry-After value with a small jitter
+                    const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
+                    delay = Math.round(retryAfterSeconds * 1000 * jitter);
+                } else {
+                    // Fall back to exponential backoff with jitter
+                    const baseDelay = Math.min(
+                        RATE_LIMIT_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
+                        RATE_LIMIT_MAX_RETRY_DELAY_MS
+                    );
+                    const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
+                    delay = Math.round(baseDelay * jitter);
+                }
                 args.context.logger.warn(
-                    `Received 429 Too Many Requests. Retrying in ${(delay / 1000).toFixed(1)}s (attempt ${attempt + 1}/${TOO_MANY_REQUESTS_MAX_RETRIES})...`
+                    `Received 429 Too Many Requests. Retrying in ${(delay / 1000).toFixed(1)}s (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES})...`
                 );
                 await new Promise((resolve) => setTimeout(resolve, delay));
             } else {
@@ -124,9 +133,12 @@ async function createJobWithOptionalRetry(
 }
 
 class TooManyRequestsError extends Error {
-    constructor() {
+    public readonly retryAfterSeconds: number | undefined;
+
+    constructor(retryAfterSeconds?: number) {
         super("Received 429 Too Many Requests");
         Object.setPrototypeOf(this, TooManyRequestsError.prototype);
+        this.retryAfterSeconds = retryAfterSeconds;
     }
 }
 
@@ -188,7 +200,13 @@ async function createJob({
         // biome-ignore lint/suspicious/noExplicitAny: the error shape from the SDK is not well-typed
         const rawError = createResponse.error as any;
         if (rawError?.content?.reason === "status-code" && rawError.content.statusCode === 429) {
-            throw new TooManyRequestsError();
+            // Extract Retry-After header value if available in the response
+            const retryAfterHeader = rawError.content.headers?.["retry-after"];
+            const retryAfterSeconds =
+                retryAfterHeader != null && !Number.isNaN(Number(retryAfterHeader))
+                    ? Number(retryAfterHeader)
+                    : undefined;
+            throw new TooManyRequestsError(retryAfterSeconds);
         }
         return convertCreateJobError(rawError)._visit({
             illegalApiNameError: () => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -10,7 +10,6 @@ import { IntermediateRepresentation } from "@fern-api/ir-sdk";
 import { TaskContext } from "@fern-api/task-context";
 import { FernDefinition, FernWorkspace } from "@fern-api/workspace-loader";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
-import { Fetcher } from "@fern-fern/fiddle-sdk/core";
 import axios, { AxiosError } from "axios";
 import FormData from "form-data";
 import { mkdir, readFile, writeFile } from "fs/promises";
@@ -185,8 +184,10 @@ async function createJob({
     if (!createResponse.ok) {
         // Check for 429 Too Many Requests before processing the error through the visitor.
         // This allows the retry wrapper to catch and retry on rate limiting.
-        const rawError = createResponse.error as unknown as Fetcher.Error;
-        if (rawError.reason === "status-code" && rawError.statusCode === 429) {
+        // Note: The fiddle SDK wraps the error inside a `.content` property (see convertCreateJobError below).
+        // biome-ignore lint/suspicious/noExplicitAny: the error shape from the SDK is not well-typed
+        const rawError = createResponse.error as any;
+        if (rawError?.content?.reason === "status-code" && rawError.content.statusCode === 429) {
             throw new TooManyRequestsError();
         }
         return convertCreateJobError(rawError)._visit({

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -142,13 +142,7 @@ async function createJob({
         // biome-ignore lint/suspicious/noExplicitAny: the error shape from the SDK is not well-typed
         const rawError = createResponse.error as any;
         if (rawError?.content?.reason === "status-code" && rawError.content.statusCode === 429) {
-            // Extract Retry-After header value if available in the response
-            const retryAfterHeader = rawError.content.headers?.["retry-after"];
-            const retryAfterSeconds =
-                retryAfterHeader != null && !Number.isNaN(Number(retryAfterHeader))
-                    ? Number(retryAfterHeader)
-                    : undefined;
-            throw new TooManyRequestsError(retryAfterSeconds);
+            throw new TooManyRequestsError();
         }
         return convertCreateJobError(rawError)._visit({
             illegalApiNameError: () => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/retryWithRateLimit.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/retryWithRateLimit.ts
@@ -1,0 +1,84 @@
+import { Logger } from "@fern-api/logger";
+
+const RATE_LIMIT_INITIAL_RETRY_DELAY_MS = 2_000;
+const RATE_LIMIT_MAX_RETRY_DELAY_MS = 120_000;
+const RATE_LIMIT_MAX_RETRIES = 3;
+const RATE_LIMIT_JITTER_FACTOR = 0.2;
+
+export class TooManyRequestsError extends Error {
+    public readonly retryAfterSeconds: number | undefined;
+
+    constructor(retryAfterSeconds?: number) {
+        super("Received 429 Too Many Requests");
+        Object.setPrototypeOf(this, TooManyRequestsError.prototype);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+}
+
+/**
+ * Wraps a function call with optional retry logic for 429 Too Many Requests errors.
+ *
+ * When `retryRateLimited` is false and a TooManyRequestsError is thrown, it calls `onRateLimitedWithoutRetry`
+ * to let the caller handle it (e.g. show a helpful message suggesting --retry-rate-limited).
+ *
+ * When `retryRateLimited` is true, retries up to RATE_LIMIT_MAX_RETRIES times with:
+ * - Server-provided Retry-After delay (if available), plus jitter
+ * - Exponential backoff with jitter as fallback (2s initial, 120s max)
+ */
+export async function retryWithRateLimit<T>({
+    fn,
+    retryRateLimited,
+    logger,
+    onRateLimitedWithoutRetry,
+    delayFn = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+}: {
+    fn: () => Promise<T>;
+    retryRateLimited: boolean;
+    logger: Logger;
+    onRateLimitedWithoutRetry: () => never;
+    delayFn?: (ms: number) => Promise<unknown>;
+}): Promise<T> {
+    if (!retryRateLimited) {
+        try {
+            return await fn();
+        } catch (error) {
+            if (error instanceof TooManyRequestsError) {
+                return onRateLimitedWithoutRetry();
+            }
+            throw error;
+        }
+    }
+
+    for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+        try {
+            return await fn();
+        } catch (error) {
+            if (error instanceof TooManyRequestsError && attempt < RATE_LIMIT_MAX_RETRIES) {
+                const retryAfterSeconds = error.retryAfterSeconds;
+                let delay: number;
+                if (retryAfterSeconds != null) {
+                    // Use the server-provided Retry-After value with a small jitter
+                    const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
+                    delay = Math.round(retryAfterSeconds * 1000 * jitter);
+                } else {
+                    // Fall back to exponential backoff with jitter
+                    const baseDelay = Math.min(
+                        RATE_LIMIT_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
+                        RATE_LIMIT_MAX_RETRY_DELAY_MS
+                    );
+                    const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
+                    delay = Math.round(baseDelay * jitter);
+                }
+                logger.warn(
+                    `Received 429 Too Many Requests. Retrying in ${(delay / 1000).toFixed(1)}s (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES})...`
+                );
+                await delayFn(delay);
+            } else {
+                throw error;
+            }
+        }
+    }
+
+    // Unreachable, but TypeScript needs this
+    throw new Error("Exceeded maximum retries for 429 Too Many Requests.");
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/retryWithRateLimit.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/retryWithRateLimit.ts
@@ -57,9 +57,9 @@ export async function retryWithRateLimit<T>({
                 const retryAfterSeconds = error.retryAfterSeconds;
                 let delay: number;
                 if (retryAfterSeconds != null) {
-                    // Use the server-provided Retry-After value with a small jitter
+                    // Use the server-provided Retry-After value with a small jitter, capped at max
                     const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
-                    delay = Math.round(retryAfterSeconds * 1000 * jitter);
+                    delay = Math.min(Math.round(retryAfterSeconds * 1000 * jitter), RATE_LIMIT_MAX_RETRY_DELAY_MS);
                 } else {
                     // Fall back to exponential backoff with jitter
                     const baseDelay = Math.min(

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/retryWithRateLimit.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/retryWithRateLimit.ts
@@ -6,12 +6,9 @@ const RATE_LIMIT_MAX_RETRIES = 3;
 const RATE_LIMIT_JITTER_FACTOR = 0.2;
 
 export class TooManyRequestsError extends Error {
-    public readonly retryAfterSeconds: number | undefined;
-
-    constructor(retryAfterSeconds?: number) {
+    constructor() {
         super("Received 429 Too Many Requests");
         Object.setPrototypeOf(this, TooManyRequestsError.prototype);
-        this.retryAfterSeconds = retryAfterSeconds;
     }
 }
 
@@ -21,9 +18,8 @@ export class TooManyRequestsError extends Error {
  * When `retryRateLimited` is false and a TooManyRequestsError is thrown, it calls `onRateLimitedWithoutRetry`
  * to let the caller handle it (e.g. show a helpful message suggesting --retry-rate-limited).
  *
- * When `retryRateLimited` is true, retries up to RATE_LIMIT_MAX_RETRIES times with:
- * - Server-provided Retry-After delay (if available), plus jitter
- * - Exponential backoff with jitter as fallback (2s initial, 120s max)
+ * When `retryRateLimited` is true, retries up to RATE_LIMIT_MAX_RETRIES times with
+ * exponential backoff and jitter (2s initial, 120s max).
  */
 export async function retryWithRateLimit<T>({
     fn,
@@ -54,21 +50,12 @@ export async function retryWithRateLimit<T>({
             return await fn();
         } catch (error) {
             if (error instanceof TooManyRequestsError && attempt < RATE_LIMIT_MAX_RETRIES) {
-                const retryAfterSeconds = error.retryAfterSeconds;
-                let delay: number;
-                if (retryAfterSeconds != null) {
-                    // Use the server-provided Retry-After value with a small jitter, capped at max
-                    const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
-                    delay = Math.min(Math.round(retryAfterSeconds * 1000 * jitter), RATE_LIMIT_MAX_RETRY_DELAY_MS);
-                } else {
-                    // Fall back to exponential backoff with jitter
-                    const baseDelay = Math.min(
-                        RATE_LIMIT_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
-                        RATE_LIMIT_MAX_RETRY_DELAY_MS
-                    );
-                    const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
-                    delay = Math.round(baseDelay * jitter);
-                }
+                const baseDelay = Math.min(
+                    RATE_LIMIT_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
+                    RATE_LIMIT_MAX_RETRY_DELAY_MS
+                );
+                const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
+                const delay = Math.round(baseDelay * jitter);
                 logger.warn(
                     `Received 429 Too Many Requests. Retrying in ${(delay / 1000).toFixed(1)}s (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES})...`
                 );

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -32,7 +32,8 @@ export async function runRemoteGenerationForAPIWorkspace({
     mode,
     fernignorePath,
     dynamicIrOnly,
-    validateWorkspace
+    validateWorkspace,
+    handleTooManyRequests
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     organization: string;
@@ -48,6 +49,7 @@ export async function runRemoteGenerationForAPIWorkspace({
     fernignorePath: string | undefined;
     dynamicIrOnly: boolean;
     validateWorkspace?: boolean;
+    handleTooManyRequests: boolean;
 }): Promise<RemoteGenerationForAPIWorkspaceResponse | null> {
     if (generatorGroup.generators.length === 0) {
         context.logger.warn("No generators specified.");
@@ -114,7 +116,8 @@ export async function runRemoteGenerationForAPIWorkspace({
                     irVersionOverride: generatorInvocation.irVersionOverride,
                     absolutePathToPreview,
                     fernignorePath,
-                    dynamicIrOnly
+                    dynamicIrOnly,
+                    handleTooManyRequests
                 });
                 if (remoteTaskHandlerResponse != null && remoteTaskHandlerResponse.createdSnippets) {
                     snippetsProducedBy.push(generatorInvocation);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -33,7 +33,7 @@ export async function runRemoteGenerationForAPIWorkspace({
     fernignorePath,
     dynamicIrOnly,
     validateWorkspace,
-    handleTooManyRequests
+    retryRateLimited
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     organization: string;
@@ -49,7 +49,7 @@ export async function runRemoteGenerationForAPIWorkspace({
     fernignorePath: string | undefined;
     dynamicIrOnly: boolean;
     validateWorkspace?: boolean;
-    handleTooManyRequests: boolean;
+    retryRateLimited: boolean;
 }): Promise<RemoteGenerationForAPIWorkspaceResponse | null> {
     if (generatorGroup.generators.length === 0) {
         context.logger.warn("No generators specified.");
@@ -117,7 +117,7 @@ export async function runRemoteGenerationForAPIWorkspace({
                     absolutePathToPreview,
                     fernignorePath,
                     dynamicIrOnly,
-                    handleTooManyRequests
+                    retryRateLimited
                 });
                 if (remoteTaskHandlerResponse != null && remoteTaskHandlerResponse.createdSnippets) {
                     snippetsProducedBy.push(generatorInvocation);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -36,7 +36,7 @@ export async function runRemoteGenerationForGenerator({
     readme,
     fernignorePath,
     dynamicIrOnly,
-    handleTooManyRequests
+    retryRateLimited
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     organization: string;
@@ -53,7 +53,7 @@ export async function runRemoteGenerationForGenerator({
     readme: generatorsYml.ReadmeSchema | undefined;
     fernignorePath: string | undefined;
     dynamicIrOnly: boolean;
-    handleTooManyRequests: boolean;
+    retryRateLimited: boolean;
 }): Promise<RemoteTaskHandler.Response | undefined> {
     const fdr = createFdrService({ token: token.value });
 
@@ -254,7 +254,7 @@ export async function runRemoteGenerationForGenerator({
         irVersionOverride,
         absolutePathToPreview,
         fernignorePath,
-        handleTooManyRequests
+        retryRateLimited
     });
     interactiveTaskContext.logger.debug(`Job ID: ${job.jobId}`);
 

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -35,7 +35,8 @@ export async function runRemoteGenerationForGenerator({
     absolutePathToPreview,
     readme,
     fernignorePath,
-    dynamicIrOnly
+    dynamicIrOnly,
+    handleTooManyRequests
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     organization: string;
@@ -52,6 +53,7 @@ export async function runRemoteGenerationForGenerator({
     readme: generatorsYml.ReadmeSchema | undefined;
     fernignorePath: string | undefined;
     dynamicIrOnly: boolean;
+    handleTooManyRequests: boolean;
 }): Promise<RemoteTaskHandler.Response | undefined> {
     const fdr = createFdrService({ token: token.value });
 
@@ -251,7 +253,8 @@ export async function runRemoteGenerationForGenerator({
         whitelabel: whitelabel != null ? substituteEnvVars(whitelabel) : undefined,
         irVersionOverride,
         absolutePathToPreview,
-        fernignorePath
+        fernignorePath,
+        handleTooManyRequests
     });
     interactiveTaskContext.logger.debug(`Job ID: ${job.jobId}`);
 


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger
[Link to Devin Session](https://app.devin.ai/sessions/03417b84322c4cf7b98e12e1c987e9ca)

Adds a `--retry-rate-limited` CLI flag to `fern generate` that enables automatic retry with exponential backoff and jitter when the remote generation service returns 429 Too Many Requests. Retries up to 3 times (2s → 4s → 8s with ±10% jitter, capped at 120s).

## Changes Made

- Added `--retry-rate-limited` boolean flag (default: `false`) to the `fern generate` command
- Threaded the flag through the full generation pipeline: `cli.ts` → `generateAPIWorkspaces` → `generateWorkspace` → `runRemoteGenerationForAPIWorkspace` → `runRemoteGenerationForGenerator` → `createAndStartJob`
- Extracted retry logic into a reusable `retryWithRateLimit` utility (`retryWithRateLimit.ts`) with:
  - Exponential backoff with jitter (2s initial, 120s max, 3 retries, 20% jitter)
  - Injectable `delayFn` for testability (defaults to `setTimeout`)
- When flag is **off** and a 429 is received, shows a helpful error message suggesting `--retry-rate-limited`
- When flag is **on**, retries with backoff and logs each retry attempt to the user
- Introduced `TooManyRequestsError` to cleanly signal 429s from within `createJob` before the error is consumed by `context.failAndThrow`
- 429 detection uses `rawError?.content?.reason === "status-code"` nesting to match the fiddle SDK's actual error shape (consistent with `convertCreateJobError`)
- Added `versions.yml` entry for v4.4.0
- [ ] Updated README.md generator (not applicable)

## Updates Since Last Revision

- **Removed dead Retry-After header code**: Investigation of the fiddle SDK source (`Fetcher.js` and `Fetcher.d.ts`) revealed that response headers are only included in successful responses (`ok: true`), not in error responses. The `Retry-After` header extraction at `rawError.content.headers?.["retry-after"]` was always `undefined`. Removed the dead code and simplified `TooManyRequestsError` (no longer carries `retryAfterSeconds`).
- **Simplified retry logic**: `retryWithRateLimit.ts` now only uses exponential backoff — the Retry-After branch was removed since it was unreachable.
- **Updated tests**: Removed 4 Retry-After-specific test cases; 12 tests remain covering all backoff/retry behavior.

## Human Review Checklist

- [ ] **Verify `biome-ignore` cast on error shape** — `createAndStartJob.ts` uses `as any` with a `biome-ignore` comment to access the nested error structure (`rawError?.content?.reason`). This matches the pattern used by `convertCreateJobError` on the same file, but if the fiddle SDK changes its error wrapping, the 429 detection could break silently.
- [ ] **Verify SDK's built-in 429 retry interaction** — The fiddle SDK's `Fetcher.js` already retries 429s internally (up to 2 retries with exponential backoff). When the SDK exhausts its retries and surfaces a 429 error, the CLI's `--retry-rate-limited` adds 3 more retry attempts. This means up to ~5 total attempts occur. Verify this interaction is acceptable.
- [ ] **Verify `versions.yml` changelog entry accuracy** — The changelog mentions "When a server provides a `Retry-After` header, that value is used" but the code no longer supports this. Consider updating the changelog to remove the Retry-After reference.
- [ ] Verify the unreachable fallback in `retryWithRateLimit.ts` throws a plain `Error` instead of calling `context.failAndThrow` — this is fine since the code path is unreachable, but differs slightly from the original pattern.
- [ ] Verify retry logic: exponential backoff formula (2s → 4s → 8s), jitter calculation (±10%), max retries (3)
- [ ] Confirm the helpful error message (when flag is off) is user-friendly
- [ ] Verify the flag is threaded correctly through all layers (including `LegacyRemoteGenerationRunner` in cli-v2, which defaults to `false`)

## Testing

- [x] Lint checks passed (`pnpm lint:biome`, `biome check`)
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] All required CI checks passing (compile, lint, biome, depcheck, test, test-ete, Validate versions.yml)
- [x] Validate Changelogs passing (v4.4.0 minor bump for feat)
- [x] Unit tests added — 12 tests in `retryWithRateLimit.test.ts` covering:
  - `TooManyRequestsError` construction
  - `retryRateLimited=false`: pass-through success, 429 → `onRateLimitedWithoutRetry`, non-429 rethrow
  - `retryRateLimited=true`: retry then succeed, max retries exhaustion (4 calls total), non-429 immediate rethrow
  - Exponential backoff delays (2s → 4s → 8s with no jitter)
  - Jitter application (±10% based on mocked `Math.random`)
  - Exponential backoff max delay cap verification (≤120s)
  - Attempt count in warning logs (`attempt 1/3`, `attempt 2/3`, etc.)
- [ ] Manual testing not performed (requires hitting rate limits on production services)

**Note**: End-to-end testing with real 429 responses was not performed. Unit tests verify the retry logic, delay calculations, and error handling paths, but do not test the 429 detection in `createJob` or the integration with the fiddle SDK's actual error shape.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
