### PR TITLE
fix(cli): cache key test validates both priorChangelog and specCommitMessage differentiation

### DIFF
--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningCache.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningCache.test.ts
@@ -67,25 +67,39 @@ describe("AutoVersioningCache", () => {
         expect(secondComputed).toBe(false);
     });
 
-    it("produces different cache keys for same diff but different language, version, or specCommitMessage", () => {
+    it("produces different cache keys for same diff but different language, version, priorChangelog, or specCommitMessage", () => {
         const cache = new AutoVersioningCache();
         const diff = "diff --git a/src/index.ts\n+export const foo = true;";
 
         const keyTs = cache.key(diff, "typescript", "1.0.0");
         const keyPy = cache.key(diff, "python", "1.0.0");
         const keyTsDiffVer = cache.key(diff, "typescript", "2.0.0");
-        const keyWithSpec = cache.key(diff, "typescript", "1.0.0", "add /payments endpoint");
-        const keyWithDiffSpec = cache.key(diff, "typescript", "1.0.0", "remove /users endpoint");
-        const keyNoSpec = cache.key(diff, "typescript", "1.0.0", "");
+
+        // priorChangelog differentiation (4th param)
+        const keyWithChangelog = cache.key(diff, "typescript", "1.0.0", "## [1.0.0] prior entry", "");
+        const keyWithDiffChangelog = cache.key(diff, "typescript", "1.0.0", "## [0.9.0] other entry", "");
+        const keyNoChangelog = cache.key(diff, "typescript", "1.0.0", "");
+
+        // specCommitMessage differentiation (5th param)
+        const keyWithSpec = cache.key(diff, "typescript", "1.0.0", "", "add /payments endpoint");
+        const keyWithDiffSpec = cache.key(diff, "typescript", "1.0.0", "", "remove /users endpoint");
+        const keyNoSpec = cache.key(diff, "typescript", "1.0.0", "", "");
 
         // Same diff but different language → different keys
         expect(keyTs).not.toBe(keyPy);
         // Same diff and language but different previous version → different keys
         expect(keyTs).not.toBe(keyTsDiffVer);
-        // Same diff but different spec commit message → different keys
+
+        // Different priorChangelog → different keys
+        expect(keyTs).not.toBe(keyWithChangelog);
+        expect(keyWithChangelog).not.toBe(keyWithDiffChangelog);
+        // Empty string priorChangelog matches default (no arg)
+        expect(keyTs).toBe(keyNoChangelog);
+
+        // Different specCommitMessage → different keys
         expect(keyTs).not.toBe(keyWithSpec);
         expect(keyWithSpec).not.toBe(keyWithDiffSpec);
-        // Empty string spec commit message matches default (no arg)
+        // Empty string specCommitMessage matches default (no arg)
         expect(keyTs).toBe(keyNoSpec);
     });
 


### PR DESCRIPTION
## Description

Refs #13177

Fixes the `AutoVersioningCache` test that was silently testing the wrong parameter after `priorChangelog` was inserted before `specCommitMessage` in the `key()` method signature.

**[Link to Devin Session](https://app.devin.ai/sessions/44a2062592ef4ed19bea8211c40bc537)**
Requested by: @Swimburger

## Changes Made

When the `key()` signature changed from `(cleanedDiff, language, previousVersion, specCommitMessage="")` to `(cleanedDiff, language, previousVersion, priorChangelog="", specCommitMessage="")`, the old test — `cache.key(diff, "typescript", "1.0.0", "add /payments endpoint")` — was silently passing that value as `priorChangelog` (4th param) instead of `specCommitMessage` (5th param). The test still passed because any different value in any position produces a different hash, but `specCommitMessage` differentiation was no longer actually validated.

- Updated test to explicitly pass all 5 arguments when testing each parameter dimension
- Added dedicated `priorChangelog` differentiation assertions (4th param)
- Fixed `specCommitMessage` assertions to correctly target the 5th param

## Testing

- [x] Unit tests updated — 158/158 tests pass locally
- [x] No production code changes

## Human Review Checklist

- [ ] Verify parameter ordering in test calls matches `AutoVersioningCache.key(cleanedDiff, language, previousVersion, priorChangelog, specCommitMessage)`
- [ ] Confirm empty string `""` is passed for the untested param in each group (e.g., `priorChangelog=""` when testing `specCommitMessage` and vice versa)
- [ ] Verify `keyTs` (3-arg call) correctly equals `keyNoChangelog` / `keyNoSpec` (5-arg calls with empty strings) — relies on default params being `""`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
