### PR TITLE
feat(cli): Add --json output flag to check commands

### DIFF
--- a/packages/cli/cli-v2/src/__test__/check.test.ts
+++ b/packages/cli/cli-v2/src/__test__/check.test.ts
@@ -1,0 +1,194 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { randomUUID } from "crypto";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Writable } from "stream";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CheckCommand } from "../commands/check/command.js";
+import { CheckCommand as SdkCheckCommand } from "../commands/sdk/check/command.js";
+import { Context } from "../context/Context.js";
+
+function createCapturingStream(): { stream: NodeJS.WriteStream; getOutput: () => string } {
+    const chunks: Buffer[] = [];
+    const stream = new Writable({
+        write(chunk, _encoding, callback) {
+            chunks.push(Buffer.from(chunk));
+            callback();
+        }
+    }) as NodeJS.WriteStream;
+    return {
+        stream,
+        getOutput: () => Buffer.concat(chunks as unknown as Uint8Array[]).toString("utf-8")
+    };
+}
+
+function createTestContextWithCapture({ cwd }: { cwd: AbsoluteFilePath }): {
+    context: Context;
+    getStdout: () => string;
+    getStderr: () => string;
+} {
+    const stdout = createCapturingStream();
+    const stderr = createCapturingStream();
+    return {
+        context: new Context({ stdout: stdout.stream, stderr: stderr.stream, cwd }),
+        getStdout: stdout.getOutput,
+        getStderr: stderr.getOutput
+    };
+}
+
+describe("fern check --json", () => {
+    let testDir: AbsoluteFilePath;
+
+    beforeEach(async () => {
+        testDir = AbsoluteFilePath.of(join(tmpdir(), `fern-check-json-test-${randomUUID()}`));
+        await mkdir(testDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("outputs structured JSON with violations and no stderr", async () => {
+        await writeFile(
+            join(testDir, "fern.yml"),
+            `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+sdks:
+  defaultGroup: nonexistent-group
+  targets:
+    typescript:
+      version: "1.0.0"
+      output:
+        path: ./sdks/typescript
+      group:
+        - other-group
+`
+        );
+        await writeFile(
+            join(testDir, "openapi.yml"),
+            `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`
+        );
+
+        const { context, getStdout, getStderr } = createTestContextWithCapture({ cwd: testDir });
+        const cmd = new CheckCommand();
+
+        // The sdk checker will find the defaultGroup violation, which causes an error exit.
+        try {
+            await cmd.handle(context, {
+                json: true,
+                strict: false,
+                "log-level": "info"
+            });
+        } catch {
+            // expected CliError.exit()
+        }
+
+        const stdout = getStdout();
+        const stderr = getStderr();
+
+        // No human-readable output on stderr.
+        expect(stderr).toBe("");
+
+        // stdout contains valid JSON.
+        const parsed = JSON.parse(stdout);
+        expect(parsed.success).toBe(false);
+        expect(parsed.results).toBeDefined();
+        expect(parsed.results.sdks).toBeDefined();
+        expect(parsed.results.sdks.length).toBeGreaterThan(0);
+
+        // Each violation has the expected shape.
+        for (const violation of parsed.results.sdks) {
+            expect(violation.severity).toBeDefined();
+            expect(violation.message).toBeDefined();
+        }
+    });
+});
+
+describe("fern sdk check --json", () => {
+    let testDir: AbsoluteFilePath;
+
+    beforeEach(async () => {
+        testDir = AbsoluteFilePath.of(join(tmpdir(), `fern-sdk-check-json-test-${randomUUID()}`));
+        await mkdir(testDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("outputs structured JSON with violations and no stderr", async () => {
+        await writeFile(
+            join(testDir, "fern.yml"),
+            `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+sdks:
+  defaultGroup: nonexistent-group
+  targets:
+    typescript:
+      version: "1.0.0"
+      output:
+        path: ./sdks/typescript
+      group:
+        - other-group
+`
+        );
+        await writeFile(
+            join(testDir, "openapi.yml"),
+            `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`
+        );
+
+        const { context, getStdout, getStderr } = createTestContextWithCapture({ cwd: testDir });
+        const cmd = new SdkCheckCommand();
+
+        try {
+            await cmd.handle(context, {
+                json: true,
+                strict: false,
+                "log-level": "info"
+            });
+        } catch {
+            // expected CliError.exit()
+        }
+
+        const stdout = getStdout();
+        const stderr = getStderr();
+
+        // No human-readable output on stderr.
+        expect(stderr).toBe("");
+
+        // stdout contains valid JSON.
+        const parsed = JSON.parse(stdout);
+        expect(parsed.success).toBe(false);
+        expect(parsed.results).toBeDefined();
+        expect(parsed.results.sdks).toBeDefined();
+        expect(parsed.results.sdks.length).toBeGreaterThan(0);
+
+        // Each violation has the expected shape.
+        for (const violation of parsed.results.sdks) {
+            expect(violation.severity).toBeDefined();
+            expect(violation.message).toBeDefined();
+            expect(violation.filepath).toBeDefined();
+        }
+    });
+});

--- a/packages/cli/cli-v2/src/commands/_internal/toJsonViolation.ts
+++ b/packages/cli/cli-v2/src/commands/_internal/toJsonViolation.ts
@@ -1,0 +1,60 @@
+import type { ValidationViolation } from "@fern-api/fern-definition-validator";
+
+export declare namespace JsonOutput {
+    export interface Violation {
+        api?: string;
+        severity: string;
+        rule?: string;
+        filepath?: string;
+        line?: number;
+        column?: number;
+        message: string;
+    }
+
+    export interface Results {
+        apis?: Violation[];
+        docs?: Violation[];
+        sdks?: Violation[];
+    }
+
+    export interface Response {
+        success: boolean;
+        results: Results;
+    }
+}
+
+const ANSI_REGEX = new RegExp(`${String.fromCodePoint(0x1b)}\\[[0-9;]*m`, "g");
+
+function stripAnsi(text: string): string {
+    return text.replace(ANSI_REGEX, "");
+}
+
+export function toJsonViolation(
+    violation: Pick<ValidationViolation, "severity" | "message" | "name"> & {
+        displayRelativeFilepath?: string;
+        line?: number;
+        column?: number;
+    },
+    options?: { api?: string }
+): JsonOutput.Violation {
+    const result: JsonOutput.Violation = {
+        severity: violation.severity,
+        message: stripAnsi(violation.message)
+    };
+    if (options?.api != null) {
+        result.api = options.api;
+    }
+    if (violation.name != null) {
+        result.rule = violation.name;
+    }
+    if (violation.displayRelativeFilepath != null) {
+        result.filepath = violation.displayRelativeFilepath;
+    }
+    if (violation.line != null) {
+        result.line = violation.line;
+    }
+    if (violation.column != null) {
+        result.column = violation.column;
+    }
+    return result;
+}

--- a/packages/cli/cli-v2/src/commands/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/check/command.ts
@@ -8,6 +8,7 @@ import { SdkChecker } from "../../sdk/checker/SdkChecker.js";
 import { Icons } from "../../ui/format.js";
 import type { Workspace } from "../../workspace/Workspace.js";
 import { command } from "../_internal/command.js";
+import { type JsonOutput, toJsonViolation } from "../_internal/toJsonViolation.js";
 
 export declare namespace CheckCommand {
     export interface Args extends GlobalArgs {
@@ -15,6 +16,8 @@ export declare namespace CheckCommand {
         api?: string;
         /** Treat warnings as errors */
         strict: boolean;
+        /** Output results as JSON to stdout */
+        json: boolean;
     }
 }
 
@@ -24,10 +27,24 @@ export class CheckCommand {
 
         this.validateArgs(args, workspace);
 
-        const { totalErrors, totalWarnings } = await this.runChecks({ context, workspace });
+        const { apiCheckResult, sdkCheckResult } = await this.runChecks({ context, workspace, args });
+
+        const totalErrors =
+            (apiCheckResult.invalidApis.size > 0 ? apiCheckResult.errorCount : 0) + sdkCheckResult.errorCount;
+        const totalWarnings = apiCheckResult.warningCount + sdkCheckResult.warningCount;
+        const hasErrors = totalErrors > 0 || (args.strict && totalWarnings > 0);
+
+        if (args.json) {
+            const response = this.buildJsonResponse({ apiCheckResult, sdkCheckResult, hasErrors });
+            context.stdout.info(JSON.stringify(response, null, 2));
+            if (hasErrors) {
+                throw CliError.exit();
+            }
+            return;
+        }
 
         // Fail if there are errors, or if strict mode and there are warnings.
-        if (totalErrors > 0 || (args.strict && totalWarnings > 0)) {
+        if (hasErrors) {
             throw CliError.exit();
         }
 
@@ -42,37 +59,34 @@ export class CheckCommand {
 
     private async runChecks({
         context,
-        workspace
+        workspace,
+        args
     }: {
         context: Context;
         workspace: Workspace;
-    }): Promise<{ totalErrors: number; totalWarnings: number }> {
-        const violations: (ApiChecker.ResolvedViolation | SdkChecker.ResolvedViolation)[] = [];
-
+        args: CheckCommand.Args;
+    }): Promise<{ apiCheckResult: ApiChecker.Result; sdkCheckResult: SdkChecker.Result }> {
         const apiChecker = new ApiChecker({
             context,
             cliVersion: workspace.cliVersion
         });
         const apiCheckResult = await apiChecker.check({ workspace });
-        if (apiCheckResult.violations.length > 0) {
-            violations.push(...apiCheckResult.violations);
-        }
 
         const sdkChecker = new SdkChecker({ context });
         const sdkCheckResult = await sdkChecker.check({ workspace });
-        if (sdkCheckResult.violations.length > 0) {
-            violations.push(...sdkCheckResult.violations);
+
+        if (!args.json) {
+            const violations: (ApiChecker.ResolvedViolation | SdkChecker.ResolvedViolation)[] = [
+                ...apiCheckResult.violations,
+                ...sdkCheckResult.violations
+            ];
+
+            if (violations.length > 0) {
+                this.displayViolations(violations);
+            }
         }
 
-        if (violations.length > 0) {
-            this.displayViolations(violations);
-        }
-
-        return {
-            totalErrors:
-                (apiCheckResult.invalidApis.size > 0 ? apiCheckResult.errorCount : 0) + sdkCheckResult.errorCount,
-            totalWarnings: apiCheckResult.warningCount + sdkCheckResult.warningCount
-        };
+        return { apiCheckResult, sdkCheckResult };
     }
 
     private displayViolations(
@@ -81,6 +95,34 @@ export class CheckCommand {
         for (const v of violations) {
             process.stderr.write(`${chalk.red(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`);
         }
+    }
+
+    private buildJsonResponse({
+        apiCheckResult,
+        sdkCheckResult,
+        hasErrors
+    }: {
+        apiCheckResult: ApiChecker.Result;
+        sdkCheckResult: SdkChecker.Result;
+        hasErrors: boolean;
+    }): JsonOutput.Response {
+        const results: JsonOutput.Results = {};
+
+        const showApiNames = new Set(apiCheckResult.violations.map((v) => v.apiName)).size > 1;
+        if (apiCheckResult.violations.length > 0) {
+            results.apis = apiCheckResult.violations.map((v) =>
+                toJsonViolation(v, showApiNames ? { api: v.apiName } : undefined)
+            );
+        }
+
+        if (sdkCheckResult.violations.length > 0) {
+            results.sdks = sdkCheckResult.violations.map((v) => toJsonViolation(v));
+        }
+
+        return {
+            success: !hasErrors,
+            results
+        };
     }
 
     private validateArgs(args: CheckCommand.Args, workspace: Workspace): void {
@@ -110,6 +152,11 @@ export function addCheckCommand(cli: Argv<GlobalArgs>): void {
                 .option("strict", {
                     type: "boolean",
                     description: "Treat warnings as errors",
+                    default: false
+                })
+                .option("json", {
+                    type: "boolean",
+                    description: "Output results as JSON to stdout",
                     default: false
                 })
     );

--- a/packages/cli/cli-v2/src/commands/sdk/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/check/command.ts
@@ -6,11 +6,14 @@ import { CliError } from "../../../errors/CliError.js";
 import { SdkChecker } from "../../../sdk/checker/SdkChecker.js";
 import { Icons } from "../../../ui/format.js";
 import { command } from "../../_internal/command.js";
+import { type JsonOutput, toJsonViolation } from "../../_internal/toJsonViolation.js";
 
 export declare namespace CheckCommand {
     export interface Args extends GlobalArgs {
         /** Treat warnings as errors. */
         strict: boolean;
+        /** Output results as JSON to stdout */
+        json: boolean;
     }
 }
 
@@ -21,6 +24,17 @@ export class CheckCommand {
         const checker = new SdkChecker({ context });
         const result = await checker.check({ workspace });
 
+        const hasErrors = result.errorCount > 0 || (args.strict && result.warningCount > 0);
+
+        if (args.json) {
+            const response = this.buildJsonResponse({ sdkCheckResult: result, hasErrors });
+            context.stdout.info(JSON.stringify(response, null, 2));
+            if (hasErrors) {
+                throw CliError.exit();
+            }
+            return;
+        }
+
         if (result.violations.length > 0) {
             for (const v of result.violations) {
                 process.stderr.write(
@@ -29,7 +43,7 @@ export class CheckCommand {
             }
         }
 
-        if (result.errorCount > 0 || (args.strict && result.warningCount > 0)) {
+        if (hasErrors) {
             throw CliError.exit();
         }
 
@@ -39,6 +53,25 @@ export class CheckCommand {
         }
 
         context.stderr.info(`${Icons.success} ${chalk.green("All checks passed")}`);
+    }
+
+    private buildJsonResponse({
+        sdkCheckResult,
+        hasErrors
+    }: {
+        sdkCheckResult: SdkChecker.Result;
+        hasErrors: boolean;
+    }): JsonOutput.Response {
+        const results: JsonOutput.Results = {};
+
+        if (sdkCheckResult.violations.length > 0) {
+            results.sdks = sdkCheckResult.violations.map((v) => toJsonViolation(v));
+        }
+
+        return {
+            success: !hasErrors,
+            results
+        };
     }
 }
 
@@ -50,11 +83,17 @@ export function addCheckCommand(cli: Argv<GlobalArgs>, parentPath?: string): voi
         "Validate SDK configuration",
         (context, args) => cmd.handle(context, args as CheckCommand.Args),
         (yargs) =>
-            yargs.option("strict", {
-                type: "boolean",
-                description: "Treat warnings as errors",
-                default: false
-            }),
+            yargs
+                .option("strict", {
+                    type: "boolean",
+                    description: "Treat warnings as errors",
+                    default: false
+                })
+                .option("json", {
+                    type: "boolean",
+                    description: "Output results as JSON to stdout",
+                    default: false
+                }),
         parentPath
     );
 }


### PR DESCRIPTION
## Description

Re: https://github.com/fern-api/fern/pull/12693

This introduces the `--json` flag to both the new `fern check` and `fern sdk check` commands. Along the way, this also surfaces the source file, line, and column number:

```sh
$ fern check --json
{
  "success": false,
  "results": {
    "apis": [
      {
        "severity": "fatal",
        "message": "endpoints -> listPets - Path parameter is unreferenced in endpoint: limit.",
        "rule": "no-undefined-path-parameters",
        "filepath": "openapi/openapi.yml",
        "line": 1,
        "column": 1
      }
    ],
    "sdks": [
      {
        "severity": "error",
        "message": "Default group 'example' is not referenced by any target",
        "filepath": "fern.yml",
        "line": 7,
        "column": 17
      },
      {
        "severity": "error",
        "message": "Version '5.0.0' does not exist for generator 'python'",
        "filepath": "fern.yml",
        "line": 12,
        "column": 7
      }
    ]
  }
}
```

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
