### PR TITLE
fix(ci): correct version extraction in bulk-update-cli job

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -205,7 +205,7 @@ jobs:
             echo "CLI_VERSION=${{ inputs.version }}" >> $GITHUB_OUTPUT
           else
             # Automatic publish - extract from versions.yml
-            version=$(head -n 20 packages/cli/cli/versions.yml | grep -m 1 "version:" | awk '{print $2}')
+            version=$(head -n 20 packages/cli/cli/versions.yml | grep -m 1 "version:" | awk '{print $3}')
             echo "CLI_VERSION=${version}" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Description

Fixes the version extraction in the `bulk-update-cli` job so the log correctly displays the CLI version instead of the literal string `version:`.

Refs: https://app.devin.ai/sessions/d9183111086b4f538c9f871a5db4ab47
Requested by: @Swimburger

## Changes Made

The `versions.yml` entries use YAML list format: `- version: 4.13.0`. The `awk` command was printing field `$2` (`version:`) instead of field `$3` (`4.13.0`).

This caused the workflow log to show `Triggering bulk update for CLI version: version:` instead of the actual version number.

> **Note:** This is cosmetic — the actual API call hardcodes `"newVersion": "latest"`, so the extracted version is only used in log output.

## Testing

- [x] Verified locally that `awk '{print $3}'` correctly extracts `4.13.0` from the current `versions.yml`
- [ ] Cannot be tested in CI (job only runs on main after a successful CLI publish)

## Human Review Checklist

- Confirm the YAML list format assumption (`- version: X.Y.Z`) by glancing at `packages/cli/cli/versions.yml`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
