### PR TITLE
feat(cli): add LICENSE file exclusion to autoversioning diff cleaning

### DIFF
--- a/packages/cli/generation/local-generation/local-workspace-runner/src/AutoVersioningService.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/AutoVersioningService.ts
@@ -86,6 +86,7 @@ const EXCLUDED_FILE_PATTERNS: RegExp[] = [
     /(?:^|\/)reference\.md$/i,
     /(?:^|\/)changelog(?:\.[^/]*)?$/i,
     /(?:^|\/)readme(?:\.[^/]*)?$/i,
+    /(?:^|\/)license(?:\.[^/]*)?$/i,
 
     // Lock files (dependency resolution, zero semantic value)
     /(?:^|\/)pnpm-lock\.yaml$/i,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
@@ -2287,6 +2287,45 @@ describe("AutoVersioningService", () => {
         expect(cleaned).not.toContain("CHANGELOG");
         expect(cleaned.trim()).toBe("");
     });
+
+    it("testCleanDiffForAI_excludesLicenseFiles", () => {
+        const diff =
+            "diff --git a/LICENSE b/LICENSE\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/LICENSE\n" +
+            "+++ b/LICENSE\n" +
+            "@@ -1,2 +1,3 @@\n" +
+            " MIT License\n" +
+            "+Copyright 2026\n" +
+            "diff --git a/LICENSE.md b/LICENSE.md\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/LICENSE.md\n" +
+            "+++ b/LICENSE.md\n" +
+            "@@ -1,2 +1,3 @@\n" +
+            " # License\n" +
+            "+Apache 2.0\n" +
+            "diff --git a/LICENSE.txt b/LICENSE.txt\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/LICENSE.txt\n" +
+            "+++ b/LICENSE.txt\n" +
+            "@@ -1,2 +1,3 @@\n" +
+            " BSD License\n" +
+            "+Updated\n" +
+            "diff --git a/src/api.ts b/src/api.ts\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/src/api.ts\n" +
+            "+++ b/src/api.ts\n" +
+            "@@ -1,2 +1,3 @@\n" +
+            " export function hello() {\n" +
+            "+    return 'world';\n" +
+            " }\n";
+
+        const cleaned = new AutoVersioningService({ logger: mockLogger }).cleanDiffForAI(diff, "505.503.4455");
+
+        expect(cleaned).not.toContain("LICENSE");
+        expect(cleaned).toContain("src/api.ts");
+        expect(cleaned).toContain("return 'world'");
+    });
 });
 
 describe("countFilesInDiff", () => {


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger
[Devin Session](https://app.devin.ai/sessions/7c30c6df0797491dbabd7e7d8bbf5b1e)

Adds LICENSE files (LICENSE, LICENSE.md, LICENSE.txt, etc.) to the autoversioning diff exclusion list. License files are boilerplate with zero API surface relevance and should not be sent to the FernAI endpoint for semantic version analysis.

## Changes Made

- Added `license(?:\.[^/]*)?$` pattern to `EXCLUDED_FILE_PATTERNS` — identical format to the existing `changelog` and `readme` patterns (case-insensitive, matches any extension)
- Added test `testCleanDiffForAI_excludesLicenseFiles` covering `LICENSE`, `LICENSE.md`, and `LICENSE.txt` while verifying source files are preserved

## Testing

- [x] Unit tests added (85 total, all passing)
- [x] Verified pattern matches LICENSE, LICENSE.md, LICENSE.txt variants
- [x] Verified source files like `src/api.ts` are not excluded

## Review Checklist

- [ ] Regex follows same anchoring convention as existing readme/changelog patterns
- [ ] No false positives on source files containing "license" in the path (the `(?:^|\/)` prefix + `$` anchor ensures only standalone filenames match)

A companion PR with the same change for Fiddle (Java) is also being created.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
