### PR TITLE
Restore base_url, environment imports/params, and pagination comments in v2 README/reference generation

### DIFF
--- a/generators/python-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/python-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -25,6 +25,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     private readonly packageName: string;
     private readonly clientClassName: string;
     private readonly asyncClientClassName: string;
+    private _paginationSecondSnippets: string[] = [];
 
     constructor({
         context,
@@ -121,6 +122,14 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             snippetsByFeatureId[featureId] = this.renderSnippetsTemplateForFeature(featureId, renderer, predicate);
         }
 
+        // Append additional pagination snippets (iter_pages pattern) if any were collected
+        const paginationSnippets = snippetsByFeatureId[ReadmeSnippetBuilder.PAGINATION_FEATURE_ID];
+        if (this._paginationSecondSnippets.length > 0 && paginationSnippets != null) {
+            paginationSnippets.push(
+                ...this._paginationSecondSnippets
+            );
+        }
+
         // Always add custom client snippet (not endpoint-specific)
         snippetsByFeatureId[FernGeneratorCli.StructuredFeatureId.CustomClient] = [this.renderCustomClientSnippet()];
 
@@ -168,7 +177,10 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
                 ? (this.extractConstructorArgsFromSyncSnippet(syncSnippet) ?? this.getClientConstructorArgs())
                 : this.getClientConstructorArgs();
 
-        const extraImports = syncSnippet != null ? this.extractExtraImportsFromSyncSnippet(syncSnippet) : [];
+        const extraImports =
+            syncSnippet != null
+                ? this.extractExtraImportsFromSyncSnippet(syncSnippet)
+                : this.getClientConstructorExtraImports();
 
         const methodCallBlock = syncSnippet != null ? this.extractMethodCallFromSyncSnippet(syncSnippet) : undefined;
 
@@ -305,14 +317,26 @@ asyncio.run(main())`
             }
         }
 
-        // Add environment arg
-        if (this.context.ir.environments != null) {
-            // Has environments - don't add explicit base_url
+        // Add environment or base_url
+        const environmentInfo = this.getEnvironmentInfo();
+        if (environmentInfo != null) {
+            args.push(environmentInfo.constructorArg);
         } else {
             args.push(`    base_url="https://yourhost.com/path/to/api",`);
         }
 
         return args.join("\n");
+    }
+
+    /**
+     * Gets extra imports needed for the client constructor (e.g., environment import).
+     */
+    private getClientConstructorExtraImports(): string[] {
+        const environmentInfo = this.getEnvironmentInfo();
+        if (environmentInfo != null) {
+            return [environmentInfo.importLine];
+        }
+        return [];
     }
 
     private renderExceptionHandlingSnippet(endpoint: EndpointWithFilepath): string {
@@ -384,6 +408,42 @@ for chunk in response:
     }
 
     private renderPaginationSnippet(endpoint: EndpointWithFilepath): string {
+        // Use the prerendered snippet if available (includes full client setup),
+        // and append the pagination iteration boilerplate matching v1 output.
+        const prerenderedSnippet = this.prerenderedSnippetsByEndpointId[endpoint.endpoint.id];
+        if (prerenderedSnippet != null) {
+            const methodCall = this.getMethodCall(endpoint);
+            const hasParams = this.endpointHasParameters(endpoint.endpoint);
+
+            // Extract the method call variable name from the prerendered snippet
+            // v1 format: response = client.foo.bar(...) then iterates with response
+            const varMatch = prerenderedSnippet.match(/^(\w+)\s*=\s*client\./m);
+            const varName = varMatch?.[1] ?? "response";
+
+            // Build the first snippet: prerendered + pagination iteration boilerplate
+            const firstSnippet = `${prerenderedSnippet.trimEnd()}
+for item in ${varName}:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in ${varName}.iter_pages():
+    yield page
+`;
+
+            // Build the second snippet: iter_pages with typed response access
+            const secondSnippet = `# You can also iterate through pages and access the typed response per page
+pager = ${methodCall}(${hasParams ? "..." : ""})
+for page in pager.iter_pages():
+    print(page.response)  # access the typed response for each page
+    for item in page:
+        print(item)
+`;
+
+            // Store both snippets; we'll return them via the pagination feature handler
+            this._paginationSecondSnippets.push(secondSnippet);
+            return firstSnippet;
+        }
+
+        // Fallback: template-based snippet
         const methodCall = this.getMethodCall(endpoint);
         const hasParams = this.endpointHasParameters(endpoint.endpoint);
         return this.writeCode(
@@ -498,9 +558,136 @@ client = ${this.clientClassName}(
             if (snippets[endpointSnippet.id.identifierOverride] != null) {
                 continue;
             }
-            snippets[endpointSnippet.id.identifierOverride] = endpointSnippet.snippet.syncClient;
+            snippets[endpointSnippet.id.identifierOverride] = this.injectClientSetupIntoSnippet(
+                endpointSnippet.snippet.syncClient
+            );
         }
         return snippets;
+    }
+
+    /**
+     * Post-processes a prerendered snippet to inject base_url or environment setup
+     * into the client constructor, matching v1 output.
+     */
+    private injectClientSetupIntoSnippet(snippet: string): string {
+        const lines = snippet.split("\n");
+        const clientLineIdx = lines.findIndex((line) => line.startsWith("client = "));
+        if (clientLineIdx === -1) {
+            return snippet;
+        }
+
+        const clientLine = lines[clientLineIdx] ?? "";
+
+        // Find the closing paren of the constructor
+        let closingParenIdx = -1;
+        if (clientLine.endsWith("()")) {
+            // No-args constructor: client = SeedFoo()
+            closingParenIdx = clientLineIdx;
+        } else if (clientLine.endsWith("(")) {
+            // Multi-line constructor: find the closing paren
+            for (let i = clientLineIdx + 1; i < lines.length; i++) {
+                if (lines[i] === ")") {
+                    closingParenIdx = i;
+                    break;
+                }
+            }
+        }
+
+        if (closingParenIdx === -1) {
+            return snippet;
+        }
+
+        const environmentInfo = this.getEnvironmentInfo();
+        if (environmentInfo != null) {
+            // Has environments: inject environment import and param
+            const { importLine, constructorArg } = environmentInfo;
+
+            // Insert environment import after the package import
+            const packageImportIdx = lines.findIndex(
+                (line) => line.startsWith(`from ${this.packageName} import`)
+            );
+            if (packageImportIdx !== -1) {
+                lines.splice(packageImportIdx + 1, 0, importLine);
+                // Adjust indices after insertion
+                const adjustedClientLineIdx = clientLineIdx + 1;
+                const adjustedClosingParenIdx = closingParenIdx + 1;
+
+                // Inject environment arg into constructor
+                this.injectConstructorArg(lines, adjustedClientLineIdx, adjustedClosingParenIdx, constructorArg);
+            }
+        } else {
+            // No environments: inject base_url
+            const baseUrlArg = `    base_url="https://yourhost.com/path/to/api",`;
+            this.injectConstructorArg(lines, clientLineIdx, closingParenIdx, baseUrlArg);
+        }
+
+        return lines.join("\n");
+    }
+
+    /**
+     * Injects a constructor argument into the client constructor.
+     */
+    private injectConstructorArg(
+        lines: string[],
+        clientLineIdx: number,
+        closingParenIdx: number,
+        arg: string
+    ): void {
+        const clientLine = lines[clientLineIdx] ?? "";
+
+        if (clientLine.endsWith("()")) {
+            // No-args: convert to multi-line with the arg
+            const className = clientLine.slice("client = ".length, -2);
+            lines[clientLineIdx] = `client = ${className}(`;
+            lines.splice(clientLineIdx + 1, 0, arg, ")");
+        } else {
+            // Multi-line: insert the arg as the last argument before closing paren
+            lines.splice(closingParenIdx, 0, arg);
+        }
+    }
+
+    /**
+     * Gets environment info for snippet injection, or undefined if no environments.
+     */
+    private getEnvironmentInfo(): { importLine: string; constructorArg: string } | undefined {
+        const envConfig = this.context.ir.environments;
+        if (envConfig == null) {
+            return undefined;
+        }
+
+        const envClassName = `${this.clientClassName}Environment`;
+        const importLine = `from ${this.packageName}.environment import ${envClassName}`;
+
+        // Get the default environment or first environment
+        let firstEnvName: string | undefined;
+        if (envConfig.environments.type === "singleBaseUrl") {
+            const defaultEnvId = envConfig.defaultEnvironment;
+            const envs = envConfig.environments.environments;
+            if (defaultEnvId != null) {
+                const defaultEnv = envs.find((e) => e.id === defaultEnvId);
+                firstEnvName = defaultEnv?.name.screamingSnakeCase.unsafeName;
+            }
+            if (firstEnvName == null && envs.length > 0 && envs[0] != null) {
+                firstEnvName = envs[0].name.screamingSnakeCase.unsafeName;
+            }
+        } else if (envConfig.environments.type === "multipleBaseUrls") {
+            const defaultEnvId = envConfig.defaultEnvironment;
+            const envs = envConfig.environments.environments;
+            if (defaultEnvId != null) {
+                const defaultEnv = envs.find((e) => e.id === defaultEnvId);
+                firstEnvName = defaultEnv?.name.screamingSnakeCase.unsafeName;
+            }
+            if (firstEnvName == null && envs.length > 0 && envs[0] != null) {
+                firstEnvName = envs[0].name.screamingSnakeCase.unsafeName;
+            }
+        }
+
+        if (firstEnvName == null) {
+            return undefined;
+        }
+
+        const constructorArg = `    environment=${envClassName}.${firstEnvName},`;
+        return { importLine, constructorArg };
     }
 
     private getEndpointsForFeature(featureId: FernIr.FeatureId): EndpointWithFilepath[] {

--- a/generators/python-v2/sdk/src/reference/buildReference.ts
+++ b/generators/python-v2/sdk/src/reference/buildReference.ts
@@ -14,7 +14,7 @@ export function buildReference({
     const builder = new ReferenceConfigBuilder();
     const serviceEntries = Object.entries(context.ir.services);
 
-    const snippetsByEndpointId = buildSnippetsByEndpointId(endpointSnippets ?? []);
+    const snippetsByEndpointId = buildSnippetsByEndpointId({ context, endpointSnippets: endpointSnippets ?? [] });
 
     serviceEntries.forEach(([serviceId, service]) => {
         const section = isRootServiceId({ context, serviceId })
@@ -29,7 +29,13 @@ export function buildReference({
     return builder;
 }
 
-function buildSnippetsByEndpointId(endpointSnippets: FernGeneratorExec.Endpoint[]): Record<string, string> {
+function buildSnippetsByEndpointId({
+    context,
+    endpointSnippets
+}: {
+    context: SdkGeneratorContext;
+    endpointSnippets: FernGeneratorExec.Endpoint[];
+}): Record<string, string> {
     const snippets: Record<string, string> = {};
     for (const endpointSnippet of endpointSnippets) {
         if (endpointSnippet.id.identifierOverride == null) {
@@ -41,7 +47,10 @@ function buildSnippetsByEndpointId(endpointSnippets: FernGeneratorExec.Endpoint[
         if (snippets[endpointSnippet.id.identifierOverride] != null) {
             continue;
         }
-        snippets[endpointSnippet.id.identifierOverride] = endpointSnippet.snippet.syncClient;
+        snippets[endpointSnippet.id.identifierOverride] = injectClientSetupIntoSnippet({
+            context,
+            snippet: endpointSnippet.snippet.syncClient
+        });
     }
     return snippets;
 }
@@ -397,4 +406,143 @@ function fixSnippetMethodPath({
         return snippet.replace(wrongMethodCall, expectedMethodCall);
     }
     return snippet;
+}
+
+/**
+ * Post-processes a prerendered snippet to inject base_url or environment setup
+ * into the client constructor, matching v1 output.
+ */
+function injectClientSetupIntoSnippet({
+    context,
+    snippet
+}: {
+    context: SdkGeneratorContext;
+    snippet: string;
+}): string {
+    const lines = snippet.split("\n");
+    const clientLineIdx = lines.findIndex((line) => line.startsWith("client = "));
+    if (clientLineIdx === -1) {
+        return snippet;
+    }
+
+    const clientLine = lines[clientLineIdx] ?? "";
+
+    // Find the closing paren of the constructor
+    let closingParenIdx = -1;
+    if (clientLine.endsWith("()")) {
+        closingParenIdx = clientLineIdx;
+    } else if (clientLine.endsWith("(")) {
+        for (let i = clientLineIdx + 1; i < lines.length; i++) {
+            if (lines[i] === ")") {
+                closingParenIdx = i;
+                break;
+            }
+        }
+    }
+
+    if (closingParenIdx === -1) {
+        return snippet;
+    }
+
+    const environmentInfo = getEnvironmentInfo({ context });
+    if (environmentInfo != null) {
+        const { importLine, constructorArg } = environmentInfo;
+
+        const packageName = context.getModulePath();
+        const packageImportIdx = lines.findIndex(
+            (line) => line.startsWith(`from ${packageName} import`)
+        );
+        if (packageImportIdx !== -1) {
+            lines.splice(packageImportIdx + 1, 0, importLine);
+            const adjustedClientLineIdx = clientLineIdx + 1;
+            const adjustedClosingParenIdx = closingParenIdx + 1;
+            injectConstructorArg(lines, adjustedClientLineIdx, adjustedClosingParenIdx, constructorArg);
+        }
+    } else {
+        const baseUrlArg = `    base_url="https://yourhost.com/path/to/api",`;
+        injectConstructorArg(lines, clientLineIdx, closingParenIdx, baseUrlArg);
+    }
+
+    return lines.join("\n");
+}
+
+function injectConstructorArg(
+    lines: string[],
+    clientLineIdx: number,
+    closingParenIdx: number,
+    arg: string
+): void {
+    const clientLine = lines[clientLineIdx] ?? "";
+
+    if (clientLine.endsWith("()")) {
+        const className = clientLine.slice("client = ".length, -2);
+        lines[clientLineIdx] = `client = ${className}(`;
+        lines.splice(clientLineIdx + 1, 0, arg, ")");
+    } else {
+        lines.splice(closingParenIdx, 0, arg);
+    }
+}
+
+function getEnvironmentInfo({
+    context
+}: {
+    context: SdkGeneratorContext;
+}): { importLine: string; constructorArg: string } | undefined {
+    const envConfig = context.ir.environments;
+    if (envConfig == null) {
+        return undefined;
+    }
+
+    const clientClassName = getClientClassName({ context });
+    const envClassName = `${clientClassName}Environment`;
+    const packageName = context.getModulePath();
+    const importLine = `from ${packageName}.environment import ${envClassName}`;
+
+    let firstEnvName: string | undefined;
+    if (envConfig.environments.type === "singleBaseUrl") {
+        const defaultEnvId = envConfig.defaultEnvironment;
+        const envs = envConfig.environments.environments;
+        if (defaultEnvId != null) {
+            const defaultEnv = envs.find((e) => e.id === defaultEnvId);
+            firstEnvName = defaultEnv?.name.screamingSnakeCase.unsafeName;
+        }
+        if (firstEnvName == null && envs.length > 0 && envs[0] != null) {
+            firstEnvName = envs[0].name.screamingSnakeCase.unsafeName;
+        }
+    } else if (envConfig.environments.type === "multipleBaseUrls") {
+        const defaultEnvId = envConfig.defaultEnvironment;
+        const envs = envConfig.environments.environments;
+        if (defaultEnvId != null) {
+            const defaultEnv = envs.find((e) => e.id === defaultEnvId);
+            firstEnvName = defaultEnv?.name.screamingSnakeCase.unsafeName;
+        }
+        if (firstEnvName == null && envs.length > 0 && envs[0] != null) {
+            firstEnvName = envs[0].name.screamingSnakeCase.unsafeName;
+        }
+    }
+
+    if (firstEnvName == null) {
+        return undefined;
+    }
+
+    const constructorArg = `    environment=${envClassName}.${firstEnvName},`;
+    return { importLine, constructorArg };
+}
+
+function getClientClassName({ context }: { context: SdkGeneratorContext }): string {
+    if (context.customConfig.client?.exported_class_name != null) {
+        return context.customConfig.client.exported_class_name;
+    }
+    if (context.customConfig.client_class_name != null) {
+        return context.customConfig.client_class_name;
+    }
+    if (context.customConfig.client?.class_name != null) {
+        return context.customConfig.client.class_name;
+    }
+    const toPascalCase = (s: string): string =>
+        s
+            .split(/[-_\s]+/)
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+            .join("");
+    return toPascalCase(context.config.organization) + toPascalCase(context.config.workspaceName);
 }

--- a/seed/python-sdk/accept-header/README.md
+++ b/seed/python-sdk/accept-header/README.md
@@ -38,6 +38,7 @@ from seed import SeedAccept
 
 client = SeedAccept(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.endpoint()
@@ -54,6 +55,7 @@ from seed import AsyncSeedAccept
 
 client = AsyncSeedAccept(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/accept-header/reference.md
+++ b/seed/python-sdk/accept-header/reference.md
@@ -17,6 +17,7 @@ from seed import SeedAccept
 
 client = SeedAccept(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.endpoint()

--- a/seed/python-sdk/alias-extends/no-custom-config/README.md
+++ b/seed/python-sdk/alias-extends/no-custom-config/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedAliasExtends
 
-client = SeedAliasExtends()
+client = SeedAliasExtends(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.extended_inline_request_body(
     parent="parent",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedAliasExtends
 
-client = AsyncSeedAliasExtends()
+client = AsyncSeedAliasExtends(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/alias-extends/no-custom-config/reference.md
+++ b/seed/python-sdk/alias-extends/no-custom-config/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedAliasExtends
 
-client = SeedAliasExtends()
+client = SeedAliasExtends(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.extended_inline_request_body(
     parent="parent",

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/README.md
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedAliasExtends
 
-client = SeedAliasExtends()
+client = SeedAliasExtends(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.extended_inline_request_body(
     parent="parent",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedAliasExtends
 
-client = AsyncSeedAliasExtends()
+client = AsyncSeedAliasExtends(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/reference.md
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedAliasExtends
 
-client = SeedAliasExtends()
+client = SeedAliasExtends(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.extended_inline_request_body(
     parent="parent",

--- a/seed/python-sdk/alias/README.md
+++ b/seed/python-sdk/alias/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedAlias
 
-client = SeedAlias()
+client = SeedAlias(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get(
     type_id="typeId",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedAlias
 
-client = AsyncSeedAlias()
+client = AsyncSeedAlias(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/alias/reference.md
+++ b/seed/python-sdk/alias/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedAlias
 
-client = SeedAlias()
+client = SeedAlias(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get(
     type_id="typeId",

--- a/seed/python-sdk/any-auth/README.md
+++ b/seed/python-sdk/any-auth/README.md
@@ -39,6 +39,7 @@ from seed import SeedAnyAuth
 
 client = SeedAnyAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -58,6 +59,7 @@ from seed import AsyncSeedAnyAuth
 
 client = AsyncSeedAnyAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/any-auth/reference.md
+++ b/seed/python-sdk/any-auth/reference.md
@@ -17,6 +17,7 @@ from seed import SeedAnyAuth
 
 client = SeedAnyAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -100,6 +101,7 @@ from seed import SeedAnyAuth
 
 client = SeedAnyAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get()
@@ -147,6 +149,7 @@ from seed import SeedAnyAuth
 
 client = SeedAnyAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_admins()

--- a/seed/python-sdk/api-wide-base-path/README.md
+++ b/seed/python-sdk/api-wide-base-path/README.md
@@ -38,6 +38,7 @@ from seed import SeedApiWideBasePath
 
 client = SeedApiWideBasePath(
     path_param="pathParam",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.post(
@@ -59,6 +60,7 @@ from seed import AsyncSeedApiWideBasePath
 
 client = AsyncSeedApiWideBasePath(
     path_param="pathParam",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/api-wide-base-path/reference.md
+++ b/seed/python-sdk/api-wide-base-path/reference.md
@@ -17,6 +17,7 @@ from seed import SeedApiWideBasePath
 
 client = SeedApiWideBasePath(
     path_param="pathParam",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.post(

--- a/seed/python-sdk/audiences/reference.md
+++ b/seed/python-sdk/audiences/reference.md
@@ -14,8 +14,11 @@
 
 ```python
 from seed import SeedAudiences
+from seed.environment import SeedAudiencesEnvironment
 
-client = SeedAudiences()
+client = SeedAudiences(
+    environment=SeedAudiencesEnvironment.ENVIRONMENT_A,
+)
 
 client.folder_a.service.get_direct_thread(
     ids=[
@@ -83,8 +86,11 @@ client.folder_a.service.get_direct_thread(
 
 ```python
 from seed import SeedAudiences
+from seed.environment import SeedAudiencesEnvironment
 
-client = SeedAudiences()
+client = SeedAudiences(
+    environment=SeedAudiencesEnvironment.ENVIRONMENT_A,
+)
 
 client.folder_d.service.get_direct_thread()
 
@@ -129,8 +135,11 @@ client.folder_d.service.get_direct_thread()
 
 ```python
 from seed import SeedAudiences
+from seed.environment import SeedAudiencesEnvironment
 
-client = SeedAudiences()
+client = SeedAudiences(
+    environment=SeedAudiencesEnvironment.ENVIRONMENT_A,
+)
 
 client.foo.find(
     optional_string="optionalString",

--- a/seed/python-sdk/basic-auth-environment-variables/README.md
+++ b/seed/python-sdk/basic-auth-environment-variables/README.md
@@ -39,6 +39,7 @@ from seed import SeedBasicAuthEnvironmentVariables
 client = SeedBasicAuthEnvironmentVariables(
     username="<username>",
     access_token="<password>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.basic_auth.post_with_basic_auth(
@@ -58,6 +59,7 @@ from seed import AsyncSeedBasicAuthEnvironmentVariables
 client = AsyncSeedBasicAuthEnvironmentVariables(
     username="<username>",
     access_token="<password>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/basic-auth-environment-variables/reference.md
+++ b/seed/python-sdk/basic-auth-environment-variables/reference.md
@@ -32,6 +32,7 @@ from seed import SeedBasicAuthEnvironmentVariables
 client = SeedBasicAuthEnvironmentVariables(
     username="<username>",
     access_token="<password>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.basic_auth.get_with_basic_auth()
@@ -94,6 +95,7 @@ from seed import SeedBasicAuthEnvironmentVariables
 client = SeedBasicAuthEnvironmentVariables(
     username="<username>",
     access_token="<password>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.basic_auth.post_with_basic_auth(

--- a/seed/python-sdk/basic-auth/README.md
+++ b/seed/python-sdk/basic-auth/README.md
@@ -39,6 +39,7 @@ from seed import SeedBasicAuth
 client = SeedBasicAuth(
     username="<username>",
     password="<password>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.basic_auth.post_with_basic_auth(
@@ -58,6 +59,7 @@ from seed import AsyncSeedBasicAuth
 client = AsyncSeedBasicAuth(
     username="<username>",
     password="<password>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/basic-auth/reference.md
+++ b/seed/python-sdk/basic-auth/reference.md
@@ -32,6 +32,7 @@ from seed import SeedBasicAuth
 client = SeedBasicAuth(
     username="<username>",
     password="<password>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.basic_auth.get_with_basic_auth()
@@ -94,6 +95,7 @@ from seed import SeedBasicAuth
 client = SeedBasicAuth(
     username="<username>",
     password="<password>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.basic_auth.post_with_basic_auth(

--- a/seed/python-sdk/bearer-token-environment-variable/README.md
+++ b/seed/python-sdk/bearer-token-environment-variable/README.md
@@ -38,6 +38,7 @@ from seed import SeedBearerTokenEnvironmentVariable
 
 client = SeedBearerTokenEnvironmentVariable(
     api_key="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.get_with_bearer_token()
@@ -54,6 +55,7 @@ from seed import AsyncSeedBearerTokenEnvironmentVariable
 
 client = AsyncSeedBearerTokenEnvironmentVariable(
     api_key="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/bearer-token-environment-variable/reference.md
+++ b/seed/python-sdk/bearer-token-environment-variable/reference.md
@@ -31,6 +31,7 @@ from seed import SeedBearerTokenEnvironmentVariable
 
 client = SeedBearerTokenEnvironmentVariable(
     api_key="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.get_with_bearer_token()

--- a/seed/python-sdk/bytes-download/README.md
+++ b/seed/python-sdk/bytes-download/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedBytesDownload
 
-client = SeedBytesDownload()
+client = SeedBytesDownload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.simple()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedBytesDownload
 
-client = AsyncSeedBytesDownload()
+client = AsyncSeedBytesDownload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/bytes-download/reference.md
+++ b/seed/python-sdk/bytes-download/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedBytesDownload
 
-client = SeedBytesDownload()
+client = SeedBytesDownload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.simple()
 

--- a/seed/python-sdk/bytes-upload/README.md
+++ b/seed/python-sdk/bytes-upload/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedBytesUpload
 
-client = SeedBytesUpload()
+client = SeedBytesUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.upload()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedBytesUpload
 
-client = AsyncSeedBytesUpload()
+client = AsyncSeedBytesUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/bytes-upload/reference.md
+++ b/seed/python-sdk/bytes-upload/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedBytesUpload
 
-client = SeedBytesUpload()
+client = SeedBytesUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.upload()
 

--- a/seed/python-sdk/client-side-params/README.md
+++ b/seed/python-sdk/client-side-params/README.md
@@ -38,6 +38,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.search_resources(
@@ -61,6 +62,7 @@ from seed import AsyncSeedClientSideParams
 
 client = AsyncSeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/client-side-params/reference.md
+++ b/seed/python-sdk/client-side-params/reference.md
@@ -31,6 +31,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.list_resources(
@@ -156,6 +157,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.get_resource(
@@ -245,6 +247,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.search_resources(
@@ -345,6 +348,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.list_users(
@@ -479,6 +483,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.get_user_by_id(
@@ -568,6 +573,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.create_user(
@@ -651,6 +657,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.update_user(
@@ -743,6 +750,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.delete_user(
@@ -814,6 +822,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.list_connections(
@@ -903,6 +912,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.get_connection(
@@ -983,6 +993,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.list_clients(
@@ -1120,6 +1131,7 @@ from seed import SeedClientSideParams
 
 client = SeedClientSideParams(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.get_client(

--- a/seed/python-sdk/content-type/README.md
+++ b/seed/python-sdk/content-type/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedContentTypes
 
-client = SeedContentTypes()
+client = SeedContentTypes(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.patch(
     application="application",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedContentTypes
 
-client = AsyncSeedContentTypes()
+client = AsyncSeedContentTypes(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/content-type/reference.md
+++ b/seed/python-sdk/content-type/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedContentTypes
 
-client = SeedContentTypes()
+client = SeedContentTypes(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.patch(
     application="application",
@@ -96,7 +98,9 @@ This endpoint demonstrates the distinction between:
 ```python
 from seed import SeedContentTypes
 
-client = SeedContentTypes()
+client = SeedContentTypes(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.patch_complex(
     id="id",
@@ -263,7 +267,9 @@ This should trigger the NPE issue when optional fields aren't initialized.
 ```python
 from seed import SeedContentTypes
 
-client = SeedContentTypes()
+client = SeedContentTypes(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.named_patch_with_mixed(
     id="id",
@@ -362,7 +368,9 @@ This endpoint should:
 ```python
 from seed import SeedContentTypes
 
-client = SeedContentTypes()
+client = SeedContentTypes(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.optional_merge_patch_test(
     required_field="requiredField",
@@ -467,7 +475,9 @@ Regular PATCH endpoint without merge-patch semantics
 ```python
 from seed import SeedContentTypes
 
-client = SeedContentTypes()
+client = SeedContentTypes(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.regular_patch(
     id="id",

--- a/seed/python-sdk/cross-package-type-names/README.md
+++ b/seed/python-sdk/cross-package-type-names/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedCrossPackageTypeNames
 
-client = SeedCrossPackageTypeNames()
+client = SeedCrossPackageTypeNames(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.foo.find(
     optional_string="optionalString",
@@ -54,7 +56,9 @@ import asyncio
 
 from seed import AsyncSeedCrossPackageTypeNames
 
-client = AsyncSeedCrossPackageTypeNames()
+client = AsyncSeedCrossPackageTypeNames(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/cross-package-type-names/reference.md
+++ b/seed/python-sdk/cross-package-type-names/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedCrossPackageTypeNames
 
-client = SeedCrossPackageTypeNames()
+client = SeedCrossPackageTypeNames(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.folder_a.service.get_direct_thread()
 
@@ -61,7 +63,9 @@ client.folder_a.service.get_direct_thread()
 ```python
 from seed import SeedCrossPackageTypeNames
 
-client = SeedCrossPackageTypeNames()
+client = SeedCrossPackageTypeNames(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.folder_a.service.get_direct_thread()
 
@@ -107,7 +111,9 @@ client.folder_a.service.get_direct_thread()
 ```python
 from seed import SeedCrossPackageTypeNames
 
-client = SeedCrossPackageTypeNames()
+client = SeedCrossPackageTypeNames(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.foo.find(
     optional_string="optionalString",

--- a/seed/python-sdk/endpoint-security-auth/README.md
+++ b/seed/python-sdk/endpoint-security-auth/README.md
@@ -39,6 +39,7 @@ from seed import SeedEndpointSecurityAuth
 
 client = SeedEndpointSecurityAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -58,6 +59,7 @@ from seed import AsyncSeedEndpointSecurityAuth
 
 client = AsyncSeedEndpointSecurityAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/endpoint-security-auth/reference.md
+++ b/seed/python-sdk/endpoint-security-auth/reference.md
@@ -17,6 +17,7 @@ from seed import SeedEndpointSecurityAuth
 
 client = SeedEndpointSecurityAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -100,6 +101,7 @@ from seed import SeedEndpointSecurityAuth
 
 client = SeedEndpointSecurityAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_with_bearer()
@@ -147,6 +149,7 @@ from seed import SeedEndpointSecurityAuth
 
 client = SeedEndpointSecurityAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_with_bearer()
@@ -194,6 +197,7 @@ from seed import SeedEndpointSecurityAuth
 
 client = SeedEndpointSecurityAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_with_bearer()
@@ -241,6 +245,7 @@ from seed import SeedEndpointSecurityAuth
 
 client = SeedEndpointSecurityAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_with_bearer()
@@ -288,6 +293,7 @@ from seed import SeedEndpointSecurityAuth
 
 client = SeedEndpointSecurityAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_with_bearer()
@@ -335,6 +341,7 @@ from seed import SeedEndpointSecurityAuth
 
 client = SeedEndpointSecurityAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_with_bearer()
@@ -382,6 +389,7 @@ from seed import SeedEndpointSecurityAuth
 
 client = SeedEndpointSecurityAuth(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_with_bearer()

--- a/seed/python-sdk/enum/no-custom-config/README.md
+++ b/seed/python-sdk/enum/no-custom-config/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     operand=">",
@@ -54,7 +56,9 @@ import asyncio
 
 from seed import AsyncSeedEnum
 
-client = AsyncSeedEnum()
+client = AsyncSeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/enum/no-custom-config/reference.md
+++ b/seed/python-sdk/enum/no-custom-config/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     operand=">",
@@ -97,7 +99,9 @@ client.headers.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.inlined_request.send(
     operand=">",
@@ -251,7 +255,9 @@ client.multipart_form.multipart_form(...)
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.path_param.send(
     operand=">",
@@ -316,7 +322,9 @@ client.path_param.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.query_param.send(
     operand=">",
@@ -396,7 +404,9 @@ client.query_param.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.query_param.send_list(
     operand=[

--- a/seed/python-sdk/enum/real-enum-forward-compat/README.md
+++ b/seed/python-sdk/enum/real-enum-forward-compat/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     operand=">",
@@ -54,7 +56,9 @@ import asyncio
 
 from seed import AsyncSeedEnum
 
-client = AsyncSeedEnum()
+client = AsyncSeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/enum/real-enum-forward-compat/reference.md
+++ b/seed/python-sdk/enum/real-enum-forward-compat/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     operand=">",
@@ -97,7 +99,9 @@ client.headers.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.inlined_request.send(
     operand=">",
@@ -251,7 +255,9 @@ client.multipart_form.multipart_form(...)
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.path_param.send(
     operand=">",
@@ -316,7 +322,9 @@ client.path_param.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.query_param.send(
     operand=">",
@@ -396,7 +404,9 @@ client.query_param.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.query_param.send_list(
     operand=[

--- a/seed/python-sdk/enum/real-enum/README.md
+++ b/seed/python-sdk/enum/real-enum/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     operand=">",
@@ -54,7 +56,9 @@ import asyncio
 
 from seed import AsyncSeedEnum
 
-client = AsyncSeedEnum()
+client = AsyncSeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/enum/real-enum/reference.md
+++ b/seed/python-sdk/enum/real-enum/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     operand=">",
@@ -97,7 +99,9 @@ client.headers.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.inlined_request.send(
     operand=">",
@@ -251,7 +255,9 @@ client.multipart_form.multipart_form(...)
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.path_param.send(
     operand=">",
@@ -316,7 +322,9 @@ client.path_param.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.query_param.send(
     operand=">",
@@ -396,7 +404,9 @@ client.query_param.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.query_param.send_list(
     operand=[

--- a/seed/python-sdk/enum/strenum/README.md
+++ b/seed/python-sdk/enum/strenum/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     operand=">",
@@ -54,7 +56,9 @@ import asyncio
 
 from seed import AsyncSeedEnum
 
-client = AsyncSeedEnum()
+client = AsyncSeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/enum/strenum/reference.md
+++ b/seed/python-sdk/enum/strenum/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     operand=">",
@@ -97,7 +99,9 @@ client.headers.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.inlined_request.send(
     operand=">",
@@ -251,7 +255,9 @@ client.multipart_form.multipart_form(...)
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.path_param.send(
     operand=">",
@@ -316,7 +322,9 @@ client.path_param.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.query_param.send(
     operand=">",
@@ -396,7 +404,9 @@ client.query_param.send(
 ```python
 from seed import SeedEnum
 
-client = SeedEnum()
+client = SeedEnum(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.query_param.send_list(
     operand=[

--- a/seed/python-sdk/error-property/README.md
+++ b/seed/python-sdk/error-property/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedErrorProperty
 
-client = SeedErrorProperty()
+client = SeedErrorProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.property_based_error.throw_error()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedErrorProperty
 
-client = AsyncSeedErrorProperty()
+client = AsyncSeedErrorProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/error-property/reference.md
+++ b/seed/python-sdk/error-property/reference.md
@@ -29,7 +29,9 @@ GET request that always throws an error
 ```python
 from seed import SeedErrorProperty
 
-client = SeedErrorProperty()
+client = SeedErrorProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.property_based_error.throw_error()
 

--- a/seed/python-sdk/errors/README.md
+++ b/seed/python-sdk/errors/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedErrors
 
-client = SeedErrors()
+client = SeedErrors(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.simple.foo_without_endpoint_error(
     bar="bar",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedErrors
 
-client = AsyncSeedErrors()
+client = AsyncSeedErrors(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/errors/reference.md
+++ b/seed/python-sdk/errors/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedErrors
 
-client = SeedErrors()
+client = SeedErrors(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.simple.foo_without_endpoint_error(
     bar="bar",
@@ -70,7 +72,9 @@ client.simple.foo_without_endpoint_error(
 ```python
 from seed import SeedErrors
 
-client = SeedErrors()
+client = SeedErrors(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.simple.foo(
     bar="bar",
@@ -125,7 +129,9 @@ client.simple.foo(
 ```python
 from seed import SeedErrors
 
-client = SeedErrors()
+client = SeedErrors(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.simple.foo_with_examples(
     bar="hello",

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/reference.md
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/reference.md
@@ -13,9 +13,11 @@
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.echo(
@@ -70,9 +72,11 @@ client.echo(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.echo(
@@ -128,9 +132,11 @@ client.echo(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.file.notification.service.get_exception(
@@ -200,9 +206,11 @@ This endpoint returns a file by its name.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.file.service.get_file(
@@ -273,9 +281,11 @@ This endpoint checks the health of a resource.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.health.service.check(
@@ -344,9 +354,11 @@ This endpoint checks the health of the service.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.health.service.ping()
@@ -392,9 +404,11 @@ client.health.service.ping()
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.get_movie(
@@ -449,9 +463,11 @@ client.service.get_movie(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.create_movie(
@@ -517,9 +533,11 @@ client.service.create_movie(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.get_metadata(
@@ -594,11 +612,13 @@ client.service.get_metadata(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 from uuid import UUID
 from datetime import date, datetime
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.create_big_entity(
@@ -853,9 +873,11 @@ client.service.create_big_entity(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.refresh_token()

--- a/seed/python-sdk/examples/client-filename/reference.md
+++ b/seed/python-sdk/examples/client-filename/reference.md
@@ -13,9 +13,11 @@
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.echo(
@@ -70,9 +72,11 @@ client.echo(
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.echo(
@@ -128,9 +132,11 @@ client.echo(
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.file.notification.service.get_exception(
@@ -200,9 +206,11 @@ This endpoint returns a file by its name.
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.file.service.get_file(
@@ -273,9 +281,11 @@ This endpoint checks the health of a resource.
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.health.service.check(
@@ -344,9 +354,11 @@ This endpoint checks the health of the service.
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.health.service.ping()
@@ -392,9 +404,11 @@ client.health.service.ping()
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.service.get_movie(
@@ -449,9 +463,11 @@ client.service.get_movie(
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.service.create_movie(
@@ -517,9 +533,11 @@ client.service.create_movie(
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.service.get_metadata(
@@ -594,11 +612,13 @@ client.service.get_metadata(
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 from uuid import UUID
 from datetime import date, datetime
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.service.create_big_entity(
@@ -853,9 +873,11 @@ client.service.create_big_entity(
 
 ```python
 from seed import SeedExhaustive
+from seed.environment import SeedExhaustiveEnvironment
 
 client = SeedExhaustive(
     token="<token>",
+    environment=SeedExhaustiveEnvironment.PRODUCTION,
 )
 
 client.service.refresh_token()

--- a/seed/python-sdk/examples/legacy-wire-tests/reference.md
+++ b/seed/python-sdk/examples/legacy-wire-tests/reference.md
@@ -13,9 +13,11 @@
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.echo(
@@ -70,9 +72,11 @@ client.echo(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.echo(
@@ -128,9 +132,11 @@ client.echo(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.file.notification.service.get_exception(
@@ -200,9 +206,11 @@ This endpoint returns a file by its name.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.file.service.get_file(
@@ -273,9 +281,11 @@ This endpoint checks the health of a resource.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.health.service.check(
@@ -344,9 +354,11 @@ This endpoint checks the health of the service.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.health.service.ping()
@@ -392,9 +404,11 @@ client.health.service.ping()
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.get_movie(
@@ -449,9 +463,11 @@ client.service.get_movie(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.create_movie(
@@ -517,9 +533,11 @@ client.service.create_movie(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.get_metadata(
@@ -594,11 +612,13 @@ client.service.get_metadata(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 from uuid import UUID
 from datetime import date, datetime
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.create_big_entity(
@@ -853,9 +873,11 @@ client.service.create_big_entity(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.refresh_token()

--- a/seed/python-sdk/examples/no-custom-config/reference.md
+++ b/seed/python-sdk/examples/no-custom-config/reference.md
@@ -13,9 +13,11 @@
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.echo(
@@ -70,9 +72,11 @@ client.echo(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.echo(
@@ -128,9 +132,11 @@ client.echo(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.file.notification.service.get_exception(
@@ -200,9 +206,11 @@ This endpoint returns a file by its name.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.file.service.get_file(
@@ -273,9 +281,11 @@ This endpoint checks the health of a resource.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.health.service.check(
@@ -344,9 +354,11 @@ This endpoint checks the health of the service.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.health.service.ping()
@@ -392,9 +404,11 @@ client.health.service.ping()
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.get_movie(
@@ -449,9 +463,11 @@ client.service.get_movie(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.create_movie(
@@ -517,9 +533,11 @@ client.service.create_movie(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.get_metadata(
@@ -594,11 +612,13 @@ client.service.get_metadata(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 from uuid import UUID
 from datetime import date, datetime
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.create_big_entity(
@@ -853,9 +873,11 @@ client.service.create_big_entity(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.refresh_token()

--- a/seed/python-sdk/examples/readme/reference.md
+++ b/seed/python-sdk/examples/readme/reference.md
@@ -13,9 +13,11 @@
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.echo(
@@ -70,9 +72,11 @@ client.echo(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.echo(
@@ -128,9 +132,11 @@ client.echo(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.file.notification.service.get_exception(
@@ -200,9 +206,11 @@ This endpoint returns a file by its name.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.file.service.get_file(
@@ -273,9 +281,11 @@ This endpoint checks the health of a resource.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.health.service.check(
@@ -344,9 +354,11 @@ This endpoint checks the health of the service.
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.health.service.ping()
@@ -392,9 +404,11 @@ client.health.service.ping()
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.get_movie(
@@ -449,9 +463,11 @@ client.service.get_movie(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.create_movie(
@@ -517,9 +533,11 @@ client.service.create_movie(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.get_metadata(
@@ -594,11 +612,13 @@ client.service.get_metadata(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 from uuid import UUID
 from datetime import date, datetime
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.create_big_entity(
@@ -853,9 +873,11 @@ client.service.create_big_entity(
 
 ```python
 from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
 
 client = SeedExamples(
     token="<token>",
+    environment=SeedExamplesEnvironment.PRODUCTION,
 )
 
 client.service.refresh_token()

--- a/seed/python-sdk/exhaustive/additional_init_exports/README.md
+++ b/seed/python-sdk/exhaustive/additional_init_exports/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/additional_init_exports/reference.md
+++ b/seed/python-sdk/exhaustive/additional_init_exports/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/aliases_with_validation/README.md
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/reference.md
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/aliases_without_validation/README.md
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/reference.md
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/custom-transport/README.md
+++ b/seed/python-sdk/exhaustive/custom-transport/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/custom-transport/reference.md
+++ b/seed/python-sdk/exhaustive/custom-transport/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/README.md
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/reference.md
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/eager-imports/README.md
+++ b/seed/python-sdk/exhaustive/eager-imports/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/eager-imports/reference.md
+++ b/seed/python-sdk/exhaustive/eager-imports/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/extra_dependencies/README.md
+++ b/seed/python-sdk/exhaustive/extra_dependencies/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/extra_dependencies/reference.md
+++ b/seed/python-sdk/exhaustive/extra_dependencies/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/README.md
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/reference.md
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/five-second-timeout/README.md
+++ b/seed/python-sdk/exhaustive/five-second-timeout/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/five-second-timeout/reference.md
+++ b/seed/python-sdk/exhaustive/five-second-timeout/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/README.md
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/reference.md
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/import-paths/README.md
+++ b/seed/python-sdk/exhaustive/import-paths/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/import-paths/reference.md
+++ b/seed/python-sdk/exhaustive/import-paths/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/improved_imports/README.md
+++ b/seed/python-sdk/exhaustive/improved_imports/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/improved_imports/reference.md
+++ b/seed/python-sdk/exhaustive/improved_imports/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/infinite-timeout/README.md
+++ b/seed/python-sdk/exhaustive/infinite-timeout/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/infinite-timeout/reference.md
+++ b/seed/python-sdk/exhaustive/infinite-timeout/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/inline-path-params/README.md
+++ b/seed/python-sdk/exhaustive/inline-path-params/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/inline-path-params/reference.md
+++ b/seed/python-sdk/exhaustive/inline-path-params/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/inline_request_params/README.md
+++ b/seed/python-sdk/exhaustive/inline_request_params/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/inline_request_params/reference.md
+++ b/seed/python-sdk/exhaustive/inline_request_params/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/no-custom-config/README.md
+++ b/seed/python-sdk/exhaustive/no-custom-config/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/no-custom-config/reference.md
+++ b/seed/python-sdk/exhaustive/no-custom-config/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/package-path/README.md
+++ b/seed/python-sdk/exhaustive/package-path/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -61,6 +62,7 @@ from seed.matryoshka.doll.structure import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -96,11 +98,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/package-path/reference.md
+++ b/seed/python-sdk/exhaustive/package-path/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/reference.md
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/reference.md
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/reference.md
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/reference.md
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/pydantic-v1/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-v1/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/pydantic-v1/reference.md
+++ b/seed/python-sdk/exhaustive/pydantic-v1/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/reference.md
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/pyproject_extras/README.md
+++ b/seed/python-sdk/exhaustive/pyproject_extras/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/pyproject_extras/reference.md
+++ b/seed/python-sdk/exhaustive/pyproject_extras/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/README.md
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/reference.md
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/union-utils/README.md
+++ b/seed/python-sdk/exhaustive/union-utils/README.md
@@ -39,6 +39,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncSeedExhaustive
 
 client = AsyncSeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import SeedExhaustive
 
+client = SeedExhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/union-utils/reference.md
+++ b/seed/python-sdk/exhaustive/union-utils/reference.md
@@ -17,6 +17,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/README.md
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/README.md
@@ -39,6 +39,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -60,6 +61,7 @@ from seed import AsyncExhaustive
 
 client = AsyncExhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -95,11 +97,27 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.endpoints.pagination.list_items(...)
-for item in pager:
-    print(item)
+from seed import Exhaustive
 
+client = Exhaustive(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.endpoints.pagination.list_items(
+    cursor="cursor",
+    limit=1,
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.endpoints.pagination.list_items(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/reference.md
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/reference.md
@@ -17,6 +17,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_primitives(
@@ -77,6 +78,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_list_of_objects(
@@ -141,6 +143,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_primitives(
@@ -200,6 +203,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_set_of_objects(
@@ -261,6 +265,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_prim_to_prim(
@@ -320,6 +325,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(
@@ -381,6 +387,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
@@ -440,6 +447,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.container.get_and_return_optional(
@@ -502,6 +510,7 @@ from uuid import UUID
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_type(
@@ -580,6 +589,7 @@ from uuid import UUID
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
@@ -657,6 +667,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.enum.get_and_return_enum(
@@ -715,6 +726,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_get(
@@ -772,6 +784,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_post(
@@ -829,6 +842,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_put(
@@ -897,6 +911,7 @@ from uuid import UUID
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_patch(
@@ -982,6 +997,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.http_methods.test_delete(
@@ -1042,6 +1058,7 @@ from uuid import UUID
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_optional_field(
@@ -1118,6 +1135,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_required_field(
@@ -1175,6 +1193,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_map_of_map(
@@ -1238,6 +1257,7 @@ from uuid import UUID
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
@@ -1319,6 +1339,7 @@ from uuid import UUID
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field(
@@ -1409,6 +1430,7 @@ from uuid import UUID
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(
@@ -1517,6 +1539,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_unknown_field(
@@ -1591,6 +1614,7 @@ from datetime import datetime
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
@@ -1664,6 +1688,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.pagination.list_items(
@@ -1745,6 +1770,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1816,6 +1842,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path(
@@ -1887,6 +1914,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -1967,6 +1995,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_query(
@@ -2047,6 +2076,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2127,6 +2157,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.get_with_path_and_query(
@@ -2207,6 +2238,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2287,6 +2319,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.modify_with_path(
@@ -2367,6 +2400,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.params.upload_with_path(
@@ -2433,6 +2467,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_string(
@@ -2490,6 +2525,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_int(
@@ -2547,6 +2583,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_long(
@@ -2604,6 +2641,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_double(
@@ -2661,6 +2699,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_bool(
@@ -2719,6 +2758,7 @@ from datetime import datetime
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_datetime(
@@ -2777,6 +2817,7 @@ from datetime import date
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_date(
@@ -2835,6 +2876,7 @@ from uuid import UUID
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_uuid(
@@ -2892,6 +2934,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.primitive.get_and_return_base_64(
@@ -2950,6 +2993,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.put.add(
@@ -3008,6 +3052,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.union.get_and_return_union(
@@ -3070,6 +3115,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_mixed_case()
@@ -3117,6 +3163,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.no_ending_slash()
@@ -3164,6 +3211,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_ending_slash()
@@ -3211,6 +3259,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.endpoints.urls.with_underscores()
@@ -3275,6 +3324,7 @@ from uuid import UUID
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inlined_requests.post_with_object_bodyand_response(
@@ -3386,6 +3436,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_auth.post_with_no_auth(
@@ -3444,6 +3495,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.get_with_no_request_body()
@@ -3491,6 +3543,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.no_req_body.post_with_no_request_body()
@@ -3539,6 +3592,7 @@ from seed import Exhaustive
 
 client = Exhaustive(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.req_with_headers.get_with_custom_header(

--- a/seed/python-sdk/extends/README.md
+++ b/seed/python-sdk/extends/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedExtends
 
-client = SeedExtends()
+client = SeedExtends(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.extended_inline_request_body(
     name="name",
@@ -54,7 +56,9 @@ import asyncio
 
 from seed import AsyncSeedExtends
 
-client = AsyncSeedExtends()
+client = AsyncSeedExtends(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/extends/reference.md
+++ b/seed/python-sdk/extends/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedExtends
 
-client = SeedExtends()
+client = SeedExtends(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.extended_inline_request_body(
     name="name",

--- a/seed/python-sdk/extra-properties/README.md
+++ b/seed/python-sdk/extra-properties/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedExtraProperties
 
-client = SeedExtraProperties()
+client = SeedExtraProperties(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.create_user(
     name="Alice",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedExtraProperties
 
-client = AsyncSeedExtraProperties()
+client = AsyncSeedExtraProperties(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/extra-properties/reference.md
+++ b/seed/python-sdk/extra-properties/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedExtraProperties
 
-client = SeedExtraProperties()
+client = SeedExtraProperties(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.create_user(
     name="Alice",

--- a/seed/python-sdk/file-download/default-chunk-size/README.md
+++ b/seed/python-sdk/file-download/default-chunk-size/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedFileDownload
 
-client = SeedFileDownload()
+client = SeedFileDownload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.simple()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedFileDownload
 
-client = AsyncSeedFileDownload()
+client = AsyncSeedFileDownload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/file-download/default-chunk-size/reference.md
+++ b/seed/python-sdk/file-download/default-chunk-size/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedFileDownload
 
-client = SeedFileDownload()
+client = SeedFileDownload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.simple()
 

--- a/seed/python-sdk/file-download/no-custom-config/README.md
+++ b/seed/python-sdk/file-download/no-custom-config/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedFileDownload
 
-client = SeedFileDownload()
+client = SeedFileDownload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.simple()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedFileDownload
 
-client = AsyncSeedFileDownload()
+client = AsyncSeedFileDownload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/file-download/no-custom-config/reference.md
+++ b/seed/python-sdk/file-download/no-custom-config/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedFileDownload
 
-client = SeedFileDownload()
+client = SeedFileDownload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.simple()
 

--- a/seed/python-sdk/file-upload-openapi/README.md
+++ b/seed/python-sdk/file-upload-openapi/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.file_upload_example.upload_file(
     file="example_file",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedApi
 
-client = AsyncSeedApi()
+client = AsyncSeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/file-upload-openapi/reference.md
+++ b/seed/python-sdk/file-upload-openapi/reference.md
@@ -29,7 +29,9 @@ Upload a file to the database
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.file_upload_example.upload_file(
     file="example_file",

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/README.md
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.just_file(
     file="example_file",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedFileUpload
 
-client = AsyncSeedFileUpload()
+client = AsyncSeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/reference.md
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/reference.md
@@ -175,7 +175,9 @@ client.service.post(...)
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.just_file(
     file="example_file",
@@ -686,7 +688,9 @@ client.service.with_form_encoded_containers(...)
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.optional_args(
     image_file="example_image_file",
@@ -861,7 +865,9 @@ client.service.with_json_property(...)
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.simple()
 

--- a/seed/python-sdk/file-upload/no-custom-config/README.md
+++ b/seed/python-sdk/file-upload/no-custom-config/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.just_file(
     file="example_file",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedFileUpload
 
-client = AsyncSeedFileUpload()
+client = AsyncSeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/file-upload/no-custom-config/reference.md
+++ b/seed/python-sdk/file-upload/no-custom-config/reference.md
@@ -175,7 +175,9 @@ client.service.post(...)
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.just_file(
     file="example_file",
@@ -686,7 +688,9 @@ client.service.with_form_encoded_containers(...)
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.optional_args(
     image_file="example_image_file",
@@ -861,7 +865,9 @@ client.service.with_json_property(...)
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.simple()
 

--- a/seed/python-sdk/file-upload/use_typeddict_requests/README.md
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.just_file(
     file="example_file",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedFileUpload
 
-client = AsyncSeedFileUpload()
+client = AsyncSeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/file-upload/use_typeddict_requests/reference.md
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/reference.md
@@ -175,7 +175,9 @@ client.service.post(...)
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.just_file(
     file="example_file",
@@ -686,7 +688,9 @@ client.service.with_form_encoded_containers(...)
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.optional_args(
     image_file="example_image_file",
@@ -861,7 +865,9 @@ client.service.with_json_property(...)
 ```python
 from seed import SeedFileUpload
 
-client = SeedFileUpload()
+client = SeedFileUpload(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.simple()
 

--- a/seed/python-sdk/folders/README.md
+++ b/seed/python-sdk/folders/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.foo()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedApi
 
-client = AsyncSeedApi()
+client = AsyncSeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/folders/reference.md
+++ b/seed/python-sdk/folders/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.foo()
 
@@ -60,7 +62,9 @@ client.foo()
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.a.b.foo()
 
@@ -106,7 +110,9 @@ client.a.b.foo()
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.a.c.foo()
 
@@ -152,7 +158,9 @@ client.a.c.foo()
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.folder.foo()
 
@@ -198,7 +206,9 @@ client.folder.foo()
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.folder.service.endpoint()
 
@@ -243,7 +253,9 @@ client.folder.service.endpoint()
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.folder.service.unknown_request(
     request={"key": "value"},

--- a/seed/python-sdk/header-auth-environment-variable/README.md
+++ b/seed/python-sdk/header-auth-environment-variable/README.md
@@ -38,6 +38,7 @@ from seed import SeedHeaderTokenEnvironmentVariable
 
 client = SeedHeaderTokenEnvironmentVariable(
     header_token_auth="<value>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.get_with_bearer_token()
@@ -54,6 +55,7 @@ from seed import AsyncSeedHeaderTokenEnvironmentVariable
 
 client = AsyncSeedHeaderTokenEnvironmentVariable(
     header_token_auth="<value>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/header-auth-environment-variable/reference.md
+++ b/seed/python-sdk/header-auth-environment-variable/reference.md
@@ -31,6 +31,7 @@ from seed import SeedHeaderTokenEnvironmentVariable
 
 client = SeedHeaderTokenEnvironmentVariable(
     header_token_auth="<value>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.get_with_bearer_token()

--- a/seed/python-sdk/header-auth/README.md
+++ b/seed/python-sdk/header-auth/README.md
@@ -38,6 +38,7 @@ from seed import SeedHeaderToken
 
 client = SeedHeaderToken(
     header_token_auth="<value>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.get_with_bearer_token()
@@ -54,6 +55,7 @@ from seed import AsyncSeedHeaderToken
 
 client = AsyncSeedHeaderToken(
     header_token_auth="<value>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/header-auth/reference.md
+++ b/seed/python-sdk/header-auth/reference.md
@@ -31,6 +31,7 @@ from seed import SeedHeaderToken
 
 client = SeedHeaderToken(
     header_token_auth="<value>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.get_with_bearer_token()

--- a/seed/python-sdk/http-head/README.md
+++ b/seed/python-sdk/http-head/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedHttpHead
 
-client = SeedHttpHead()
+client = SeedHttpHead(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.head()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedHttpHead
 
-client = AsyncSeedHttpHead()
+client = AsyncSeedHttpHead(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/http-head/reference.md
+++ b/seed/python-sdk/http-head/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedHttpHead
 
-client = SeedHttpHead()
+client = SeedHttpHead(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.head()
 
@@ -60,7 +62,9 @@ client.user.head()
 ```python
 from seed import SeedHttpHead
 
-client = SeedHttpHead()
+client = SeedHttpHead(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.list(
     limit=1,

--- a/seed/python-sdk/idempotency-headers/README.md
+++ b/seed/python-sdk/idempotency-headers/README.md
@@ -38,6 +38,7 @@ from seed import SeedIdempotencyHeaders
 
 client = SeedIdempotencyHeaders(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.payment.create(
@@ -57,6 +58,7 @@ from seed import AsyncSeedIdempotencyHeaders
 
 client = AsyncSeedIdempotencyHeaders(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/idempotency-headers/reference.md
+++ b/seed/python-sdk/idempotency-headers/reference.md
@@ -17,6 +17,7 @@ from seed import SeedIdempotencyHeaders
 
 client = SeedIdempotencyHeaders(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.payment.create(
@@ -83,6 +84,7 @@ from seed import SeedIdempotencyHeaders
 
 client = SeedIdempotencyHeaders(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.payment.delete(

--- a/seed/python-sdk/imdb/README.md
+++ b/seed/python-sdk/imdb/README.md
@@ -38,6 +38,7 @@ from seed import SeedApi
 
 client = SeedApi(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.imdb.create_movie(
@@ -57,6 +58,7 @@ from seed import AsyncSeedApi
 
 client = AsyncSeedApi(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/imdb/reference.md
+++ b/seed/python-sdk/imdb/reference.md
@@ -31,6 +31,7 @@ from seed import SeedApi
 
 client = SeedApi(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.imdb.create_movie(
@@ -89,6 +90,7 @@ from seed import SeedApi
 
 client = SeedApi(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.imdb.get_movie(

--- a/seed/python-sdk/inferred-auth-explicit/README.md
+++ b/seed/python-sdk/inferred-auth-explicit/README.md
@@ -41,6 +41,7 @@ client = SeedInferredAuthExplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -65,6 +66,7 @@ client = AsyncSeedInferredAuthExplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/inferred-auth-explicit/reference.md
+++ b/seed/python-sdk/inferred-auth-explicit/reference.md
@@ -20,6 +20,7 @@ client = SeedInferredAuthExplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -123,6 +124,7 @@ client = SeedInferredAuthExplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.refresh_token(
@@ -236,6 +238,7 @@ client = SeedInferredAuthExplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -287,6 +290,7 @@ client = SeedInferredAuthExplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -338,6 +342,7 @@ client = SeedInferredAuthExplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/inferred-auth-implicit-api-key/README.md
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/README.md
@@ -38,6 +38,7 @@ from seed import SeedInferredAuthImplicitApiKey
 
 client = SeedInferredAuthImplicitApiKey(
     api_key="X-Api-Key",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -56,6 +57,7 @@ from seed import AsyncSeedInferredAuthImplicitApiKey
 
 client = AsyncSeedInferredAuthImplicitApiKey(
     api_key="X-Api-Key",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/inferred-auth-implicit-api-key/reference.md
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/reference.md
@@ -17,6 +17,7 @@ from seed import SeedInferredAuthImplicitApiKey
 
 client = SeedInferredAuthImplicitApiKey(
     api_key="X-Api-Key",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -75,6 +76,7 @@ from seed import SeedInferredAuthImplicitApiKey
 
 client = SeedInferredAuthImplicitApiKey(
     api_key="X-Api-Key",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -123,6 +125,7 @@ from seed import SeedInferredAuthImplicitApiKey
 
 client = SeedInferredAuthImplicitApiKey(
     api_key="X-Api-Key",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -171,6 +174,7 @@ from seed import SeedInferredAuthImplicitApiKey
 
 client = SeedInferredAuthImplicitApiKey(
     api_key="X-Api-Key",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/README.md
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/README.md
@@ -41,6 +41,7 @@ client = SeedInferredAuthImplicitNoExpiry(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -65,6 +66,7 @@ client = AsyncSeedInferredAuthImplicitNoExpiry(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/reference.md
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/reference.md
@@ -20,6 +20,7 @@ client = SeedInferredAuthImplicitNoExpiry(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -123,6 +124,7 @@ client = SeedInferredAuthImplicitNoExpiry(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.refresh_token(
@@ -236,6 +238,7 @@ client = SeedInferredAuthImplicitNoExpiry(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -287,6 +290,7 @@ client = SeedInferredAuthImplicitNoExpiry(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -338,6 +342,7 @@ client = SeedInferredAuthImplicitNoExpiry(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/inferred-auth-implicit-reference/README.md
+++ b/seed/python-sdk/inferred-auth-implicit-reference/README.md
@@ -40,6 +40,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -62,6 +63,7 @@ client = AsyncSeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/inferred-auth-implicit-reference/reference.md
+++ b/seed/python-sdk/inferred-auth-implicit-reference/reference.md
@@ -19,6 +19,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -80,6 +81,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.refresh_token(
@@ -143,6 +145,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -193,6 +196,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -243,6 +247,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/inferred-auth-implicit/README.md
+++ b/seed/python-sdk/inferred-auth-implicit/README.md
@@ -41,6 +41,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -65,6 +66,7 @@ client = AsyncSeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/inferred-auth-implicit/reference.md
+++ b/seed/python-sdk/inferred-auth-implicit/reference.md
@@ -20,6 +20,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -123,6 +124,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.refresh_token(
@@ -236,6 +238,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -287,6 +290,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -338,6 +342,7 @@ client = SeedInferredAuthImplicit(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/license/README.md
+++ b/seed/python-sdk/license/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedLicense
 
-client = SeedLicense()
+client = SeedLicense(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedLicense
 
-client = AsyncSeedLicense()
+client = AsyncSeedLicense(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/license/reference.md
+++ b/seed/python-sdk/license/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedLicense
 
-client = SeedLicense()
+client = SeedLicense(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get()
 

--- a/seed/python-sdk/literal/no-custom-config/README.md
+++ b/seed/python-sdk/literal/no-custom-config/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     endpoint_version="02-12-2024",
@@ -54,7 +56,9 @@ import asyncio
 
 from seed import AsyncSeedLiteral
 
-client = AsyncSeedLiteral()
+client = AsyncSeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/literal/no-custom-config/reference.md
+++ b/seed/python-sdk/literal/no-custom-config/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     endpoint_version="02-12-2024",
@@ -89,7 +91,9 @@ client.headers.send(
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.inlined.send(
     temperature=10.1,
@@ -207,7 +211,9 @@ client.inlined.send(
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.path.send()
 
@@ -261,7 +267,9 @@ client.path.send()
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.query.send(
     prompt="You are a helpful assistant",
@@ -389,7 +397,9 @@ client.query.send(
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.reference.send(
     query="What is the weather today",

--- a/seed/python-sdk/literal/use_typeddict_requests/README.md
+++ b/seed/python-sdk/literal/use_typeddict_requests/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     endpoint_version="02-12-2024",
@@ -54,7 +56,9 @@ import asyncio
 
 from seed import AsyncSeedLiteral
 
-client = AsyncSeedLiteral()
+client = AsyncSeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/literal/use_typeddict_requests/reference.md
+++ b/seed/python-sdk/literal/use_typeddict_requests/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.headers.send(
     endpoint_version="02-12-2024",
@@ -89,7 +91,9 @@ client.headers.send(
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.inlined.send(
     temperature=10.1,
@@ -207,7 +211,9 @@ client.inlined.send(
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.path.send()
 
@@ -261,7 +267,9 @@ client.path.send()
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.query.send(
     prompt="You are a helpful assistant",
@@ -389,7 +397,9 @@ client.query.send(
 ```python
 from seed import SeedLiteral
 
-client = SeedLiteral()
+client = SeedLiteral(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.reference.send(
     query="What is the weather today",

--- a/seed/python-sdk/mixed-case/README.md
+++ b/seed/python-sdk/mixed-case/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedMixedCase
 
-client = SeedMixedCase()
+client = SeedMixedCase(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_resource(
     resource_id="rsc-xyz",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedMixedCase
 
-client = AsyncSeedMixedCase()
+client = AsyncSeedMixedCase(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/mixed-case/reference.md
+++ b/seed/python-sdk/mixed-case/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedMixedCase
 
-client = SeedMixedCase()
+client = SeedMixedCase(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_resource(
     resource_id="rsc-xyz",
@@ -71,7 +73,9 @@ client.service.get_resource(
 from seed import SeedMixedCase
 from datetime import date
 
-client = SeedMixedCase()
+client = SeedMixedCase(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.list_resources(
     page_limit=10,

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/README.md
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedMixedFileDirectory
 
-client = SeedMixedFileDirectory()
+client = SeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.organization.create(
     name="name",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedMixedFileDirectory
 
-client = AsyncSeedMixedFileDirectory()
+client = AsyncSeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/reference.md
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/reference.md
@@ -29,7 +29,9 @@ Create a new organization.
 ```python
 from seed import SeedMixedFileDirectory
 
-client = SeedMixedFileDirectory()
+client = SeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.organization.create(
     name="name",
@@ -99,7 +101,9 @@ List all users.
 ```python
 from seed import SeedMixedFileDirectory
 
-client = SeedMixedFileDirectory()
+client = SeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.list(
     limit=1,
@@ -169,7 +173,9 @@ List all user events.
 ```python
 from seed import SeedMixedFileDirectory
 
-client = SeedMixedFileDirectory()
+client = SeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.events.list_events(
     limit=1,
@@ -239,7 +245,9 @@ Get event metadata.
 ```python
 from seed import SeedMixedFileDirectory
 
-client = SeedMixedFileDirectory()
+client = SeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.events.metadata.get_metadata(
     id="id",

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/README.md
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedMixedFileDirectory
 
-client = SeedMixedFileDirectory()
+client = SeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.organization.create(
     name="name",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedMixedFileDirectory
 
-client = AsyncSeedMixedFileDirectory()
+client = AsyncSeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/reference.md
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/reference.md
@@ -29,7 +29,9 @@ Create a new organization.
 ```python
 from seed import SeedMixedFileDirectory
 
-client = SeedMixedFileDirectory()
+client = SeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.organization.create(
     name="name",
@@ -99,7 +101,9 @@ List all users.
 ```python
 from seed import SeedMixedFileDirectory
 
-client = SeedMixedFileDirectory()
+client = SeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.list(
     limit=1,
@@ -169,7 +173,9 @@ List all user events.
 ```python
 from seed import SeedMixedFileDirectory
 
-client = SeedMixedFileDirectory()
+client = SeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.events.list_events(
     limit=1,
@@ -239,7 +245,9 @@ Get event metadata.
 ```python
 from seed import SeedMixedFileDirectory
 
-client = SeedMixedFileDirectory()
+client = SeedMixedFileDirectory(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.events.metadata.get_metadata(
     id="id",

--- a/seed/python-sdk/multi-line-docs/README.md
+++ b/seed/python-sdk/multi-line-docs/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedMultiLineDocs
 
-client = SeedMultiLineDocs()
+client = SeedMultiLineDocs(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.create_user(
     name="name",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedMultiLineDocs
 
-client = AsyncSeedMultiLineDocs()
+client = AsyncSeedMultiLineDocs(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/multi-line-docs/reference.md
+++ b/seed/python-sdk/multi-line-docs/reference.md
@@ -30,7 +30,9 @@ This endpoint is used to retrieve a user.
 ```python
 from seed import SeedMultiLineDocs
 
-client = SeedMultiLineDocs()
+client = SeedMultiLineDocs(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.get_user(
     user_id="userId",
@@ -103,7 +105,9 @@ This endpoint is used to create a new user.
 ```python
 from seed import SeedMultiLineDocs
 
-client = SeedMultiLineDocs()
+client = SeedMultiLineDocs(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.create_user(
     name="name",

--- a/seed/python-sdk/multi-url-environment-no-default/reference.md
+++ b/seed/python-sdk/multi-url-environment-no-default/reference.md
@@ -14,9 +14,11 @@
 
 ```python
 from seed import SeedMultiUrlEnvironmentNoDefault
+from seed.environment import SeedMultiUrlEnvironmentNoDefaultEnvironment
 
 client = SeedMultiUrlEnvironmentNoDefault(
     token="<token>",
+    environment=SeedMultiUrlEnvironmentNoDefaultEnvironment.PRODUCTION,
 )
 
 client.ec_2.boot_instance(
@@ -72,9 +74,11 @@ client.ec_2.boot_instance(
 
 ```python
 from seed import SeedMultiUrlEnvironmentNoDefault
+from seed.environment import SeedMultiUrlEnvironmentNoDefaultEnvironment
 
 client = SeedMultiUrlEnvironmentNoDefault(
     token="<token>",
+    environment=SeedMultiUrlEnvironmentNoDefaultEnvironment.PRODUCTION,
 )
 
 client.s_3.get_presigned_url(

--- a/seed/python-sdk/multi-url-environment/reference.md
+++ b/seed/python-sdk/multi-url-environment/reference.md
@@ -14,9 +14,11 @@
 
 ```python
 from seed import SeedMultiUrlEnvironment
+from seed.environment import SeedMultiUrlEnvironmentEnvironment
 
 client = SeedMultiUrlEnvironment(
     token="<token>",
+    environment=SeedMultiUrlEnvironmentEnvironment.PRODUCTION,
 )
 
 client.ec_2.boot_instance(
@@ -72,9 +74,11 @@ client.ec_2.boot_instance(
 
 ```python
 from seed import SeedMultiUrlEnvironment
+from seed.environment import SeedMultiUrlEnvironmentEnvironment
 
 client = SeedMultiUrlEnvironment(
     token="<token>",
+    environment=SeedMultiUrlEnvironmentEnvironment.PRODUCTION,
 )
 
 client.s_3.get_presigned_url(

--- a/seed/python-sdk/multiple-request-bodies/reference.md
+++ b/seed/python-sdk/multiple-request-bodies/reference.md
@@ -13,9 +13,11 @@
 
 ```python
 from seed import SeedApi
+from seed.environment import SeedApiEnvironment
 
 client = SeedApi(
     token="<token>",
+    environment=SeedApiEnvironment.DEFAULT,
 )
 
 client.upload_json_document()

--- a/seed/python-sdk/no-environment/README.md
+++ b/seed/python-sdk/no-environment/README.md
@@ -38,6 +38,7 @@ from seed import SeedNoEnvironment
 
 client = SeedNoEnvironment(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.dummy.get_dummy()
@@ -54,6 +55,7 @@ from seed import AsyncSeedNoEnvironment
 
 client = AsyncSeedNoEnvironment(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/no-environment/reference.md
+++ b/seed/python-sdk/no-environment/reference.md
@@ -17,6 +17,7 @@ from seed import SeedNoEnvironment
 
 client = SeedNoEnvironment(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.dummy.get_dummy()

--- a/seed/python-sdk/no-retries/README.md
+++ b/seed/python-sdk/no-retries/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedNoRetries
 
-client = SeedNoRetries()
+client = SeedNoRetries(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.retries.get_users()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedNoRetries
 
-client = AsyncSeedNoRetries()
+client = AsyncSeedNoRetries(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/no-retries/reference.md
+++ b/seed/python-sdk/no-retries/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedNoRetries
 
-client = SeedNoRetries()
+client = SeedNoRetries(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.retries.get_users()
 

--- a/seed/python-sdk/nullable-allof-extends/reference.md
+++ b/seed/python-sdk/nullable-allof-extends/reference.md
@@ -27,8 +27,11 @@ Returns a RootObject which inherits from a nullable schema.
 
 ```python
 from seed import SeedApi
+from seed.environment import SeedApiEnvironment
 
-client = SeedApi()
+client = SeedApi(
+    environment=SeedApiEnvironment.DEFAULT,
+)
 
 client.get_test()
 
@@ -86,8 +89,11 @@ Creates a test object with nullable allOf in request body.
 
 ```python
 from seed import SeedApi
+from seed.environment import SeedApiEnvironment
 
-client = SeedApi()
+client = SeedApi(
+    environment=SeedApiEnvironment.DEFAULT,
+)
 
 client.create_test()
 

--- a/seed/python-sdk/nullable-optional/README.md
+++ b/seed/python-sdk/nullable-optional/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.create_user(
     username="username",
@@ -63,7 +65,9 @@ import asyncio
 
 from seed import AsyncSeedNullableOptional
 
-client = AsyncSeedNullableOptional()
+client = AsyncSeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/nullable-optional/reference.md
+++ b/seed/python-sdk/nullable-optional/reference.md
@@ -29,7 +29,9 @@ Get a user by ID
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.get_user(
     user_id="userId",
@@ -98,7 +100,9 @@ Create a new user
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.create_user(
     username="username",
@@ -178,7 +182,9 @@ Update a user (partial update)
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.update_user(
     user_id="userId",
@@ -267,7 +273,9 @@ List all users
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.list_users(
     limit=1,
@@ -363,7 +371,9 @@ Search users
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.search_users(
     query="query",
@@ -460,7 +470,9 @@ Create a complex profile to test nullable enums and unions
 from seed import SeedNullableOptional
 from datetime import datetime
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.create_complex_profile(
     id="id",
@@ -633,7 +645,9 @@ Get a complex profile by ID
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.get_complex_profile(
     profile_id="profileId",
@@ -703,7 +717,9 @@ Update complex profile to test nullable field updates
 from seed import SeedNullableOptional
 from datetime import datetime
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.update_complex_profile(
     profile_id="profileId",
@@ -843,7 +859,9 @@ Test endpoint for validating null deserialization
 from seed import SeedNullableOptional
 from datetime import datetime
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.test_deserialization(
     required_string="requiredString",
@@ -963,7 +981,9 @@ Filter users by role with nullable enum
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.filter_by_role(
     role="ADMIN",
@@ -1050,7 +1070,9 @@ Get notification settings which may be null
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.get_notification_settings(
     user_id="userId",
@@ -1119,7 +1141,9 @@ Update tags to test array handling
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.update_tags(
     user_id="userId",
@@ -1224,7 +1248,9 @@ Get search results with nullable unions
 ```python
 from seed import SeedNullableOptional
 
-client = SeedNullableOptional()
+client = SeedNullableOptional(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable_optional.get_search_results(
     query="query",

--- a/seed/python-sdk/nullable-request-body/README.md
+++ b/seed/python-sdk/nullable-request-body/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.test_group.test_method_name(
     path_param="path_param",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedApi
 
-client = AsyncSeedApi()
+client = AsyncSeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/nullable-request-body/reference.md
+++ b/seed/python-sdk/nullable-request-body/reference.md
@@ -29,7 +29,9 @@ Post a nullable request body
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.test_group.test_method_name(
     path_param="path_param",

--- a/seed/python-sdk/nullable/no-custom-config/README.md
+++ b/seed/python-sdk/nullable/no-custom-config/README.md
@@ -37,7 +37,9 @@ Instantiate and use the client with the following:
 from seed import SeedNullable
 from datetime import datetime
 
-client = SeedNullable()
+client = SeedNullable(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable.create_user(
     username="username",
@@ -71,7 +73,9 @@ from datetime import datetime
 
 from seed import AsyncSeedNullable
 
-client = AsyncSeedNullable()
+client = AsyncSeedNullable(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/nullable/no-custom-config/reference.md
+++ b/seed/python-sdk/nullable/no-custom-config/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedNullable
 
-client = SeedNullable()
+client = SeedNullable(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable.get_users(
     usernames=[
@@ -113,7 +115,9 @@ client.nullable.get_users(
 from seed import SeedNullable
 from datetime import datetime
 
-client = SeedNullable()
+client = SeedNullable(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable.create_user(
     username="username",
@@ -209,7 +213,9 @@ client.nullable.create_user(
 ```python
 from seed import SeedNullable
 
-client = SeedNullable()
+client = SeedNullable(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable.delete_user(
     username="xy",

--- a/seed/python-sdk/nullable/use-typeddict-requests/README.md
+++ b/seed/python-sdk/nullable/use-typeddict-requests/README.md
@@ -37,7 +37,9 @@ Instantiate and use the client with the following:
 from seed import SeedNullable
 from datetime import datetime
 
-client = SeedNullable()
+client = SeedNullable(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable.create_user(
     username="username",
@@ -71,7 +73,9 @@ from datetime import datetime
 
 from seed import AsyncSeedNullable
 
-client = AsyncSeedNullable()
+client = AsyncSeedNullable(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/nullable/use-typeddict-requests/reference.md
+++ b/seed/python-sdk/nullable/use-typeddict-requests/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedNullable
 
-client = SeedNullable()
+client = SeedNullable(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable.get_users(
     usernames=[
@@ -113,7 +115,9 @@ client.nullable.get_users(
 from seed import SeedNullable
 from datetime import datetime
 
-client = SeedNullable()
+client = SeedNullable(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable.create_user(
     username="username",
@@ -209,7 +213,9 @@ client.nullable.create_user(
 ```python
 from seed import SeedNullable
 
-client = SeedNullable()
+client = SeedNullable(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.nullable.delete_user(
     username="xy",

--- a/seed/python-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/python-sdk/oauth-client-credentials-custom/README.md
@@ -40,6 +40,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -63,6 +64,7 @@ from seed import AsyncSeedOauthClientCredentials
 client = AsyncSeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/oauth-client-credentials-custom/reference.md
+++ b/seed/python-sdk/oauth-client-credentials-custom/reference.md
@@ -18,6 +18,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -128,6 +129,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.refresh_token(
@@ -230,6 +232,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -279,6 +282,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -328,6 +332,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/oauth-client-credentials-default/README.md
+++ b/seed/python-sdk/oauth-client-credentials-default/README.md
@@ -40,6 +40,7 @@ from seed import SeedOauthClientCredentialsDefault
 client = SeedOauthClientCredentialsDefault(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -60,6 +61,7 @@ from seed import AsyncSeedOauthClientCredentialsDefault
 client = AsyncSeedOauthClientCredentialsDefault(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/oauth-client-credentials-default/reference.md
+++ b/seed/python-sdk/oauth-client-credentials-default/reference.md
@@ -18,6 +18,7 @@ from seed import SeedOauthClientCredentialsDefault
 client = SeedOauthClientCredentialsDefault(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -94,6 +95,7 @@ from seed import SeedOauthClientCredentialsDefault
 client = SeedOauthClientCredentialsDefault(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -143,6 +145,7 @@ from seed import SeedOauthClientCredentialsDefault
 client = SeedOauthClientCredentialsDefault(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -192,6 +195,7 @@ from seed import SeedOauthClientCredentialsDefault
 client = SeedOauthClientCredentialsDefault(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/README.md
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/README.md
@@ -40,6 +40,7 @@ from seed import SeedOauthClientCredentialsEnvironmentVariables
 client = SeedOauthClientCredentialsEnvironmentVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -61,6 +62,7 @@ from seed import AsyncSeedOauthClientCredentialsEnvironmentVariables
 client = AsyncSeedOauthClientCredentialsEnvironmentVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/reference.md
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/reference.md
@@ -18,6 +18,7 @@ from seed import SeedOauthClientCredentialsEnvironmentVariables
 client = SeedOauthClientCredentialsEnvironmentVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -110,6 +111,7 @@ from seed import SeedOauthClientCredentialsEnvironmentVariables
 client = SeedOauthClientCredentialsEnvironmentVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.refresh_token(
@@ -212,6 +214,7 @@ from seed import SeedOauthClientCredentialsEnvironmentVariables
 client = SeedOauthClientCredentialsEnvironmentVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -261,6 +264,7 @@ from seed import SeedOauthClientCredentialsEnvironmentVariables
 client = SeedOauthClientCredentialsEnvironmentVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -310,6 +314,7 @@ from seed import SeedOauthClientCredentialsEnvironmentVariables
 client = SeedOauthClientCredentialsEnvironmentVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/README.md
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/README.md
@@ -40,6 +40,7 @@ from seed import SeedOauthClientCredentialsMandatoryAuth
 client = SeedOauthClientCredentialsMandatoryAuth(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -61,6 +62,7 @@ from seed import AsyncSeedOauthClientCredentialsMandatoryAuth
 client = AsyncSeedOauthClientCredentialsMandatoryAuth(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/reference.md
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/reference.md
@@ -18,6 +18,7 @@ from seed import SeedOauthClientCredentialsMandatoryAuth
 client = SeedOauthClientCredentialsMandatoryAuth(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -110,6 +111,7 @@ from seed import SeedOauthClientCredentialsMandatoryAuth
 client = SeedOauthClientCredentialsMandatoryAuth(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.refresh_token(
@@ -212,6 +214,7 @@ from seed import SeedOauthClientCredentialsMandatoryAuth
 client = SeedOauthClientCredentialsMandatoryAuth(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -261,6 +264,7 @@ from seed import SeedOauthClientCredentialsMandatoryAuth
 client = SeedOauthClientCredentialsMandatoryAuth(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/oauth-client-credentials-nested-root/README.md
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/README.md
@@ -40,6 +40,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -61,6 +62,7 @@ from seed import AsyncSeedOauthClientCredentials
 client = AsyncSeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/oauth-client-credentials-nested-root/reference.md
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/reference.md
@@ -18,6 +18,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -111,6 +112,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -160,6 +162,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -209,6 +212,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/oauth-client-credentials-reference/README.md
+++ b/seed/python-sdk/oauth-client-credentials-reference/README.md
@@ -40,6 +40,7 @@ from seed import SeedOauthClientCredentialsReference
 client = SeedOauthClientCredentialsReference(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -60,6 +61,7 @@ from seed import AsyncSeedOauthClientCredentialsReference
 client = AsyncSeedOauthClientCredentialsReference(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/oauth-client-credentials-reference/reference.md
+++ b/seed/python-sdk/oauth-client-credentials-reference/reference.md
@@ -18,6 +18,7 @@ from seed import SeedOauthClientCredentialsReference
 client = SeedOauthClientCredentialsReference(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token(
@@ -78,6 +79,7 @@ from seed import SeedOauthClientCredentialsReference
 client = SeedOauthClientCredentialsReference(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/oauth-client-credentials-with-variables/README.md
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/README.md
@@ -40,6 +40,7 @@ from seed import SeedOauthClientCredentialsWithVariables
 client = SeedOauthClientCredentialsWithVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -61,6 +62,7 @@ from seed import AsyncSeedOauthClientCredentialsWithVariables
 client = AsyncSeedOauthClientCredentialsWithVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/oauth-client-credentials-with-variables/reference.md
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/reference.md
@@ -18,6 +18,7 @@ from seed import SeedOauthClientCredentialsWithVariables
 client = SeedOauthClientCredentialsWithVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -110,6 +111,7 @@ from seed import SeedOauthClientCredentialsWithVariables
 client = SeedOauthClientCredentialsWithVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.refresh_token(
@@ -212,6 +214,7 @@ from seed import SeedOauthClientCredentialsWithVariables
 client = SeedOauthClientCredentialsWithVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -261,6 +264,7 @@ from seed import SeedOauthClientCredentialsWithVariables
 client = SeedOauthClientCredentialsWithVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -310,6 +314,7 @@ from seed import SeedOauthClientCredentialsWithVariables
 client = SeedOauthClientCredentialsWithVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.post()
@@ -367,6 +372,7 @@ from seed import SeedOauthClientCredentialsWithVariables
 client = SeedOauthClientCredentialsWithVariables(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/oauth-client-credentials/README.md
+++ b/seed/python-sdk/oauth-client-credentials/README.md
@@ -40,6 +40,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -61,6 +62,7 @@ from seed import AsyncSeedOauthClientCredentials
 client = AsyncSeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/oauth-client-credentials/reference.md
+++ b/seed/python-sdk/oauth-client-credentials/reference.md
@@ -18,6 +18,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -110,6 +111,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.refresh_token(
@@ -212,6 +214,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested_no_auth.api.get_something()
@@ -261,6 +264,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.nested.api.get_something()
@@ -310,6 +314,7 @@ from seed import SeedOauthClientCredentials
 client = SeedOauthClientCredentials(
     client_id="<clientId>",
     client_secret="<clientSecret>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.simple.get_something()

--- a/seed/python-sdk/optional/README.md
+++ b/seed/python-sdk/optional/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedObjectsWithImports
 
-client = SeedObjectsWithImports()
+client = SeedObjectsWithImports(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.optional.send_optional_body(
     request={
@@ -54,7 +56,9 @@ import asyncio
 
 from seed import AsyncSeedObjectsWithImports
 
-client = AsyncSeedObjectsWithImports()
+client = AsyncSeedObjectsWithImports(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/optional/reference.md
+++ b/seed/python-sdk/optional/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedObjectsWithImports
 
-client = SeedObjectsWithImports()
+client = SeedObjectsWithImports(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.optional.send_optional_body(
     request={
@@ -72,7 +74,9 @@ client.optional.send_optional_body(
 ```python
 from seed import SeedObjectsWithImports
 
-client = SeedObjectsWithImports()
+client = SeedObjectsWithImports(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.optional.send_optional_typed_body(
     request={
@@ -144,7 +148,9 @@ This should not generate wire tests expecting {} when Optional.empty() is passed
 ```python
 from seed import SeedObjectsWithImports
 
-client = SeedObjectsWithImports()
+client = SeedObjectsWithImports(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.optional.send_optional_nullable_with_all_optional_properties(
     action_id="actionId",

--- a/seed/python-sdk/package-yml/README.md
+++ b/seed/python-sdk/package-yml/README.md
@@ -38,6 +38,7 @@ from seed import SeedPackageYml
 
 client = SeedPackageYml(
     id="id-ksfd9c1",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.echo(
@@ -58,6 +59,7 @@ from seed import AsyncSeedPackageYml
 
 client = AsyncSeedPackageYml(
     id="id-ksfd9c1",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/package-yml/reference.md
+++ b/seed/python-sdk/package-yml/reference.md
@@ -16,6 +16,7 @@ from seed import SeedPackageYml
 
 client = SeedPackageYml(
     id="id-ksfd9c1",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.echo(
@@ -84,6 +85,7 @@ from seed import SeedPackageYml
 
 client = SeedPackageYml(
     id="id-a2ijs82",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.service.nop(

--- a/seed/python-sdk/pagination-custom/README.md
+++ b/seed/python-sdk/pagination-custom/README.md
@@ -39,6 +39,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_usernames_custom(
@@ -57,6 +58,7 @@ from seed import AsyncSeedPagination
 
 client = AsyncSeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -89,11 +91,26 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.users.list_usernames_custom(...)
-for item in pager:
-    print(item)
+from seed import SeedPagination
 
+client = SeedPagination(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.users.list_usernames_custom(
+    starting_after="starting_after",
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.users.list_usernames_custom(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/pagination-custom/reference.md
+++ b/seed/python-sdk/pagination-custom/reference.md
@@ -17,6 +17,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_usernames_custom(

--- a/seed/python-sdk/pagination-uri-path/README.md
+++ b/seed/python-sdk/pagination-uri-path/README.md
@@ -39,6 +39,7 @@ from seed import SeedPaginationUriPath
 
 client = SeedPaginationUriPath(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_uri_pagination()
@@ -55,6 +56,7 @@ from seed import AsyncSeedPaginationUriPath
 
 client = AsyncSeedPaginationUriPath(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -85,11 +87,24 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.users.list_with_uri_pagination()
-for item in pager:
-    print(item)
+from seed import SeedPaginationUriPath
 
+client = SeedPaginationUriPath(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.users.list_with_uri_pagination()
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.users.list_with_uri_pagination()
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/pagination-uri-path/reference.md
+++ b/seed/python-sdk/pagination-uri-path/reference.md
@@ -17,6 +17,7 @@ from seed import SeedPaginationUriPath
 
 client = SeedPaginationUriPath(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_uri_pagination()
@@ -64,6 +65,7 @@ from seed import SeedPaginationUriPath
 
 client = SeedPaginationUriPath(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_path_pagination()

--- a/seed/python-sdk/pagination/no-custom-config/README.md
+++ b/seed/python-sdk/pagination/no-custom-config/README.md
@@ -39,6 +39,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.complex_.search(
@@ -66,6 +67,7 @@ from seed import AsyncSeedPagination
 
 client = AsyncSeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -107,11 +109,35 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.complex_.search(...)
-for item in pager:
-    print(item)
+from seed import SeedPagination
 
+client = SeedPagination(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.complex_.search(
+    index="index",
+    pagination={
+        "per_page": 1,
+        "starting_after": "starting_after"
+    },
+    query={
+        "field": "field",
+        "operator": "=",
+        "value": "value"
+    },
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.complex_.search(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/pagination/no-custom-config/reference.md
+++ b/seed/python-sdk/pagination/no-custom-config/reference.md
@@ -17,6 +17,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.complex_.search(
@@ -92,6 +93,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -179,6 +181,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_mixed_type_cursor_pagination(
@@ -236,6 +239,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_mixed_type_cursor_pagination()
@@ -294,6 +298,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -381,6 +386,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -468,6 +474,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_mixed_type_cursor_pagination()
@@ -526,6 +533,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_offset_step_pagination(
@@ -605,6 +613,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_offset_step_pagination(
@@ -685,6 +694,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_extended_results(
@@ -743,6 +753,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_extended_results(
@@ -800,6 +811,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -860,6 +872,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_global_config(
@@ -918,6 +931,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1005,6 +1019,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_mixed_type_cursor_pagination(
@@ -1062,6 +1077,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_mixed_type_cursor_pagination()
@@ -1136,6 +1152,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_top_level_body_cursor_pagination(
@@ -1205,6 +1222,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1292,6 +1310,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1379,6 +1398,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_mixed_type_cursor_pagination()
@@ -1437,6 +1457,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_offset_step_pagination(
@@ -1516,6 +1537,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_offset_step_pagination(
@@ -1596,6 +1618,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_extended_results(
@@ -1654,6 +1677,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_extended_results(
@@ -1711,6 +1735,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1771,6 +1796,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1831,6 +1857,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_global_config(
@@ -1888,6 +1915,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_optional_data(

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/README.md
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/README.md
@@ -39,6 +39,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.complex_.search(
@@ -66,6 +67,7 @@ from seed import AsyncSeedPagination
 
 client = AsyncSeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -107,11 +109,35 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.complex_.search(...)
-for item in pager:
-    print(item)
+from seed import SeedPagination
 
+client = SeedPagination(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.complex_.search(
+    index="index",
+    pagination={
+        "per_page": 1,
+        "starting_after": "starting_after"
+    },
+    query={
+        "field": "field",
+        "operator": "=",
+        "value": "value"
+    },
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.complex_.search(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/reference.md
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/reference.md
@@ -17,6 +17,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.complex_.search(
@@ -92,6 +93,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -179,6 +181,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_mixed_type_cursor_pagination(
@@ -236,6 +239,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_mixed_type_cursor_pagination()
@@ -294,6 +298,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -381,6 +386,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -468,6 +474,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_mixed_type_cursor_pagination()
@@ -526,6 +533,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_offset_step_pagination(
@@ -605,6 +613,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_offset_step_pagination(
@@ -685,6 +694,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_extended_results(
@@ -743,6 +753,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_extended_results(
@@ -800,6 +811,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -860,6 +872,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_global_config(
@@ -918,6 +931,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1005,6 +1019,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_mixed_type_cursor_pagination(
@@ -1062,6 +1077,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_mixed_type_cursor_pagination()
@@ -1136,6 +1152,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_top_level_body_cursor_pagination(
@@ -1205,6 +1222,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1292,6 +1310,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1379,6 +1398,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_mixed_type_cursor_pagination()
@@ -1437,6 +1457,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_offset_step_pagination(
@@ -1516,6 +1537,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_offset_step_pagination(
@@ -1596,6 +1618,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_extended_results(
@@ -1654,6 +1677,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_extended_results(
@@ -1711,6 +1735,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1771,6 +1796,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1831,6 +1857,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_global_config(
@@ -1888,6 +1915,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_optional_data(

--- a/seed/python-sdk/pagination/page-index-semantics/README.md
+++ b/seed/python-sdk/pagination/page-index-semantics/README.md
@@ -39,6 +39,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.complex_.search(
@@ -66,6 +67,7 @@ from seed import AsyncSeedPagination
 
 client = AsyncSeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 
@@ -107,11 +109,35 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-pager = client.complex_.search(...)
-for item in pager:
-    print(item)
+from seed import SeedPagination
 
+client = SeedPagination(
+    token="<token>",
+    base_url="https://yourhost.com/path/to/api",
+)
+
+client.complex_.search(
+    index="index",
+    pagination={
+        "per_page": 1,
+        "starting_after": "starting_after"
+    },
+    query={
+        "field": "field",
+        "operator": "=",
+        "value": "value"
+    },
+)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+
+```python
 # You can also iterate through pages and access the typed response per page
+pager = client.complex_.search(...)
 for page in pager.iter_pages():
     print(page.response)  # access the typed response for each page
     for item in page:

--- a/seed/python-sdk/pagination/page-index-semantics/reference.md
+++ b/seed/python-sdk/pagination/page-index-semantics/reference.md
@@ -17,6 +17,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.complex_.search(
@@ -92,6 +93,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -179,6 +181,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_mixed_type_cursor_pagination(
@@ -236,6 +239,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_mixed_type_cursor_pagination()
@@ -294,6 +298,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -381,6 +386,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -468,6 +474,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_mixed_type_cursor_pagination()
@@ -526,6 +533,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_offset_step_pagination(
@@ -605,6 +613,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_offset_step_pagination(
@@ -685,6 +694,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_extended_results(
@@ -743,6 +753,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_extended_results(
@@ -800,6 +811,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_cursor_pagination(
@@ -860,6 +872,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.inline_users.inline_users.list_with_global_config(
@@ -918,6 +931,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1005,6 +1019,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_mixed_type_cursor_pagination(
@@ -1062,6 +1077,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_mixed_type_cursor_pagination()
@@ -1136,6 +1152,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_top_level_body_cursor_pagination(
@@ -1205,6 +1222,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1292,6 +1310,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1379,6 +1398,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_mixed_type_cursor_pagination()
@@ -1437,6 +1457,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_offset_step_pagination(
@@ -1516,6 +1537,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_offset_step_pagination(
@@ -1596,6 +1618,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_extended_results(
@@ -1654,6 +1677,7 @@ from uuid import UUID
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_extended_results(
@@ -1711,6 +1735,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1771,6 +1796,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_cursor_pagination(
@@ -1831,6 +1857,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_global_config(
@@ -1888,6 +1915,7 @@ from seed import SeedPagination
 
 client = SeedPagination(
     token="<token>",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.users.list_with_optional_data(

--- a/seed/python-sdk/path-parameters/README.md
+++ b/seed/python-sdk/path-parameters/README.md
@@ -38,6 +38,7 @@ from seed import SeedPathParameters
 
 client = SeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.create_user(
@@ -61,6 +62,7 @@ from seed import AsyncSeedPathParameters
 
 client = AsyncSeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/path-parameters/reference.md
+++ b/seed/python-sdk/path-parameters/reference.md
@@ -17,6 +17,7 @@ from seed import SeedPathParameters
 
 client = SeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.organizations.get_organization(
@@ -83,6 +84,7 @@ from seed import SeedPathParameters
 
 client = SeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.organizations.get_organization_user(
@@ -157,6 +159,7 @@ from seed import SeedPathParameters
 
 client = SeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.organizations.search_organizations(
@@ -232,6 +235,7 @@ from seed import SeedPathParameters
 
 client = SeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_user(
@@ -297,6 +301,7 @@ from seed import SeedPathParameters
 
 client = SeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.create_user(
@@ -367,6 +372,7 @@ from seed import SeedPathParameters
 
 client = SeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.update_user(
@@ -445,6 +451,7 @@ from seed import SeedPathParameters
 
 client = SeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.search_users(
@@ -533,6 +540,7 @@ from seed import SeedPathParameters
 
 client = SeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_user_metadata(
@@ -621,6 +629,7 @@ from seed import SeedPathParameters
 
 client = SeedPathParameters(
     tenant_id="tenant_id",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.user.get_user_specifics(

--- a/seed/python-sdk/plain-text/README.md
+++ b/seed/python-sdk/plain-text/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedPlainText
 
-client = SeedPlainText()
+client = SeedPlainText(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_text()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedPlainText
 
-client = AsyncSeedPlainText()
+client = AsyncSeedPlainText(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/plain-text/reference.md
+++ b/seed/python-sdk/plain-text/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedPlainText
 
-client = SeedPlainText()
+client = SeedPlainText(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_text()
 

--- a/seed/python-sdk/property-access/README.md
+++ b/seed/python-sdk/property-access/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedPropertyAccess
 
-client = SeedPropertyAccess()
+client = SeedPropertyAccess(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.create_user(
     id="id",
@@ -61,7 +63,9 @@ import asyncio
 
 from seed import AsyncSeedPropertyAccess
 
-client = AsyncSeedPropertyAccess()
+client = AsyncSeedPropertyAccess(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/property-access/reference.md
+++ b/seed/python-sdk/property-access/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedPropertyAccess
 
-client = SeedPropertyAccess()
+client = SeedPropertyAccess(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.create_user(
     id="id",

--- a/seed/python-sdk/python-backslash-escape/README.md
+++ b/seed/python-sdk/python-backslash-escape/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedPythonBackslashEscape
 
-client = SeedPythonBackslashEscape()
+client = SeedPythonBackslashEscape(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.get(
     id="id",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedPythonBackslashEscape
 
-client = AsyncSeedPythonBackslashEscape()
+client = AsyncSeedPythonBackslashEscape(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/python-backslash-escape/reference.md
+++ b/seed/python-sdk/python-backslash-escape/reference.md
@@ -31,7 +31,9 @@ Other backslash examples: FOO\_BAR, path\to\file, C:\Users\name
 ```python
 from seed import SeedPythonBackslashEscape
 
-client = SeedPythonBackslashEscape()
+client = SeedPythonBackslashEscape(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.get(
     id="id",

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/README.md
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedPythonPositionalSingleProperty
 
-client = SeedPythonPositionalSingleProperty()
+client = SeedPythonPositionalSingleProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.create(
     instrument={
@@ -65,7 +67,9 @@ import asyncio
 
 from seed import AsyncSeedPythonPositionalSingleProperty
 
-client = AsyncSeedPythonPositionalSingleProperty()
+client = AsyncSeedPythonPositionalSingleProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/reference.md
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedPythonPositionalSingleProperty
 
-client = SeedPythonPositionalSingleProperty()
+client = SeedPythonPositionalSingleProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.create(
     instrument={

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/README.md
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedPythonPositionalSingleProperty
 
-client = SeedPythonPositionalSingleProperty()
+client = SeedPythonPositionalSingleProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.create(
     instrument={
@@ -65,7 +67,9 @@ import asyncio
 
 from seed import AsyncSeedPythonPositionalSingleProperty
 
-client = AsyncSeedPythonPositionalSingleProperty()
+client = AsyncSeedPythonPositionalSingleProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/reference.md
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedPythonPositionalSingleProperty
 
-client = SeedPythonPositionalSingleProperty()
+client = SeedPythonPositionalSingleProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.create(
     instrument={

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/README.md
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/README.md
@@ -37,7 +37,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.chat_stream(
     prompt="prompt",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedApi
 
-client = AsyncSeedApi()
+client = AsyncSeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:
@@ -87,7 +91,9 @@ The SDK supports streaming responses, as well, the response will be a generator 
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.chat_stream(
     prompt="prompt",

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/reference.md
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.chat_stream(
     prompt="prompt",
@@ -77,7 +79,9 @@ client.chat_stream(
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.chat_stream(
     prompt="Hello",

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/README.md
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/README.md
@@ -37,7 +37,9 @@ Instantiate and use the client with the following:
 from seed import SeedApi
 from datetime import date, datetime
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.search(
     limit=1,
@@ -128,7 +130,9 @@ from datetime import date, datetime
 
 from seed import AsyncSeedApi
 
-client = AsyncSeedApi()
+client = AsyncSeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/reference.md
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/reference.md
@@ -15,7 +15,9 @@
 from seed import SeedApi
 from datetime import date, datetime
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.search(
     limit=1,

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/README.md
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/README.md
@@ -37,7 +37,9 @@ Instantiate and use the client with the following:
 from seed import SeedApi
 from datetime import date, datetime
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.search(
     limit=1,
@@ -128,7 +130,9 @@ from datetime import date, datetime
 
 from seed import AsyncSeedApi
 
-client = AsyncSeedApi()
+client = AsyncSeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/reference.md
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/reference.md
@@ -15,7 +15,9 @@
 from seed import SeedApi
 from datetime import date, datetime
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.search(
     limit=1,

--- a/seed/python-sdk/query-parameters/no-custom-config/README.md
+++ b/seed/python-sdk/query-parameters/no-custom-config/README.md
@@ -38,7 +38,9 @@ from seed import SeedQueryParameters
 from uuid import UUID
 from datetime import date, datetime
 
-client = SeedQueryParameters()
+client = SeedQueryParameters(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.get_username(
     limit=1,
@@ -117,7 +119,9 @@ from datetime import date, datetime
 
 from seed import AsyncSeedQueryParameters
 
-client = AsyncSeedQueryParameters()
+client = AsyncSeedQueryParameters(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/query-parameters/no-custom-config/reference.md
+++ b/seed/python-sdk/query-parameters/no-custom-config/reference.md
@@ -17,7 +17,9 @@ from seed import SeedQueryParameters
 from uuid import UUID
 from datetime import date, datetime
 
-client = SeedQueryParameters()
+client = SeedQueryParameters(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.get_username(
     limit=1,

--- a/seed/python-sdk/request-parameters/README.md
+++ b/seed/python-sdk/request-parameters/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedRequestParameters
 
-client = SeedRequestParameters()
+client = SeedRequestParameters(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.create_username(
     tags=[
@@ -58,7 +60,9 @@ import asyncio
 
 from seed import AsyncSeedRequestParameters
 
-client = AsyncSeedRequestParameters()
+client = AsyncSeedRequestParameters(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/request-parameters/reference.md
+++ b/seed/python-sdk/request-parameters/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedRequestParameters
 
-client = SeedRequestParameters()
+client = SeedRequestParameters(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.create_username(
     tags=[
@@ -100,7 +102,9 @@ client.user.create_username(
 ```python
 from seed import SeedRequestParameters
 
-client = SeedRequestParameters()
+client = SeedRequestParameters(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.create_username_with_referenced_type(
     tags=[
@@ -169,7 +173,9 @@ client.user.create_username_with_referenced_type(
 ```python
 from seed import SeedRequestParameters
 
-client = SeedRequestParameters()
+client = SeedRequestParameters(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.create_username_optional(
     request={},
@@ -226,7 +232,9 @@ from seed import SeedRequestParameters
 from uuid import UUID
 from datetime import date, datetime
 
-client = SeedRequestParameters()
+client = SeedRequestParameters(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.get_username(
     limit=1,

--- a/seed/python-sdk/required-nullable/README.md
+++ b/seed/python-sdk/required-nullable/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get_foo(
     required_baz="required_baz",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedApi
 
-client = AsyncSeedApi()
+client = AsyncSeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/required-nullable/reference.md
+++ b/seed/python-sdk/required-nullable/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get_foo(
     required_baz="required_baz",
@@ -94,7 +96,9 @@ client.get_foo(
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.update_foo(
     id="id",

--- a/seed/python-sdk/reserved-keywords/README.md
+++ b/seed/python-sdk/reserved-keywords/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedNurseryApi
 
-client = SeedNurseryApi()
+client = SeedNurseryApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.package.test(
     for_="for",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedNurseryApi
 
-client = AsyncSeedNurseryApi()
+client = AsyncSeedNurseryApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/reserved-keywords/reference.md
+++ b/seed/python-sdk/reserved-keywords/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedNurseryApi
 
-client = SeedNurseryApi()
+client = SeedNurseryApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.package.test(
     for_="for",

--- a/seed/python-sdk/response-property/README.md
+++ b/seed/python-sdk/response-property/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedResponseProperty
 
-client = SeedResponseProperty()
+client = SeedResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_movie(
     request="string",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedResponseProperty
 
-client = AsyncSeedResponseProperty()
+client = AsyncSeedResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/response-property/reference.md
+++ b/seed/python-sdk/response-property/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedResponseProperty
 
-client = SeedResponseProperty()
+client = SeedResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_movie(
     request="string",
@@ -70,7 +72,9 @@ client.service.get_movie(
 ```python
 from seed import SeedResponseProperty
 
-client = SeedResponseProperty()
+client = SeedResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_movie(
     request="string",
@@ -125,7 +129,9 @@ client.service.get_movie(
 ```python
 from seed import SeedResponseProperty
 
-client = SeedResponseProperty()
+client = SeedResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_movie(
     request="string",
@@ -180,7 +186,9 @@ client.service.get_movie(
 ```python
 from seed import SeedResponseProperty
 
-client = SeedResponseProperty()
+client = SeedResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_movie(
     request="string",
@@ -235,7 +243,9 @@ client.service.get_movie(
 ```python
 from seed import SeedResponseProperty
 
-client = SeedResponseProperty()
+client = SeedResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_movie(
     request="string",
@@ -290,7 +300,9 @@ client.service.get_movie(
 ```python
 from seed import SeedResponseProperty
 
-client = SeedResponseProperty()
+client = SeedResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_movie(
     request="string",
@@ -345,7 +357,9 @@ client.service.get_movie(
 ```python
 from seed import SeedResponseProperty
 
-client = SeedResponseProperty()
+client = SeedResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.get_movie(
     request="string",

--- a/seed/python-sdk/server-sent-event-examples/README.md
+++ b/seed/python-sdk/server-sent-event-examples/README.md
@@ -37,7 +37,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedServerSentEvents
 
-client = SeedServerSentEvents()
+client = SeedServerSentEvents(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.completions.stream(
     query="foo",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedServerSentEvents
 
-client = AsyncSeedServerSentEvents()
+client = AsyncSeedServerSentEvents(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:
@@ -87,7 +91,9 @@ The SDK supports streaming responses, as well, the response will be a generator 
 ```python
 from seed import SeedServerSentEvents
 
-client = SeedServerSentEvents()
+client = SeedServerSentEvents(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.completions.stream(
     query="foo",

--- a/seed/python-sdk/server-sent-event-examples/reference.md
+++ b/seed/python-sdk/server-sent-event-examples/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedServerSentEvents
 
-client = SeedServerSentEvents()
+client = SeedServerSentEvents(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.completions.stream(
     query="foo",
@@ -70,7 +72,9 @@ client.completions.stream(
 ```python
 from seed import SeedServerSentEvents
 
-client = SeedServerSentEvents()
+client = SeedServerSentEvents(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.completions.stream_events(
     query="query",

--- a/seed/python-sdk/server-sent-events/with-wire-tests/README.md
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/README.md
@@ -37,7 +37,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedServerSentEvents
 
-client = SeedServerSentEvents()
+client = SeedServerSentEvents(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.completions.stream(
     query="foo",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedServerSentEvents
 
-client = AsyncSeedServerSentEvents()
+client = AsyncSeedServerSentEvents(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:
@@ -87,7 +91,9 @@ The SDK supports streaming responses, as well, the response will be a generator 
 ```python
 from seed import SeedServerSentEvents
 
-client = SeedServerSentEvents()
+client = SeedServerSentEvents(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.completions.stream(
     query="foo",

--- a/seed/python-sdk/server-sent-events/with-wire-tests/reference.md
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedServerSentEvents
 
-client = SeedServerSentEvents()
+client = SeedServerSentEvents(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.completions.stream(
     query="foo",
@@ -70,7 +72,9 @@ client.completions.stream(
 ```python
 from seed import SeedServerSentEvents
 
-client = SeedServerSentEvents()
+client = SeedServerSentEvents(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.completions.stream_without_terminator(
     query="query",

--- a/seed/python-sdk/server-url-templating/no-custom-config/reference.md
+++ b/seed/python-sdk/server-url-templating/no-custom-config/reference.md
@@ -13,8 +13,11 @@
 
 ```python
 from seed import SeedApi
+from seed.environment import SeedApiEnvironment
 
-client = SeedApi()
+client = SeedApi(
+    environment=SeedApiEnvironment.REGIONAL_API_SERVER,
+)
 
 client.get_users()
 
@@ -58,8 +61,11 @@ client.get_users()
 
 ```python
 from seed import SeedApi
+from seed.environment import SeedApiEnvironment
 
-client = SeedApi()
+client = SeedApi(
+    environment=SeedApiEnvironment.REGIONAL_API_SERVER,
+)
 
 client.get_user(
     user_id="userId",
@@ -113,8 +119,11 @@ client.get_user(
 
 ```python
 from seed import SeedApi
+from seed.environment import SeedApiEnvironment
 
-client = SeedApi()
+client = SeedApi(
+    environment=SeedApiEnvironment.REGIONAL_API_SERVER,
+)
 
 client.get_token(
     client_id="client_id",

--- a/seed/python-sdk/simple-api/reference.md
+++ b/seed/python-sdk/simple-api/reference.md
@@ -14,9 +14,11 @@
 
 ```python
 from seed import SeedSimpleApi
+from seed.environment import SeedSimpleApiEnvironment
 
 client = SeedSimpleApi(
     token="<token>",
+    environment=SeedSimpleApiEnvironment.PRODUCTION,
 )
 
 client.user.get(

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/README.md
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get_account(
     account_id="account_id",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedApi
 
-client = AsyncSeedApi()
+client = AsyncSeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/reference.md
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get_account(
     account_id="account_id",

--- a/seed/python-sdk/single-url-environment-default/reference.md
+++ b/seed/python-sdk/single-url-environment-default/reference.md
@@ -14,9 +14,11 @@
 
 ```python
 from seed import SeedSingleUrlEnvironmentDefault
+from seed.environment import SeedSingleUrlEnvironmentDefaultEnvironment
 
 client = SeedSingleUrlEnvironmentDefault(
     token="<token>",
+    environment=SeedSingleUrlEnvironmentDefaultEnvironment.PRODUCTION,
 )
 
 client.dummy.get_dummy()

--- a/seed/python-sdk/single-url-environment-no-default/reference.md
+++ b/seed/python-sdk/single-url-environment-no-default/reference.md
@@ -14,9 +14,11 @@
 
 ```python
 from seed import SeedSingleUrlEnvironmentNoDefault
+from seed.environment import SeedSingleUrlEnvironmentNoDefaultEnvironment
 
 client = SeedSingleUrlEnvironmentNoDefault(
     token="<token>",
+    environment=SeedSingleUrlEnvironmentNoDefaultEnvironment.PRODUCTION,
 )
 
 client.dummy.get_dummy()

--- a/seed/python-sdk/streaming-parameter/README.md
+++ b/seed/python-sdk/streaming-parameter/README.md
@@ -37,7 +37,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate(
     stream=False,
@@ -54,7 +56,9 @@ import asyncio
 
 from seed import AsyncSeedStreaming
 
-client = AsyncSeedStreaming()
+client = AsyncSeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:
@@ -89,7 +93,9 @@ The SDK supports streaming responses, as well, the response will be a generator 
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate(
     stream=False,

--- a/seed/python-sdk/streaming-parameter/reference.md
+++ b/seed/python-sdk/streaming-parameter/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate(
     stream=False,

--- a/seed/python-sdk/streaming/no-custom-config/README.md
+++ b/seed/python-sdk/streaming/no-custom-config/README.md
@@ -37,7 +37,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate_stream(
     num_events=1,
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedStreaming
 
-client = AsyncSeedStreaming()
+client = AsyncSeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:
@@ -87,7 +91,9 @@ The SDK supports streaming responses, as well, the response will be a generator 
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate_stream(
     num_events=1,

--- a/seed/python-sdk/streaming/no-custom-config/reference.md
+++ b/seed/python-sdk/streaming/no-custom-config/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate_stream(
     num_events=1,
@@ -78,7 +80,9 @@ client.dummy.generate_stream(
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate(
     num_events=5,

--- a/seed/python-sdk/streaming/skip-pydantic-validation/README.md
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/README.md
@@ -37,7 +37,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate_stream(
     num_events=1,
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedStreaming
 
-client = AsyncSeedStreaming()
+client = AsyncSeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:
@@ -87,7 +91,9 @@ The SDK supports streaming responses, as well, the response will be a generator 
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate_stream(
     num_events=1,

--- a/seed/python-sdk/streaming/skip-pydantic-validation/reference.md
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate_stream(
     num_events=1,
@@ -78,7 +80,9 @@ client.dummy.generate_stream(
 ```python
 from seed import SeedStreaming
 
-client = SeedStreaming()
+client = SeedStreaming(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.dummy.generate(
     num_events=5,

--- a/seed/python-sdk/trace/reference.md
+++ b/seed/python-sdk/trace/reference.md
@@ -14,9 +14,11 @@
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.v_2.test()
@@ -62,10 +64,12 @@ client.v_2.test()
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 from uuid import UUID
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.admin.update_test_submission_status(
@@ -131,11 +135,13 @@ client.admin.update_test_submission_status(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 from uuid import UUID
 from datetime import datetime
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.admin.send_test_submission_update(
@@ -202,10 +208,12 @@ client.admin.send_test_submission_update(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 from uuid import UUID
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.admin.update_workspace_submission_status(
@@ -271,11 +279,13 @@ client.admin.update_workspace_submission_status(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 from uuid import UUID
 from datetime import datetime
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.admin.send_workspace_submission_update(
@@ -342,10 +352,12 @@ client.admin.send_workspace_submission_update(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 from uuid import UUID
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.admin.store_traced_test_case(
@@ -512,10 +524,12 @@ client.admin.store_traced_test_case(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 from uuid import UUID
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.admin.store_traced_test_case_v_2(
@@ -667,10 +681,12 @@ client.admin.store_traced_test_case_v_2(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 from uuid import UUID
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.admin.store_traced_workspace(
@@ -827,10 +843,12 @@ client.admin.store_traced_workspace(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 from uuid import UUID
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.admin.store_traced_workspace_v_2(
@@ -974,9 +992,11 @@ client.admin.store_traced_workspace_v_2(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.homepage.get_homepage_problems()
@@ -1021,9 +1041,11 @@ client.homepage.get_homepage_problems()
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.homepage.set_homepage_problems(
@@ -1082,9 +1104,11 @@ client.homepage.set_homepage_problems(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.migration.get_attempted_migrations(
@@ -1154,10 +1178,12 @@ Create a new playlist
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 from datetime import datetime
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.playlist.create_playlist(
@@ -1257,9 +1283,11 @@ Returns the user's playlists
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.playlist.get_playlists(
@@ -1380,9 +1408,11 @@ Returns a playlist
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.playlist.get_playlist(
@@ -1460,9 +1490,11 @@ Updates a playlist
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.playlist.update_playlist(
@@ -1555,9 +1587,11 @@ Deletes a playlist
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.playlist.delete_playlist(
@@ -1636,9 +1670,11 @@ Creates a problem
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.problem.create_problem(
@@ -1787,9 +1823,11 @@ Updates a problem
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.problem.update_problem(
@@ -1947,9 +1985,11 @@ Soft deletes a problem
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.problem.delete_problem(
@@ -2018,9 +2058,11 @@ Returns default starter files for problem
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.problem.get_default_starter_files(
@@ -2130,9 +2172,11 @@ Returns sessionId and execution server URL for session. Spins up server.
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.submission.create_execution_session(
@@ -2201,9 +2245,11 @@ Returns execution server URL for session. Returns empty if session isn't registe
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.submission.get_execution_session(
@@ -2272,9 +2318,11 @@ Stops execution session.
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.submission.stop_execution_session(
@@ -2329,9 +2377,11 @@ client.submission.stop_execution_session(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.submission.get_execution_sessions_state()
@@ -2377,9 +2427,11 @@ client.submission.get_execution_sessions_state()
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.sysprop.set_num_warm_instances(
@@ -2443,9 +2495,11 @@ client.sysprop.set_num_warm_instances(
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.sysprop.get_num_warm_instances()
@@ -2505,9 +2559,11 @@ Returns lightweight versions of all problems
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.v_2.problem.get_lightweight_problems()
@@ -2566,9 +2622,11 @@ Returns latest versions of all problems
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.v_2.problem.get_problems()
@@ -2627,9 +2685,11 @@ Returns latest version of a problem
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.v_2.problem.get_latest_problem(
@@ -2698,9 +2758,11 @@ Returns requested version of a problem
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.v_2.problem.get_problem_version(
@@ -2779,9 +2841,11 @@ Returns lightweight versions of all problems
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.v_2.problem.get_lightweight_problems()
@@ -2840,9 +2904,11 @@ Returns latest versions of all problems
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.v_2.problem.get_problems()
@@ -2901,9 +2967,11 @@ Returns latest version of a problem
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.v_2.problem.get_latest_problem(
@@ -2972,9 +3040,11 @@ Returns requested version of a problem
 
 ```python
 from seed import SeedTrace
+from seed.environment import SeedTraceEnvironment
 
 client = SeedTrace(
     token="<token>",
+    environment=SeedTraceEnvironment.PROD,
 )
 
 client.v_2.problem.get_problem_version(

--- a/seed/python-sdk/undiscriminated-union-with-response-property/README.md
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedUndiscriminatedUnionWithResponseProperty
 
-client = SeedUndiscriminatedUnionWithResponseProperty()
+client = SeedUndiscriminatedUnionWithResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get_union()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedUndiscriminatedUnionWithResponseProperty
 
-client = AsyncSeedUndiscriminatedUnionWithResponseProperty()
+client = AsyncSeedUndiscriminatedUnionWithResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/undiscriminated-union-with-response-property/reference.md
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedUndiscriminatedUnionWithResponseProperty
 
-client = SeedUndiscriminatedUnionWithResponseProperty()
+client = SeedUndiscriminatedUnionWithResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get_union()
 
@@ -59,7 +61,9 @@ client.get_union()
 ```python
 from seed import SeedUndiscriminatedUnionWithResponseProperty
 
-client = SeedUndiscriminatedUnionWithResponseProperty()
+client = SeedUndiscriminatedUnionWithResponseProperty(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.list_unions()
 

--- a/seed/python-sdk/undiscriminated-unions/README.md
+++ b/seed/python-sdk/undiscriminated-unions/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedUndiscriminatedUnions
 
-client = SeedUndiscriminatedUnions()
+client = SeedUndiscriminatedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.get(
     request="string",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedUndiscriminatedUnions
 
-client = AsyncSeedUndiscriminatedUnions()
+client = AsyncSeedUndiscriminatedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/undiscriminated-unions/reference.md
+++ b/seed/python-sdk/undiscriminated-unions/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedUndiscriminatedUnions
 
-client = SeedUndiscriminatedUnions()
+client = SeedUndiscriminatedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.get(
     request="string",
@@ -70,7 +72,9 @@ client.union.get(
 ```python
 from seed import SeedUndiscriminatedUnions
 
-client = SeedUndiscriminatedUnions()
+client = SeedUndiscriminatedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.get_metadata()
 
@@ -115,7 +119,9 @@ client.union.get_metadata()
 ```python
 from seed import SeedUndiscriminatedUnions
 
-client = SeedUndiscriminatedUnions()
+client = SeedUndiscriminatedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.update_metadata(
     request={
@@ -172,7 +178,9 @@ client.union.update_metadata(
 ```python
 from seed import SeedUndiscriminatedUnions
 
-client = SeedUndiscriminatedUnions()
+client = SeedUndiscriminatedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.call(
     union={
@@ -229,7 +237,9 @@ client.union.call(
 ```python
 from seed import SeedUndiscriminatedUnions
 
-client = SeedUndiscriminatedUnions()
+client = SeedUndiscriminatedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.duplicate_types_union(
     request="string",
@@ -284,7 +294,9 @@ client.union.duplicate_types_union(
 ```python
 from seed import SeedUndiscriminatedUnions
 
-client = SeedUndiscriminatedUnions()
+client = SeedUndiscriminatedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.nested_unions(
     request="string",
@@ -339,7 +351,9 @@ client.union.nested_unions(
 ```python
 from seed import SeedUndiscriminatedUnions
 
-client = SeedUndiscriminatedUnions()
+client = SeedUndiscriminatedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.test_camel_case_properties(
     payment_method={

--- a/seed/python-sdk/unions-with-local-date/README.md
+++ b/seed/python-sdk/unions-with-local-date/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedUnions
 
-client = AsyncSeedUnions()
+client = AsyncSeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/unions-with-local-date/reference.md
+++ b/seed/python-sdk/unions-with-local-date/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -71,7 +73,9 @@ client.bigunion.get(
 from seed import SeedUnions
 from datetime import datetime
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.update(
     request={
@@ -133,7 +137,9 @@ client.bigunion.update(
 from seed import SeedUnions
 from datetime import datetime
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.update_many(
     request=[
@@ -204,7 +210,9 @@ client.bigunion.update_many(
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.types.get(
     id="date-example",
@@ -259,7 +267,9 @@ client.types.get(
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.types.update(
     request={
@@ -317,7 +327,9 @@ client.types.update(
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -372,7 +384,9 @@ client.bigunion.get(
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.update(
     request={

--- a/seed/python-sdk/unions/no-custom-config/README.md
+++ b/seed/python-sdk/unions/no-custom-config/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedUnions
 
-client = AsyncSeedUnions()
+client = AsyncSeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/unions/no-custom-config/reference.md
+++ b/seed/python-sdk/unions/no-custom-config/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -71,7 +73,9 @@ client.bigunion.get(
 from seed import SeedUnions
 from datetime import datetime
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.update(
     request={
@@ -133,7 +137,9 @@ client.bigunion.update(
 from seed import SeedUnions
 from datetime import datetime
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.update_many(
     request=[
@@ -204,7 +210,9 @@ client.bigunion.update_many(
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -259,7 +267,9 @@ client.bigunion.get(
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.update(
     request={

--- a/seed/python-sdk/unions/union-naming-v1/README.md
+++ b/seed/python-sdk/unions/union-naming-v1/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedUnions
 
-client = AsyncSeedUnions()
+client = AsyncSeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/unions/union-naming-v1/reference.md
+++ b/seed/python-sdk/unions/union-naming-v1/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -71,7 +73,9 @@ client.bigunion.get(
 from seed import SeedUnions
 from datetime import datetime
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.update(
     request={
@@ -133,7 +137,9 @@ client.bigunion.update(
 from seed import SeedUnions
 from datetime import datetime
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.update_many(
     request=[
@@ -204,7 +210,9 @@ client.bigunion.update_many(
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -259,7 +267,9 @@ client.bigunion.get(
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.update(
     request={

--- a/seed/python-sdk/unions/union-utils/README.md
+++ b/seed/python-sdk/unions/union-utils/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedUnions
 
-client = AsyncSeedUnions()
+client = AsyncSeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/unions/union-utils/reference.md
+++ b/seed/python-sdk/unions/union-utils/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -71,7 +73,9 @@ client.bigunion.get(
 from seed import SeedUnions
 from datetime import datetime
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.update(
     request={
@@ -133,7 +137,9 @@ client.bigunion.update(
 from seed import SeedUnions
 from datetime import datetime
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.update_many(
     request=[
@@ -204,7 +210,9 @@ client.bigunion.update_many(
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.bigunion.get(
     id="id",
@@ -259,7 +267,9 @@ client.bigunion.get(
 ```python
 from seed import SeedUnions
 
-client = SeedUnions()
+client = SeedUnions(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.union.update(
     request={

--- a/seed/python-sdk/unknown/README.md
+++ b/seed/python-sdk/unknown/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedUnknownAsAny
 
-client = SeedUnknownAsAny()
+client = SeedUnknownAsAny(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.unknown.post(
     request={"key": "value"},
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedUnknownAsAny
 
-client = AsyncSeedUnknownAsAny()
+client = AsyncSeedUnknownAsAny(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/unknown/reference.md
+++ b/seed/python-sdk/unknown/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedUnknownAsAny
 
-client = SeedUnknownAsAny()
+client = SeedUnknownAsAny(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.unknown.post(
     request={"key": "value"},
@@ -70,7 +72,9 @@ client.unknown.post(
 ```python
 from seed import SeedUnknownAsAny
 
-client = SeedUnknownAsAny()
+client = SeedUnknownAsAny(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.unknown.post_object(
     unknown={"key": "value"},

--- a/seed/python-sdk/url-form-encoded/README.md
+++ b/seed/python-sdk/url-form-encoded/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.submit_form_data(
     username="johndoe",
@@ -53,7 +55,9 @@ import asyncio
 
 from seed import AsyncSeedApi
 
-client = AsyncSeedApi()
+client = AsyncSeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/url-form-encoded/reference.md
+++ b/seed/python-sdk/url-form-encoded/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedApi
 
-client = SeedApi()
+client = SeedApi(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.submit_form_data(
     username="johndoe",

--- a/seed/python-sdk/validation/no-custom-config/README.md
+++ b/seed/python-sdk/validation/no-custom-config/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedValidation
 
-client = SeedValidation()
+client = SeedValidation(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.create(
     decimal=2.2,
@@ -55,7 +57,9 @@ import asyncio
 
 from seed import AsyncSeedValidation
 
-client = AsyncSeedValidation()
+client = AsyncSeedValidation(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/validation/no-custom-config/reference.md
+++ b/seed/python-sdk/validation/no-custom-config/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedValidation
 
-client = SeedValidation()
+client = SeedValidation(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.create(
     decimal=2.2,
@@ -96,7 +98,9 @@ client.create(
 ```python
 from seed import SeedValidation
 
-client = SeedValidation()
+client = SeedValidation(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get(
     decimal=2.2,

--- a/seed/python-sdk/validation/with-defaults/README.md
+++ b/seed/python-sdk/validation/with-defaults/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedValidation
 
-client = SeedValidation()
+client = SeedValidation(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.create(
     decimal=2.2,
@@ -55,7 +57,9 @@ import asyncio
 
 from seed import AsyncSeedValidation
 
-client = AsyncSeedValidation()
+client = AsyncSeedValidation(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/validation/with-defaults/reference.md
+++ b/seed/python-sdk/validation/with-defaults/reference.md
@@ -14,7 +14,9 @@
 ```python
 from seed import SeedValidation
 
-client = SeedValidation()
+client = SeedValidation(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.create(
     decimal=2.2,
@@ -96,7 +98,9 @@ client.create(
 ```python
 from seed import SeedValidation
 
-client = SeedValidation()
+client = SeedValidation(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.get(
     decimal=2.2,

--- a/seed/python-sdk/variables/README.md
+++ b/seed/python-sdk/variables/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedVariables
 
-client = SeedVariables()
+client = SeedVariables(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.post()
 ```
@@ -50,7 +52,9 @@ import asyncio
 
 from seed import AsyncSeedVariables
 
-client = AsyncSeedVariables()
+client = AsyncSeedVariables(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/variables/reference.md
+++ b/seed/python-sdk/variables/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedVariables
 
-client = SeedVariables()
+client = SeedVariables(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.service.post()
 

--- a/seed/python-sdk/version-no-default/README.md
+++ b/seed/python-sdk/version-no-default/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedVersion
 
-client = SeedVersion()
+client = SeedVersion(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.get_user(
     user_id="userId",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedVersion
 
-client = AsyncSeedVersion()
+client = AsyncSeedVersion(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/version-no-default/reference.md
+++ b/seed/python-sdk/version-no-default/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedVersion
 
-client = SeedVersion()
+client = SeedVersion(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.get_user(
     user_id="userId",

--- a/seed/python-sdk/version/README.md
+++ b/seed/python-sdk/version/README.md
@@ -36,7 +36,9 @@ Instantiate and use the client with the following:
 ```python
 from seed import SeedVersion
 
-client = SeedVersion()
+client = SeedVersion(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.get_user(
     user_id="userId",
@@ -52,7 +54,9 @@ import asyncio
 
 from seed import AsyncSeedVersion
 
-client = AsyncSeedVersion()
+client = AsyncSeedVersion(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 
 async def main() -> None:

--- a/seed/python-sdk/version/reference.md
+++ b/seed/python-sdk/version/reference.md
@@ -15,7 +15,9 @@
 ```python
 from seed import SeedVersion
 
-client = SeedVersion()
+client = SeedVersion(
+    base_url="https://yourhost.com/path/to/api",
+)
 
 client.user.get_user(
     user_id="userId",

--- a/seed/python-sdk/websocket-inferred-auth/README.md
+++ b/seed/python-sdk/websocket-inferred-auth/README.md
@@ -42,6 +42,7 @@ client = SeedWebsocketAuth(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -66,6 +67,7 @@ client = AsyncSeedWebsocketAuth(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 

--- a/seed/python-sdk/websocket-inferred-auth/reference.md
+++ b/seed/python-sdk/websocket-inferred-auth/reference.md
@@ -20,6 +20,7 @@ client = SeedWebsocketAuth(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.get_token_with_client_credentials(
@@ -123,6 +124,7 @@ client = SeedWebsocketAuth(
     client_id="client_id",
     client_secret="client_secret",
     scope="scope",
+    base_url="https://yourhost.com/path/to/api",
 )
 
 client.auth.refresh_token(


### PR DESCRIPTION
## Description

Refs python-v2 README generation parity with v1.

The v2 Python SDK generator was producing README.md and reference.md snippets that were missing three key elements compared to v1 output. This PR post-processes prerendered snippets to restore them.

**Link to Devin Session:** https://app.devin.ai/sessions/5e259bdf5ec34a8990891bb5d5fe1a72
**Requested by:** @iamnamananand996

## Changes Made

### 1. `base_url` injection (~200+ snippets affected)
When no environments are defined, injects `base_url="https://yourhost.com/path/to/api"` into client constructors in prerendered snippets. Previously, prerendered snippets bypassed the existing `getClientConstructorArgs()` logic that already had this.

### 2. Environment imports and params (~80 snippets affected)
When environments are defined, injects:
- `from {package}.environment import {Client}Environment` import line
- `environment={Client}Environment.{DEFAULT_ENV},` constructor arg

Uses the default environment ID if available, otherwise falls back to the first defined environment.

### 3. Pagination comments (64 snippets affected)
Restores the v1 pagination pattern with two code blocks:
- First block: prerendered snippet + `# alternatively, you can paginate page-by-page` + `iter_pages()` boilerplate
- Second block: `# You can also iterate through pages...` with typed response access

### Generator files modified
- `ReadmeSnippetBuilder.ts` — adds `injectClientSetupIntoSnippet()`, `getEnvironmentInfo()`, updated `renderPaginationSnippet()`
- `buildReference.ts` — adds parallel `injectClientSetupIntoSnippet()` and `getEnvironmentInfo()` for reference doc snippets

### Seed fixtures
- All 160/160 seed test cases regenerated and passing

## ⚠️ Key areas for review

1. **Duplicated post-processing logic** between `ReadmeSnippetBuilder.ts` and `buildReference.ts` — `injectClientSetupIntoSnippet`, `injectConstructorArg`, and `getEnvironmentInfo` are copy-pasted. Consider whether these should be extracted to a shared utility.


2. **String manipulation fragility** — The injection logic assumes specific snippet patterns:
   - `client = ` at start of line
   - `()` for no-args constructors
   - `(` at line-end for multi-line constructors
   - Lines that are exactly `)`
   
   If dynamic snippet format changes, this will silently fail (returns unmodified snippet). Should we add validation or logging?

3. **Pagination variable extraction regex** — Uses `/^(\w+)\s*=\s*client\./m` to extract the response variable name from prerendered snippets. Could this match unintended lines?

4. **Environment enum name resolution** — Uses `name.screamingSnakeCase.unsafeName` for the environment enum member. Verify this matches v1 behavior for all edge cases.

5. **Pagination snippet inconsistency** — Prerendered path uses `yield item`/`yield page` while template fallback uses `print(item)`. Is this intentional?

## Testing

- [x] All 160/160 seed fixtures regenerated successfully
- [x] Verified base_url injection in `alias` fixture (no environments)
- [x] Verified environment injection in `audiences` fixture (has environments)
- [x] Verified pagination comments in `pagination` fixture
- [x] Lint checks passing (Prettier)
- [ ] Manual verification recommended for edge cases with unusual environment configurations

## Before/After Examples

**base_url (no environments):**
```diff
 from seed import SeedAlias
 
-client = SeedAlias()
+client = SeedAlias(
+    base_url="https://yourhost.com/path/to/api",
+)
```

**Environment imports (with environments):**
```diff
 from seed import SeedAudiences
+from seed.environment import SeedAudiencesEnvironment
 
-client = SeedAudiences()
+client = SeedAudiences(
+    environment=SeedAudiencesEnvironment.ENVIRONMENT_A,
+)
```

**Pagination comments:**
```diff
-pager = client.complex_.search(...)
-for item in pager:
-    print(item)
+client.complex_.search(...)
+for item in response:
+    yield item
+# alternatively, you can paginate page-by-page
+for page in response.iter_pages():
+    yield page
+```
+(Plus a second snippet block with typed response access)