### PR TITLE
fix(cli): use pathToFileURL for dynamic imports to fix Windows compatibility

### DIFF
--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -6,6 +6,7 @@ import type { Migration, MigrationModule, MigratorResult } from "@fern-api/migra
 import { mkdir, readFile } from "fs/promises";
 import { join } from "path";
 import semver from "semver";
+import { pathToFileURL } from "url";
 import type { FernYmlEditor } from "../../config/fern-yml/FernYmlEditor.js";
 import type { Target } from "../config/Target.js";
 
@@ -211,7 +212,7 @@ export class GeneratorMigrator {
             }
 
             const packageEntryPoint = join(packageDir, packageJson.main);
-            const { migrations } = await import(packageEntryPoint);
+            const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
             return migrations as Record<string, MigrationModule>;
         })();
 

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -5,6 +5,7 @@ import { mkdir, readFile } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import semver from "semver";
+import { pathToFileURL } from "url";
 
 import { Migration, MigrationModule, MigratorResult } from "./types.js";
 
@@ -79,7 +80,7 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
         }
 
         const packageEntryPoint = join(packageDir, packageJson.main);
-        const { migrations } = await import(packageEntryPoint);
+        const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
         return migrations as Record<string, MigrationModule>;
     })();
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.4.2
+  changelogEntry:
+    - summary: |
+        Fix `fern generator upgrade` failing on Windows with
+        `Only URLs with a scheme in: file, data, and node are supported
+        by the default ESM loader. Received protocol 'c:'`. The dynamic
+        `import()` of the migration package now uses `pathToFileURL()` to
+        convert absolute filesystem paths to valid `file://` URLs, which
+        is required by the Node.js ESM loader on Windows.
+      type: fix
+  createdAt: "2026-03-05"
+  irVersion: 65
+
 - version: 4.4.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: [Slack thread](https://buildwithfern.slack.com/archives/C09NRQZ4A2X/p1772720877541889)

Fixes `fern generator upgrade` failing on Windows with:
```
Only URLs with a scheme in: file, data, and node are supported by the default ESM loader.
On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

## Changes Made

- Convert absolute filesystem paths to `file://` URLs using Node.js built-in `pathToFileURL()` before passing them to dynamic `import()` in both:
  - `packages/cli/cli/src/commands/upgrade/migrations/loader.ts` (CLI v1)
  - `packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts` (CLI v2)
- Added `versions.yml` patch changelog entry (v4.4.2) for this fix

On Windows, `path.join()` produces paths like `C:\Users\...\.fern\migration-cache\...`. Node.js ESM loader interprets `C:` as a URL protocol scheme and rejects it. `pathToFileURL()` converts this to `file:///C:/Users/...` which is valid. On Unix, this is a no-op conversion (`/foo` → `file:///foo`) so existing behavior is preserved.

No new dependencies — `url` is a Node.js core module.

## Testing

- [ ] **Not directly testable in CI** — this is a Windows-specific path handling issue. The fix uses the documented Node.js API (`pathToFileURL`) which is the standard solution for this exact problem.

## Human Review Checklist

- [ ] Verify `pathToFileURL(path).href` produces valid ESM import specifiers on both Unix and Windows
- [ ] Confirm no other dynamic `import()` calls use raw absolute filesystem paths (grepped — other occurrences use package names or relative specifiers)
- [ ] Ideally test `fern generator upgrade` on a Windows machine to confirm the fix end-to-end

---

Link to Devin session: https://app.devin.ai/sessions/005b5958f49e4a8f8a80021ce3cf3ca7
Requested by: @aditya-arolkar-swe