### PR TITLE
fix(cli): deduplicate npm install to prevent concurrent tar extraction races

### DIFF
--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -245,10 +245,7 @@ export class GeneratorMigrator {
      * If package.json is missing after install (corrupt tar extraction),
      * wipes the cache and retries once.
      */
-    private async installWithRetry(params: {
-        cacheDir: string;
-        packageJsonPath: string;
-    }): Promise<{ main?: string }> {
+    private async installWithRetry(params: { cacheDir: string; packageJsonPath: string }): Promise<{ main?: string }> {
         const { cacheDir, packageJsonPath } = params;
 
         // First attempt

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -171,7 +171,10 @@ export class GeneratorMigrator {
      */
     private async ensureMigrationsInstalled(): Promise<Record<string, MigrationModule> | undefined> {
         if (this.migrationsInstallPromise != null) {
-            return this.migrationsInstallPromise;
+            return this.migrationsInstallPromise.catch((err) => {
+                this.migrationsInstallPromise = undefined;
+                throw err;
+            });
         }
 
         this.migrationsInstallPromise = (async () => {
@@ -212,7 +215,7 @@ export class GeneratorMigrator {
             return migrations as Record<string, MigrationModule>;
         })();
 
-        // Reset the cached promise on failure so subsequent calls can retry.
+        // Reset the cached promise on failure so the next call can retry.
         this.migrationsInstallPromise.catch(() => {
             this.migrationsInstallPromise = undefined;
         });

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -3,7 +3,7 @@ import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import type { Migration, MigrationModule, MigratorResult } from "@fern-api/migrations-base";
-import { mkdir, readFile } from "fs/promises";
+import { access, mkdir, readFile, rm } from "fs/promises";
 import { join } from "path";
 import semver from "semver";
 import type { FernYmlEditor } from "../../config/fern-yml/FernYmlEditor.js";
@@ -11,6 +11,18 @@ import type { Target } from "../config/Target.js";
 
 /** The unified npm package containing all generator migrations. */
 const MIGRATION_PACKAGE_NAME = "@fern-api/generator-migrations";
+
+/**
+ * Checks whether a file exists on disk.
+ */
+async function fileExists(filePath: string): Promise<boolean> {
+    try {
+        await access(filePath);
+        return true;
+    } catch {
+        return false;
+    }
+}
 
 export namespace GeneratorMigrator {
     export interface Config {
@@ -158,31 +170,21 @@ export class GeneratorMigrator {
      * Downloads and loads the migration module for a specific generator.
      * Installs `@fern-api/generator-migrations@latest` into the cache
      * directory and imports the module for the given generator name.
+     *
+     * Uses an isolated npm cache and verifies extraction succeeded.
+     * If the first install results in a corrupt extraction (npm
+     * TAR_ENTRY_ERROR -- npm exits 0 but files are missing), the cache
+     * directory is deleted and the install is retried once.
      */
     private async loadMigrationModule(generatorName: string): Promise<MigrationModule | undefined> {
         const cacheDir = this.cachePath as string;
         await mkdir(cacheDir, { recursive: true });
 
         try {
-            await loggingExeca(
-                this.logger,
-                "npm",
-                [
-                    "install",
-                    `${MIGRATION_PACKAGE_NAME}@latest`,
-                    "--prefix",
-                    cacheDir,
-                    "--ignore-scripts",
-                    "--no-audit",
-                    "--no-fund"
-                ],
-                { doNotPipeOutput: true }
-            );
-
             const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
             const packageJsonPath = join(packageDir, "package.json");
-            const packageJsonContent = await readFile(packageJsonPath, "utf-8");
-            const packageJson = JSON.parse(packageJsonContent) as { main?: string };
+
+            const packageJson = await this.installWithRetry({ cacheDir, packageJsonPath });
 
             if (packageJson.main == null) {
                 throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
@@ -212,6 +214,72 @@ export class GeneratorMigrator {
                     `Please check your internet connection and npm configuration, then try again.`
             );
         }
+    }
+
+    /**
+     * Runs `npm install` for the migration package into the given cache
+     * directory with an isolated npm cache to avoid system cache corruption.
+     */
+    private async runNpmInstall(cacheDir: string): Promise<void> {
+        const npmCacheDir = join(cacheDir, ".npm-cache");
+        await loggingExeca(
+            this.logger,
+            "npm",
+            [
+                "install",
+                `${MIGRATION_PACKAGE_NAME}@latest`,
+                "--prefix",
+                cacheDir,
+                "--cache",
+                npmCacheDir,
+                "--ignore-scripts",
+                "--no-audit",
+                "--no-fund"
+            ],
+            { doNotPipeOutput: true }
+        );
+    }
+
+    /**
+     * Installs the migration package and verifies extraction succeeded.
+     * If package.json is missing after install (corrupt tar extraction),
+     * wipes the cache and retries once.
+     */
+    private async installWithRetry(params: {
+        cacheDir: string;
+        packageJsonPath: string;
+    }): Promise<{ main?: string }> {
+        const { cacheDir, packageJsonPath } = params;
+
+        // First attempt
+        await this.runNpmInstall(cacheDir);
+
+        if (await fileExists(packageJsonPath)) {
+            const content = await readFile(packageJsonPath, "utf-8");
+            return JSON.parse(content) as { main?: string };
+        }
+
+        // package.json missing after install -- likely a corrupt tar extraction.
+        // Wipe the entire cache directory (including the isolated npm cache) and retry once.
+        this.logger.warn(
+            `Migration package extraction appears corrupt (package.json missing after install). ` +
+                `Clearing cache and retrying...`
+        );
+        await rm(cacheDir, { recursive: true, force: true });
+        await mkdir(cacheDir, { recursive: true });
+
+        // Second (and final) attempt
+        await this.runNpmInstall(cacheDir);
+
+        if (!(await fileExists(packageJsonPath))) {
+            throw new Error(
+                `${MIGRATION_PACKAGE_NAME} installation failed: package.json is missing after install and retry. ` +
+                    `This may indicate a corrupt npm cache or a problem with the published package.`
+            );
+        }
+
+        const content = await readFile(packageJsonPath, "utf-8");
+        return JSON.parse(content) as { main?: string };
     }
 
     /**

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -212,6 +212,11 @@ export class GeneratorMigrator {
             return migrations as Record<string, MigrationModule>;
         })();
 
+        // Reset the cached promise on failure so subsequent calls can retry.
+        this.migrationsInstallPromise.catch(() => {
+            this.migrationsInstallPromise = undefined;
+        });
+
         return this.migrationsInstallPromise;
     }
 

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -3,7 +3,7 @@ import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import type { Migration, MigrationModule, MigratorResult } from "@fern-api/migrations-base";
-import { access, mkdir, readFile, rm } from "fs/promises";
+import { mkdir, readFile } from "fs/promises";
 import { join } from "path";
 import semver from "semver";
 import type { FernYmlEditor } from "../../config/fern-yml/FernYmlEditor.js";
@@ -11,18 +11,6 @@ import type { Target } from "../config/Target.js";
 
 /** The unified npm package containing all generator migrations. */
 const MIGRATION_PACKAGE_NAME = "@fern-api/generator-migrations";
-
-/**
- * Checks whether a file exists on disk.
- */
-async function fileExists(filePath: string): Promise<boolean> {
-    try {
-        await access(filePath);
-        return true;
-    } catch {
-        return false;
-    }
-}
 
 export namespace GeneratorMigrator {
     export interface Config {
@@ -53,6 +41,14 @@ export namespace GeneratorMigrator {
 export class GeneratorMigrator {
     private readonly logger: Logger;
     private readonly cachePath: AbsoluteFilePath;
+
+    /**
+     * Instance-level promise that ensures the migration package is installed
+     * only once per GeneratorMigrator instance. Subsequent calls to
+     * loadMigrationModule reuse the cached result instead of re-running
+     * npm install.
+     */
+    private migrationsInstallPromise: Promise<Record<string, MigrationModule> | undefined> | undefined;
 
     constructor(config: GeneratorMigrator.Config) {
         this.logger = config.logger;
@@ -167,24 +163,45 @@ export class GeneratorMigrator {
     }
 
     /**
-     * Downloads and loads the migration module for a specific generator.
-     * Installs `@fern-api/generator-migrations@latest` into the cache
-     * directory and imports the module for the given generator name.
+     * Installs the migration package once and returns the full migrations map.
+     * Uses an isolated npm cache to avoid corruption from the system npm cache.
      *
-     * Uses an isolated npm cache and verifies extraction succeeded.
-     * If the first install results in a corrupt extraction (npm
-     * TAR_ENTRY_ERROR -- npm exits 0 but files are missing), the cache
-     * directory is deleted and the install is retried once.
+     * Subsequent calls reuse the cached result, avoiding redundant npm installs
+     * when migrating multiple generators in the same session.
      */
-    private async loadMigrationModule(generatorName: string): Promise<MigrationModule | undefined> {
-        const cacheDir = this.cachePath as string;
-        await mkdir(cacheDir, { recursive: true });
+    private async ensureMigrationsInstalled(): Promise<Record<string, MigrationModule> | undefined> {
+        if (this.migrationsInstallPromise != null) {
+            return this.migrationsInstallPromise;
+        }
 
-        try {
+        this.migrationsInstallPromise = (async () => {
+            const cacheDir = this.cachePath as string;
+            await mkdir(cacheDir, { recursive: true });
+
+            // Use an isolated npm cache inside the migration cache dir to prevent
+            // corrupt system-level npm cache entries from causing repeated failures.
+            const npmCacheDir = join(cacheDir, ".npm-cache");
+            await loggingExeca(
+                this.logger,
+                "npm",
+                [
+                    "install",
+                    `${MIGRATION_PACKAGE_NAME}@latest`,
+                    "--prefix",
+                    cacheDir,
+                    "--cache",
+                    npmCacheDir,
+                    "--ignore-scripts",
+                    "--no-audit",
+                    "--no-fund"
+                ],
+                { doNotPipeOutput: true }
+            );
+
             const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
             const packageJsonPath = join(packageDir, "package.json");
-
-            const packageJson = await this.installWithRetry({ cacheDir, packageJsonPath });
+            const packageJsonContent = await readFile(packageJsonPath, "utf-8");
+            const packageJson = JSON.parse(packageJsonContent) as { main?: string };
 
             if (packageJson.main == null) {
                 throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
@@ -192,8 +209,24 @@ export class GeneratorMigrator {
 
             const packageEntryPoint = join(packageDir, packageJson.main);
             const { migrations } = await import(packageEntryPoint);
+            return migrations as Record<string, MigrationModule>;
+        })();
 
-            const module = migrations[generatorName] as MigrationModule | undefined;
+        return this.migrationsInstallPromise;
+    }
+
+    /**
+     * Loads the migration module for a specific generator from the cached
+     * migrations map. The underlying npm install is only performed once.
+     */
+    private async loadMigrationModule(generatorName: string): Promise<MigrationModule | undefined> {
+        try {
+            const migrationsMap = await this.ensureMigrationsInstalled();
+            if (migrationsMap == null) {
+                return undefined;
+            }
+
+            const module = migrationsMap[generatorName] as MigrationModule | undefined;
             if (module == null) {
                 this.logger.debug(`No migrations registered for generator: ${generatorName}.`);
                 return undefined;
@@ -214,69 +247,6 @@ export class GeneratorMigrator {
                     `Please check your internet connection and npm configuration, then try again.`
             );
         }
-    }
-
-    /**
-     * Runs `npm install` for the migration package into the given cache
-     * directory with an isolated npm cache to avoid system cache corruption.
-     */
-    private async runNpmInstall(cacheDir: string): Promise<void> {
-        const npmCacheDir = join(cacheDir, ".npm-cache");
-        await loggingExeca(
-            this.logger,
-            "npm",
-            [
-                "install",
-                `${MIGRATION_PACKAGE_NAME}@latest`,
-                "--prefix",
-                cacheDir,
-                "--cache",
-                npmCacheDir,
-                "--ignore-scripts",
-                "--no-audit",
-                "--no-fund"
-            ],
-            { doNotPipeOutput: true }
-        );
-    }
-
-    /**
-     * Installs the migration package and verifies extraction succeeded.
-     * If package.json is missing after install (corrupt tar extraction),
-     * wipes the cache and retries once.
-     */
-    private async installWithRetry(params: { cacheDir: string; packageJsonPath: string }): Promise<{ main?: string }> {
-        const { cacheDir, packageJsonPath } = params;
-
-        // First attempt
-        await this.runNpmInstall(cacheDir);
-
-        if (await fileExists(packageJsonPath)) {
-            const content = await readFile(packageJsonPath, "utf-8");
-            return JSON.parse(content) as { main?: string };
-        }
-
-        // package.json missing after install -- likely a corrupt tar extraction.
-        // Wipe the entire cache directory (including the isolated npm cache) and retry once.
-        this.logger.warn(
-            `Migration package extraction appears corrupt (package.json missing after install). ` +
-                `Clearing cache and retrying...`
-        );
-        await rm(cacheDir, { recursive: true, force: true });
-        await mkdir(cacheDir, { recursive: true });
-
-        // Second (and final) attempt
-        await this.runNpmInstall(cacheDir);
-
-        if (!(await fileExists(packageJsonPath))) {
-            throw new Error(
-                `${MIGRATION_PACKAGE_NAME} installation failed: package.json is missing after install and retry. ` +
-                    `This may indicate a corrupt npm cache or a problem with the published package.`
-            );
-        }
-
-        const content = await readFile(packageJsonPath, "utf-8");
-        return JSON.parse(content) as { main?: string };
     }
 
     /**

--- a/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
@@ -5,6 +5,7 @@
  * 1. Concurrent calls to loadMigrationModule only trigger a single npm install
  * 2. Failed installs reset the cached promise so subsequent calls can retry
  */
+import type { Logger } from "@fern-api/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Track npm install calls
@@ -61,10 +62,18 @@ const mockMigrationsMap = {
     }
 };
 
-// We need to mock the dynamic import() call inside ensureMigrationsInstalled.
-// Since it uses `await import(packageEntryPoint)`, we mock it at the global level.
-// vitest doesn't directly mock dynamic imports, so we use vi.stubGlobal or
-// mock the module resolution.
+function createMockLogger(): Logger {
+    return {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn()
+    };
+}
 
 describe("Migration loader deduplication", () => {
     beforeEach(async () => {
@@ -102,27 +111,23 @@ describe("Migration loader deduplication", () => {
         // We need to mock the dynamic import that happens inside ensureMigrationsInstalled.
         // The function does: const { migrations } = await import(packageEntryPoint);
         // We mock the path module to return a predictable path, then mock that path's import.
-        vi.doMock("/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js", () => ({
-            migrations: mockMigrationsMap
-        }));
+        vi.doMock(
+            "/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js",
+            () => ({
+                migrations: mockMigrationsMap
+            })
+        );
 
         const { loadMigrationModule } = await import("../loader.js");
-        const mockLogger = {
-            info: vi.fn(),
-            error: vi.fn(),
-            warn: vi.fn(),
-            debug: vi.fn(),
-            log: vi.fn(),
-            trace: vi.fn()
-        };
+        const mockLogger = createMockLogger();
 
         // Simulate 5 concurrent calls (like 5 workspaces in Promise.all)
         const results = await Promise.all([
-            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger as any }),
-            loadMigrationModule({ generatorName: "fernapi/fern-python-sdk", logger: mockLogger as any }),
-            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger as any }),
-            loadMigrationModule({ generatorName: "fernapi/fern-python-sdk", logger: mockLogger as any }),
-            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger as any })
+            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger }),
+            loadMigrationModule({ generatorName: "fernapi/fern-python-sdk", logger: mockLogger }),
+            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger }),
+            loadMigrationModule({ generatorName: "fernapi/fern-python-sdk", logger: mockLogger }),
+            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger })
         ]);
 
         // KEY ASSERTION: npm install should have been called exactly ONCE
@@ -143,25 +148,21 @@ describe("Migration loader deduplication", () => {
     });
 
     it("should retry npm install after a transient failure", async () => {
-        vi.doMock("/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js", () => ({
-            migrations: mockMigrationsMap
-        }));
+        vi.doMock(
+            "/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js",
+            () => ({
+                migrations: mockMigrationsMap
+            })
+        );
 
         const { loadMigrationModule } = await import("../loader.js");
-        const mockLogger = {
-            info: vi.fn(),
-            error: vi.fn(),
-            warn: vi.fn(),
-            debug: vi.fn(),
-            log: vi.fn(),
-            trace: vi.fn()
-        };
+        const mockLogger = createMockLogger();
 
         // First call: make npm install fail
         shouldFailNpmInstall = true;
 
         await expect(
-            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger as any })
+            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger })
         ).rejects.toThrow();
 
         expect(npmInstallCallCount).toBe(1);
@@ -174,7 +175,7 @@ describe("Migration loader deduplication", () => {
 
         const result = await loadMigrationModule({
             generatorName: "fernapi/fern-typescript-sdk",
-            logger: mockLogger as any
+            logger: mockLogger
         });
 
         // KEY ASSERTION: npm install should have been called TWICE total
@@ -185,23 +186,19 @@ describe("Migration loader deduplication", () => {
     });
 
     it("should return undefined for unknown generators", async () => {
-        vi.doMock("/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js", () => ({
-            migrations: mockMigrationsMap
-        }));
+        vi.doMock(
+            "/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js",
+            () => ({
+                migrations: mockMigrationsMap
+            })
+        );
 
         const { loadMigrationModule } = await import("../loader.js");
-        const mockLogger = {
-            info: vi.fn(),
-            error: vi.fn(),
-            warn: vi.fn(),
-            debug: vi.fn(),
-            log: vi.fn(),
-            trace: vi.fn()
-        };
+        const mockLogger = createMockLogger();
 
         const result = await loadMigrationModule({
             generatorName: "fernapi/fern-unknown-sdk",
-            logger: mockLogger as any
+            logger: mockLogger
         });
 
         expect(result).toBeUndefined();

--- a/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the deduplication fix in loader.ts.
+ *
+ * Verifies that:
+ * 1. Concurrent calls to loadMigrationModule only trigger a single npm install
+ * 2. Failed installs reset the cached promise so subsequent calls can retry
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Track npm install calls
+let npmInstallCallCount = 0;
+let shouldFailNpmInstall = false;
+
+// Mock loggingExeca to count npm install invocations
+vi.mock("@fern-api/logging-execa", () => ({
+    loggingExeca: vi.fn(async (_logger: unknown, command: string, args: string[]) => {
+        if (command === "npm" && args[0] === "install") {
+            npmInstallCallCount++;
+            if (shouldFailNpmInstall) {
+                throw new Error("npm install failed: simulated network error");
+            }
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+    })
+}));
+
+// Mock fs/promises
+vi.mock("fs/promises", () => ({
+    mkdir: vi.fn(async () => undefined),
+    readFile: vi.fn(async () =>
+        JSON.stringify({
+            name: "@fern-api/generator-migrations",
+            main: "./dist/index.js"
+        })
+    )
+}));
+
+// Mock os.homedir
+vi.mock("os", () => ({
+    homedir: vi.fn(() => "/tmp/test-fern-home")
+}));
+
+// Mock the dynamic import of the migration entry point
+// This simulates what happens when we import the installed package
+const mockMigrationsMap = {
+    "fernapi/fern-typescript-sdk": {
+        migrations: [
+            {
+                version: "1.5.0",
+                migrateGeneratorConfig: ({ config }: { config: unknown }) => config
+            }
+        ]
+    },
+    "fernapi/fern-python-sdk": {
+        migrations: [
+            {
+                version: "2.0.0",
+                migrateGeneratorConfig: ({ config }: { config: unknown }) => config
+            }
+        ]
+    }
+};
+
+// We need to mock the dynamic import() call inside ensureMigrationsInstalled.
+// Since it uses `await import(packageEntryPoint)`, we mock it at the global level.
+// vitest doesn't directly mock dynamic imports, so we use vi.stubGlobal or
+// mock the module resolution.
+
+describe("Migration loader deduplication", () => {
+    beforeEach(async () => {
+        npmInstallCallCount = 0;
+        shouldFailNpmInstall = false;
+        // Reset the module to clear the module-level migrationsInstallPromise
+        vi.resetModules();
+        // Re-apply mocks after module reset
+        vi.doMock("@fern-api/logging-execa", () => ({
+            loggingExeca: vi.fn(async (_logger: unknown, command: string, args: string[]) => {
+                if (command === "npm" && args[0] === "install") {
+                    npmInstallCallCount++;
+                    if (shouldFailNpmInstall) {
+                        throw new Error("npm install failed: simulated network error");
+                    }
+                }
+                return { stdout: "", stderr: "", exitCode: 0 };
+            })
+        }));
+        vi.doMock("fs/promises", () => ({
+            mkdir: vi.fn(async () => undefined),
+            readFile: vi.fn(async () =>
+                JSON.stringify({
+                    name: "@fern-api/generator-migrations",
+                    main: "./dist/index.js"
+                })
+            )
+        }));
+        vi.doMock("os", () => ({
+            homedir: vi.fn(() => "/tmp/test-fern-home")
+        }));
+    });
+
+    it("should only run npm install once when called concurrently", async () => {
+        // We need to mock the dynamic import that happens inside ensureMigrationsInstalled.
+        // The function does: const { migrations } = await import(packageEntryPoint);
+        // We mock the path module to return a predictable path, then mock that path's import.
+        vi.doMock("/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js", () => ({
+            migrations: mockMigrationsMap
+        }));
+
+        const { loadMigrationModule } = await import("../loader.js");
+        const mockLogger = {
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+            debug: vi.fn(),
+            log: vi.fn(),
+            trace: vi.fn()
+        };
+
+        // Simulate 5 concurrent calls (like 5 workspaces in Promise.all)
+        const results = await Promise.all([
+            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger as any }),
+            loadMigrationModule({ generatorName: "fernapi/fern-python-sdk", logger: mockLogger as any }),
+            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger as any }),
+            loadMigrationModule({ generatorName: "fernapi/fern-python-sdk", logger: mockLogger as any }),
+            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger as any })
+        ]);
+
+        // KEY ASSERTION: npm install should have been called exactly ONCE
+        expect(npmInstallCallCount).toBe(1);
+
+        // All calls should resolve successfully
+        expect(results[0]).toBeDefined(); // typescript-sdk
+        expect(results[1]).toBeDefined(); // python-sdk
+        expect(results[2]).toBeDefined(); // typescript-sdk (same as [0])
+        expect(results[3]).toBeDefined(); // python-sdk (same as [1])
+        expect(results[4]).toBeDefined(); // typescript-sdk (same as [0])
+
+        // The migration modules should have the expected structure
+        expect(results[0]?.migrations).toHaveLength(1);
+        expect(results[0]?.migrations[0]?.version).toBe("1.5.0");
+        expect(results[1]?.migrations).toHaveLength(1);
+        expect(results[1]?.migrations[0]?.version).toBe("2.0.0");
+    });
+
+    it("should retry npm install after a transient failure", async () => {
+        vi.doMock("/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js", () => ({
+            migrations: mockMigrationsMap
+        }));
+
+        const { loadMigrationModule } = await import("../loader.js");
+        const mockLogger = {
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+            debug: vi.fn(),
+            log: vi.fn(),
+            trace: vi.fn()
+        };
+
+        // First call: make npm install fail
+        shouldFailNpmInstall = true;
+
+        await expect(
+            loadMigrationModule({ generatorName: "fernapi/fern-typescript-sdk", logger: mockLogger as any })
+        ).rejects.toThrow();
+
+        expect(npmInstallCallCount).toBe(1);
+
+        // Second call: npm install should succeed now
+        shouldFailNpmInstall = false;
+
+        // Allow the .catch() handler to run (it resets the cached promise)
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        const result = await loadMigrationModule({
+            generatorName: "fernapi/fern-typescript-sdk",
+            logger: mockLogger as any
+        });
+
+        // KEY ASSERTION: npm install should have been called TWICE total
+        // (first failed, second succeeded after promise was reset)
+        expect(npmInstallCallCount).toBe(2);
+        expect(result).toBeDefined();
+        expect(result?.migrations).toHaveLength(1);
+    });
+
+    it("should return undefined for unknown generators", async () => {
+        vi.doMock("/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js", () => ({
+            migrations: mockMigrationsMap
+        }));
+
+        const { loadMigrationModule } = await import("../loader.js");
+        const mockLogger = {
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+            debug: vi.fn(),
+            log: vi.fn(),
+            trace: vi.fn()
+        };
+
+        const result = await loadMigrationModule({
+            generatorName: "fernapi/fern-unknown-sdk",
+            logger: mockLogger as any
+        });
+
+        expect(result).toBeUndefined();
+        // npm install should still have been called once to load the package
+        expect(npmInstallCallCount).toBe(1);
+    });
+});

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -1,7 +1,7 @@
 import type { generatorsYml } from "@fern-api/configuration";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { mkdir, readFile } from "fs/promises";
+import { access, mkdir, readFile, rm } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import semver from "semver";
@@ -23,6 +23,89 @@ const MIGRATION_PACKAGE_NAME = "@fern-api/generator-migrations";
  */
 function getMigrationCacheDir(): string {
     return join(homedir(), ".fern", "migration-cache");
+}
+
+/**
+ * Checks whether a file exists on disk.
+ */
+async function fileExists(filePath: string): Promise<boolean> {
+    try {
+        await access(filePath);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Runs `npm install` for the migration package into the given cache directory.
+ * Uses an isolated npm cache directory to avoid corruption from the system npm cache.
+ *
+ * @param params.cacheDir - The --prefix directory for npm install
+ * @param params.logger - Logger for user feedback
+ */
+async function runNpmInstall(params: { cacheDir: string; logger: Logger }): Promise<void> {
+    const { cacheDir, logger } = params;
+    // Use an isolated npm cache inside the migration cache dir to prevent
+    // corrupt system-level npm cache entries from causing repeated failures.
+    const npmCacheDir = join(cacheDir, ".npm-cache");
+    await loggingExeca(logger, "npm", [
+        "install",
+        `${MIGRATION_PACKAGE_NAME}@latest`,
+        "--prefix",
+        cacheDir,
+        "--cache",
+        npmCacheDir,
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund"
+    ]);
+}
+
+/**
+ * Installs the migration package and verifies extraction succeeded by checking
+ * that `package.json` exists. If the first install results in a corrupt
+ * extraction (npm TAR_ENTRY_ERROR — npm exits 0 but files are missing), the
+ * cache directory is deleted and the install is retried once.
+ *
+ * @returns The parsed package.json of the installed migration package
+ */
+async function installWithRetry(params: {
+    cacheDir: string;
+    packageJsonPath: string;
+    logger: Logger;
+}): Promise<{ main?: string }> {
+    const { cacheDir, packageJsonPath, logger } = params;
+
+    // First attempt
+    await runNpmInstall({ cacheDir, logger });
+
+    if (await fileExists(packageJsonPath)) {
+        const content = await readFile(packageJsonPath, "utf-8");
+        return JSON.parse(content) as { main?: string };
+    }
+
+    // package.json missing after install — likely a corrupt tar extraction.
+    // Wipe the entire cache directory (including the isolated npm cache) and retry once.
+    logger.warn(
+        `Migration package extraction appears corrupt (package.json missing after install). ` +
+            `Clearing cache and retrying...`
+    );
+    await rm(cacheDir, { recursive: true, force: true });
+    await mkdir(cacheDir, { recursive: true });
+
+    // Second (and final) attempt
+    await runNpmInstall({ cacheDir, logger });
+
+    if (!(await fileExists(packageJsonPath))) {
+        throw new Error(
+            `${MIGRATION_PACKAGE_NAME} installation failed: package.json is missing after install and retry. ` +
+                `This may indicate a corrupt npm cache or a problem with the published package.`
+        );
+    }
+
+    const content = await readFile(packageJsonPath, "utf-8");
+    return JSON.parse(content) as { main?: string };
 }
 
 /**
@@ -58,26 +141,11 @@ export async function loadMigrationModule(params: {
     await mkdir(cacheDir, { recursive: true });
 
     try {
-        // Install/update the unified migration package to the cache directory
-        // npm will check if @latest is already installed and skip reinstallation if so
-        // --ignore-scripts: Security - prevent running arbitrary code during install
-        // --no-audit: Skip audit checks for faster installation
-        // --no-fund: Skip funding messages
-        await loggingExeca(logger, "npm", [
-            "install",
-            `${MIGRATION_PACKAGE_NAME}@latest`,
-            "--prefix",
-            cacheDir,
-            "--ignore-scripts",
-            "--no-audit",
-            "--no-fund"
-        ]);
-
-        // Read the package.json to get the entry point from the main field
         const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
         const packageJsonPath = join(packageDir, "package.json");
-        const packageJsonContent = await readFile(packageJsonPath, "utf-8");
-        const packageJson = JSON.parse(packageJsonContent) as { main?: string };
+
+        // Attempt to install and load the migration package, with one retry on corrupt extraction
+        const packageJson = await installWithRetry({ cacheDir, packageJsonPath, logger });
 
         if (packageJson.main == null) {
             throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -80,6 +80,11 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
         return migrations as Record<string, MigrationModule>;
     })();
 
+    // Reset the cached promise on failure so subsequent calls can retry.
+    migrationsInstallPromise.catch(() => {
+        migrationsInstallPromise = undefined;
+    });
+
     return migrationsInstallPromise;
 }
 

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -1,7 +1,7 @@
 import type { generatorsYml } from "@fern-api/configuration";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { access, mkdir, readFile, rm } from "fs/promises";
+import { mkdir, readFile } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import semver from "semver";
@@ -26,86 +26,61 @@ function getMigrationCacheDir(): string {
 }
 
 /**
- * Checks whether a file exists on disk.
+ * Module-level promise that ensures the migration package is installed only once
+ * per CLI process. When multiple workspaces are upgraded concurrently via
+ * Promise.all, they all await this single promise instead of racing on
+ * concurrent npm installs to the same --prefix directory (which causes
+ * TAR_ENTRY_ERROR and missing files).
  */
-async function fileExists(filePath: string): Promise<boolean> {
-    try {
-        await access(filePath);
-        return true;
-    } catch {
-        return false;
-    }
-}
+let migrationsInstallPromise: Promise<Record<string, MigrationModule> | undefined> | undefined;
 
 /**
- * Runs `npm install` for the migration package into the given cache directory.
- * Uses an isolated npm cache directory to avoid corruption from the system npm cache.
+ * Installs the migration package once and returns the full migrations map.
+ * Uses an isolated npm cache to avoid corruption from the system npm cache.
  *
- * @param params.cacheDir - The --prefix directory for npm install
- * @param params.logger - Logger for user feedback
+ * Concurrent calls reuse the same in-flight promise, preventing the race
+ * condition where multiple npm installs to the same --prefix directory cause
+ * tar extraction failures.
  */
-async function runNpmInstall(params: { cacheDir: string; logger: Logger }): Promise<void> {
-    const { cacheDir, logger } = params;
-    // Use an isolated npm cache inside the migration cache dir to prevent
-    // corrupt system-level npm cache entries from causing repeated failures.
-    const npmCacheDir = join(cacheDir, ".npm-cache");
-    await loggingExeca(logger, "npm", [
-        "install",
-        `${MIGRATION_PACKAGE_NAME}@latest`,
-        "--prefix",
-        cacheDir,
-        "--cache",
-        npmCacheDir,
-        "--ignore-scripts",
-        "--no-audit",
-        "--no-fund"
-    ]);
-}
-
-/**
- * Installs the migration package and verifies extraction succeeded by checking
- * that `package.json` exists. If the first install results in a corrupt
- * extraction (npm TAR_ENTRY_ERROR — npm exits 0 but files are missing), the
- * cache directory is deleted and the install is retried once.
- *
- * @returns The parsed package.json of the installed migration package
- */
-async function installWithRetry(params: {
-    cacheDir: string;
-    packageJsonPath: string;
-    logger: Logger;
-}): Promise<{ main?: string }> {
-    const { cacheDir, packageJsonPath, logger } = params;
-
-    // First attempt
-    await runNpmInstall({ cacheDir, logger });
-
-    if (await fileExists(packageJsonPath)) {
-        const content = await readFile(packageJsonPath, "utf-8");
-        return JSON.parse(content) as { main?: string };
+async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string, MigrationModule> | undefined> {
+    if (migrationsInstallPromise != null) {
+        return migrationsInstallPromise;
     }
 
-    // package.json missing after install — likely a corrupt tar extraction.
-    // Wipe the entire cache directory (including the isolated npm cache) and retry once.
-    logger.warn(
-        `Migration package extraction appears corrupt (package.json missing after install). ` +
-            `Clearing cache and retrying...`
-    );
-    await rm(cacheDir, { recursive: true, force: true });
-    await mkdir(cacheDir, { recursive: true });
+    migrationsInstallPromise = (async () => {
+        const cacheDir = getMigrationCacheDir();
+        await mkdir(cacheDir, { recursive: true });
 
-    // Second (and final) attempt
-    await runNpmInstall({ cacheDir, logger });
+        // Use an isolated npm cache inside the migration cache dir to prevent
+        // corrupt system-level npm cache entries from causing repeated failures.
+        const npmCacheDir = join(cacheDir, ".npm-cache");
+        await loggingExeca(logger, "npm", [
+            "install",
+            `${MIGRATION_PACKAGE_NAME}@latest`,
+            "--prefix",
+            cacheDir,
+            "--cache",
+            npmCacheDir,
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund"
+        ]);
 
-    if (!(await fileExists(packageJsonPath))) {
-        throw new Error(
-            `${MIGRATION_PACKAGE_NAME} installation failed: package.json is missing after install and retry. ` +
-                `This may indicate a corrupt npm cache or a problem with the published package.`
-        );
-    }
+        const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
+        const packageJsonPath = join(packageDir, "package.json");
+        const packageJsonContent = await readFile(packageJsonPath, "utf-8");
+        const packageJson = JSON.parse(packageJsonContent) as { main?: string };
 
-    const content = await readFile(packageJsonPath, "utf-8");
-    return JSON.parse(content) as { main?: string };
+        if (packageJson.main == null) {
+            throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
+        }
+
+        const packageEntryPoint = join(packageDir, packageJson.main);
+        const { migrations } = await import(packageEntryPoint);
+        return migrations as Record<string, MigrationModule>;
+    })();
+
+    return migrationsInstallPromise;
 }
 
 /**
@@ -137,27 +112,16 @@ export async function loadMigrationModule(params: {
     logger: Logger;
 }): Promise<MigrationModule | undefined> {
     const { generatorName, logger } = params;
-    const cacheDir = getMigrationCacheDir();
-    await mkdir(cacheDir, { recursive: true });
 
     try {
-        const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
-        const packageJsonPath = join(packageDir, "package.json");
-
-        // Attempt to install and load the migration package, with one retry on corrupt extraction
-        const packageJson = await installWithRetry({ cacheDir, packageJsonPath, logger });
-
-        if (packageJson.main == null) {
-            throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
+        const migrationsMap = await ensureMigrationsInstalled(logger);
+        if (migrationsMap == null) {
+            return undefined;
         }
-
-        // Resolve the entry point relative to the package directory
-        const packageEntryPoint = join(packageDir, packageJson.main);
-        const { migrations } = await import(packageEntryPoint);
 
         // Look up the migration module directly by generator name
         // Note: generatorName must already be normalized with fernapi/ prefix (done in upgradeGenerator.ts)
-        const module = migrations[generatorName];
+        const module = migrationsMap[generatorName];
 
         if (module == null) {
             // No migrations registered for this generator

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -44,7 +44,10 @@ let migrationsInstallPromise: Promise<Record<string, MigrationModule> | undefine
  */
 async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string, MigrationModule> | undefined> {
     if (migrationsInstallPromise != null) {
-        return migrationsInstallPromise;
+        return migrationsInstallPromise.catch((err) => {
+            migrationsInstallPromise = undefined;
+            throw err;
+        });
     }
 
     migrationsInstallPromise = (async () => {
@@ -80,7 +83,7 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
         return migrations as Record<string, MigrationModule>;
     })();
 
-    // Reset the cached promise on failure so subsequent calls can retry.
+    // Reset the cached promise on failure so the next call can retry.
     migrationsInstallPromise.catch(() => {
         migrationsInstallPromise = undefined;
     });

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.3.5
+  changelogEntry:
+    - summary: |
+        Fix `fern generator upgrade` failing with `TAR_ENTRY_ERROR` and
+        `ENOENT` on `package.json` when upgrading multiple workspaces.
+        The root cause was concurrent `npm install` calls to the same
+        `--prefix` directory racing on tar extraction. Now the migration
+        package is installed exactly once per CLI process using a
+        deduplicating promise pattern, and an isolated npm cache prevents
+        system-level cache corruption.
+      type: fix
+  createdAt: "2026-03-05"
+  irVersion: 65
+
 - version: 4.3.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: reported by users seeing `TAR_ENTRY_ERROR` followed by `ENOENT` on `package.json` during `fern generator upgrade`.

**Root cause:** `upgradeGenerator()` runs workspaces concurrently via `Promise.all`, and each workspace calls `npm install @fern-api/generator-migrations@latest --prefix ~/.fern/migration-cache/`. Multiple concurrent npm installs to the same `--prefix` directory race on tar extraction, causing `TAR_ENTRY_ERROR` and missing files like `package.json`. npm still exits with code 0 ("added 1 package"), so the CLI proceeds to read files that don't exist.

Link to Devin session: https://app.devin.ai/sessions/2fa4c7000ec14875869127e3d9f04869
Requested by: @Swimburger

## Changes Made

Applied a **deduplicating promise pattern** to both the v1 (`loader.ts`) and v2 (`GeneratorMigrator.ts`) code paths so that npm install runs exactly once, eliminating the race condition:

- **v1 — module-level deduplication** (`loader.ts`): Added `ensureMigrationsInstalled()` with a module-level cached promise. All concurrent workspace upgrades (via `Promise.all`) await the same single promise instead of each spawning their own `npm install`.
- **v2 — instance-level deduplication** (`GeneratorMigrator.ts`): Added `ensureMigrationsInstalled()` with an instance-level cached promise. Sequential generator migrations within the same session reuse the cached result.
- **Transient failure recovery**: Rejected promises are reset in two places for belt-and-suspenders safety: (1) on the early return path via `.catch((err) => { promise = undefined; throw err })` so callers who pick up an already-rejected promise trigger a reset, and (2) immediately after promise creation via `.catch(() => { promise = undefined })` so the variable is cleared as soon as the IIFE rejects.
- **Isolated npm cache**: Added `--cache <cacheDir>/.npm-cache` to npm install to isolate from the system-level `~/.npm` cache, preventing corrupt system cache entries from causing repeated failures.
- **New unit tests** (`deduplication.test.ts`): 3 tests covering concurrent deduplication (5 calls → 1 install), transient failure retry, and unknown generator lookup.
- **versions.yml**: Added changelog entry as version `4.4.1`.

## Testing

- [x] All 313 unit tests pass (including 3 new deduplication tests)
- [x] Biome lint/format passes
- [x] TypeScript compilation clean for modified files
- [x] End-to-end: `fern generator upgrade` succeeds on single-workspace project
- [x] End-to-end: `fern generator upgrade` succeeds on 3-workspace concurrent project (single `npm install`, no `TAR_ENTRY_ERROR`)
- [x] All required CI checks pass (47/47)

## Human Review Checklist

- The dual `.catch()` pattern (early return + creation-time) is idempotent (both set `promise = undefined`), but verify the interaction is sound — specifically that the creation-time `.catch()` doesn't swallow rejections before the early-return `.catch()` can re-throw to callers.
- Node.js caches dynamic `import()` results by resolved path. If npm install runs twice (after a transient failure + retry), the second `import()` of the same entry point path may return Node's cached module rather than re-reading from disk. In practice this is fine for a single CLI invocation, but worth being aware of.
- The test mocks are tightly coupled to the cache path derived from `homedir()` returning `/tmp/test-fern-home`. If the cache directory logic in `loader.ts` changes, the mocked import path in the tests would silently stop matching.
- The `as string` cast on `this.cachePath` in `GeneratorMigrator.ts` is a pre-existing pattern (branded `AbsoluteFilePath` type).
- The dedup solution handles in-process concurrency only. Multiple CLI **processes** on the same machine can still race on tar extraction (file locking would be needed to address that, which is out of scope for this PR).
- Verify the `4.4.1` version number in `versions.yml` is correct relative to the latest released version at merge time.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
