### PR TITLE
fix(python): filter SSE dict to variant model fields in parse_sse_obj

### DIFF
--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -152,6 +152,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -225,7 +234,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -233,6 +242,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
@@ -136,6 +136,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -197,7 +206,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -205,6 +214,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -125,6 +125,12 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -186,7 +192,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -194,6 +200,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
@@ -122,6 +122,12 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -183,7 +189,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -191,6 +197,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.61.6
+  changelogEntry:
+    - summary: |
+        Fix `parse_sse_obj` to filter the SSE dict down to only the fields declared on the
+        matching variant model before passing it to `parse_obj_as`. For event-level discrimination
+        (where the discriminator like `"event"` lives on the SSE envelope), extra SSE fields such
+        as `id`, `retry`, and `comment` no longer leak into the parsed variant as attributes.
+      type: fix
+  createdAt: "2026-03-05"
+  irVersion: 65
+
 - version: 4.61.5
   changelogEntry:
     - summary: |

--- a/seed/fastapi/accept-header/core/pydantic_utilities.py
+++ b/seed/fastapi/accept-header/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/alias-extends/no-custom-config/core/pydantic_utilities.py
+++ b/seed/fastapi/alias-extends/no-custom-config/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/alias-extends/no-inheritance-for-extended-models/core/pydantic_utilities.py
+++ b/seed/fastapi/alias-extends/no-inheritance-for-extended-models/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/alias/core/pydantic_utilities.py
+++ b/seed/fastapi/alias/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/api-wide-base-path/core/pydantic_utilities.py
+++ b/seed/fastapi/api-wide-base-path/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/audiences/core/pydantic_utilities.py
+++ b/seed/fastapi/audiences/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/basic-auth-environment-variables/core/pydantic_utilities.py
+++ b/seed/fastapi/basic-auth-environment-variables/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/basic-auth/core/pydantic_utilities.py
+++ b/seed/fastapi/basic-auth/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/circular-references-advanced/no-custom-config/core/pydantic_utilities.py
+++ b/seed/fastapi/circular-references-advanced/no-custom-config/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/circular-references-advanced/no-inheritance-for-extended-models/core/pydantic_utilities.py
+++ b/seed/fastapi/circular-references-advanced/no-inheritance-for-extended-models/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/circular-references/no-custom-config/core/pydantic_utilities.py
+++ b/seed/fastapi/circular-references/no-custom-config/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/circular-references/no-inheritance-for-extended-models/core/pydantic_utilities.py
+++ b/seed/fastapi/circular-references/no-inheritance-for-extended-models/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/content-type/core/pydantic_utilities.py
+++ b/seed/fastapi/content-type/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/cross-package-type-names/core/pydantic_utilities.py
+++ b/seed/fastapi/cross-package-type-names/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/dollar-string-examples/core/pydantic_utilities.py
+++ b/seed/fastapi/dollar-string-examples/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/empty-clients/core/pydantic_utilities.py
+++ b/seed/fastapi/empty-clients/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/error-property/core/pydantic_utilities.py
+++ b/seed/fastapi/error-property/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/errors/core/pydantic_utilities.py
+++ b/seed/fastapi/errors/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/examples/generate-package-deps/src/seed/examples/core/pydantic_utilities.py
+++ b/seed/fastapi/examples/generate-package-deps/src/seed/examples/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/examples/no-custom-config/core/pydantic_utilities.py
+++ b/seed/fastapi/examples/no-custom-config/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/extends/core/pydantic_utilities.py
+++ b/seed/fastapi/extends/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/extra-properties/core/pydantic_utilities.py
+++ b/seed/fastapi/extra-properties/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/file-download/no-custom-config/core/pydantic_utilities.py
+++ b/seed/fastapi/file-download/no-custom-config/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/file-download/no-inheritance-for-extended-models/core/pydantic_utilities.py
+++ b/seed/fastapi/file-download/no-inheritance-for-extended-models/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/file-upload-openapi/core/pydantic_utilities.py
+++ b/seed/fastapi/file-upload-openapi/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/file-upload/core/pydantic_utilities.py
+++ b/seed/fastapi/file-upload/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/folders/core/pydantic_utilities.py
+++ b/seed/fastapi/folders/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/header-auth-environment-variable/core/pydantic_utilities.py
+++ b/seed/fastapi/header-auth-environment-variable/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/header-auth/core/pydantic_utilities.py
+++ b/seed/fastapi/header-auth/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/http-head/core/pydantic_utilities.py
+++ b/seed/fastapi/http-head/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/idempotency-headers/core/pydantic_utilities.py
+++ b/seed/fastapi/idempotency-headers/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/imdb/async-handlers/core/pydantic_utilities.py
+++ b/seed/fastapi/imdb/async-handlers/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/imdb/includes-extra-fields/core/pydantic_utilities.py
+++ b/seed/fastapi/imdb/includes-extra-fields/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/imdb/no-custom-config/core/pydantic_utilities.py
+++ b/seed/fastapi/imdb/no-custom-config/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/imdb/v1_on_v2/core/pydantic_utilities.py
+++ b/seed/fastapi/imdb/v1_on_v2/core/pydantic_utilities.py
@@ -124,6 +124,12 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -185,7 +191,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -193,6 +199,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/license/core/pydantic_utilities.py
+++ b/seed/fastapi/license/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/literals-unions/core/pydantic_utilities.py
+++ b/seed/fastapi/literals-unions/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/mixed-case/core/pydantic_utilities.py
+++ b/seed/fastapi/mixed-case/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/mixed-file-directory/core/pydantic_utilities.py
+++ b/seed/fastapi/mixed-file-directory/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/multi-line-docs/core/pydantic_utilities.py
+++ b/seed/fastapi/multi-line-docs/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/multi-url-environment-no-default/core/pydantic_utilities.py
+++ b/seed/fastapi/multi-url-environment-no-default/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/multi-url-environment/core/pydantic_utilities.py
+++ b/seed/fastapi/multi-url-environment/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/no-environment/core/pydantic_utilities.py
+++ b/seed/fastapi/no-environment/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/no-retries/core/pydantic_utilities.py
+++ b/seed/fastapi/no-retries/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/nullable-allof-extends/core/pydantic_utilities.py
+++ b/seed/fastapi/nullable-allof-extends/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/nullable-optional/core/pydantic_utilities.py
+++ b/seed/fastapi/nullable-optional/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/nullable/core/pydantic_utilities.py
+++ b/seed/fastapi/nullable/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/oauth-client-credentials-custom/core/pydantic_utilities.py
+++ b/seed/fastapi/oauth-client-credentials-custom/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/oauth-client-credentials-default/core/pydantic_utilities.py
+++ b/seed/fastapi/oauth-client-credentials-default/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/oauth-client-credentials-environment-variables/core/pydantic_utilities.py
+++ b/seed/fastapi/oauth-client-credentials-environment-variables/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/oauth-client-credentials-mandatory-auth/core/pydantic_utilities.py
+++ b/seed/fastapi/oauth-client-credentials-mandatory-auth/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/oauth-client-credentials-nested-root/core/pydantic_utilities.py
+++ b/seed/fastapi/oauth-client-credentials-nested-root/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/oauth-client-credentials-reference/core/pydantic_utilities.py
+++ b/seed/fastapi/oauth-client-credentials-reference/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/oauth-client-credentials-with-variables/core/pydantic_utilities.py
+++ b/seed/fastapi/oauth-client-credentials-with-variables/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/oauth-client-credentials/core/pydantic_utilities.py
+++ b/seed/fastapi/oauth-client-credentials/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/object/core/pydantic_utilities.py
+++ b/seed/fastapi/object/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/objects-with-imports/core/pydantic_utilities.py
+++ b/seed/fastapi/objects-with-imports/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/optional/core/pydantic_utilities.py
+++ b/seed/fastapi/optional/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/package-yml/core/pydantic_utilities.py
+++ b/seed/fastapi/package-yml/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/pagination-custom/core/pydantic_utilities.py
+++ b/seed/fastapi/pagination-custom/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/pagination-uri-path/core/pydantic_utilities.py
+++ b/seed/fastapi/pagination-uri-path/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/pagination/no-custom-config/core/pydantic_utilities.py
+++ b/seed/fastapi/pagination/no-custom-config/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/pagination/no-inheritance-for-extended-models/core/pydantic_utilities.py
+++ b/seed/fastapi/pagination/no-inheritance-for-extended-models/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/path-parameters/core/pydantic_utilities.py
+++ b/seed/fastapi/path-parameters/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/plain-text/core/pydantic_utilities.py
+++ b/seed/fastapi/plain-text/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/property-access/core/pydantic_utilities.py
+++ b/seed/fastapi/property-access/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/public-object/core/pydantic_utilities.py
+++ b/seed/fastapi/public-object/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/required-nullable/core/pydantic_utilities.py
+++ b/seed/fastapi/required-nullable/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/reserved-keywords/core/pydantic_utilities.py
+++ b/seed/fastapi/reserved-keywords/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/server-url-templating/core/pydantic_utilities.py
+++ b/seed/fastapi/server-url-templating/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/simple-api/core/pydantic_utilities.py
+++ b/seed/fastapi/simple-api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/simple-fhir/no-custom-config/core/pydantic_utilities.py
+++ b/seed/fastapi/simple-fhir/no-custom-config/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/simple-fhir/no-inheritance-for-extended-models/core/pydantic_utilities.py
+++ b/seed/fastapi/simple-fhir/no-inheritance-for-extended-models/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/single-url-environment-default/core/pydantic_utilities.py
+++ b/seed/fastapi/single-url-environment-default/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/single-url-environment-no-default/core/pydantic_utilities.py
+++ b/seed/fastapi/single-url-environment-no-default/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/trace/core/pydantic_utilities.py
+++ b/seed/fastapi/trace/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/undiscriminated-unions/core/pydantic_utilities.py
+++ b/seed/fastapi/undiscriminated-unions/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/unions-with-local-date/core/pydantic_utilities.py
+++ b/seed/fastapi/unions-with-local-date/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/unions/no-custom-config/core/pydantic_utilities.py
+++ b/seed/fastapi/unions/no-custom-config/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/unions/no-inheritance-for-extended-models/core/pydantic_utilities.py
+++ b/seed/fastapi/unions/no-inheritance-for-extended-models/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/unknown/core/pydantic_utilities.py
+++ b/seed/fastapi/unknown/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/url-form-encoded/core/pydantic_utilities.py
+++ b/seed/fastapi/url-form-encoded/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/validation/core/pydantic_utilities.py
+++ b/seed/fastapi/validation/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/variables/core/pydantic_utilities.py
+++ b/seed/fastapi/variables/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/version-no-default/core/pydantic_utilities.py
+++ b/seed/fastapi/version-no-default/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/version/core/pydantic_utilities.py
+++ b/seed/fastapi/version/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/webhook-audience/core/pydantic_utilities.py
+++ b/seed/fastapi/webhook-audience/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/webhooks/core/pydantic_utilities.py
+++ b/seed/fastapi/webhooks/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/websocket-bearer-auth/core/pydantic_utilities.py
+++ b/seed/fastapi/websocket-bearer-auth/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/fastapi/websocket/core/pydantic_utilities.py
+++ b/seed/fastapi/websocket/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/accept-header/src/seed/accept/core/pydantic_utilities.py
+++ b/seed/pydantic/accept-header/src/seed/accept/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/alias-extends/no-custom-config/src/seed/alias_extends/core/pydantic_utilities.py
+++ b/seed/pydantic/alias-extends/no-custom-config/src/seed/alias_extends/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/alias-extends/no-inheritance-for-extended-models/src/seed/alias_extends/core/pydantic_utilities.py
+++ b/seed/pydantic/alias-extends/no-inheritance-for-extended-models/src/seed/alias_extends/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/alias/src/seed/alias/core/pydantic_utilities.py
+++ b/seed/pydantic/alias/src/seed/alias/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/any-auth/src/seed/any_auth/core/pydantic_utilities.py
+++ b/seed/pydantic/any-auth/src/seed/any_auth/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/api-wide-base-path/src/seed/api_wide_base_path/core/pydantic_utilities.py
+++ b/seed/pydantic/api-wide-base-path/src/seed/api_wide_base_path/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/audiences/src/seed/audiences/core/pydantic_utilities.py
+++ b/seed/pydantic/audiences/src/seed/audiences/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/basic-auth-environment-variables/src/seed/basic_auth_environment_variables/core/pydantic_utilities.py
+++ b/seed/pydantic/basic-auth-environment-variables/src/seed/basic_auth_environment_variables/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/basic-auth/src/seed/basic_auth/core/pydantic_utilities.py
+++ b/seed/pydantic/basic-auth/src/seed/basic_auth/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/bearer-token-environment-variable/src/seed/bearer_token_environment_variable/core/pydantic_utilities.py
+++ b/seed/pydantic/bearer-token-environment-variable/src/seed/bearer_token_environment_variable/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/bytes-download/src/seed/bytes_download/core/pydantic_utilities.py
+++ b/seed/pydantic/bytes-download/src/seed/bytes_download/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/bytes-upload/src/seed/bytes_upload/core/pydantic_utilities.py
+++ b/seed/pydantic/bytes-upload/src/seed/bytes_upload/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/circular-references-advanced/no-custom-config/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/circular-references-advanced/no-custom-config/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/circular-references-advanced/no-inheritance-for-extended-models/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/circular-references-advanced/no-inheritance-for-extended-models/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/circular-references/no-custom-config/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/circular-references/no-custom-config/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/circular-references/no-inheritance-for-extended-models/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/circular-references/no-inheritance-for-extended-models/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/client-side-params/src/seed/client_side_params/core/pydantic_utilities.py
+++ b/seed/pydantic/client-side-params/src/seed/client_side_params/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/content-type/src/seed/content_types/core/pydantic_utilities.py
+++ b/seed/pydantic/content-type/src/seed/content_types/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/core/pydantic_utilities.py
+++ b/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/dollar-string-examples/src/seed/dollar_string_examples/core/pydantic_utilities.py
+++ b/seed/pydantic/dollar-string-examples/src/seed/dollar_string_examples/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/empty-clients/src/seed/empty_clients/core/pydantic_utilities.py
+++ b/seed/pydantic/empty-clients/src/seed/empty_clients/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/endpoint-security-auth/src/seed/endpoint_security_auth/core/pydantic_utilities.py
+++ b/seed/pydantic/endpoint-security-auth/src/seed/endpoint_security_auth/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/enum/src/seed/enum/core/pydantic_utilities.py
+++ b/seed/pydantic/enum/src/seed/enum/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/error-property/src/seed/error_property/core/pydantic_utilities.py
+++ b/seed/pydantic/error-property/src/seed/error_property/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/errors/src/seed/errors/core/pydantic_utilities.py
+++ b/seed/pydantic/errors/src/seed/errors/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/examples/src/seed/examples/core/pydantic_utilities.py
+++ b/seed/pydantic/examples/src/seed/examples/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/exhaustive/pydantic-v1/src/seed/exhaustive/core/pydantic_utilities.py
+++ b/seed/pydantic/exhaustive/pydantic-v1/src/seed/exhaustive/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/exhaustive/pydantic-v2/src/seed/exhaustive/core/pydantic_utilities.py
+++ b/seed/pydantic/exhaustive/pydantic-v2/src/seed/exhaustive/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/extends/src/seed/extends/core/pydantic_utilities.py
+++ b/seed/pydantic/extends/src/seed/extends/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/extra-properties/src/seed/extra_properties/core/pydantic_utilities.py
+++ b/seed/pydantic/extra-properties/src/seed/extra_properties/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/file-download/no-custom-config/src/seed/file_download/core/pydantic_utilities.py
+++ b/seed/pydantic/file-download/no-custom-config/src/seed/file_download/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/file-download/no-inheritance-for-extended-models/src/seed/file_download/core/pydantic_utilities.py
+++ b/seed/pydantic/file-download/no-inheritance-for-extended-models/src/seed/file_download/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/file-upload-openapi/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/file-upload-openapi/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/file-upload/src/seed/file_upload/core/pydantic_utilities.py
+++ b/seed/pydantic/file-upload/src/seed/file_upload/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/folders/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/folders/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/header-auth-environment-variable/src/seed/header_token_environment_variable/core/pydantic_utilities.py
+++ b/seed/pydantic/header-auth-environment-variable/src/seed/header_token_environment_variable/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/header-auth/src/seed/header_token/core/pydantic_utilities.py
+++ b/seed/pydantic/header-auth/src/seed/header_token/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/http-head/src/seed/http_head/core/pydantic_utilities.py
+++ b/seed/pydantic/http-head/src/seed/http_head/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/idempotency-headers/src/seed/idempotency_headers/core/pydantic_utilities.py
+++ b/seed/pydantic/idempotency-headers/src/seed/idempotency_headers/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/imdb/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/imdb/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/inferred-auth-explicit/src/seed/inferred_auth_explicit/core/pydantic_utilities.py
+++ b/seed/pydantic/inferred-auth-explicit/src/seed/inferred_auth_explicit/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/inferred-auth-implicit-api-key/src/seed/inferred_auth_implicit_api_key/core/pydantic_utilities.py
+++ b/seed/pydantic/inferred-auth-implicit-api-key/src/seed/inferred_auth_implicit_api_key/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/inferred-auth-implicit-no-expiry/src/seed/inferred_auth_implicit_no_expiry/core/pydantic_utilities.py
+++ b/seed/pydantic/inferred-auth-implicit-no-expiry/src/seed/inferred_auth_implicit_no_expiry/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/inferred-auth-implicit-reference/src/seed/inferred_auth_implicit/core/pydantic_utilities.py
+++ b/seed/pydantic/inferred-auth-implicit-reference/src/seed/inferred_auth_implicit/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/inferred-auth-implicit/src/seed/inferred_auth_implicit/core/pydantic_utilities.py
+++ b/seed/pydantic/inferred-auth-implicit/src/seed/inferred_auth_implicit/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/license/src/seed/license/core/pydantic_utilities.py
+++ b/seed/pydantic/license/src/seed/license/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/literal/src/seed/literal/core/pydantic_utilities.py
+++ b/seed/pydantic/literal/src/seed/literal/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/literals-unions/src/seed/literals_unions/core/pydantic_utilities.py
+++ b/seed/pydantic/literals-unions/src/seed/literals_unions/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/mixed-case/src/seed/mixed_case/core/pydantic_utilities.py
+++ b/seed/pydantic/mixed-case/src/seed/mixed_case/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/mixed-file-directory/src/seed/mixed_file_directory/core/pydantic_utilities.py
+++ b/seed/pydantic/mixed-file-directory/src/seed/mixed_file_directory/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/multi-line-docs/src/seed/multi_line_docs/core/pydantic_utilities.py
+++ b/seed/pydantic/multi-line-docs/src/seed/multi_line_docs/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/multi-url-environment-no-default/src/seed/multi_url_environment_no_default/core/pydantic_utilities.py
+++ b/seed/pydantic/multi-url-environment-no-default/src/seed/multi_url_environment_no_default/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/multi-url-environment/src/seed/multi_url_environment/core/pydantic_utilities.py
+++ b/seed/pydantic/multi-url-environment/src/seed/multi_url_environment/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/multiple-request-bodies/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/multiple-request-bodies/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/no-environment/src/seed/no_environment/core/pydantic_utilities.py
+++ b/seed/pydantic/no-environment/src/seed/no_environment/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/no-retries/src/seed/no_retries/core/pydantic_utilities.py
+++ b/seed/pydantic/no-retries/src/seed/no_retries/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/nullable-allof-extends/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/nullable-allof-extends/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/nullable-optional/src/seed/nullable_optional/core/pydantic_utilities.py
+++ b/seed/pydantic/nullable-optional/src/seed/nullable_optional/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/nullable-request-body/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/nullable-request-body/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/nullable/src/seed/nullable/core/pydantic_utilities.py
+++ b/seed/pydantic/nullable/src/seed/nullable/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/oauth-client-credentials-custom/src/seed/oauth_client_credentials/core/pydantic_utilities.py
+++ b/seed/pydantic/oauth-client-credentials-custom/src/seed/oauth_client_credentials/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/oauth-client-credentials-default/src/seed/oauth_client_credentials_default/core/pydantic_utilities.py
+++ b/seed/pydantic/oauth-client-credentials-default/src/seed/oauth_client_credentials_default/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/oauth-client-credentials-environment-variables/src/seed/oauth_client_credentials_environment_variables/core/pydantic_utilities.py
+++ b/seed/pydantic/oauth-client-credentials-environment-variables/src/seed/oauth_client_credentials_environment_variables/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/oauth-client-credentials-mandatory-auth/src/seed/oauth_client_credentials_mandatory_auth/core/pydantic_utilities.py
+++ b/seed/pydantic/oauth-client-credentials-mandatory-auth/src/seed/oauth_client_credentials_mandatory_auth/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/oauth-client-credentials-nested-root/src/seed/oauth_client_credentials/core/pydantic_utilities.py
+++ b/seed/pydantic/oauth-client-credentials-nested-root/src/seed/oauth_client_credentials/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/oauth-client-credentials-reference/src/seed/oauth_client_credentials_reference/core/pydantic_utilities.py
+++ b/seed/pydantic/oauth-client-credentials-reference/src/seed/oauth_client_credentials_reference/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/oauth-client-credentials-with-variables/src/seed/oauth_client_credentials_with_variables/core/pydantic_utilities.py
+++ b/seed/pydantic/oauth-client-credentials-with-variables/src/seed/oauth_client_credentials_with_variables/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/oauth-client-credentials/src/seed/oauth_client_credentials/core/pydantic_utilities.py
+++ b/seed/pydantic/oauth-client-credentials/src/seed/oauth_client_credentials/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/object/src/seed/object/core/pydantic_utilities.py
+++ b/seed/pydantic/object/src/seed/object/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/objects-with-imports/src/seed/objects_with_imports/core/pydantic_utilities.py
+++ b/seed/pydantic/objects-with-imports/src/seed/objects_with_imports/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/optional/src/seed/objects_with_imports/core/pydantic_utilities.py
+++ b/seed/pydantic/optional/src/seed/objects_with_imports/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/package-yml/src/seed/package_yml/core/pydantic_utilities.py
+++ b/seed/pydantic/package-yml/src/seed/package_yml/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/pagination-custom/src/seed/pagination/core/pydantic_utilities.py
+++ b/seed/pydantic/pagination-custom/src/seed/pagination/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/pagination-uri-path/src/seed/pagination_uri_path/core/pydantic_utilities.py
+++ b/seed/pydantic/pagination-uri-path/src/seed/pagination_uri_path/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/pagination/no-custom-config/src/seed/pagination/core/pydantic_utilities.py
+++ b/seed/pydantic/pagination/no-custom-config/src/seed/pagination/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/pagination/no-inheritance-for-extended-models/src/seed/pagination/core/pydantic_utilities.py
+++ b/seed/pydantic/pagination/no-inheritance-for-extended-models/src/seed/pagination/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/path-parameters/src/seed/path_parameters/core/pydantic_utilities.py
+++ b/seed/pydantic/path-parameters/src/seed/path_parameters/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/plain-text/src/seed/plain_text/core/pydantic_utilities.py
+++ b/seed/pydantic/plain-text/src/seed/plain_text/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/property-access/src/seed/property_access/core/pydantic_utilities.py
+++ b/seed/pydantic/property-access/src/seed/property_access/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/public-object/src/seed/public_object/core/pydantic_utilities.py
+++ b/seed/pydantic/public-object/src/seed/public_object/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/query-parameters-openapi-as-objects/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/query-parameters-openapi-as-objects/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/query-parameters-openapi/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/query-parameters-openapi/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/query-parameters/src/seed/query_parameters/core/pydantic_utilities.py
+++ b/seed/pydantic/query-parameters/src/seed/query_parameters/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/request-parameters/src/seed/request_parameters/core/pydantic_utilities.py
+++ b/seed/pydantic/request-parameters/src/seed/request_parameters/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/required-nullable/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/required-nullable/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/reserved-keywords/src/seed/nursery_api/core/pydantic_utilities.py
+++ b/seed/pydantic/reserved-keywords/src/seed/nursery_api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/response-property/src/seed/response_property/core/pydantic_utilities.py
+++ b/seed/pydantic/response-property/src/seed/response_property/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/server-sent-event-examples/src/seed/server_sent_events/core/pydantic_utilities.py
+++ b/seed/pydantic/server-sent-event-examples/src/seed/server_sent_events/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/server-sent-events/src/seed/server_sent_events/core/pydantic_utilities.py
+++ b/seed/pydantic/server-sent-events/src/seed/server_sent_events/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/server-url-templating/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/server-url-templating/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/simple-api/src/seed/simple_api/core/pydantic_utilities.py
+++ b/seed/pydantic/simple-api/src/seed/simple_api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/simple-fhir/no-custom-config/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/simple-fhir/no-custom-config/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/simple-fhir/no-inheritance-for-extended-models/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/simple-fhir/no-inheritance-for-extended-models/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/single-url-environment-default/src/seed/single_url_environment_default/core/pydantic_utilities.py
+++ b/seed/pydantic/single-url-environment-default/src/seed/single_url_environment_default/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/single-url-environment-no-default/src/seed/single_url_environment_no_default/core/pydantic_utilities.py
+++ b/seed/pydantic/single-url-environment-no-default/src/seed/single_url_environment_no_default/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/streaming-parameter/src/seed/streaming/core/pydantic_utilities.py
+++ b/seed/pydantic/streaming-parameter/src/seed/streaming/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/streaming/src/seed/streaming/core/pydantic_utilities.py
+++ b/seed/pydantic/streaming/src/seed/streaming/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/trace/src/seed/trace/core/pydantic_utilities.py
+++ b/seed/pydantic/trace/src/seed/trace/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/undiscriminated-union-with-response-property/src/seed/undiscriminated_union_with_response_property/core/pydantic_utilities.py
+++ b/seed/pydantic/undiscriminated-union-with-response-property/src/seed/undiscriminated_union_with_response_property/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/undiscriminated-unions/src/seed/undiscriminated_unions/core/pydantic_utilities.py
+++ b/seed/pydantic/undiscriminated-unions/src/seed/undiscriminated_unions/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/unions-with-local-date/src/seed/unions/core/pydantic_utilities.py
+++ b/seed/pydantic/unions-with-local-date/src/seed/unions/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/unions/no-custom-config/src/seed/unions/core/pydantic_utilities.py
+++ b/seed/pydantic/unions/no-custom-config/src/seed/unions/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/unions/no-inheritance-for-extended-models/src/seed/unions/core/pydantic_utilities.py
+++ b/seed/pydantic/unions/no-inheritance-for-extended-models/src/seed/unions/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/unknown/src/seed/unknown_as_any/core/pydantic_utilities.py
+++ b/seed/pydantic/unknown/src/seed/unknown_as_any/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/url-form-encoded/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/url-form-encoded/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/validation/src/seed/validation/core/pydantic_utilities.py
+++ b/seed/pydantic/validation/src/seed/validation/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/variables/src/seed/variables/core/pydantic_utilities.py
+++ b/seed/pydantic/variables/src/seed/variables/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/version-no-default/src/seed/version/core/pydantic_utilities.py
+++ b/seed/pydantic/version-no-default/src/seed/version/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/version/src/seed/version/core/pydantic_utilities.py
+++ b/seed/pydantic/version/src/seed/version/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/webhook-audience/src/seed/api/core/pydantic_utilities.py
+++ b/seed/pydantic/webhook-audience/src/seed/api/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/webhooks/src/seed/webhooks/core/pydantic_utilities.py
+++ b/seed/pydantic/webhooks/src/seed/webhooks/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/websocket-bearer-auth/src/seed/websocket_bearer_auth/core/pydantic_utilities.py
+++ b/seed/pydantic/websocket-bearer-auth/src/seed/websocket_bearer_auth/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/websocket-inferred-auth/src/seed/websocket_auth/core/pydantic_utilities.py
+++ b/seed/pydantic/websocket-inferred-auth/src/seed/websocket_auth/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/pydantic/websocket/src/seed/websocket/core/pydantic_utilities.py
+++ b/seed/pydantic/websocket/src/seed/websocket/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/accept-header/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/accept-header/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/alias/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/any-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/any-auth/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/audiences/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/audiences/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/basic-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/bytes-download/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/bytes-upload/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/client-side-params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/content-type/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/content-type/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/empty-clients/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/enum/real-enum/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/enum/strenum/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/error-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/error-property/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/errors/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/errors/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/examples/client-filename/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/examples/readme/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/pydantic_utilities.py
@@ -138,6 +138,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -199,7 +208,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -207,6 +216,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/extends/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/extends/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/extra-properties/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/folders/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/folders/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/header-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/header-auth/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/http-head/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/http-head/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/idempotency-headers/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/license/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/license/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/literals-unions/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/mixed-case/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/multi-line-docs/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/multi-url-environment/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/no-environment/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/no-environment/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/no-retries/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/no-retries/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/nullable-optional/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/nullable-request-body/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/object/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/object/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/objects-with-imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/optional/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/optional/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/package-yml/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/package-yml/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/pagination-custom/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/path-parameters/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/plain-text/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/plain-text/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/property-access/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/property-access/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/public-object/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/public-object/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/request-parameters/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/required-nullable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/reserved-keywords/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/response-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/response-property/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/simple-api/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/simple-api/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/streaming-parameter/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/trace/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/trace/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/unions/union-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/unknown/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unknown/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/url-form-encoded/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/variables/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/version-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/version/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/version/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/webhook-audience/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/webhooks/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/webhooks/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/pydantic_utilities.py
@@ -154,6 +154,15 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+def _filter_dict_to_variant_fields(data: Dict[str, Any], variant: Type[Any]) -> Dict[str, Any]:
+    """Filter a dict to only include keys that are declared fields on the variant model."""
+    if IS_PYDANTIC_V2:
+        variant_fields = set(getattr(variant, "model_fields", {}).keys())
+    else:
+        variant_fields = set(getattr(variant, "__fields__", {}).keys())
+    return {k: v for k, v in data.items() if k in variant_fields}
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -227,7 +236,7 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                         parsed_data = json.loads(data_value)
                         new_object = dict(sse_event)
                         new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        return parse_obj_as(type_, _filter_dict_to_variant_fields(new_object, matching_variant))
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
@@ -235,6 +244,8 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
         # Either no matching variant, data is string type, or JSON parse failed
