### PR TITLE
chore(cli): Add target-level README.md configuration

### DIFF
--- a/packages/cli/cli-v2/src/migrator/converters/convertSdkTargets.ts
+++ b/packages/cli/cli-v2/src/migrator/converters/convertSdkTargets.ts
@@ -397,18 +397,67 @@ function convertOutputConfig(
     return { output, publish };
 }
 
-function convertReadme(readme: generatorsYml.ReadmeSchema): schemas.ReadmeSchema | undefined {
-    if (readme.defaultEndpoint != null) {
-        const endpoint = readme.defaultEndpoint;
-        if (typeof endpoint === "string") {
-            return { defaultEndpoint: endpoint };
-        }
-        // If it's an object with method/path, convert to "METHOD /path" format
-        if (typeof endpoint === "object" && "method" in endpoint && "path" in endpoint) {
-            return { defaultEndpoint: `${endpoint.method} ${endpoint.path}` };
-        }
+function convertReadmeEndpoint(endpoint: generatorsYml.ReadmeEndpointSchema): schemas.ReadmeEndpointSchema {
+    if (typeof endpoint === "string") {
+        return endpoint;
     }
-    return undefined;
+    return {
+        method: endpoint.method,
+        path: endpoint.path,
+        ...(endpoint.stream != null ? { stream: endpoint.stream } : {})
+    };
+}
+
+function convertReadme(readme: generatorsYml.ReadmeSchema): schemas.ReadmeSchema | undefined {
+    const result: schemas.ReadmeSchema = {};
+    let hasFields = false;
+
+    if (readme.bannerLink != null) {
+        result.bannerLink = readme.bannerLink;
+        hasFields = true;
+    }
+    if (readme.introduction != null) {
+        result.introduction = readme.introduction;
+        hasFields = true;
+    }
+    if (readme.apiReferenceLink != null) {
+        result.apiReferenceLink = readme.apiReferenceLink;
+        hasFields = true;
+    }
+    if (readme.apiName != null) {
+        result.apiName = readme.apiName;
+        hasFields = true;
+    }
+    if (readme.disabledSections != null) {
+        result.disabledSections = readme.disabledSections;
+        hasFields = true;
+    }
+    if (readme.defaultEndpoint != null) {
+        result.defaultEndpoint = convertReadmeEndpoint(readme.defaultEndpoint);
+        hasFields = true;
+    }
+    if (readme.features != null) {
+        const features: Record<string, schemas.ReadmeEndpointSchema[]> = {};
+        for (const [key, endpoints] of Object.entries(readme.features)) {
+            features[key] = endpoints.map(convertReadmeEndpoint);
+        }
+        result.features = features;
+        hasFields = true;
+    }
+    if (readme.customSections != null) {
+        result.customSections = readme.customSections.map((section) => ({
+            title: section.title,
+            language: section.language as schemas.SdkTargetLanguageSchema | undefined,
+            content: section.content
+        }));
+        hasFields = true;
+    }
+    if (readme.exampleStyle != null) {
+        result.exampleStyle = readme.exampleStyle as schemas.ExampleStyleSchema;
+        hasFields = true;
+    }
+
+    return hasFields ? result : undefined;
 }
 
 export interface ConvertSdkTargetsFromRawOptions {
@@ -789,13 +838,53 @@ function convertRawOutputConfig(
 function convertRawReadme(readme: RawReadmeConfig): schemas.ReadmeSchema | undefined {
     const endpoint = readme.defaultEndpoint ?? readme["default-endpoint"];
 
-    if (endpoint != null) {
-        if (typeof endpoint === "string") {
-            return { defaultEndpoint: endpoint };
-        }
-        if (typeof endpoint === "object" && "method" in endpoint && "path" in endpoint) {
-            return { defaultEndpoint: `${endpoint.method} ${endpoint.path}` };
-        }
+    const result: schemas.ReadmeSchema = {};
+    let hasFields = false;
+
+    if (readme.bannerLink != null) {
+        result.bannerLink = readme.bannerLink;
+        hasFields = true;
     }
-    return undefined;
+    if (readme.introduction != null) {
+        result.introduction = readme.introduction;
+        hasFields = true;
+    }
+    if (readme.apiReferenceLink != null) {
+        result.apiReferenceLink = readme.apiReferenceLink;
+        hasFields = true;
+    }
+    if (readme.apiName != null) {
+        result.apiName = readme.apiName;
+        hasFields = true;
+    }
+    if (readme.disabledSections != null) {
+        result.disabledSections = readme.disabledSections;
+        hasFields = true;
+    }
+    if (endpoint != null) {
+        result.defaultEndpoint = convertReadmeEndpoint(endpoint);
+        hasFields = true;
+    }
+    if (readme.features != null) {
+        const features: Record<string, schemas.ReadmeEndpointSchema[]> = {};
+        for (const [key, endpoints] of Object.entries(readme.features)) {
+            features[key] = endpoints.map(convertReadmeEndpoint);
+        }
+        result.features = features;
+        hasFields = true;
+    }
+    if (readme.customSections != null) {
+        result.customSections = readme.customSections.map((section) => ({
+            title: section.title,
+            language: section.language as schemas.SdkTargetLanguageSchema | undefined,
+            content: section.content
+        }));
+        hasFields = true;
+    }
+    if (readme.exampleStyle != null) {
+        result.exampleStyle = readme.exampleStyle as schemas.ExampleStyleSchema;
+        hasFields = true;
+    }
+
+    return hasFields ? result : undefined;
 }

--- a/packages/cli/cli-v2/src/sdk/adapter/LegacyGeneratorInvocationAdapter.ts
+++ b/packages/cli/cli-v2/src/sdk/adapter/LegacyGeneratorInvocationAdapter.ts
@@ -32,7 +32,7 @@ export class LegacyGeneratorInvocationAdapter {
             outputMode: await this.buildOutputMode(target),
             absolutePathToLocalOutput: this.context.resolveOutputFilePath(target.output.path),
             smartCasing: target.smartCasing ?? true,
-            readme: target.readme,
+            readme: this.buildReadme(target),
 
             // Legacy options which are no longer supported.
             absolutePathToLocalSnippets: undefined,
@@ -309,6 +309,46 @@ export class LegacyGeneratorInvocationAdapter {
         }
         const contents = await readFile(absolutePath, "utf-8");
         return FernFiddle.GithubLicense.custom({ contents });
+    }
+
+    private buildReadme(target: Target): generatorsYml.ReadmeSchema | undefined {
+        const readme = target.readme;
+        if (readme == null) {
+            return undefined;
+        }
+        const result: generatorsYml.ReadmeSchema = {};
+        if (readme.bannerLink != null) {
+            result.bannerLink = readme.bannerLink;
+        }
+        if (readme.introduction != null) {
+            result.introduction = readme.introduction;
+        }
+        if (readme.apiReferenceLink != null) {
+            result.apiReferenceLink = readme.apiReferenceLink;
+        }
+        if (readme.apiName != null) {
+            result.apiName = readme.apiName;
+        }
+        if (readme.disabledSections != null) {
+            result.disabledSections = readme.disabledSections;
+        }
+        if (readme.defaultEndpoint != null) {
+            result.defaultEndpoint = readme.defaultEndpoint as generatorsYml.ReadmeEndpointSchema;
+        }
+        if (readme.features != null) {
+            result.features = readme.features as Record<string, generatorsYml.ReadmeEndpointSchema[]>;
+        }
+        if (readme.customSections != null) {
+            result.customSections = readme.customSections.map((section) => ({
+                title: section.title,
+                language: (section.language ?? target.lang) as generatorsYml.Language,
+                content: section.content
+            }));
+        }
+        if (readme.exampleStyle != null) {
+            result.exampleStyle = readme.exampleStyle as generatorsYml.ExampleStyle;
+        }
+        return result;
     }
 
     private mapLanguage(lang: string): generatorsYml.GenerationLanguage | undefined {

--- a/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
+++ b/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
@@ -65,7 +65,8 @@ export class SdkConfigConverter {
             defaultGroupLocation: sourced.defaultGroup?.$loc,
             targets: this.convertTargets({
                 targetsConfig: sdks.targets,
-                sourced: sourced.targets
+                sourced: sourced.targets,
+                globalReadme: sdks.readme
             })
         };
         if (this.issues.length > 0) {
@@ -82,10 +83,12 @@ export class SdkConfigConverter {
 
     private convertTargets({
         targetsConfig,
-        sourced
+        sourced,
+        globalReadme
     }: {
         targetsConfig: Record<string, schemas.SdkTargetSchema>;
         sourced: Sourced<Record<string, schemas.SdkTargetSchema>>;
+        globalReadme: schemas.ReadmeSchema | undefined;
     }): Target[] {
         const targets: Target[] = [];
         for (const [name, target] of Object.entries(targetsConfig)) {
@@ -96,7 +99,8 @@ export class SdkConfigConverter {
             const converted = this.convertTarget({
                 name,
                 target,
-                sourced: sourcedTarget
+                sourced: sourcedTarget,
+                globalReadme
             });
             if (converted != null) {
                 targets.push(converted);
@@ -108,16 +112,19 @@ export class SdkConfigConverter {
     private convertTarget({
         name,
         target,
-        sourced
+        sourced,
+        globalReadme
     }: {
         name: string;
         target: schemas.SdkTargetSchema;
         sourced: Sourced<schemas.SdkTargetSchema>;
+        globalReadme: schemas.ReadmeSchema | undefined;
     }): Target | undefined {
         const generatorInfo = this.resolveGeneratorInfo({ name, target, sourced });
         if (generatorInfo == null) {
             return undefined;
         }
+        const readme = this.mergeReadme({ globalReadme, targetReadme: target.readme });
         return {
             name,
             lang: generatorInfo.lang,
@@ -129,8 +136,32 @@ export class SdkConfigConverter {
             output: schemas.resolveOutputObjectSchema(target.output),
             publish: target.publish,
             groups: target.group ?? [],
-            metadata: target.metadata
+            metadata: target.metadata,
+            readme
         };
+    }
+
+    private mergeReadme({
+        globalReadme,
+        targetReadme
+    }: {
+        globalReadme: schemas.ReadmeSchema | undefined;
+        targetReadme: schemas.ReadmeSchema | undefined;
+    }): schemas.ReadmeSchema | undefined {
+        if (globalReadme == null && targetReadme == null) {
+            return undefined;
+        }
+        if (globalReadme == null) {
+            return targetReadme;
+        }
+        if (targetReadme == null) {
+            return globalReadme;
+        }
+        const merged: schemas.ReadmeSchema = { ...globalReadme, ...targetReadme };
+        if (globalReadme.customSections != null || targetReadme.customSections != null) {
+            merged.customSections = [...(globalReadme.customSections ?? []), ...(targetReadme.customSections ?? [])];
+        }
+        return merged;
     }
 
     private resolveApi({ api }: { api: string | undefined }): string {

--- a/packages/cli/config/src/schemas/ReadmeSchema.ts
+++ b/packages/cli/config/src/schemas/ReadmeSchema.ts
@@ -1,7 +1,39 @@
 import { z } from "zod";
+import { SdkTargetLanguageSchema } from "./SdkTargetLanguageSchema.js";
+
+export const ReadmeEndpointSchema = z.union([
+    z.string(),
+    z.object({
+        method: z.string(),
+        path: z.string(),
+        stream: z.boolean().optional()
+    })
+]);
+
+export type ReadmeEndpointSchema = z.infer<typeof ReadmeEndpointSchema>;
+
+export const ReadmeCustomSectionSchema = z.object({
+    title: z.string(),
+    language: SdkTargetLanguageSchema.optional(),
+    content: z.string()
+});
+
+export type ReadmeCustomSectionSchema = z.infer<typeof ReadmeCustomSectionSchema>;
+
+export const ExampleStyleSchema = z.enum(["minimal", "comprehensive"]);
+
+export type ExampleStyleSchema = z.infer<typeof ExampleStyleSchema>;
 
 export const ReadmeSchema = z.object({
-    defaultEndpoint: z.string().optional()
+    bannerLink: z.string().optional(),
+    introduction: z.string().optional(),
+    apiReferenceLink: z.string().optional(),
+    apiName: z.string().optional(),
+    disabledSections: z.array(z.string()).optional(),
+    defaultEndpoint: ReadmeEndpointSchema.optional(),
+    features: z.record(z.string(), z.array(ReadmeEndpointSchema)).optional(),
+    customSections: z.array(ReadmeCustomSectionSchema).optional(),
+    exampleStyle: ExampleStyleSchema.optional()
 });
 
 export type ReadmeSchema = z.infer<typeof ReadmeSchema>;

--- a/packages/cli/config/src/schemas/SdkTargetSchema.ts
+++ b/packages/cli/config/src/schemas/SdkTargetSchema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { MetadataSchema } from "./MetadataSchema.js";
 import { OutputSchema } from "./OutputSchema.js";
 import { PublishSchema } from "./PublishSchema.js";
+import { ReadmeSchema } from "./ReadmeSchema.js";
 import { SdkTargetLanguageSchema } from "./SdkTargetLanguageSchema.js";
 
 export const SdkTargetSchema = z.object({
@@ -13,7 +14,8 @@ export const SdkTargetSchema = z.object({
     publish: PublishSchema.optional(),
     output: OutputSchema,
     group: z.array(z.string()).optional(),
-    metadata: MetadataSchema.optional()
+    metadata: MetadataSchema.optional(),
+    readme: ReadmeSchema.optional()
 });
 
 export type SdkTargetSchema = z.infer<typeof SdkTargetSchema>;

--- a/packages/cli/config/src/schemas/index.ts
+++ b/packages/cli/config/src/schemas/index.ts
@@ -34,7 +34,7 @@ export { OutputObjectSchema } from "./OutputObjectSchema.js";
 export { OutputSchema } from "./OutputSchema.js";
 export { PublishSchema } from "./PublishSchema.js";
 export { PypiMetadataSchema, PypiPublishSchema } from "./PypiPublishSchema.js";
-export { ReadmeSchema } from "./ReadmeSchema.js";
+export { ExampleStyleSchema, ReadmeCustomSectionSchema, ReadmeEndpointSchema, ReadmeSchema } from "./ReadmeSchema.js";
 export { ReviewersSchema } from "./ReviewersSchema.js";
 export { RubygemsPublishSchema } from "./RubygemsPublishSchema.js";
 export { resolveOutputObjectSchema } from "./resolveOutputObjectSchema.js";


### PR DESCRIPTION
## Description

This ports over the README.md configuration and makes it possible for users to specify README.md configuration on a per-target basis.

## Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
