### PR TITLE
chore(cli): Improve --help text format

### DIFF
--- a/packages/cli/cli-v2/src/commands/_internal/command.ts
+++ b/packages/cli/cli-v2/src/commands/_internal/command.ts
@@ -25,12 +25,11 @@ export function command<T extends GlobalArgs = GlobalArgs>(
     builder?: BuilderCallback<GlobalArgs, T>,
     parentPath?: string
 ): void {
-    const fullName = parentPath != null ? `${parentPath} ${name}` : name;
     cli.command(
         name,
         description,
         (yargs) => {
-            const configured = yargs.version(false).usage(`$0 ${fullName} [options]\n\n${description}`);
+            const configured = yargs.version(false).usage(description);
             return builder != null ? builder(configured) : configured;
         },
         withContext(handler) as unknown as () => void

--- a/packages/cli/cli-v2/src/commands/_internal/commandGroup.ts
+++ b/packages/cli/cli-v2/src/commands/_internal/commandGroup.ts
@@ -25,7 +25,7 @@ export function commandGroup(
             add(yargs, name);
         }
         return yargs
-            .usage(`$0 ${name}\n\n${description}`)
+            .usage(description)
             .demandCommand(1)
             .fail((msg, err, y) => {
                 if (err != null) {

--- a/packages/cli/cli-v2/src/commands/init/command.ts
+++ b/packages/cli/cli-v2/src/commands/init/command.ts
@@ -181,7 +181,6 @@ export function addInitCommand(cli: Argv<GlobalArgs>): void {
                 })
                 .option("yes", {
                     type: "boolean",
-                    alias: "y",
                     description: "Accept all defaults (non-interactive mode)",
                     default: false
                 })

--- a/packages/cli/cli-v2/src/commands/sdk/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/add/command.ts
@@ -280,7 +280,6 @@ export function addAddCommand(cli: Argv<GlobalArgs>, parentPath?: string): void 
                 })
                 .option("yes", {
                     type: "boolean",
-                    alias: "y",
                     description: "Accept all defaults (non-interactive mode)",
                     default: false
                 }),

--- a/packages/cli/cli-v2/src/commands/sdk/update/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/update/command.ts
@@ -244,7 +244,6 @@ export function addUpdateCommand(cli: Argv<GlobalArgs>, parentPath?: string): vo
                 })
                 .option("yes", {
                     type: "boolean",
-                    alias: "y",
                     description: "Accept all defaults (non-interactive mode)",
                     default: false
                 }),


### PR DESCRIPTION
## Description

This makes a mild improvement to our `--help` text so that we don't have a redundant command name.

**Before**

```sh
$ fern sdk --help
fern sdk

Configure and generate SDKs

Commands:
  fern sdk add       Add a new SDK target to fern.yml
  fern sdk check     Validate SDK configuration
  fern sdk generate  Generate SDKs from fern.yml or directly from an API spec
  fern sdk update    Update SDK targets to the latest version

Options:
  --help       Show help                                                                                       [boolean]
  --version    Show version number                                                                             [boolean]
  --log-level  Set log level                      [string] [choices: "debug", "info", "warn", "error"] [default: "info"]
```

**After**

```sh
$ fern sdk --help
Configure and generate SDKs

Commands:
  fern sdk add       Add a new SDK target to fern.yml
  fern sdk check     Validate SDK configuration
  fern sdk generate  Generate SDKs from fern.yml or directly from an API spec
  fern sdk update    Update SDK targets to the latest version

Options:
  --help       Show help                                                                                       [boolean]
  --version    Show version number                                                                             [boolean]
  --log-level  Set log level                      [string] [choices: "debug", "info", "warn", "error"] [default: "info"]
```

This also removes any flag alias for now. We'll likely introduce these at a later point, but I'd rather it be consistent across the board to start rather than have _some_ aliases in arbitrary places. It's backwards compatible to _add_ an alias later, but not vice versa.