### PR TITLE
fix(python): websocket clients use `construct_type` on `skip_validation`

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.61.5
+  changelogEntry:
+    - summary: |
+        Fix WebSocket client generation to respect `pydantic_config.skip_validation: true`.
+        Previously, socket clients always used `parse_obj_as` (full Pydantic validation)
+        regardless of the skip_validation flag. They now correctly use `construct_type`
+        (no validation) when the flag is enabled, matching the behavior of HTTP clients.
+      type: fix
+  createdAt: "2026-03-05"
+  irVersion: 65
+
 - version: 4.61.4
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/socket_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/socket_client_generator.py
@@ -192,7 +192,7 @@ class SocketClientGenerator:
                     writer.write_line("try:")
                     with writer.indent():
                         writer.write("yield ")
-                        writer.write_reference(self._context.core_utilities.get_parse_obj_as())
+                        writer.write_reference(self._context.core_utilities.get_construct_or_parse_ref())
                         writer.write(f"({self._get_response_type_name()}, json.loads(message))  # type: ignore")
                         writer.write_line()
                     writer.write_line("except Exception:")
@@ -247,7 +247,7 @@ class SocketClientGenerator:
                         writer.write_line("try:")
                         with writer.indent():
                             writer.write("parsed = ")
-                            writer.write_reference(self._context.core_utilities.get_parse_obj_as())
+                            writer.write_reference(self._context.core_utilities.get_construct_or_parse_ref())
                             writer.write(f"({self._get_response_type_name()}, json_data)  # type: ignore")
                             writer.write_line()
                         writer.write_line("except Exception:")
@@ -376,7 +376,7 @@ class SocketClientGenerator:
             writer.write_line("try:")
             with writer.indent():
                 writer.write("return ")
-                writer.write_reference(self._context.core_utilities.get_parse_obj_as())
+                writer.write_reference(self._context.core_utilities.get_construct_or_parse_ref())
                 writer.write(f"({self._get_response_type_name()}, json_data)  # type: ignore")
                 writer.write_line()
             writer.write_line("except Exception:")

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -690,6 +690,9 @@ class CoreUtilities:
             else self.get_universal_base_model()
         )
 
+    def get_construct_or_parse_ref(self) -> AST.Reference:
+        return self.get_construct_type() if self._allow_skipping_validation else self.get_parse_obj_as()
+
     def get_construct_type(self) -> AST.Reference:
         return AST.Reference(
             qualified_name_excluding_import=(),


### PR DESCRIPTION
## Description
Fix Websocket compliance with `skip_validation`.

## Changes Made
Three-liner to Websocket client generator.

## Testing
Seed, and Deepgram's config.
- [X] Unit tests added/updated
- [X] Manual testing completed
