### PR TITLE
fix(rust): deduplicate module declarations and use collision-aware WebSocket type names

### DIFF
--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -981,6 +981,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
 
     private getResourceExports(context: SdkGeneratorContext): string[] {
         const exports: string[] = [];
+        const seen = new Set<string>();
 
         // Only export top-level subpackages from the root package
         const topLevelSubpackageIds = context.ir.rootPackage.subpackages;
@@ -989,8 +990,13 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             const subpackage = context.ir.subpackages[subpackageId];
             if (subpackage) {
                 // Use registered client name from context
+                // Deduplicate - multiple subpackages can resolve to the same client name
+                // (e.g., HTTP and AsyncAPI sources both creating a "market_data" subpackage)
                 const subClientName = context.getUniqueClientNameForSubpackage(subpackage);
-                exports.push(subClientName);
+                if (!seen.has(subClientName)) {
+                    seen.add(subClientName);
+                    exports.push(subClientName);
+                }
             }
         });
 

--- a/generators/rust/sdk/src/generators/RootClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/RootClientGenerator.ts
@@ -37,20 +37,27 @@ export class RootClientGenerator {
         moduleDoc.push("");
 
         // Add documentation based on available subpackages
+        // Deduplicate by display name since multiple subpackages can share the same name
         if (subpackages.length > 0) {
             moduleDoc.push("This module contains client implementations for:");
             moduleDoc.push("");
+            const seenDocNames = new Set<string>();
             subpackages.forEach((subpackage) => {
                 const name = subpackage.name.pascalCase.safeName;
                 const displayName = subpackage.displayName ?? name;
 
                 // Try to get service docs if the subpackage has a service
+                let docEntry: string;
                 if (subpackage.service) {
                     const service = this.context.getHttpServiceOrThrow(subpackage.service);
                     const serviceDisplayName = service.displayName ?? displayName;
-                    moduleDoc.push(`- **${serviceDisplayName}**`);
+                    docEntry = serviceDisplayName;
                 } else {
-                    moduleDoc.push(`- **${displayName}**`);
+                    docEntry = displayName;
+                }
+                if (!seenDocNames.has(docEntry)) {
+                    seenDocNames.add(docEntry);
+                    moduleDoc.push(`- **${docEntry}**`);
                 }
             });
         } else {
@@ -111,11 +118,36 @@ export class RootClientGenerator {
     }
 
     private generateModuleDeclarations(subpackages: FernIr.Subpackage[]): string {
-        return subpackages.map((subpackage) => `pub mod ${subpackage.name.snakeCase.safeName};`).join("\n");
+        // Deduplicate module names - multiple subpackages can share the same name
+        // (e.g., HTTP and AsyncAPI sources both creating a "market_data" subpackage)
+        const seen = new Set<string>();
+        return subpackages
+            .filter((subpackage) => {
+                const moduleName = subpackage.name.snakeCase.safeName;
+                if (seen.has(moduleName)) {
+                    return false;
+                }
+                seen.add(moduleName);
+                return true;
+            })
+            .map((subpackage) => `pub mod ${subpackage.name.snakeCase.safeName};`)
+            .join("\n");
     }
 
     private generateReExports(subpackages: FernIr.Subpackage[]): string {
+        // Deduplicate re-exports - multiple subpackages with the same name/path
+        // resolve to the same client name via getUniqueClientNameForSubpackage
+        const seen = new Set<string>();
         return subpackages
+            .filter((subpackage) => {
+                const clientName = this.getSubClientName(subpackage);
+                const reExport = `${subpackage.name.snakeCase.safeName}::${clientName}`;
+                if (seen.has(reExport)) {
+                    return false;
+                }
+                seen.add(reExport);
+                return true;
+            })
             .map((subpackage) => {
                 const clientName = this.getSubClientName(subpackage);
                 return `pub use ${subpackage.name.snakeCase.safeName}::${clientName};`;

--- a/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
+++ b/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
@@ -453,10 +453,11 @@ ${queryLines.join("\n")}
             return msg.body.name.pascalCase.safeName;
         }
         // For reference body types, derive variant name from the referenced type
+        // Use disambiguated name so variant matches body type (e.g., AuthResponse2(AuthResponse2))
         if (msg.body.type === "reference") {
             const typeRef = msg.body.bodyType;
             if (typeRef.type === "named") {
-                return typeRef.name.pascalCase.safeName;
+                return this.context.getUniqueTypeNameForReference(typeRef);
             }
         }
         // Fallback: capitalize the message type ID
@@ -481,7 +482,10 @@ ${queryLines.join("\n")}
         if (msg.body.type === "reference") {
             const typeRef = msg.body.bodyType;
             if (typeRef.type === "named") {
-                return typeRef.name.pascalCase.safeName;
+                // Use the context's type disambiguation to get the correct unique type name.
+                // Without this, types like AuthResponse in the trading namespace would resolve
+                // to the market_data AuthResponse instead of the disambiguated AuthResponse2.
+                return this.context.getUniqueTypeNameForReference(typeRef);
             }
             if (typeRef.type === "primitive") {
                 return "String";

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.18.3
+  changelogEntry:
+    - summary: |
+        Fix duplicate module declarations and WebSocket type name collisions when multiple
+        subpackages (e.g., HTTP REST and AsyncAPI WebSocket) map to the same namespace. Deduplicates
+        `pub mod` declarations, client re-exports, and doc comments. WebSocket channel generators
+        now use collision-aware type names (e.g., `AuthResponse2` instead of `AuthResponse`) to
+        correctly reference disambiguated types in the trading namespace.
+      type: fix
+  createdAt: "2026-03-06"
+  irVersion: 62
+
 - version: 0.18.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Follow-up to #13187 (v0.18.2). Fixes three compilation errors discovered when generating against `@fern-demo/immix-fern-config` (which combines HTTP REST and AsyncAPI WebSocket sources into the same namespace).

Link to Devin Session: https://app.devin.ai/sessions/5d39b24dcd814ff2ba711bf26fe88851
Requested by: @iamnamananand996

## Problem

When multiple IR subpackages map to the same namespace (e.g., HTTP `market_data` + AsyncAPI `market_data`), the generator produced:

1. **Duplicate `pub mod market_data;`** declarations in `resources/mod.rs`
2. **Duplicate `MarketDataClient`** re-exports in both `resources/mod.rs` and `api/mod.rs`
3. **Wrong type names in WebSocket client** — `TradingServerMessage` enum used `AuthResponse` (market_data's type) instead of `AuthResponse2` (the disambiguated trading type), causing unresolved type errors

## Changes Made

- **`RootClientGenerator.ts`**: Added `Set`-based deduplication to `generateModuleDeclarations()`, `generateReExports()`, and doc comment generation
- **`SdkGeneratorCli.ts`**: Added deduplication to `getResourceExports()` to prevent duplicate client names in `api/mod.rs`
- **`WebSocketChannelGenerator.ts`**: Changed `getMessageVariantName()` and `getMessageBodyType()` from using raw `typeRef.name.pascalCase.safeName` to `this.context.getUniqueTypeNameForReference(typeRef)`, which resolves through the collision registry (e.g., `AuthResponse` → `AuthResponse2`)
- **`versions.yml`**: Added v0.18.3 changelog entry

## Testing

- [x] `pnpm run check` (lint) passed
- [x] All existing seed tests pass (no snapshot changes needed — existing seeds don't have dual HTTP+AsyncAPI sources)
- [x] Local Docker generation against `@fern-demo/immix-fern-config` (branch `rust-wss`) verified:
  - No duplicate `pub mod` or `pub use` declarations
  - WebSocket trading client correctly uses `AuthResponse2`, `SubscribeResponse2`, `ErrorEvent2`

## ⚠️ Human Review Checklist

1. **`getUniqueTypeNameForReference()` in WebSocket context**: Verify this method returns the unsuffixed name when there's no collision (i.e., it's a no-op for non-colliding types). If it behaves differently for single-source APIs, it could break existing WebSocket generation.
2. **Dedup strategy**: Deduplication uses string-based `Set` checks rather than subpackage IDs. This is intentional (different subpackage IDs can map to the same module), but worth confirming no edge case silently drops a subpackage that contributes unique functionality.
3. **Missing seed test coverage**: No existing seed test captures HTTP+AsyncAPI dual sources. Consider adding one to prevent regression.