### PR TITLE
fix(cli): detect JSON-formatted Swagger 2.0 specs in docs validation rules

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,12 +2,7 @@
 - version: 4.4.3
   changelogEntry:
     - summary: |
-        Fix `fern check` failing with thousands of false-positive errors on JSON-formatted
-        Swagger 2.0 specs (e.g. `"swagger": "2.0"`). The docs validation rules
-        `no-non-component-refs`, `no-openapi-v2-in-docs`, and `valid-local-references`
-        only detected YAML-formatted Swagger 2.0 (`swagger: "2.0"`) and missed JSON
-        format, causing all `#/definitions/` references to be incorrectly flagged as
-        invalid non-component references.
+        Fix `fern check` false-positives on JSON-formatted Swagger 2.0 specs
       type: fix
   createdAt: "2026-03-05"
   irVersion: 65

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.4.3
+  changelogEntry:
+    - summary: |
+        Fix `fern check` failing with thousands of false-positive errors on JSON-formatted
+        Swagger 2.0 specs (e.g. `"swagger": "2.0"`). The docs validation rules
+        `no-non-component-refs`, `no-openapi-v2-in-docs`, and `valid-local-references`
+        only detected YAML-formatted Swagger 2.0 (`swagger: "2.0"`) and missed JSON
+        format, causing all `#/definitions/` references to be incorrectly flagged as
+        invalid non-component references.
+      type: fix
+  createdAt: "2026-03-05"
+  irVersion: 65
+
 - version: 4.4.2
   changelogEntry:
     - summary: |

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
@@ -27,13 +27,17 @@ export const NoNonComponentRefsRule: Rule = {
                                     );
 
                                     // Skip OpenAPI v2 files - they should be handled by the v2 rule first
-                                    const isOpenApiV2 =
+                                    // Check both YAML format (swagger: "2.0") and JSON format ("swagger": "2.0")
+                                    const isOpenApiV2Yaml =
                                         contents.includes("swagger:") &&
                                         (contents.includes('swagger: "2.0"') ||
                                             contents.includes("swagger: '2.0'") ||
                                             contents.includes("swagger: 2.0"));
+                                    const isOpenApiV2Json =
+                                        contents.includes('"swagger"') &&
+                                        contents.includes('"2.0"');
 