+        if matching_variant is not None:
+            return parse_obj_as(type_, _filter_dict_to_variant_fields(sse_event, matching_variant))
         return parse_obj_as(type_, sse_event)
 
     else:


### PR DESCRIPTION
## Description

Refs: Requested by @aditya-arolkar-swe
[Devin Session](https://app.devin.ai/sessions/cd04be4dc9cb434cb3d235224acb7b34)

When `parse_sse_obj` handles event-level discrimination (discriminator like `"event"` on the SSE envelope), it converts the full SSE dataclass to a dict via `asdict(sse)`, which includes all envelope fields (`event`, `data`, `id`, `retry`). Because variant models use `extra="allow"`, extra SSE fields like `id`, `retry`, and `comment` were leaking into the parsed variant as spurious attributes.

This PR filters the SSE dict to only the fields declared on the matching variant model before passing it to `parse_obj_as`, without modifying the auto-generated `extra="allow"` config on variant models.

## Changes Made

- Added `_filter_dict_to_variant_fields(data, variant)` helper that introspects the variant's declared fields (`model_fields` for Pydantic v2, `__fields__` for v1) and returns a filtered copy of the dict
- Applied the filter in both event-level discrimination code paths inside `parse_sse_obj`:
  1. Where `data` is swapped in as parsed JSON (`new_object`)
  2. The fallback path that passes `sse_event` directly
- Applied consistently across all 4 `pydantic_utilities.py` variants:
  - `shared/pydantic_utilities.py` (dual v1/v2)
  - `shared/with_pydantic_aliases/pydantic_utilities.py` (dual v1/v2)
  - `shared/with_pydantic_v1_on_v2/pydantic_utilities.py` (v1 only)
  - `shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py` (v1 only)
- Added version `4.61.6` to `generators/python/sdk/versions.yml`
- Regenerated all seed snapshots (pydantic, fastapi, python-sdk) — 160 python-sdk fixtures, 102 pydantic fixtures, 102 fastapi fixtures updated

## Human Review Checklist

- [ ] Verify that variant model field names (Python attribute names from `model_fields`/`__fields__`) match the SSE dict keys (dataclass field names: `event`, `data`, etc.). If variants use Pydantic aliases, the filter uses Python names, not alias names — confirm this is correct for all generated variant models.
- [ ] Confirm `getattr(variant, "model_fields", {})` fallback to `{}` is acceptable — if it ever triggers unexpectedly, all keys would be filtered out, silently producing an empty dict.
- [ ] Data-level discrimination path is intentionally unchanged (no filtering needed there since only `data` payload is passed through).
- [ ] In the fallback path, `matching_variant is not None` now takes a separate early-return with filtering, while `matching_variant is None` falls through to the unfiltered `parse_obj_as(type_, sse_event)`. Confirm this branching is correct.

## Testing

- [x] Pre-commit hooks pass (`poetry run pre-commit run -a`)
- [x] Seed snapshots regenerated for pydantic, fastapi, and python-sdk generators
- [ ] No new unit tests added — this is a runtime utility change in generated SDK core code