### PR TITLE
Update copyright from 2025 to 2026

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AbstractWebSocketChannelWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AbstractWebSocketChannelWriter.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2025 Birch Solutions Inc. All rights reserved.
+ * (c) Copyright 2026 Birch Solutions Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AsyncWebSocketChannelWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AsyncWebSocketChannelWriter.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2025 Birch Solutions Inc. All rights reserved.
+ * (c) Copyright 2026 Birch Solutions Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/SyncWebSocketChannelWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/SyncWebSocketChannelWriter.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2025 Birch Solutions Inc. All rights reserved.
+ * (c) Copyright 2026 Birch Solutions Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Refs: Requested by @kgowru
[Devin session](https://app.devin.ai/sessions/cc1428e2471940088f76b22acf765d81)

Updates the copyright year in Birch Solutions Inc. license headers from 2025 to 2026.

## Changes Made
- Updated `(c) Copyright 2025 Birch Solutions Inc.` → `(c) Copyright 2026 Birch Solutions Inc.` in 3 Java websocket files under `generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/`

## Human Review Checklist
- [ ] Verify no other hand-written files in the repo still reference `Copyright 2025 Birch Solutions` (note: third-party copyrights like Font Awesome and NVIDIA in test fixtures were intentionally left unchanged)
- [ ] Note: auto-generated files under `fern-generated/` directories are not updated here — they will pick up the new year on next generation

## Testing
- No functional code changes; only copyright header text updated
- Pre-commit hooks passed successfully