-                                    if (isOpenApiV2) {
+                                    if (isOpenApiV2Yaml || isOpenApiV2Json) {
                                         continue; // Skip v2 files
                                     }
 

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
@@ -35,8 +35,7 @@ export const NoNonComponentRefsRule: Rule = {
                                             contents.includes("swagger: 2.0"));
                                     const isOpenApiV2Json =
                                         contents.includes('"swagger":') &&
-                                        (contents.includes('"swagger":"2.0"') ||
-                                            contents.includes('"swagger": "2.0"'));
+                                        (contents.includes('"swagger":"2.0"') || contents.includes('"swagger": "2.0"'));
 
                                     if (isOpenApiV2Yaml || isOpenApiV2Json) {
                                         continue; // Skip v2 files

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
@@ -34,8 +34,9 @@ export const NoNonComponentRefsRule: Rule = {
                                             contents.includes("swagger: '2.0'") ||
                                             contents.includes("swagger: 2.0"));
                                     const isOpenApiV2Json =
-                                        contents.includes('"swagger"') &&
-                                        contents.includes('"2.0"');
+                                        contents.includes('"swagger":') &&
+                                        (contents.includes('"swagger":"2.0"') ||
+                                            contents.includes('"swagger": "2.0"'));
 
                                     if (isOpenApiV2Yaml || isOpenApiV2Json) {
                                         continue; // Skip v2 files

--- a/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
@@ -29,8 +29,9 @@ export const NoOpenApiV2InDocsRule: Rule = {
                                         contents.includes("swagger: '2.0'") ||
                                         contents.includes("swagger: 2.0"));
                                 const isOpenApiV2Json =
-                                    contents.includes('"swagger"') &&
-                                    contents.includes('"2.0"');
+                                    contents.includes('"swagger":') &&
+                                    (contents.includes('"swagger":"2.0"') ||
+                                        contents.includes('"swagger": "2.0"'));
                                 if (isOpenApiV2Yaml || isOpenApiV2Json) {
                                     violations.push({
                                         severity: "error",

--- a/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
@@ -30,8 +30,7 @@ export const NoOpenApiV2InDocsRule: Rule = {
                                         contents.includes("swagger: 2.0"));
                                 const isOpenApiV2Json =
                                     contents.includes('"swagger":') &&
-                                    (contents.includes('"swagger":"2.0"') ||
-                                        contents.includes('"swagger": "2.0"'));
+                                    (contents.includes('"swagger":"2.0"') || contents.includes('"swagger": "2.0"'));
                                 if (isOpenApiV2Yaml || isOpenApiV2Json) {
                                     violations.push({
                                         severity: "error",

--- a/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-openapi-v2-in-docs/no-openapi-v2-in-docs.ts
@@ -21,13 +21,17 @@ export const NoOpenApiV2InDocsRule: Rule = {
                                 // Use the docs workspace as reference point for more descriptive path
                                 const relativePath = relative(docsWorkspace.absoluteFilePath, spec.absoluteFilepath);
 
-                                // Simple check for OpenAPI v2 by looking for "swagger: " pattern
-                                if (
+                                // Simple check for OpenAPI v2 by looking for "swagger" pattern
+                                // Check both YAML format (swagger: "2.0") and JSON format ("swagger": "2.0")
+                                const isOpenApiV2Yaml =
                                     contents.includes("swagger:") &&
                                     (contents.includes('swagger: "2.0"') ||
                                         contents.includes("swagger: '2.0'") ||
-                                        contents.includes("swagger: 2.0"))
-                                ) {
+                                        contents.includes("swagger: 2.0"));
+                                const isOpenApiV2Json =
+                                    contents.includes('"swagger"') &&
+                                    contents.includes('"2.0"');
+                                if (isOpenApiV2Yaml || isOpenApiV2Json) {
                                     violations.push({
                                         severity: "error",
                                         name: "OpenAPI v2.0 not supported",

--- a/packages/cli/yaml/docs-validator/src/rules/valid-local-references/valid-local-references.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-local-references/valid-local-references.ts
@@ -106,8 +106,7 @@ export const ValidLocalReferencesRule: Rule = {
                                         contents.includes("swagger: 2.0"));
                                 const isOpenApiV2Json =
                                     contents.includes('"swagger":') &&
-                                    (contents.includes('"swagger":"2.0"') ||
-                                        contents.includes('"swagger": "2.0"'));
+                                    (contents.includes('"swagger":"2.0"') || contents.includes('"swagger": "2.0"'));
 
                                 if (isOpenApiV2Yaml || isOpenApiV2Json) {
                                     continue; // Skip v2 files

--- a/packages/cli/yaml/docs-validator/src/rules/valid-local-references/valid-local-references.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-local-references/valid-local-references.ts
@@ -105,8 +105,9 @@ export const ValidLocalReferencesRule: Rule = {
                                         contents.includes("swagger: '2.0'") ||
                                         contents.includes("swagger: 2.0"));
                                 const isOpenApiV2Json =
-                                    contents.includes('"swagger"') &&
-                                    contents.includes('"2.0"');
+                                    contents.includes('"swagger":') &&
+                                    (contents.includes('"swagger":"2.0"') ||
+                                        contents.includes('"swagger": "2.0"'));
 
                                 if (isOpenApiV2Yaml || isOpenApiV2Json) {
                                     continue; // Skip v2 files

--- a/packages/cli/yaml/docs-validator/src/rules/valid-local-references/valid-local-references.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-local-references/valid-local-references.ts
@@ -98,13 +98,17 @@ export const ValidLocalReferencesRule: Rule = {
                                 const relativePath = relative(docsWorkspace.absoluteFilePath, spec.absoluteFilepath);
 
                                 // Skip OpenAPI v2 files - they should be handled by the v2 rule first
-                                const isOpenApiV2 =
+                                // Check both YAML format (swagger: "2.0") and JSON format ("swagger": "2.0")
+                                const isOpenApiV2Yaml =
                                     contents.includes("swagger:") &&
                                     (contents.includes('swagger: "2.0"') ||
                                         contents.includes("swagger: '2.0'") ||
                                         contents.includes("swagger: 2.0"));
+                                const isOpenApiV2Json =
+                                    contents.includes('"swagger"') &&
+                                    contents.includes('"2.0"');
 
-                                if (isOpenApiV2) {
+                                if (isOpenApiV2Yaml || isOpenApiV2Json) {
                                     continue; // Skip v2 files
                                 }
 


### PR DESCRIPTION
## Description

Refs: Customer repo [fern-support/docusign-demo](https://github.com/fern-support/docusign-demo)

`fern check` produces ~6,825 false-positive errors on JSON-formatted Swagger 2.0 specs because three docs validation rules only detect YAML-formatted `swagger: "2.0"` and miss JSON-formatted `"swagger": "2.0"`. In JSON the key is quoted (`"swagger":`), so `contents.includes("swagger:")` never matches.

## Changes Made

- **`no-non-component-refs`**: Added JSON-format Swagger 2.0 detection so the rule correctly skips v2 files instead of flagging every `#/definitions/` ref as an error.
- **`no-openapi-v2-in-docs`**: Same JSON-format detection fix so the rule correctly identifies JSON v2 specs.
- **`valid-local-references`**: Same JSON-format detection fix so the rule correctly skips v2 files.
- Updated `versions.yml` with changelog entry for v4.4.4.

The JSON detection matches the key-value pair `"swagger":"2.0"` or `"swagger": "2.0"` (covers both minified and standard JSON formatting). This avoids false-matching OpenAPI 3.0 files that might independently contain `"swagger"` and `"2.0"` substrings.

### Updates since last revision

- **Shortened changelog summary** per reviewer feedback (thesandlord).
- **Bumped version to 4.4.4** after resolving merge conflict with main (v4.4.3 was taken by another change).

## ⚠️ Key Review Points

1. **`no-openapi-v2-in-docs` now fires on JSON v2 specs**: Previously, JSON v2 specs silently bypassed this rule. Now they'll get "OpenAPI v2.0 not supported" errors. However, v2 specs **are** actually supported — `OpenAPILoader.ts` auto-converts them to v3 via `swagger2openapi`. This means the customer will go from ~6,825 ref errors → 2 "v2 not supported" errors, which is a significant improvement but possibly still incorrect. Should this rule be demoted to a warning, or should it be removed/updated to reflect that v2 is in fact supported?

2. **Whitespace sensitivity**: Only `"swagger":"2.0"` (no space) and `"swagger": "2.0"` (single space) are matched. Non-standard JSON formatting with extra whitespace (e.g., `"swagger" : "2.0"`) would not be detected. Standard JSON serializers always produce one of the two matched patterns, so this should be safe in practice.

## Human Review Checklist

- [ ] Verify the 2 remaining "v2 not supported" errors are acceptable, or decide whether `no-openapi-v2-in-docs` should be demoted to a warning given Fern auto-converts v2→v3
- [ ] Confirm v4.4.4 version number in `versions.yml` doesn't conflict with any in-flight releases
- [ ] Spot-check that the substring detection `"swagger":"2.0"` / `"swagger": "2.0"` won't produce false matches in realistic specs

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed — dev CLI build against docusign-demo repo confirms errors reduced from 6,825 → 2

---

[Link to Devin Session](https://app.devin.ai/sessions/be73afdd31644c06ae9363f86dd06d24)
Requested by: @jon-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
