### PR TITLE
fix(java): pass custom-plugins config in local/download-files mode

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/Cli.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/Cli.java
@@ -179,6 +179,7 @@ public final class Cli extends AbstractGeneratorCli<JavaSdkCustomConfig, JavaSdk
                 .collapseOptionalNullable(customConfig.collapseOptionalNullable())
                 .gradleCentralDependencyManagement(customConfig.gradleCentralDependencyManagement())
                 .customInterceptors(customConfig.customInterceptors())
+                .customPlugins(customConfig.customPlugins())
                 .build();
 
         Boolean generateFullProject = ir.getPublishConfig()

--- a/generators/java/sdk/src/main/java/com/fern/java/client/JavaSdkDownloadFilesCustomConfig.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/JavaSdkDownloadFilesCustomConfig.java
@@ -62,6 +62,9 @@ public interface JavaSdkDownloadFilesCustomConfig extends IDownloadFilesCustomCo
         return false;
     }
 
+    @JsonProperty("custom-plugins")
+    Optional<List<String>> customPlugins();
+
     @Value.Default
     @JsonProperty("custom-interceptors")
     default Boolean customInterceptors() {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.2
+  changelogEntry:
+    - summary: |
+        Fix `custom-plugins` configuration not being applied when running in
+        local/download-files mode (`fern generate --local`). The download-files
+        config class was missing the `customPlugins` field, causing the values
+        to be silently dropped during deserialization.
+      type: fix
+  createdAt: "2026-03-05"
+  irVersion: 65
+
 - version: 3.42.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Summary
- `custom-plugins` config was silently dropped when running `fern generate --local` (download-files mode) for the Java SDK generator
- `JavaSdkDownloadFilesCustomConfig` was missing the `customPlugins` field, so Jackson dropped the value during deserialization
- The manual config reconstruction in `Cli.runInDownloadFilesModeHook` also omitted `.customPlugins()` from the builder

## Test plan
- [ ] Add `custom-plugins: ["com.github.johnrengelman.shadow:8.1.1"]` to a Java SDK config with `local-file-system` output
- [ ] Run `fern generate --group java-sdk --local`
- [ ] Verify the generated `build.gradle` contains the Shadow plugin in the `plugins` block
- [ ] Verify existing GitHub/publish mode generation still works with custom-plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)