### PR TITLE
fix(cli): improve error messages when AI analysis fails during AUTO versioning

### DIFF
--- a/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
+++ b/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
@@ -96,7 +96,7 @@ export async function sdkDiffCommand({
 
     const diffSizeKB = (gitDiff.length / 1024).toFixed(1);
     const fileCount = (gitDiff.match(/^diff --git /gm) || []).length;
-    context.logger.debug(`Generated diff: ${diffSizeKB}KB (${gitDiff.length} chars), ${fileCount} files changed`);
+    context.logger.debug(`Generated diff: ${diffSizeKB}KB (${gitDiff.length} bytes), ${fileCount} files changed`);
 
     // The FAI /sdks/analyze-commit-diff endpoint rejects diffs exceeding 100,000 characters
     const DIFF_SIZE_LIMIT = 100_000; // 100K characters — matches FAI endpoint MAX_DIFF_SIZE

--- a/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
+++ b/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
@@ -98,11 +98,13 @@ export async function sdkDiffCommand({
     const fileCount = (gitDiff.match(/^diff --git /gm) || []).length;
     context.logger.debug(`Generated diff: ${diffSizeKB}KB (${gitDiff.length} bytes), ${fileCount} files changed`);
 
-    const DIFF_SIZE_WARNING_THRESHOLD = 15 * 1024; // 15KB
-    if (gitDiff.length > DIFF_SIZE_WARNING_THRESHOLD) {
+    // The FAI /sdks/analyze-commit-diff endpoint rejects diffs exceeding 100,000 characters
+    const DIFF_SIZE_LIMIT = 100_000; // 100K characters — matches FAI endpoint MAX_DIFF_SIZE
+    if (gitDiff.length > DIFF_SIZE_LIMIT) {
         context.logger.warn(
-            `Diff is very large (${diffSizeKB}KB, ${fileCount} files). ` +
-                `AI analysis may fail or return empty results for diffs exceeding ~15KB.`
+            `Diff is too large for AI analysis ` +
+                `(${gitDiff.length.toLocaleString()} chars / ${diffSizeKB}KB, ${fileCount} files). ` +
+                `The AI endpoint limit is 100,000 characters.`
         );
     }
 
@@ -119,9 +121,9 @@ export async function sdkDiffCommand({
         const errorMessage = error instanceof Error ? error.message : String(error);
         context.failWithoutThrowing(
             `Failed to analyze SDK diff. ` +
-                `Diff stats: ${diffSizeKB}KB, ${fileCount} files changed. ` +
-                (gitDiff.length > DIFF_SIZE_WARNING_THRESHOLD
-                    ? `The diff likely exceeds the AI endpoint's size limit (~15KB). `
+                `Diff stats: ${gitDiff.length.toLocaleString()} chars, ${diffSizeKB}KB, ${fileCount} files changed. ` +
+                (gitDiff.length > DIFF_SIZE_LIMIT
+                    ? `The diff exceeds the AI endpoint's 100,000 character limit. `
                     : "") +
                 `Error: ${errorMessage}`
         );

--- a/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
+++ b/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
@@ -10,6 +10,7 @@ import { ClientRegistry } from "@boundaryml/baml";
 import { AnalyzeCommitDiffResponse, b as BamlClient, configureBamlClient, VersionBump } from "@fern-api/cli-ai";
 import { loadGeneratorsConfiguration } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, cwd, doesPathExist, resolve } from "@fern-api/fs-utils";
+import { countFilesInDiff, DIFF_SIZE_LIMIT, formatSizeKB } from "@fern-api/local-workspace-runner";
 import { Project } from "@fern-api/project-loader";
 import { FernCliError, TaskContext } from "@fern-api/task-context";
 import { exec } from "child_process";
@@ -94,12 +95,10 @@ export async function sdkDiffCommand({
         };
     }
 
-    const diffSizeKB = (gitDiff.length / 1024).toFixed(1);
-    const fileCount = (gitDiff.match(/^diff --git /gm) || []).length;
-    context.logger.debug(`Generated diff: ${diffSizeKB}KB (${gitDiff.length} bytes), ${fileCount} files changed`);
+    const diffSizeKB = formatSizeKB(gitDiff.length);
+    const fileCount = countFilesInDiff(gitDiff);
+    context.logger.debug(`Generated diff: ${diffSizeKB}KB (${gitDiff.length} chars), ${fileCount} files changed`);
 
-    // The FAI /sdks/analyze-commit-diff endpoint rejects diffs exceeding 100,000 characters
-    const DIFF_SIZE_LIMIT = 100_000; // 100K characters — matches FAI endpoint MAX_DIFF_SIZE
     if (gitDiff.length > DIFF_SIZE_LIMIT) {
         context.logger.warn(
             `Diff is too large for AI analysis ` +

--- a/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
+++ b/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
@@ -96,7 +96,7 @@ export async function sdkDiffCommand({
 
     const diffSizeKB = (gitDiff.length / 1024).toFixed(1);
     const fileCount = (gitDiff.match(/^diff --git /gm) || []).length;
-    context.logger.debug(`Generated diff: ${diffSizeKB}KB (${gitDiff.length} bytes), ${fileCount} files changed`);
+    context.logger.debug(`Generated diff: ${diffSizeKB}KB (${gitDiff.length} chars), ${fileCount} files changed`);
 
     // The FAI /sdks/analyze-commit-diff endpoint rejects diffs exceeding 100,000 characters
     const DIFF_SIZE_LIMIT = 100_000; // 100K characters — matches FAI endpoint MAX_DIFF_SIZE

--- a/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
+++ b/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
@@ -94,7 +94,17 @@ export async function sdkDiffCommand({
         };
     }
 
-    context.logger.debug(`Generated diff (${gitDiff.length} characters)`);
+    const diffSizeKB = (gitDiff.length / 1024).toFixed(1);
+    const fileCount = (gitDiff.match(/^diff --git /gm) || []).length;
+    context.logger.debug(`Generated diff: ${diffSizeKB}KB (${gitDiff.length} bytes), ${fileCount} files changed`);
+
+    const DIFF_SIZE_WARNING_THRESHOLD = 15 * 1024; // 15KB
+    if (gitDiff.length > DIFF_SIZE_WARNING_THRESHOLD) {
+        context.logger.warn(
+            `Diff is very large (${diffSizeKB}KB, ${fileCount} files). ` +
+                `AI analysis may fail or return empty results for diffs exceeding ~15KB.`
+        );
+    }
 
     // Analyze the diff using LLM with the configured client
     context.logger.info("Analyzing diff with LLM...");
@@ -106,8 +116,14 @@ export async function sdkDiffCommand({
         context.logger.debug("Analysis complete");
         return analysis;
     } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
         context.failWithoutThrowing(
-            `Failed to analyze SDK diff: ${error instanceof Error ? error.message : String(error)}`
+            `Failed to analyze SDK diff. ` +
+                `Diff stats: ${diffSizeKB}KB, ${fileCount} files changed. ` +
+                (gitDiff.length > DIFF_SIZE_WARNING_THRESHOLD
+                    ? `The diff likely exceeds the AI endpoint's size limit (~15KB). `
+                    : "") +
+                `Error: ${errorMessage}`
         );
         throw new FernCliError();
     }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.4.5
+  changelogEntry:
+    - summary: |
+        Improve error messages when AI analysis fails during AUTO versioning.
+        Error and warning logs now include diff size (in KB), number of files
+        changed, and guidance when the diff exceeds the ~15KB AI endpoint limit.
+        Previously, failures only logged a generic "AI analysis failed, falling
+        back to PATCH" message with no actionable context.
+      type: fix
+  createdAt: "2026-03-05"
+  irVersion: 65
+
 - version: 4.4.4
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -3,10 +3,11 @@
   changelogEntry:
     - summary: |
         Improve error messages when AI analysis fails during AUTO versioning.
-        Error and warning logs now include diff size (in KB), number of files
-        changed, and guidance when the diff exceeds the ~15KB AI endpoint limit.
-        Previously, failures only logged a generic "AI analysis failed, falling
-        back to PATCH" message with no actionable context.
+        Error and warning logs now include diff size (in characters and KB),
+        number of files changed, and guidance when the diff exceeds the FAI
+        endpoint's 100,000 character limit. Previously, failures only logged a
+        generic "AI analysis failed, falling back to PATCH" message with no
+        actionable context.
       type: fix
   createdAt: "2026-03-05"
   irVersion: 65

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/AutoVersioningService.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/AutoVersioningService.ts
@@ -26,6 +26,42 @@ export interface AutoVersionResult {
     commitMessage: string;
 }
 
+/**
+ * Maximum diff size in characters that the FAI /sdks/analyze-commit-diff endpoint accepts.
+ * Roughly 100KB ≈ 25k–30k tokens for Claude. Diffs exceeding this are rejected with HTTP 413.
+ * This constant is the single source of truth — LocalTaskHandler and sdkDiffCommand both reference it.
+ */
+export const DIFF_SIZE_LIMIT = 100_000;
+
+/**
+ * Counts the number of files changed in a git diff by scanning for "diff --git" headers.
+ * Uses indexOf-based scanning instead of regex to avoid O(n) regex overhead on large diffs.
+ */
+export function countFilesInDiff(diffContent: string): number {
+    const marker = "diff --git ";
+    let count = 0;
+    let pos = 0;
+    while (true) {
+        const idx = diffContent.indexOf(marker, pos);
+        if (idx === -1) {
+            break;
+        }
+        // Only count if the marker is at the start of a line
+        if (idx === 0 || diffContent[idx - 1] === "\n") {
+            count++;
+        }
+        pos = idx + marker.length;
+    }
+    return count;
+}
+
+/**
+ * Formats a character length as a human-readable KB string with one decimal place.
+ */
+export function formatSizeKB(charLength: number): string {
+    return (charLength / 1024).toFixed(1);
+}
+
 interface FileSection {
     lines: string[];
 }
@@ -278,7 +314,7 @@ export class AutoVersioningService {
         }
 
         this.logger.debug(
-            `Cleaned diff: removed ${diffContent.length - result.join("\n").length} bytes containing version changes`
+            `Cleaned diff: removed ${diffContent.length - result.join("\n").length} chars containing version changes`
         );
         return result.join("\n");
     }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -10,7 +10,14 @@ import { tmpdir } from "os";
 import { join as pathJoin } from "path";
 import semver from "semver";
 import tmp from "tmp-promise";
-import { AutoVersioningException, AutoVersioningService, AutoVersionResult } from "./AutoVersioningService.js";
+import {
+    AutoVersioningException,
+    AutoVersioningService,
+    AutoVersionResult,
+    countFilesInDiff,
+    DIFF_SIZE_LIMIT,
+    formatSizeKB
+} from "./AutoVersioningService.js";
 import { isAutoVersion } from "./VersionUtils.js";
 
 export declare namespace LocalTaskHandler {
@@ -137,13 +144,13 @@ export class LocalTaskHandler {
             const previousVersion = autoVersioningService.extractPreviousVersion(diffContent, this.version);
             const cleanedDiff = autoVersioningService.cleanDiffForAI(diffContent, this.version);
 
-            const rawDiffSizeKB = (diffContent.length / 1024).toFixed(1);
-            const cleanedDiffSizeKB = (cleanedDiff.length / 1024).toFixed(1);
-            const fileCount = (diffContent.match(/^diff --git /gm) || []).length;
+            const rawDiffSizeKB = formatSizeKB(diffContent.length);
+            const cleanedDiffSizeKB = formatSizeKB(cleanedDiff.length);
+            const fileCount = countFilesInDiff(diffContent);
 
             this.context.logger.debug(
-                `Generated diff size: ${rawDiffSizeKB}KB (${diffContent.length} bytes), ` +
-                    `cleaned diff size: ${cleanedDiffSizeKB}KB (${cleanedDiff.length} bytes), ` +
+                `Generated diff size: ${rawDiffSizeKB}KB (${diffContent.length} chars), ` +
+                    `cleaned diff size: ${cleanedDiffSizeKB}KB (${cleanedDiff.length} chars), ` +
                     `files changed: ${fileCount}`
             );
 
@@ -171,8 +178,6 @@ export class LocalTaskHandler {
                 return null;
             }
 
-            // The FAI /sdks/analyze-commit-diff endpoint rejects diffs exceeding 100,000 characters
-            const DIFF_SIZE_LIMIT = 100_000; // 100K characters — matches FAI endpoint MAX_DIFF_SIZE
             if (cleanedDiff.length > DIFF_SIZE_LIMIT) {
                 this.context.logger.warn(
                     `Cleaned diff is too large for AI analysis ` +

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -142,8 +142,8 @@ export class LocalTaskHandler {
             const fileCount = (diffContent.match(/^diff --git /gm) || []).length;
 
             this.context.logger.debug(
-                `Generated diff size: ${rawDiffSizeKB}KB (${diffContent.length} chars), ` +
-                    `cleaned diff size: ${cleanedDiffSizeKB}KB (${cleanedDiff.length} chars), ` +
+                `Generated diff size: ${rawDiffSizeKB}KB (${diffContent.length} bytes), ` +
+                    `cleaned diff size: ${cleanedDiffSizeKB}KB (${cleanedDiff.length} bytes), ` +
                     `files changed: ${fileCount}`
             );
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -171,12 +171,13 @@ export class LocalTaskHandler {
                 return null;
             }
 
-            // Warn if the cleaned diff is very large — AI endpoints typically struggle above ~15KB
-            const DIFF_SIZE_WARNING_THRESHOLD = 15 * 1024; // 15KB
-            if (cleanedDiff.length > DIFF_SIZE_WARNING_THRESHOLD) {
+            // The FAI /sdks/analyze-commit-diff endpoint rejects diffs exceeding 100,000 characters
+            const DIFF_SIZE_LIMIT = 100_000; // 100K characters — matches FAI endpoint MAX_DIFF_SIZE
+            if (cleanedDiff.length > DIFF_SIZE_LIMIT) {
                 this.context.logger.warn(
-                    `Cleaned diff is very large (${cleanedDiffSizeKB}KB, ${fileCount} files). ` +
-                        `AI analysis may fail or return empty results for diffs exceeding ~15KB. ` +
+                    `Cleaned diff is too large for AI analysis ` +
+                        `(${cleanedDiff.length.toLocaleString()} chars / ${cleanedDiffSizeKB}KB, ${fileCount} files). ` +
+                        `The AI endpoint limit is 100,000 characters. ` +
                         `Consider excluding generated documentation files (e.g. reference.md) and lock files ` +
                         `(e.g. pnpm-lock.yaml, poetry.lock) from the diff to reduce its size.`
                 );
@@ -210,9 +211,10 @@ export class LocalTaskHandler {
                 const errorMessage = aiError instanceof Error ? aiError.message : String(aiError);
                 this.context.logger.warn(
                     `AI analysis failed, falling back to PATCH increment. ` +
-                        `Diff stats: ${cleanedDiffSizeKB}KB cleaned (${rawDiffSizeKB}KB raw), ${fileCount} files changed. ` +
-                        (cleanedDiff.length > DIFF_SIZE_WARNING_THRESHOLD
-                            ? `The diff likely exceeds the AI endpoint's size limit (~15KB). ` +
+                        `Diff stats: ${cleanedDiff.length.toLocaleString()} chars cleaned ` +
+                        `(${cleanedDiffSizeKB}KB cleaned, ${rawDiffSizeKB}KB raw), ${fileCount} files changed. ` +
+                        (cleanedDiff.length > DIFF_SIZE_LIMIT
+                            ? `The diff exceeds the AI endpoint's 100,000 character limit. ` +
                               `To fix this, reduce the diff size by excluding generated docs (e.g. reference.md) ` +
                               `and lock files (e.g. pnpm-lock.yaml, poetry.lock). `
                             : "") +

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -137,8 +137,15 @@ export class LocalTaskHandler {
             const previousVersion = autoVersioningService.extractPreviousVersion(diffContent, this.version);
             const cleanedDiff = autoVersioningService.cleanDiffForAI(diffContent, this.version);
 
-            this.context.logger.debug(`Generated diff size: ${diffContent.length} bytes`);
-            this.context.logger.debug(`Cleaned diff size: ${cleanedDiff.length} bytes`);
+            const rawDiffSizeKB = (diffContent.length / 1024).toFixed(1);
+            const cleanedDiffSizeKB = (cleanedDiff.length / 1024).toFixed(1);
+            const fileCount = (diffContent.match(/^diff --git /gm) || []).length;
+
+            this.context.logger.debug(
+                `Generated diff size: ${rawDiffSizeKB}KB (${diffContent.length} bytes), ` +
+                    `cleaned diff size: ${cleanedDiffSizeKB}KB (${cleanedDiff.length} bytes), ` +
+                    `files changed: ${fileCount}`
+            );
 
             // Handle new SDK repository with no previous version
             if (previousVersion == null) {
@@ -162,6 +169,17 @@ export class LocalTaskHandler {
                     "No actual changes detected after filtering version-only changes. Cancelling generation."
                 );
                 return null;
+            }
+
+            // Warn if the cleaned diff is very large — AI endpoints typically struggle above ~15KB
+            const DIFF_SIZE_WARNING_THRESHOLD = 15 * 1024; // 15KB
+            if (cleanedDiff.length > DIFF_SIZE_WARNING_THRESHOLD) {
+                this.context.logger.warn(
+                    `Cleaned diff is very large (${cleanedDiffSizeKB}KB, ${fileCount} files). ` +
+                        `AI analysis may fail or return empty results for diffs exceeding ~15KB. ` +
+                        `Consider excluding generated documentation files (e.g. reference.md) and lock files ` +
+                        `(e.g. pnpm-lock.yaml, poetry.lock) from the diff to reduce its size.`
+                );
             }
 
             // Call AI to analyze the diff
@@ -189,7 +207,17 @@ export class LocalTaskHandler {
                     commitMessage
                 };
             } catch (aiError) {
-                this.context.logger.warn(`AI analysis failed, falling back to PATCH increment: ${aiError}`);
+                const errorMessage = aiError instanceof Error ? aiError.message : String(aiError);
+                this.context.logger.warn(
+                    `AI analysis failed, falling back to PATCH increment. ` +
+                        `Diff stats: ${cleanedDiffSizeKB}KB cleaned (${rawDiffSizeKB}KB raw), ${fileCount} files changed. ` +
+                        (cleanedDiff.length > DIFF_SIZE_WARNING_THRESHOLD
+                            ? `The diff likely exceeds the AI endpoint's size limit (~15KB). ` +
+                              `To fix this, reduce the diff size by excluding generated docs (e.g. reference.md) ` +
+                              `and lock files (e.g. pnpm-lock.yaml, poetry.lock). `
+                            : "") +
+                        `Error: ${errorMessage}`
+                );
                 const newVersion = this.incrementVersion(previousVersion, VersionBump.PATCH);
                 const fallbackMessage = this.isWhitelabel
                     ? "SDK regeneration"

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -146,12 +146,12 @@ export class LocalTaskHandler {
 
             const rawDiffSizeKB = formatSizeKB(diffContent.length);
             const cleanedDiffSizeKB = formatSizeKB(cleanedDiff.length);
-            const fileCount = countFilesInDiff(diffContent);
+            const rawFileCount = countFilesInDiff(diffContent);
+            const cleanedFileCount = countFilesInDiff(cleanedDiff);
 
             this.context.logger.debug(
-                `Generated diff size: ${rawDiffSizeKB}KB (${diffContent.length} chars), ` +
-                    `cleaned diff size: ${cleanedDiffSizeKB}KB (${cleanedDiff.length} chars), ` +
-                    `files changed: ${fileCount}`
+                `Generated diff size: ${rawDiffSizeKB}KB (${diffContent.length} chars), ${rawFileCount} files changed. ` +
+                    `Cleaned diff size: ${cleanedDiffSizeKB}KB (${cleanedDiff.length} chars), ${cleanedFileCount} files remaining`
             );
 
             // Handle new SDK repository with no previous version
@@ -181,10 +181,10 @@ export class LocalTaskHandler {
             if (cleanedDiff.length > DIFF_SIZE_LIMIT) {
                 this.context.logger.warn(
                     `Cleaned diff is too large for AI analysis ` +
-                        `(${cleanedDiff.length.toLocaleString()} chars / ${cleanedDiffSizeKB}KB, ${fileCount} files). ` +
+                        `(${cleanedDiff.length.toLocaleString()} chars / ${cleanedDiffSizeKB}KB, ${cleanedFileCount} files). ` +
                         `The AI endpoint limit is 100,000 characters. ` +
-                        `Consider excluding generated documentation files (e.g. reference.md) and lock files ` +
-                        `(e.g. pnpm-lock.yaml, poetry.lock) from the diff to reduce its size.`
+                        `Lock files, test files, and generated docs are already excluded. ` +
+                        `Consider splitting the SDK into smaller packages or reducing the number of endpoints.`
                 );
             }
 
@@ -217,11 +217,11 @@ export class LocalTaskHandler {
                 this.context.logger.warn(
                     `AI analysis failed, falling back to PATCH increment. ` +
                         `Diff stats: ${cleanedDiff.length.toLocaleString()} chars cleaned ` +
-                        `(${cleanedDiffSizeKB}KB cleaned, ${rawDiffSizeKB}KB raw), ${fileCount} files changed. ` +
+                        `(${cleanedDiffSizeKB}KB cleaned, ${rawDiffSizeKB}KB raw), ${cleanedFileCount} files remaining. ` +
                         (cleanedDiff.length > DIFF_SIZE_LIMIT
                             ? `The diff exceeds the AI endpoint's 100,000 character limit. ` +
-                              `To fix this, reduce the diff size by excluding generated docs (e.g. reference.md) ` +
-                              `and lock files (e.g. pnpm-lock.yaml, poetry.lock). `
+                              `Lock files, test files, and generated docs are already excluded. ` +
+                              `Consider splitting the SDK into smaller packages or reducing the number of endpoints. `
                             : "") +
                         `Error: ${errorMessage}`
                 );

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -142,8 +142,8 @@ export class LocalTaskHandler {
             const fileCount = (diffContent.match(/^diff --git /gm) || []).length;
 
             this.context.logger.debug(
-                `Generated diff size: ${rawDiffSizeKB}KB (${diffContent.length} bytes), ` +
-                    `cleaned diff size: ${cleanedDiffSizeKB}KB (${cleanedDiff.length} bytes), ` +
+                `Generated diff size: ${rawDiffSizeKB}KB (${diffContent.length} chars), ` +
+                    `cleaned diff size: ${cleanedDiffSizeKB}KB (${cleanedDiff.length} chars), ` +
                     `files changed: ${fileCount}`
             );
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
@@ -2,7 +2,13 @@ import { execSync } from "child_process";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { describe, expect, it } from "vitest";
-import { AutoVersioningException, AutoVersioningService } from "../AutoVersioningService.js";
+import {
+    AutoVersioningException,
+    AutoVersioningService,
+    countFilesInDiff,
+    DIFF_SIZE_LIMIT,
+    formatSizeKB
+} from "../AutoVersioningService.js";
 
 // Mock logger for tests
 const mockLogger = {
@@ -2280,5 +2286,98 @@ describe("AutoVersioningService", () => {
         expect(cleaned).not.toContain("README");
         expect(cleaned).not.toContain("CHANGELOG");
         expect(cleaned.trim()).toBe("");
+    });
+});
+
+describe("countFilesInDiff", () => {
+    it("counts zero files in empty string", () => {
+        expect(countFilesInDiff("")).toBe(0);
+    });
+
+    it("counts a single file", () => {
+        const diff =
+            "diff --git a/src/Client.ts b/src/Client.ts\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/src/Client.ts\n" +
+            "+++ b/src/Client.ts\n" +
+            "@@ -1,3 +1,4 @@\n" +
+            " export class Client {\n" +
+            "+    newMethod() {}\n" +
+            " }\n";
+        expect(countFilesInDiff(diff)).toBe(1);
+    });
+
+    it("counts multiple files", () => {
+        const diff =
+            "diff --git a/package.json b/package.json\n" +
+            "index abc..def 100644\n" +
+            "--- a/package.json\n" +
+            "+++ b/package.json\n" +
+            "@@ -1,3 +1,3 @@\n" +
+            " {\n" +
+            '-  "version": "1.0.0"\n' +
+            '+  "version": "2.0.0"\n' +
+            " }\n" +
+            "diff --git a/src/index.ts b/src/index.ts\n" +
+            "index abc..def 100644\n" +
+            "--- a/src/index.ts\n" +
+            "+++ b/src/index.ts\n" +
+            "@@ -1,2 +1,3 @@\n" +
+            " export { Client } from './Client';\n" +
+            "+export { NewType } from './NewType';\n" +
+            "diff --git a/README.md b/README.md\n" +
+            "index abc..def 100644\n" +
+            "--- a/README.md\n" +
+            "+++ b/README.md\n" +
+            "@@ -1,2 +1,3 @@\n" +
+            " # My SDK\n" +
+            "+Updated\n";
+        expect(countFilesInDiff(diff)).toBe(3);
+    });
+
+    it("does not count 'diff --git' appearing mid-line", () => {
+        const diff =
+            "diff --git a/src/test.ts b/src/test.ts\n" +
+            "index abc..def 100644\n" +
+            "--- a/src/test.ts\n" +
+            "+++ b/src/test.ts\n" +
+            "@@ -1,3 +1,4 @@\n" +
+            " // This line mentions diff --git but is not a header\n" +
+            "+    newLine();\n" +
+            " }\n";
+        expect(countFilesInDiff(diff)).toBe(1);
+    });
+
+    it("handles diff with no trailing newline", () => {
+        const diff = "diff --git a/file.txt b/file.txt";
+        expect(countFilesInDiff(diff)).toBe(1);
+    });
+});
+
+describe("formatSizeKB", () => {
+    it("formats zero", () => {
+        expect(formatSizeKB(0)).toBe("0.0");
+    });
+
+    it("formats exactly 1KB", () => {
+        expect(formatSizeKB(1024)).toBe("1.0");
+    });
+
+    it("formats fractional KB with one decimal place", () => {
+        expect(formatSizeKB(1536)).toBe("1.5");
+    });
+
+    it("formats large sizes", () => {
+        expect(formatSizeKB(100_000)).toBe("97.7");
+    });
+
+    it("formats small sizes", () => {
+        expect(formatSizeKB(500)).toBe("0.5");
+    });
+});
+
+describe("DIFF_SIZE_LIMIT", () => {
+    it("is 100,000 characters", () => {
+        expect(DIFF_SIZE_LIMIT).toBe(100_000);
     });
 });


### PR DESCRIPTION
## Description

Refs: [Devin Session](https://app.devin.ai/sessions/cb982e37b44242c7a8456476cb661ccf)
Requested by: @Swimburger

When AUTO versioning's AI analysis fails (typically because the diff is too large for the AI endpoint), the error messages were generic and unhelpful — just `"AI analysis failed, falling back to PATCH increment: [error]"`. This made it difficult to diagnose why analysis failed and what to do about it.

The actual limit was identified by inspecting the FAI service source (`fern-platform/servers/fai/src/fai/routes/sdks.py`): **`MAX_DIFF_SIZE = 100_000` characters** (~100KB). Diffs exceeding this limit receive an HTTP 413 response.

## Changes Made

- **`AutoVersioningService.ts`**:
  - Extracted shared utilities as public exports: `DIFF_SIZE_LIMIT` (single source of truth for 100K char limit), `countFilesInDiff()` (indexOf-based scanner, avoids regex overhead on large diffs), `formatSizeKB()` (human-readable KB formatting)
  - Fixed `"bytes"` → `"chars"` in the `cleanDiffForAI` debug log for consistency (`string.length` returns characters, not bytes)

- **`LocalTaskHandler.ts`**: 
  - Uses shared utilities from `AutoVersioningService` instead of inline constants/logic
  - Consolidated two debug logs into one with human-readable KB sizes + separate raw/cleaned file counts
  - Added a pre-flight `warn` when the cleaned diff exceeds the 100K character FAI endpoint limit, with actionable guidance (explains that lock files, test files, and generated docs are already excluded; suggests splitting the SDK or reducing endpoints)
  - Enriched the AI failure catch block with diff stats and conditional advice when the diff is over the limit
  - Uses `cleanedFileCount` (not raw) in cleaned-diff warning/error messages so the file count matches the diff being discussed
  
- **`sdkDiffCommand.ts`**: Same pattern — imports shared utilities from `@fern-api/local-workspace-runner`, diff size/file count logging, pre-flight size warning, and enriched error messages on failure

- **`AutoVersioningService.test.ts`**: Added 11 unit tests for the extracted utilities (`countFilesInDiff`, `formatSizeKB`, `DIFF_SIZE_LIMIT`)

- **`versions.yml`**: Added v4.4.5 changelog entry

## Updates Since Last Revision

- **Fixed misleading guidance text**: Warning/error messages in `LocalTaskHandler.ts` previously suggested excluding lock files and `reference.md`, but `cleanDiffForAI()` already strips those files before the size check. Now says "Lock files, test files, and generated docs are already excluded. Consider splitting the SDK into smaller packages or reducing the number of endpoints."
- **Separated raw vs cleaned file counts**: Now computes both `rawFileCount` (from `diffContent`) and `cleanedFileCount` (from `cleanedDiff`). Debug log uses raw count; warning/error messages about the cleaned diff use the cleaned count so the reported file count matches the diff being discussed.

## Human Review Checklist

- [ ] Verify `countFilesInDiff` indexOf-based scanning is behaviorally equivalent to the original regex (`/^diff --git /gm`) — the new version explicitly checks `idx === 0 || diffContent[idx - 1] === "\n"` for start-of-line
- [ ] The hardcoded `"100,000 characters"` in warning/error strings does not reference `DIFF_SIZE_LIMIT` — if the constant changes, these strings would need manual updating
- [ ] `formatSizeKB` divides `string.length` (characters) by 1024 — this approximates KB for ASCII diffs but is not a true byte-size measurement. The function name and JSDoc reflect this is intentional.
- [ ] `sdkDiffCommand.ts` imports from `@fern-api/local-workspace-runner` — confirm this package is available at build time (it's listed as a `devDependency` in `packages/cli/cli/package.json`)
- [ ] `sdkDiffCommand.ts` operates on the raw diff (no `cleanDiffForAI` step), so its guidance text does not claim files are already excluded — verify this is the intended behavior for `fern sdk-diff`

## Testing
- [x] `pnpm run check` (biome lint) passes
- [x] Unit tests added (11 tests for `countFilesInDiff`, `formatSizeKB`, `DIFF_SIZE_LIMIT`) — all 84 tests pass
- [x] Manual verification: the original checklist items (file count from raw diff vs size check on cleaned diff, toLocaleString output, conditional string concatenation) were verified
- [x] Devin Review bot findings addressed: guidance text now actionable, file counts now match the diff being referenced
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
