### PR TITLE
fix(rust): escape reserved keywords in path parameter names

### DIFF
--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -946,8 +946,9 @@ export class SubClientGenerator {
             if (part.pathParameter) {
                 const pathParam = endpoint.allPathParameters.find((p) => p.name.originalName === part.pathParameter);
                 if (pathParam) {
+                    const paramName = this.context.escapeRustKeyword(pathParam.name.snakeCase.safeName);
                     params.push({
-                        name: pathParam.name.snakeCase.safeName,
+                        name: paramName,
                         type: generateRustTypeForTypeReference(pathParam.valueType, this.context),
                         isRef: this.shouldPassByReference(pathParam.valueType),
                         optional: false
@@ -1394,9 +1395,10 @@ export class SubClientGenerator {
                 const pathParam = endpoint.allPathParameters.find((p) => p.name.originalName === part.pathParameter);
                 if (pathParam) {
                     path += "{}";
+                    const escapedName = this.context.escapeRustKeyword(pathParam.name.snakeCase.safeName);
                     const paramName = this.getPathParameterExpression(
                         pathParam.valueType,
-                        pathParam.name.snakeCase.safeName
+                        escapedName
                     );
                     pathParams.push(paramName);
                 }

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.18.1
+  changelogEntry:
+    - summary: |
+        Escape Rust reserved keywords (e.g., `type`, `match`, `self`) when used as path parameter
+        names in generated client methods. Previously, reserved keywords like `type` were emitted
+        as-is, causing `rustfmt` and compilation failures. Now they are properly escaped with the
+        `r#` prefix (e.g., `r#type`).
+      type: fix
+  createdAt: "2026-03-06"
+  irVersion: 62
+
 - version: 0.18.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Reported by user running `fern generate --group rust-sdk` on an API with a path parameter named `type`

The Rust SDK generator was emitting reserved keywords (e.g., `type`) as-is in generated client method signatures, causing `rustfmt` parse failures and Rust compilation errors.

Link to Devin Session: https://app.devin.ai/sessions/5d39b24dcd814ff2ba711bf26fe88851
Requested by: @iamnamananand996

## Changes Made

- Apply `escapeRustKeyword()` to path parameter names in `addPathParameters()` so method signatures use `r#type` instead of `type`
- Apply the same escaping in `getPathExpression()` so the `format!()` macro references the escaped variable name consistently
- Added version `0.18.1` changelog entry

Note: `addIndividualQueryParameters` (line 934) already called `escapeRustKeyword` — this fix brings path parameters in line with query parameters.

## Human Review Checklist


- [ ] Verify path parameter name escaping is consistent: method signature parameter name (`r#type`) must match variable references in `format!()` macro (line ~1411)
- [ ] (Edge case) If an API has pagination + reserved keyword path params: verify cloning statements like `let r#type_clone = r#type.clone();` and async variable renaming (`r#type_for_async`) are syntactically valid Rust

## Testing

- [ ] Lint checks pass (`pnpm run check`)
- [ ] CI will run seed tests for rust-sdk generator
- [ ] Manual testing: the user's failing API definition (with `type` as a path parameter) should now generate valid Rust code that passes `rustfmt`