### PR TITLE
fix(go): use v9 of `golintci` action

### DIFF
--- a/generators/go/internal/writer/workflows/ci.yml
+++ b/generators/go/internal/writer/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.28.2
+  changelogEntry:
+    - summary: |
+        Upgrade generated CI workflow to use `golangci/golangci-lint-action@v9`
+        (from `@v6`) for proper compatibility with golangci-lint v2.x.
+      type: fix
+  createdAt: "2026-03-05"
+  irVersion: 61
+
 - version: 1.28.1
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/accept-header/.github/workflows/ci.yml
+++ b/seed/go-sdk/accept-header/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/alias/.github/workflows/ci.yml
+++ b/seed/go-sdk/alias/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/any-auth/.github/workflows/ci.yml
+++ b/seed/go-sdk/any-auth/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/api-wide-base-path/.github/workflows/ci.yml
+++ b/seed/go-sdk/api-wide-base-path/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/audiences/.github/workflows/ci.yml
+++ b/seed/go-sdk/audiences/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/basic-auth-environment-variables/.github/workflows/ci.yml
+++ b/seed/go-sdk/basic-auth-environment-variables/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/basic-auth/.github/workflows/ci.yml
+++ b/seed/go-sdk/basic-auth/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/bearer-token-environment-variable/.github/workflows/ci.yml
+++ b/seed/go-sdk/bearer-token-environment-variable/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/bytes-upload/.github/workflows/ci.yml
+++ b/seed/go-sdk/bytes-upload/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/circular-references-advanced/.github/workflows/ci.yml
+++ b/seed/go-sdk/circular-references-advanced/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/circular-references/.github/workflows/ci.yml
+++ b/seed/go-sdk/circular-references/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/client-side-params/.github/workflows/ci.yml
+++ b/seed/go-sdk/client-side-params/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/content-type/.github/workflows/ci.yml
+++ b/seed/go-sdk/content-type/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/cross-package-type-names/.github/workflows/ci.yml
+++ b/seed/go-sdk/cross-package-type-names/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/dollar-string-examples/.github/workflows/ci.yml
+++ b/seed/go-sdk/dollar-string-examples/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/empty-clients/.github/workflows/ci.yml
+++ b/seed/go-sdk/empty-clients/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/endpoint-security-auth/.github/workflows/ci.yml
+++ b/seed/go-sdk/endpoint-security-auth/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/enum/.github/workflows/ci.yml
+++ b/seed/go-sdk/enum/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/error-property/.github/workflows/ci.yml
+++ b/seed/go-sdk/error-property/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/errors/.github/workflows/ci.yml
+++ b/seed/go-sdk/errors/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/examples/always-send-required-properties/.github/workflows/ci.yml
+++ b/seed/go-sdk/examples/always-send-required-properties/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/.github/workflows/ci.yml
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/examples/client-name/.github/workflows/ci.yml
+++ b/seed/go-sdk/examples/client-name/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/examples/export-all-requests-at-root/.github/workflows/ci.yml
+++ b/seed/go-sdk/examples/export-all-requests-at-root/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/examples/exported-client-name/.github/workflows/ci.yml
+++ b/seed/go-sdk/examples/exported-client-name/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/examples/getters-pass-by-value/.github/workflows/ci.yml
+++ b/seed/go-sdk/examples/getters-pass-by-value/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/examples/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/examples/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/examples/package-path/.github/workflows/ci.yml
+++ b/seed/go-sdk/examples/package-path/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/examples/readme-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/examples/readme-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/examples/v0/.github/workflows/ci.yml
+++ b/seed/go-sdk/examples/v0/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/extends/.github/workflows/ci.yml
+++ b/seed/go-sdk/extends/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/extra-properties/.github/workflows/ci.yml
+++ b/seed/go-sdk/extra-properties/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/file-download/.github/workflows/ci.yml
+++ b/seed/go-sdk/file-download/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/file-upload-openapi/.github/workflows/ci.yml
+++ b/seed/go-sdk/file-upload-openapi/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/file-upload/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/file-upload/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/file-upload/package-name/.github/workflows/ci.yml
+++ b/seed/go-sdk/file-upload/package-name/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/file-upload/v0/.github/workflows/ci.yml
+++ b/seed/go-sdk/file-upload/v0/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/folders/.github/workflows/ci.yml
+++ b/seed/go-sdk/folders/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/go-bytes-request/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/.github/workflows/ci.yml
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/go-content-type/.github/workflows/ci.yml
+++ b/seed/go-sdk/go-content-type/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/go-optional-literal-alias/.github/workflows/ci.yml
+++ b/seed/go-sdk/go-optional-literal-alias/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/.github/workflows/ci.yml
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/header-auth-environment-variable/.github/workflows/ci.yml
+++ b/seed/go-sdk/header-auth-environment-variable/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/header-auth/.github/workflows/ci.yml
+++ b/seed/go-sdk/header-auth/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/http-head/.github/workflows/ci.yml
+++ b/seed/go-sdk/http-head/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/idempotency-headers/.github/workflows/ci.yml
+++ b/seed/go-sdk/idempotency-headers/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/imdb/deep-package-path/.github/workflows/ci.yml
+++ b/seed/go-sdk/imdb/deep-package-path/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/imdb/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/imdb/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/imdb/package-path/.github/workflows/ci.yml
+++ b/seed/go-sdk/imdb/package-path/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/imdb/with-wiremock-tests/.github/workflows/ci.yml
+++ b/seed/go-sdk/imdb/with-wiremock-tests/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/inferred-auth-explicit/.github/workflows/ci.yml
+++ b/seed/go-sdk/inferred-auth-explicit/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/inferred-auth-implicit-api-key/.github/workflows/ci.yml
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/.github/workflows/ci.yml
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/inferred-auth-implicit-reference/.github/workflows/ci.yml
+++ b/seed/go-sdk/inferred-auth-implicit-reference/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/inferred-auth-implicit/.github/workflows/ci.yml
+++ b/seed/go-sdk/inferred-auth-implicit/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/license/.github/workflows/ci.yml
+++ b/seed/go-sdk/license/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/literal/.github/workflows/ci.yml
+++ b/seed/go-sdk/literal/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/literals-unions/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/literals-unions/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/mixed-case/default-values/.github/workflows/ci.yml
+++ b/seed/go-sdk/mixed-case/default-values/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/mixed-case/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/mixed-case/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/mixed-file-directory/.github/workflows/ci.yml
+++ b/seed/go-sdk/mixed-file-directory/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/multi-line-docs/.github/workflows/ci.yml
+++ b/seed/go-sdk/multi-line-docs/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/multi-url-environment-no-default/.github/workflows/ci.yml
+++ b/seed/go-sdk/multi-url-environment-no-default/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/multi-url-environment/.github/workflows/ci.yml
+++ b/seed/go-sdk/multi-url-environment/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/multiple-request-bodies/.github/workflows/ci.yml
+++ b/seed/go-sdk/multiple-request-bodies/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/no-environment/.github/workflows/ci.yml
+++ b/seed/go-sdk/no-environment/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/no-retries/.github/workflows/ci.yml
+++ b/seed/go-sdk/no-retries/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/nullable-allof-extends/.github/workflows/ci.yml
+++ b/seed/go-sdk/nullable-allof-extends/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/nullable-optional/.github/workflows/ci.yml
+++ b/seed/go-sdk/nullable-optional/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/.github/workflows/ci.yml
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/nullable/.github/workflows/ci.yml
+++ b/seed/go-sdk/nullable/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/oauth-client-credentials-custom/.github/workflows/ci.yml
+++ b/seed/go-sdk/oauth-client-credentials-custom/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/oauth-client-credentials-default/.github/workflows/ci.yml
+++ b/seed/go-sdk/oauth-client-credentials-default/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/.github/workflows/ci.yml
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/oauth-client-credentials-nested-root/.github/workflows/ci.yml
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/oauth-client-credentials-reference/.github/workflows/ci.yml
+++ b/seed/go-sdk/oauth-client-credentials-reference/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/oauth-client-credentials-with-variables/.github/workflows/ci.yml
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/oauth-client-credentials/.github/workflows/ci.yml
+++ b/seed/go-sdk/oauth-client-credentials/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/object/.github/workflows/ci.yml
+++ b/seed/go-sdk/object/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/objects-with-imports/.github/workflows/ci.yml
+++ b/seed/go-sdk/objects-with-imports/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/optional/.github/workflows/ci.yml
+++ b/seed/go-sdk/optional/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/package-yml/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/package-yml/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/pagination-uri-path/.github/workflows/ci.yml
+++ b/seed/go-sdk/pagination-uri-path/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/pagination/.github/workflows/ci.yml
+++ b/seed/go-sdk/pagination/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/path-parameters/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/path-parameters/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/path-parameters/package-name/.github/workflows/ci.yml
+++ b/seed/go-sdk/path-parameters/package-name/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/path-parameters/v0/.github/workflows/ci.yml
+++ b/seed/go-sdk/path-parameters/v0/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/plain-text/.github/workflows/ci.yml
+++ b/seed/go-sdk/plain-text/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/property-access/.github/workflows/ci.yml
+++ b/seed/go-sdk/property-access/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/public-object/.github/workflows/ci.yml
+++ b/seed/go-sdk/public-object/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/query-parameters-openapi-as-objects/.github/workflows/ci.yml
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/query-parameters-openapi/.github/workflows/ci.yml
+++ b/seed/go-sdk/query-parameters-openapi/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/query-parameters/.github/workflows/ci.yml
+++ b/seed/go-sdk/query-parameters/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/required-nullable/.github/workflows/ci.yml
+++ b/seed/go-sdk/required-nullable/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/reserved-keywords/.github/workflows/ci.yml
+++ b/seed/go-sdk/reserved-keywords/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/response-property/.github/workflows/ci.yml
+++ b/seed/go-sdk/response-property/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/.github/workflows/ci.yml
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/server-sent-events/with-wire-tests/.github/workflows/ci.yml
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/server-url-templating/.github/workflows/ci.yml
+++ b/seed/go-sdk/server-url-templating/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/simple-api/.github/workflows/ci.yml
+++ b/seed/go-sdk/simple-api/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/simple-fhir/.github/workflows/ci.yml
+++ b/seed/go-sdk/simple-fhir/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/single-url-environment-default/.github/workflows/ci.yml
+++ b/seed/go-sdk/single-url-environment-default/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/single-url-environment-no-default/.github/workflows/ci.yml
+++ b/seed/go-sdk/single-url-environment-no-default/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/streaming/.github/workflows/ci.yml
+++ b/seed/go-sdk/streaming/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/undiscriminated-union-with-response-property/.github/workflows/ci.yml
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/undiscriminated-unions/v0/.github/workflows/ci.yml
+++ b/seed/go-sdk/undiscriminated-unions/v0/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/unions-with-local-date/.github/workflows/ci.yml
+++ b/seed/go-sdk/unions-with-local-date/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/unions/no-custom-config/.github/workflows/ci.yml
+++ b/seed/go-sdk/unions/no-custom-config/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/unions/package-name/.github/workflows/ci.yml
+++ b/seed/go-sdk/unions/package-name/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/unions/v0/.github/workflows/ci.yml
+++ b/seed/go-sdk/unions/v0/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/unknown/.github/workflows/ci.yml
+++ b/seed/go-sdk/unknown/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/url-form-encoded/.github/workflows/ci.yml
+++ b/seed/go-sdk/url-form-encoded/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/validation/.github/workflows/ci.yml
+++ b/seed/go-sdk/validation/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/variables/.github/workflows/ci.yml
+++ b/seed/go-sdk/variables/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/version-no-default/.github/workflows/ci.yml
+++ b/seed/go-sdk/version-no-default/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/version/.github/workflows/ci.yml
+++ b/seed/go-sdk/version/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/webhook-audience/.github/workflows/ci.yml
+++ b/seed/go-sdk/webhook-audience/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/webhooks/.github/workflows/ci.yml
+++ b/seed/go-sdk/webhooks/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/websocket-bearer-auth/.github/workflows/ci.yml
+++ b/seed/go-sdk/websocket-bearer-auth/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/websocket-inferred-auth/.github/workflows/ci.yml
+++ b/seed/go-sdk/websocket-inferred-auth/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:

--- a/seed/go-sdk/websocket/.github/workflows/ci.yml
+++ b/seed/go-sdk/websocket/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
   test:


### PR DESCRIPTION
## Description
Use v9 of `golangci-lint-action`, which has proper compatibility with v2.x of `golangci`.

## Changes Made
One-liner.

## Testing
Seed regen!
- [X] Unit tests added/updated
- [X] Manual testing completed
