### PR TITLE
fix(python): use random docker-compose project name for wiremock tests

### DIFF
--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -213,22 +213,6 @@ def verify_request_count(
     }
 
     /**
-     * Computes a Docker Compose project name at code-generation time.
-     *
-     * Docker Compose project names must consist only of lowercase alphanumeric
-     * characters, hyphens, and underscores, and must start with a letter or number.
-     * Computing this at generation time avoids runtime issues with directory names
-     * that contain dots or other invalid characters (e.g. `.seed`).
-     */
-    private getDockerProjectName(): string {
-        const orgName = this.context.config.organization;
-        const workspaceName = this.context.config.workspaceName;
-        const raw = `${orgName}-${workspaceName}`.toLowerCase();
-        const sanitized = raw.replace(/[^a-z0-9_-]/g, "").replace(/^[^a-z0-9]+/, "");
-        return sanitized || "wiremock-tests";
-    }
-
-    /**
      * Builds the content for the pytest plugin that manages the WireMock container lifecycle.
      *
      * The plugin is loaded via pytest_plugins declared in tests/wire/__init__.py and is
@@ -236,7 +220,6 @@ def verify_request_count(
      * controller process only, so that all workers reuse a single instance.
      */
     private buildPytestPluginContent(): string {
-        const projectName = this.getDockerProjectName();
         return `"""
 Pytest plugin that manages the WireMock container lifecycle for wire tests.
 
@@ -249,13 +232,14 @@ by pytest's normal test collection rules.
 """
 
 import os
+import secrets
 import subprocess
 
 import pytest
 
 _STARTED: bool = False
 _WIREMOCK_URL: str = "http://localhost:8080"  # Default, will be updated after container starts
-_PROJECT_NAME: str = "${projectName}"
+_PROJECT_NAME: str = f"wiremock-{secrets.token_hex(8)}"
 
 # This file lives at tests/conftest.py, so the project root is one level up.
 _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.61.6
+  changelogEntry:
+    - summary: |
+        Use a random Docker Compose project name (`wiremock-<random-hex>`) for wire tests
+        instead of a deterministic name derived from the package. This prevents project-name
+        collisions when multiple wiremock test suites run concurrently in CI.
+      type: fix
+  createdAt: "2026-03-05"
+  irVersion: 65
+
 - version: 4.61.5
   changelogEntry:
     - summary: |

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/conftest.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/conftest.py
@@ -10,13 +10,14 @@ by pytest's normal test collection rules.
 """
 
 import os
+import secrets
 import subprocess
 
 import pytest
 
 _STARTED: bool = False
 _WIREMOCK_URL: str = "http://localhost:8080"  # Default, will be updated after container starts
-_PROJECT_NAME: str = "seed-exhaustive"
+_PROJECT_NAME: str = f"wiremock-{secrets.token_hex(8)}"
 
 # This file lives at tests/conftest.py, so the project root is one level up.
 _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/tests/conftest.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/tests/conftest.py
@@ -10,13 +10,14 @@ by pytest's normal test collection rules.
 """
 
 import os
+import secrets
 import subprocess
 
 import pytest
 
 _STARTED: bool = False
 _WIREMOCK_URL: str = "http://localhost:8080"  # Default, will be updated after container starts
-_PROJECT_NAME: str = "seed-exhaustive"
+_PROJECT_NAME: str = f"wiremock-{secrets.token_hex(8)}"
 
 # This file lives at tests/conftest.py, so the project root is one level up.
 _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/tests/conftest.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/tests/conftest.py
@@ -10,13 +10,14 @@ by pytest's normal test collection rules.
 """
 
 import os
+import secrets
 import subprocess
 
 import pytest
 
 _STARTED: bool = False
 _WIREMOCK_URL: str = "http://localhost:8080"  # Default, will be updated after container starts
-_PROJECT_NAME: str = "seed-api"
+_PROJECT_NAME: str = f"wiremock-{secrets.token_hex(8)}"
 
 # This file lives at tests/conftest.py, so the project root is one level up.
 _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/seed/python-sdk/server-sent-events/with-wire-tests/tests/conftest.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/tests/conftest.py
@@ -10,13 +10,14 @@ by pytest's normal test collection rules.
 """
 
 import os
+import secrets
 import subprocess
 
 import pytest
 
 _STARTED: bool = False
 _WIREMOCK_URL: str = "http://localhost:8080"  # Default, will be updated after container starts
-_PROJECT_NAME: str = "seed-server-sent-events"
+_PROJECT_NAME: str = f"wiremock-{secrets.token_hex(8)}"
 
 # This file lives at tests/conftest.py, so the project root is one level up.
 _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))


### PR DESCRIPTION
## Description

Refs: Concurrent wiremock CI collision issue

When multiple wiremock test suites run concurrently in CI, their docker-compose project names can collide because they were derived deterministically from the org/workspace name. This PR switches to a random hex project name generated at runtime in the Python test code.

Requested by: @jsklan
[Link to Devin Session](https://app.devin.ai/sessions/13bd899048a5427ab73e64f4fd6e295f)

## Changes Made

- **Removed `getDockerProjectName()`** from `WireTestSetupGenerator.ts` — the deterministic project name computed at code-generation time is no longer needed.
- **Updated `buildPytestPluginContent()`** to emit Python code that generates a random project name at runtime via `secrets.token_hex(8)`, producing names like `wiremock-a1b2c3d4e5f6g7h8`.
- Updated 4 seed test snapshots to reflect the new generated output.
- Added version `4.61.6` to `generators/python/sdk/versions.yml`.

## Important Review Notes

- **xdist safety**: Workers never call `_start_wiremock()` / `_stop_wiremock()` — they skip lifecycle management and rely on the controller's `WIREMOCK_URL` env var. So each worker getting a different `_PROJECT_NAME` on import is harmless.
- **Seed snapshots were manually edited** rather than regenerated via `pnpm seed`. Verify the generated output matches expectations, especially the `import secrets` placement (alphabetical, between `os` and `subprocess`).
- `secrets` is a Python stdlib module (3.6+), so no new runtime dependencies are introduced.

## Testing
- [ ] Seed test snapshots updated to match expected generator output
- [ ] Manual review of generated conftest.py structure
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
