### PR TITLE
feat(rust): add WebSocket connector pattern and README snippets

### DIFF
--- a/generators/rust/sdk/features.yml
+++ b/generators/rust/sdk/features.yml
@@ -41,6 +41,10 @@ features:
     description: |
       You can add custom query parameters to requests using `RequestOptions`.
 
+  - id: WEBSOCKETS
+    description: |
+      The SDK supports WebSocket connections for real-time communication. Use the generated channel clients to connect, send, and receive messages.
+
   - id: PAGINATION
     description: |
       For paginated endpoints, the SDK automatically handles pagination using async streams. Use `futures::StreamExt` to iterate through all pages.

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -743,20 +743,24 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
     private async generateReadme(context: SdkGeneratorContext): Promise<void> {
         try {
             const snippetCount = context.ir.dynamic?.endpoints ? Object.keys(context.ir.dynamic.endpoints).length : 0;
-            context.logger.debug(`Generating README.md with ${snippetCount} endpoint example(s)...`);
+            const hasWebSocket = this.hasWebSocketChannels(context);
+            context.logger.debug(`Generating README.md with ${snippetCount} endpoint example(s), websocket=${hasWebSocket}...`);
 
-            // If there are no endpoints, generate a simplified README
-            if (!snippetCount) {
-                context.logger.debug(`Generated simplified README.md for SDK with no endpoints`);
+            // If there are no endpoints and no WebSocket channels, skip README generation
+            if (!snippetCount && !hasWebSocket) {
+                context.logger.debug(`Generated simplified README.md for SDK with no endpoints and no WebSocket channels`);
                 return;
             }
 
-            // Generate endpoint snippets
-            const endpointSnippets = this.generateSnippets(context);
+            // Generate endpoint snippets (may be empty for WebSocket-only SDKs)
+            let endpointSnippets: FernGeneratorExec.Endpoint[] = [];
+            if (snippetCount) {
+                endpointSnippets = this.generateSnippets(context);
+            }
 
-            // If there are no endpoint snippets (i.e., no examples defined), skip README generation
-            if (endpointSnippets.length === 0) {
-                context.logger.debug(`Skipping README.md generation - no endpoint examples defined`);
+            // If there are no endpoint snippets and no WebSocket channels, skip README generation
+            if (endpointSnippets.length === 0 && !hasWebSocket) {
+                context.logger.debug(`Skipping README.md generation - no endpoint examples defined and no WebSocket channels`);
                 return;
             }
 

--- a/generators/rust/sdk/src/generators/RootClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/RootClientGenerator.ts
@@ -6,12 +6,19 @@ import { rust, UseStatement } from "@fern-api/rust-codegen";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 import { ClientGeneratorContext } from "./ClientGeneratorContext.js";
 import { SubClientGenerator } from "./SubClientGenerator.js";
+import { WebSocketChannelGenerator } from "./WebSocketChannelGenerator.js";
 
 export class RootClientGenerator {
     private readonly context: SdkGeneratorContext;
     private readonly package: FernIr.Package;
     private readonly projectName: string;
     private readonly clientGeneratorContext: ClientGeneratorContext;
+    private readonly wsConnectors: Array<{
+        connectorName: string;
+        fieldName: string;
+        clientName: string;
+        moduleName: string;
+    }>;
 
     constructor(context: SdkGeneratorContext) {
         this.context = context;
@@ -21,6 +28,10 @@ export class RootClientGenerator {
             packageOrSubpackage: this.package,
             sdkGeneratorContext: context
         });
+
+        // Gather WebSocket connector info
+        const wsGen = new WebSocketChannelGenerator(context);
+        this.wsConnectors = wsGen.getConnectorInfo();
     }
 
     // =============================================================================
@@ -156,12 +167,26 @@ export class RootClientGenerator {
     }
 
     private generateImports(): UseStatement[] {
-        return [
+        const imports: UseStatement[] = [
             new UseStatement({
                 path: "crate",
                 items: ["ClientConfig", "ApiError"]
             })
         ];
+
+        // Import WebSocket connector types from the websocket module
+        const httpFieldNames = new Set(this.clientGeneratorContext.subClients.map((c) => c.fieldName));
+        const uniqueWsConnectors = this.getUniqueWsConnectors(httpFieldNames);
+        if (uniqueWsConnectors.length > 0) {
+            imports.push(
+                new UseStatement({
+                    path: "crate::api::websocket",
+                    items: uniqueWsConnectors.map((c) => c.connectorName)
+                })
+            );
+        }
+
+        return imports;
     }
 
     // =============================================================================
@@ -179,6 +204,9 @@ export class RootClientGenerator {
     }
 
     private generateFields(subpackages: FernIr.Subpackage[]): rust.Client.Field[] {
+        // Collect HTTP sub-client field names to avoid collisions with WS connectors
+        const httpFieldNames = new Set(this.clientGeneratorContext.subClients.map((c) => c.fieldName));
+
         return [
             {
                 name: "config",
@@ -189,14 +217,37 @@ export class RootClientGenerator {
                 name: fieldName,
                 type: rust.Type.reference(rust.reference({ name: clientName })).toString(),
                 visibility: "pub" as const
+            })),
+            ...this.getUniqueWsConnectors(httpFieldNames).map(({ fieldName, connectorName }) => ({
+                name: fieldName,
+                type: rust.Type.reference(rust.reference({ name: connectorName })).toString(),
+                visibility: "pub" as const
             }))
         ];
     }
 
+    /**
+     * Returns WebSocket connectors that don't collide with existing HTTP sub-client field names.
+     */
+    private getUniqueWsConnectors(httpFieldNames: Set<string>): typeof this.wsConnectors {
+        return this.wsConnectors.filter((c) => !httpFieldNames.has(c.fieldName));
+    }
+
     private generateConstructor(subpackages: FernIr.Subpackage[]): rust.Client.SimpleMethod {
-        const subClientInits = this.clientGeneratorContext.subClients
-            .map(({ fieldName, clientName }) => `${fieldName}: ${clientName}::new(config.clone())?`)
-            .join(",\n            ");
+        const allInits: string[] = [];
+        const httpFieldNames = new Set(this.clientGeneratorContext.subClients.map((c) => c.fieldName));
+
+        // HTTP sub-client initializations
+        for (const { fieldName, clientName } of this.clientGeneratorContext.subClients) {
+            allInits.push(`${fieldName}: ${clientName}::new(config.clone())?`);
+        }
+
+        // WebSocket connector initializations (only those not colliding with HTTP sub-clients)
+        for (const { fieldName, connectorName } of this.getUniqueWsConnectors(httpFieldNames)) {
+            allInits.push(`${fieldName}: ${connectorName}::new(config.base_url.clone())`);
+        }
+
+        const initStr = allInits.join(",\n            ");
 
         const configType = rust.Type.reference(rust.reference({ name: "ClientConfig" }));
         const selfType = rust.Type.reference(rust.reference({ name: "Self" }));
@@ -210,7 +261,7 @@ export class RootClientGenerator {
             isAsync: false,
             body: `Ok(Self {
             config: config.clone(),
-            ${subClientInits}
+            ${initStr}
         })`
         };
     }

--- a/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
+++ b/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
@@ -14,6 +14,53 @@ export class WebSocketChannelGenerator {
         this.context = context;
     }
 
+    /**
+     * Returns the connector info for each WebSocket channel so the root client
+     * can include connector fields. Each entry maps a channel to its connector
+     * struct name, field name, and the underlying client connect() parameters.
+     */
+    public getConnectorInfo(): Array<{
+        connectorName: string;
+        fieldName: string;
+        clientName: string;
+        moduleName: string;
+        channel: FernIr.WebSocketChannel;
+    }> {
+        const websocketChannels = this.context.ir.websocketChannels;
+        if (!websocketChannels) {
+            return [];
+        }
+
+        // Ensure name map is built
+        if (this.channelNameMap.size === 0) {
+            this.buildChannelNameMap(websocketChannels);
+        }
+
+        const result: Array<{
+            connectorName: string;
+            fieldName: string;
+            clientName: string;
+            moduleName: string;
+            channel: FernIr.WebSocketChannel;
+        }> = [];
+
+        for (const [channelId, channel] of Object.entries(websocketChannels)) {
+            const names = this.channelNameMap.get(channelId);
+            if (names == null) {
+                continue;
+            }
+            result.push({
+                connectorName: `${names.clientName.replace(/Client$/, "")}Connector`,
+                fieldName: names.moduleName,
+                clientName: names.clientName,
+                moduleName: names.moduleName,
+                channel
+            });
+        }
+
+        return result;
+    }
+
     public generateAll(): RustFile[] {
         const files: RustFile[] = [];
         const websocketChannels = this.context.ir.websocketChannels;
@@ -98,6 +145,7 @@ export class WebSocketChannelGenerator {
             }
             moduleDeclarations.push(`pub mod ${names.moduleName};`);
             reExports.push(`pub use ${names.moduleName}::${names.clientName};`);
+            reExports.push(`pub use ${names.moduleName}::${names.clientName.replace(/Client$/, "")}Connector;`);
 
             const serverMessages = channel.messages.filter((m) => m.origin === "server");
             const jsonServerMessages = serverMessages.filter((m) => !this.isBinaryMessage(m));
@@ -159,6 +207,9 @@ export class WebSocketChannelGenerator {
         rawDeclarations.push(
             this.generateImplBlock(clientName, enumPrefix, channel, clientMessages, jsonServerMessages, hasBinaryServerMessages)
         );
+
+        // Generate connector struct that wraps base_url and delegates to the client's connect()
+        rawDeclarations.push(this.generateConnectorStruct(clientName, channel));
 
         const hasJsonServerMessages = jsonServerMessages.length > 0;
         const useStatements = this.generateImports(hasJsonServerMessages);
@@ -420,6 +471,58 @@ ${queryLines.join("\n")}
         return `    pub async fn close(&self) -> Result<(), ApiError> {
         self.ws.close().await
     }`;
+    }
+
+    /**
+     * Generates a connector struct that wraps the base URL and delegates to the
+     * client's connect() method. This allows WebSocket clients to be accessed
+     * through the root client (e.g., `client.realtime.connect(...)`).
+     */
+    private generateConnectorStruct(clientName: string, channel: FernIr.WebSocketChannel): string {
+        const connectorName = `${clientName.replace(/Client$/, "")}Connector`;
+
+        // Build the connect method parameters (same as client but without url)
+        const params: string[] = ["&self"];
+        const forwardArgs: string[] = ["&self.base_url"];
+
+        for (const pathParam of channel.pathParameters) {
+            const paramName = pathParam.name.snakeCase.safeName;
+            params.push(`${paramName}: &str`);
+            forwardArgs.push(paramName);
+        }
+
+        for (const header of channel.headers) {
+            const paramName = header.name.name.snakeCase.safeName;
+            params.push(`${paramName}: &str`);
+            forwardArgs.push(paramName);
+        }
+
+        for (const qp of channel.queryParameters) {
+            const paramName = qp.name.name.snakeCase.safeName;
+            const isOptional = this.isOptionalType(qp.valueType);
+            if (isOptional) {
+                params.push(`${paramName}: Option<&str>`);
+            } else {
+                params.push(`${paramName}: &str`);
+            }
+            forwardArgs.push(paramName);
+        }
+
+        return `/// Connector for the ${clientName.replace(/Client$/, "")} WebSocket channel.
+/// Provides access to the WebSocket channel through the root client.
+pub struct ${connectorName} {
+    base_url: String,
+}
+
+impl ${connectorName} {
+    pub fn new(base_url: String) -> Self {
+        Self { base_url }
+    }
+
+    pub async fn connect(${params.join(", ")}) -> Result<${clientName}, ApiError> {
+        ${clientName}::connect(${forwardArgs.join(", ")}).await
+    }
+}`;
     }
 
     private buildPathExpression(channel: FernIr.WebSocketChannel): string {

--- a/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
+++ b/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
@@ -50,7 +50,7 @@ export class WebSocketChannelGenerator {
                 continue;
             }
             result.push({
-                connectorName: `${names.clientName.replace(/Client$/, "")}Connector`,
+                connectorName: this.getConnectorName(names.clientName),
                 fieldName: names.moduleName,
                 clientName: names.clientName,
                 moduleName: names.moduleName,
@@ -145,7 +145,7 @@ export class WebSocketChannelGenerator {
             }
             moduleDeclarations.push(`pub mod ${names.moduleName};`);
             reExports.push(`pub use ${names.moduleName}::${names.clientName};`);
-            reExports.push(`pub use ${names.moduleName}::${names.clientName.replace(/Client$/, "")}Connector;`);
+            reExports.push(`pub use ${names.moduleName}::${this.getConnectorName(names.clientName)};`);
 
             const serverMessages = channel.messages.filter((m) => m.origin === "server");
             const jsonServerMessages = serverMessages.filter((m) => !this.isBinaryMessage(m));
@@ -345,22 +345,49 @@ ${methods.join("\n\n")}
 }`;
     }
 
+    /**
+     * Builds the shared connect parameter list from a WebSocket channel's IR definition.
+     * Used by both generateConnectMethod() and generateConnectorStruct() to ensure
+     * parameter signatures stay in sync.
+     */
+    private buildConnectParams(channel: FernIr.WebSocketChannel): Array<{ name: string; type: string }> {
+        const params: Array<{ name: string; type: string }> = [];
+
+        for (const pathParam of channel.pathParameters) {
+            params.push({ name: pathParam.name.snakeCase.safeName, type: "&str" });
+        }
+
+        for (const header of channel.headers) {
+            params.push({ name: header.name.name.snakeCase.safeName, type: "&str" });
+        }
+
+        for (const qp of channel.queryParameters) {
+            const isOptional = this.isOptionalType(qp.valueType);
+            params.push({
+                name: qp.name.name.snakeCase.safeName,
+                type: isOptional ? "Option<&str>" : "&str"
+            });
+        }
+
+        return params;
+    }
+
+    /**
+     * Derives the connector struct name from a client name.
+     * Single source of truth used by getConnectorInfo(), generateWebSocketModFile(),
+     * and generateConnectorStruct().
+     */
+    private getConnectorName(clientName: string): string {
+        return `${clientName.replace(/Client$/, "")}Connector`;
+    }
+
     private generateConnectMethod(
         clientName: string,
         channel: FernIr.WebSocketChannel,
         pathExpression: string
     ): string {
-        const params: string[] = ["url: &str"];
-
-        for (const pathParam of channel.pathParameters) {
-            const paramName = pathParam.name.snakeCase.safeName;
-            params.push(`${paramName}: &str`);
-        }
-
-        for (const header of channel.headers) {
-            const paramName = header.name.name.snakeCase.safeName;
-            params.push(`${paramName}: &str`);
-        }
+        const connectParams = this.buildConnectParams(channel);
+        const params: string[] = ["url: &str", ...connectParams.map((p) => `${p.name}: ${p.type}`)];
 
         const headerInserts = channel.headers
             .map((header) => {
@@ -377,12 +404,10 @@ ${methods.join("\n\n")}
                 const wireValue = qp.name.wireValue;
                 const isOptional = this.isOptionalType(qp.valueType);
                 if (isOptional) {
-                    params.push(`${paramName}: Option<&str>`);
                     queryLines.push(`        if let Some(v) = ${paramName} {`);
                     queryLines.push(`            options.query_params.push(("${wireValue}".to_string(), v.to_string()));`);
                     queryLines.push(`        }`);
                 } else {
-                    params.push(`${paramName}: &str`);
                     queryLines.push(`        options.query_params.push(("${wireValue}".to_string(), ${paramName}.to_string()));`);
                 }
             }
@@ -479,34 +504,12 @@ ${queryLines.join("\n")}
      * through the root client (e.g., `client.realtime.connect(...)`).
      */
     private generateConnectorStruct(clientName: string, channel: FernIr.WebSocketChannel): string {
-        const connectorName = `${clientName.replace(/Client$/, "")}Connector`;
+        const connectorName = this.getConnectorName(clientName);
 
-        // Build the connect method parameters (same as client but without url)
-        const params: string[] = ["&self"];
-        const forwardArgs: string[] = ["&self.base_url"];
-
-        for (const pathParam of channel.pathParameters) {
-            const paramName = pathParam.name.snakeCase.safeName;
-            params.push(`${paramName}: &str`);
-            forwardArgs.push(paramName);
-        }
-
-        for (const header of channel.headers) {
-            const paramName = header.name.name.snakeCase.safeName;
-            params.push(`${paramName}: &str`);
-            forwardArgs.push(paramName);
-        }
-
-        for (const qp of channel.queryParameters) {
-            const paramName = qp.name.name.snakeCase.safeName;
-            const isOptional = this.isOptionalType(qp.valueType);
-            if (isOptional) {
-                params.push(`${paramName}: Option<&str>`);
-            } else {
-                params.push(`${paramName}: &str`);
-            }
-            forwardArgs.push(paramName);
-        }
+        // Reuse shared parameter list — same order and types as generateConnectMethod()
+        const connectParams = this.buildConnectParams(channel);
+        const params: string[] = ["&self", ...connectParams.map((p) => `${p.name}: ${p.type}`)];
+        const forwardArgs: string[] = ["&self.base_url", ...connectParams.map((p) => p.name)];
 
         return `/// Connector for the ${clientName.replace(/Client$/, "")} WebSocket channel.
 /// Provides access to the WebSocket channel through the root client.

--- a/generators/rust/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/rust/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -40,13 +40,12 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
 
         this.endpointsById = this.buildEndpointsById();
         this.prerenderedSnippetsByEndpointId = this.buildPrerenderedSnippetsByEndpointId(endpointSnippets);
-        if (this.context.ir.readmeConfig?.defaultEndpoint != null) {
-            this.defaultEndpointId = this.context.ir.readmeConfig.defaultEndpoint;
-        } else if (endpointSnippets.length > 0) {
-            this.defaultEndpointId = this.getDefaultEndpointId();
-        } else {
-            this.defaultEndpointId = undefined;
-        }
+        this.defaultEndpointId =
+            this.context.ir.readmeConfig?.defaultEndpoint != null
+                ? this.context.ir.readmeConfig.defaultEndpoint
+                : endpointSnippets.length > 0
+                  ? this.getDefaultEndpointId()
+                  : undefined;
         this.crateName = this.context.getCrateName();
     }
 
@@ -607,15 +606,14 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             return [];
         }
 
-        const { clientName } = names;
         const clientMessages = channel.messages.filter((m) => m.origin === "client");
         const serverMessages = channel.messages.filter((m) => m.origin === "server");
 
         // Get the subpackage access path (e.g., "market_data" or "realtime")
         const subpackageName = subpackage.name.snakeCase.safeName;
 
-        // Build connect params from IR
-        const connectParams: string[] = ['"wss://api.example.com"'];
+        // Build connect params from IR (without the url, since connectors provide it from config)
+        const connectParams: string[] = [];
         for (const pathParam of channel.pathParameters) {
             connectParams.push(`"${pathParam.name.snakeCase.safeName}"`);
         }
@@ -633,24 +631,51 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
 
         const snippets: string[] = [];
 
-        // --- Snippet: Connect + send + receive + close ---
+        // --- Snippet: Connect via root client + send + receive + close ---
         const writer = new Writer();
 
-        // Use statement for the WebSocket client
-        writer.write(`use ${crateName}::api::websocket::${clientName};`);
+        // Use statement
+        writer.write(`use ${crateName}::prelude::*;`);
         writer.newLine();
         writer.newLine();
 
-        // Connect
-        writer.write(`let mut ${subpackageName} = ${clientName}::connect(`);
+        // Create client config and root client (same pattern as pagination snippets)
+        const rootClientName = this.context.getClientName();
+        const configStatement = Statement.let({
+            name: "config",
+            value: this.getClientConfigStruct("error")
+        });
+        configStatement.write(writer);
         writer.newLine();
-        writer.indent();
-        for (const param of connectParams) {
-            writer.write(param + ",");
+        const clientBuild = Expression.methodCall({
+            target: Expression.raw(`${rootClientName}::new(config)`),
+            method: "expect",
+            args: [Expression.stringLiteral("Failed to build client")]
+        });
+        const clientStatement = Statement.let({
+            name: "client",
+            value: clientBuild
+        });
+        clientStatement.write(writer);
+        writer.newLine();
+        writer.newLine();
+
+        // Connect via root client accessor (e.g., client.realtime.connect(...))
+        writer.write(`// Connect to the WebSocket`);
+        writer.newLine();
+        if (connectParams.length > 0) {
+            writer.write(`let mut ${subpackageName} = client.${subpackageName}.connect(`);
             writer.newLine();
+            writer.indent();
+            for (const param of connectParams) {
+                writer.write(param + ",");
+                writer.newLine();
+            }
+            writer.dedent();
+            writer.write(").await.expect(\"Failed to connect\");");
+        } else {
+            writer.write(`let mut ${subpackageName} = client.${subpackageName}.connect().await.expect("Failed to connect");`);
         }
-        writer.dedent();
-        writer.write(").await.expect(\"Failed to connect\");");
         writer.newLine();
         writer.newLine();
 

--- a/generators/rust/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/rust/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -20,11 +20,12 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     private static ADDITIONAL_HEADERS_FEATURE_ID: FernGeneratorCli.FeatureId = "ADDITIONAL_HEADERS";
     private static ADDITIONAL_QUERY_STRING_PARAMETERS_FEATURE_ID: FernGeneratorCli.FeatureId =
         "ADDITIONAL_QUERY_STRING_PARAMETERS";
+    private static WEBSOCKETS_FEATURE_ID: FernGeneratorCli.FeatureId = "WEBSOCKETS";
 
     private readonly context: SdkGeneratorContext;
     private readonly endpointsById: Record<FernIr.EndpointId, EndpointWithFilepath> = {};
     private readonly prerenderedSnippetsByEndpointId: Record<FernIr.EndpointId, string> = {};
-    private readonly defaultEndpointId: FernIr.EndpointId;
+    private readonly defaultEndpointId: FernIr.EndpointId | undefined;
     private readonly crateName: string;
 
     constructor({
@@ -39,10 +40,13 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
 
         this.endpointsById = this.buildEndpointsById();
         this.prerenderedSnippetsByEndpointId = this.buildPrerenderedSnippetsByEndpointId(endpointSnippets);
-        this.defaultEndpointId =
-            this.context.ir.readmeConfig?.defaultEndpoint != null
-                ? this.context.ir.readmeConfig.defaultEndpoint
-                : this.getDefaultEndpointId();
+        if (this.context.ir.readmeConfig?.defaultEndpoint != null) {
+            this.defaultEndpointId = this.context.ir.readmeConfig.defaultEndpoint;
+        } else if (endpointSnippets.length > 0) {
+            this.defaultEndpointId = this.getDefaultEndpointId();
+        } else {
+            this.defaultEndpointId = undefined;
+        }
         this.crateName = this.context.getCrateName();
     }
 
@@ -71,6 +75,12 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         snippets[ReadmeSnippetBuilder.ADDITIONAL_QUERY_STRING_PARAMETERS_FEATURE_ID] =
             this.buildAdditionalQueryStringParametersSnippets();
 
+        // WebSocket
+        const wsSnippets = this.buildWebSocketSnippets();
+        if (wsSnippets.length > 0) {
+            snippets[ReadmeSnippetBuilder.WEBSOCKETS_FEATURE_ID] = wsSnippets;
+        }
+
         // Pagination disable it for now, currently only support normal pagination
         // snippets[ReadmeSnippetBuilder.PAGINATION_FEATURE_ID] = this.buildPaginationSnippets();
 
@@ -81,6 +91,9 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         const endpointIds = this.getConfiguredEndpointIdsForFeature(FernGeneratorCli.StructuredFeatureId.Usage);
         if (endpointIds != null && endpointIds.length > 0) {
             return endpointIds.map((endpointId) => this.getSnippetForEndpointId(endpointId)).filter(isNonNullish);
+        }
+        if (this.defaultEndpointId == null) {
+            return [];
         }
         const snippet = this.getSnippetForEndpointId(this.defaultEndpointId);
         return snippet != null ? [snippet] : [];
@@ -213,7 +226,8 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     }
 
     private getEndpointsForFeature(featureId: FernIr.FeatureId): EndpointWithFilepath[] {
-        const endpointIds = this.getConfiguredEndpointIdsForFeature(featureId) ?? [this.defaultEndpointId];
+        const configuredIds = this.getConfiguredEndpointIdsForFeature(featureId);
+        const endpointIds = configuredIds ?? (this.defaultEndpointId != null ? [this.defaultEndpointId] : []);
         return endpointIds.map(this.lookupEndpointById.bind(this)).filter(isNonNullish);
     }
 
@@ -565,6 +579,180 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         }`);
 
         return [configVar, clientVar, streamVar, whileLoop];
+    }
+
+    private buildWebSocketSnippets(): string[] {
+        if (!this.context.hasWebSocketChannels()) {
+            return [];
+        }
+
+        const websocketChannels = this.context.ir.websocketChannels;
+        if (!websocketChannels) {
+            return [];
+        }
+
+        const snippets: string[] = [];
+        const crateName = this.crateName;
+
+        // Build channel name map using the same logic as WebSocketChannelGenerator
+        const channelNameMap = this.buildWebSocketChannelNameMap(websocketChannels);
+
+        for (const [channelId, channel] of Object.entries(websocketChannels)) {
+            const names = channelNameMap.get(channelId);
+            if (names == null) {
+                continue;
+            }
+
+            const { clientName, moduleName } = names;
+            const clientMessages = channel.messages.filter((m) => m.origin === "client");
+            const serverMessages = channel.messages.filter((m) => m.origin === "server");
+
+            const writer = new Writer();
+
+            // Import statement
+            writer.write(`use ${crateName}::api::websocket::${clientName};`);
+            writer.newLine();
+            writer.newLine();
+
+            // Build connect call
+            const connectParams: string[] = ['"wss://api.example.com"'];
+            for (const pathParam of channel.pathParameters) {
+                connectParams.push(`"${pathParam.name.snakeCase.safeName}"`);
+            }
+            for (const header of channel.headers) {
+                connectParams.push(`"${header.name.name.snakeCase.safeName}"`);
+            }
+            for (const qp of channel.queryParameters) {
+                const isOptional = qp.valueType.type === "container" && qp.valueType.container.type === "optional";
+                if (isOptional) {
+                    connectParams.push("None");
+                } else {
+                    connectParams.push(`"${qp.name.name.snakeCase.safeName}"`);
+                }
+            }
+
+            writer.write(`let mut client = ${clientName}::connect(`);
+            writer.newLine();
+            writer.indent();
+            for (let i = 0; i < connectParams.length; i++) {
+                writer.write(connectParams[i] + ",");
+                writer.newLine();
+            }
+            writer.dedent();
+            writer.write(").await.expect(\"Failed to connect\");");
+            writer.newLine();
+            writer.newLine();
+
+            // Show a send example if there are client messages
+            if (clientMessages.length > 0) {
+                const firstMsg = clientMessages[0];
+                if (firstMsg != null) {
+                    const methodName = this.getWebSocketMessageMethodName(firstMsg, "send");
+                    const bodyType = this.getWebSocketMessageBodyType(firstMsg);
+                    if (bodyType) {
+                        writer.write(`// Send a message`);
+                        writer.newLine();
+                        writer.write(`client.${methodName}(&${bodyType} { /* fields */ }).await.expect("Failed to send");`);
+                    } else {
+                        writer.write(`// Send a message`);
+                        writer.newLine();
+                        writer.write(`client.${methodName}(&serde_json::json!({})).await.expect("Failed to send");`);
+                    }
+                    writer.newLine();
+                    writer.newLine();
+                }
+            }
+
+            // Show receive example if there are server messages
+            if (serverMessages.length > 0) {
+                writer.write(`// Receive messages`);
+                writer.newLine();
+                writer.write(`while let Some(Ok(message)) = client.recv().await {`);
+                writer.newLine();
+                writer.indent();
+                writer.write(`println!("{:?}", message);`);
+                writer.dedent();
+                writer.newLine();
+                writer.write(`}`);
+                writer.newLine();
+                writer.newLine();
+            }
+
+            // Close
+            writer.write(`// Close the connection`);
+            writer.newLine();
+            writer.write(`client.close().await.expect("Failed to close");`);
+
+            snippets.push(writer.toString().trim() + "\n");
+
+            // Only generate one snippet — the first channel is enough for the README
+            break;
+        }
+
+        return snippets;
+    }
+
+    private buildWebSocketChannelNameMap(
+        websocketChannels: Record<FernIr.WebSocketChannelId, FernIr.WebSocketChannel>
+    ): Map<string, { moduleName: string; clientName: string }> {
+        const nameMap = new Map<string, { moduleName: string; clientName: string }>();
+
+        // Detect name collisions
+        const nameCount = new Map<string, number>();
+        for (const channel of Object.values(websocketChannels)) {
+            const baseName = channel.name.snakeCase.safeName;
+            nameCount.set(baseName, (nameCount.get(baseName) ?? 0) + 1);
+        }
+
+        for (const [channelId, channel] of Object.entries(websocketChannels)) {
+            const baseName = channel.name.snakeCase.safeName;
+
+            if ((nameCount.get(baseName) ?? 0) > 1) {
+                // Derive unique name from channel ID
+                const cleaned = channelId.replace(/^channel_/, "").replace(/\//g, "_");
+                const pascalCase = cleaned
+                    .split("_")
+                    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+                    .join("");
+                nameMap.set(channelId, {
+                    moduleName: cleaned,
+                    clientName: `${pascalCase}Client`
+                });
+            } else {
+                nameMap.set(channelId, {
+                    moduleName: channel.name.snakeCase.safeName,
+                    clientName: `${channel.name.pascalCase.safeName}Client`
+                });
+            }
+        }
+
+        return nameMap;
+    }
+
+    private getWebSocketMessageMethodName(msg: FernIr.WebSocketMessage, prefix: string): string {
+        const name = msg.body.type === "inlinedBody"
+            ? msg.body.name.snakeCase.safeName
+            : msg.type
+                .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+                .replace(/([A-Z])([A-Z][a-z])/g, "$1_$2")
+                .toLowerCase();
+        return `${prefix}_${name}`;
+    }
+
+    private getWebSocketMessageBodyType(msg: FernIr.WebSocketMessage): string | undefined {
+        if (msg.body.type === "reference") {
+            const typeRef = msg.body.bodyType;
+            if (typeRef.type === "named") {
+                return this.context.getUniqueTypeNameForReference(typeRef);
+            }
+            if (typeRef.type === "primitive") {
+                return undefined;
+            }
+        }
+        if (msg.body.type === "inlinedBody") {
+            return msg.body.name.pascalCase.safeName;
+        }
+        return undefined;
     }
 
     private writeCode(code: string): string {

--- a/generators/rust/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/rust/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -591,105 +591,140 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             return [];
         }
 
-        const snippets: string[] = [];
-        const crateName = this.crateName;
-
-        // Build channel name map using the same logic as WebSocketChannelGenerator
-        const channelNameMap = this.buildWebSocketChannelNameMap(websocketChannels);
-
-        for (const [channelId, channel] of Object.entries(websocketChannels)) {
-            const names = channelNameMap.get(channelId);
-            if (names == null) {
-                continue;
-            }
-
-            const { clientName, moduleName } = names;
-            const clientMessages = channel.messages.filter((m) => m.origin === "client");
-            const serverMessages = channel.messages.filter((m) => m.origin === "server");
-
-            const writer = new Writer();
-
-            // Import statement
-            writer.write(`use ${crateName}::api::websocket::${clientName};`);
-            writer.newLine();
-            writer.newLine();
-
-            // Build connect call
-            const connectParams: string[] = ['"wss://api.example.com"'];
-            for (const pathParam of channel.pathParameters) {
-                connectParams.push(`"${pathParam.name.snakeCase.safeName}"`);
-            }
-            for (const header of channel.headers) {
-                connectParams.push(`"${header.name.name.snakeCase.safeName}"`);
-            }
-            for (const qp of channel.queryParameters) {
-                const isOptional = qp.valueType.type === "container" && qp.valueType.container.type === "optional";
-                if (isOptional) {
-                    connectParams.push("None");
-                } else {
-                    connectParams.push(`"${qp.name.name.snakeCase.safeName}"`);
-                }
-            }
-
-            writer.write(`let mut client = ${clientName}::connect(`);
-            writer.newLine();
-            writer.indent();
-            for (let i = 0; i < connectParams.length; i++) {
-                writer.write(connectParams[i] + ",");
-                writer.newLine();
-            }
-            writer.dedent();
-            writer.write(").await.expect(\"Failed to connect\");");
-            writer.newLine();
-            writer.newLine();
-
-            // Show a send example if there are client messages
-            if (clientMessages.length > 0) {
-                const firstMsg = clientMessages[0];
-                if (firstMsg != null) {
-                    const methodName = this.getWebSocketMessageMethodName(firstMsg, "send");
-                    const bodyType = this.getWebSocketMessageBodyType(firstMsg);
-                    if (bodyType) {
-                        writer.write(`// Send a message`);
-                        writer.newLine();
-                        writer.write(`client.${methodName}(&${bodyType} { /* fields */ }).await.expect("Failed to send");`);
-                    } else {
-                        writer.write(`// Send a message`);
-                        writer.newLine();
-                        writer.write(`client.${methodName}(&serde_json::json!({})).await.expect("Failed to send");`);
-                    }
-                    writer.newLine();
-                    writer.newLine();
-                }
-            }
-
-            // Show receive example if there are server messages
-            if (serverMessages.length > 0) {
-                writer.write(`// Receive messages`);
-                writer.newLine();
-                writer.write(`while let Some(Ok(message)) = client.recv().await {`);
-                writer.newLine();
-                writer.indent();
-                writer.write(`println!("{:?}", message);`);
-                writer.dedent();
-                writer.newLine();
-                writer.write(`}`);
-                writer.newLine();
-                writer.newLine();
-            }
-
-            // Close
-            writer.write(`// Close the connection`);
-            writer.newLine();
-            writer.write(`client.close().await.expect("Failed to close");`);
-
-            snippets.push(writer.toString().trim() + "\n");
-
-            // Only generate one snippet — the first channel is enough for the README
-            break;
+        // Find the first WebSocket channel via subpackages (like Python's _get_example_websocket_channel)
+        const exampleChannel = this.getExampleWebSocketChannel();
+        if (exampleChannel == null) {
+            return [];
         }
 
+        const { subpackage, channel, channelId } = exampleChannel;
+        const crateName = this.crateName;
+
+        // Build channel name map to get proper client name
+        const channelNameMap = this.buildWebSocketChannelNameMap(websocketChannels);
+        const names = channelNameMap.get(channelId);
+        if (names == null) {
+            return [];
+        }
+
+        const { clientName } = names;
+        const clientMessages = channel.messages.filter((m) => m.origin === "client");
+        const serverMessages = channel.messages.filter((m) => m.origin === "server");
+
+        // Get the subpackage access path (e.g., "market_data" or "realtime")
+        const subpackageName = subpackage.name.snakeCase.safeName;
+
+        // Build connect params from IR
+        const connectParams: string[] = ['"wss://api.example.com"'];
+        for (const pathParam of channel.pathParameters) {
+            connectParams.push(`"${pathParam.name.snakeCase.safeName}"`);
+        }
+        for (const header of channel.headers) {
+            connectParams.push(`"${header.name.name.snakeCase.safeName}"`);
+        }
+        for (const qp of channel.queryParameters) {
+            const isOptional = qp.valueType.type === "container" && qp.valueType.container.type === "optional";
+            if (isOptional) {
+                connectParams.push("None");
+            } else {
+                connectParams.push(`"${qp.name.name.snakeCase.safeName}"`);
+            }
+        }
+
+        const snippets: string[] = [];
+
+        // --- Snippet: Connect + send + receive + close ---
+        const writer = new Writer();
+
+        // Use statement for the WebSocket client
+        writer.write(`use ${crateName}::api::websocket::${clientName};`);
+        writer.newLine();
+        writer.newLine();
+
+        // Connect
+        writer.write(`let mut ${subpackageName} = ${clientName}::connect(`);
+        writer.newLine();
+        writer.indent();
+        for (const param of connectParams) {
+            writer.write(param + ",");
+            writer.newLine();
+        }
+        writer.dedent();
+        writer.write(").await.expect(\"Failed to connect\");");
+        writer.newLine();
+        writer.newLine();
+
+        // Receive messages
+        if (serverMessages.length > 0) {
+            writer.write(`// Iterate over messages as they arrive`);
+            writer.newLine();
+            writer.write(`while let Some(Ok(message)) = ${subpackageName}.recv().await {`);
+            writer.newLine();
+            writer.indent();
+            writer.write(`println!("{:?}", message);`);
+            writer.dedent();
+            writer.newLine();
+            writer.write(`}`);
+            writer.newLine();
+            writer.newLine();
+        }
+
+        // Send a message
+        if (clientMessages.length > 0) {
+            const firstMsg = clientMessages[0];
+            if (firstMsg != null) {
+                const methodName = this.getWebSocketMessageMethodName(firstMsg, "send");
+                const bodyType = this.getWebSocketMessageBodyType(firstMsg);
+                writer.write(`// Send a message`);
+                writer.newLine();
+                if (bodyType) {
+                    writer.write(`${subpackageName}.${methodName}(&${bodyType} { /* fields */ }).await.expect("Failed to send");`);
+                } else {
+                    writer.write(`${subpackageName}.${methodName}(&serde_json::json!({})).await.expect("Failed to send");`);
+                }
+                writer.newLine();
+                writer.newLine();
+            }
+        }
+
+        // Close
+        writer.write(`// Close the connection when done`);
+        writer.newLine();
+        writer.write(`${subpackageName}.close().await.expect("Failed to close");`);
+
+        snippets.push(writer.toString().trim() + "\n");
+
         return snippets;
+    }
+
+    /**
+     * Find the first WebSocket channel by checking subpackages (mirrors Python's _get_example_websocket_channel).
+     */
+    private getExampleWebSocketChannel(): {
+        subpackage: FernIr.Subpackage;
+        channel: FernIr.WebSocketChannel;
+        channelId: string;
+    } | undefined {
+        const websocketChannels = this.context.ir.websocketChannels;
+        if (websocketChannels == null) {
+            return undefined;
+        }
+
+        for (const subpackageId of Object.keys(this.context.ir.subpackages)) {
+            const subpackage = this.context.ir.subpackages[subpackageId];
+            if (subpackage != null && subpackage.websocket != null && subpackage.websocket in websocketChannels) {
+                const channel = websocketChannels[subpackage.websocket];
+                if (channel != null) {
+                    return {
+                        subpackage,
+                        channel,
+                        channelId: subpackage.websocket
+                    };
+                }
+            }
+        }
+
+        return undefined;
     }
 
     private buildWebSocketChannelNameMap(

--- a/seed/rust-sdk/seed.yml
+++ b/seed/rust-sdk/seed.yml
@@ -137,6 +137,14 @@ fixtures:
     - customConfig:
         enableWebsockets: true
       outputFolder: .
+  websocket-bearer-auth:
+    - customConfig:
+        enableWebsockets: true
+      outputFolder: .
+  websocket-inferred-auth:
+    - customConfig:
+        enableWebsockets: true
+      outputFolder: .
   license:
     - customConfig: null
       outputFolder: basic

--- a/seed/rust-sdk/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/rust-sdk/websocket-bearer-auth/.fern/metadata.json
@@ -2,5 +2,8 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "latest",
+  "generatorConfig": {
+    "enableWebsockets": true
+  },
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/websocket-bearer-auth/Cargo.toml
+++ b/seed/rust-sdk/websocket-bearer-auth/Cargo.toml
@@ -23,8 +23,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls"], optional = true }
+urlencoding = { version = "2.1", optional = true }
 uuid = { version = "1.0", features = ["serde"] }
 
 [dev-dependencies]
 tokio-test = "0.4"
 
+[features]
+default = ["websocket"]
+websocket = ["tokio-tungstenite", "urlencoding"]

--- a/seed/rust-sdk/websocket-bearer-auth/README.md
+++ b/seed/rust-sdk/websocket-bearer-auth/README.md
@@ -38,22 +38,22 @@ The SDK supports WebSocket connections for real-time communication. Use the gene
 ```rust
 use seed_websocket_bearer_auth::api::websocket::RealtimeNoAuthClient;
 
-let mut client = RealtimeNoAuthClient::connect(
+let mut realtime_no_auth = RealtimeNoAuthClient::connect(
     "wss://api.example.com",
     "session_id",
     None,
 ).await.expect("Failed to connect");
 
-// Send a message
-client.send_send(&NoAuthSendEvent { /* fields */ }).await.expect("Failed to send");
-
-// Receive messages
-while let Some(Ok(message)) = client.recv().await {
+// Iterate over messages as they arrive
+while let Some(Ok(message)) = realtime_no_auth.recv().await {
     println!("{:?}", message);
 }
 
-// Close the connection
-client.close().await.expect("Failed to close");
+// Send a message
+realtime_no_auth.send_send(&NoAuthSendEvent { /* fields */ }).await.expect("Failed to send");
+
+// Close the connection when done
+realtime_no_auth.close().await.expect("Failed to close");
 ```
 
 ## Contributing

--- a/seed/rust-sdk/websocket-bearer-auth/README.md
+++ b/seed/rust-sdk/websocket-bearer-auth/README.md
@@ -36,10 +36,16 @@ A full reference for this library is available [here](./reference.md).
 The SDK supports WebSocket connections for real-time communication. Use the generated channel clients to connect, send, and receive messages.
 
 ```rust
-use seed_websocket_bearer_auth::api::websocket::RealtimeNoAuthClient;
+use seed_websocket_bearer_auth::prelude::*;
 
-let mut realtime_no_auth = RealtimeNoAuthClient::connect(
-    "wss://api.example.com",
+let config = ClientConfig {
+    base_url: " ".to_string(),
+    api_key: Some("your-api-key".to_string())
+};
+let client = WebsocketBearerAuthClient::new(config).expect("Failed to build client");
+
+// Connect to the WebSocket
+let mut realtime_no_auth = client.realtime_no_auth.connect(
     "session_id",
     None,
 ).await.expect("Failed to connect");

--- a/seed/rust-sdk/websocket-bearer-auth/README.md
+++ b/seed/rust-sdk/websocket-bearer-auth/README.md
@@ -1,0 +1,67 @@
+# Seed Rust Library
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FRust)
+[![crates.io shield](https://img.shields.io/crates/v/seed_websocket_bearer_auth)](https://crates.io/crates/seed_websocket_bearer_auth)
+
+The Seed Rust library provides convenient access to the Seed APIs from Rust.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Websockets](#websockets)
+- [Contributing](#contributing)
+
+## Installation
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+seed_websocket_bearer_auth = "0.0.1"
+```
+
+Or install via cargo:
+
+```sh
+cargo add seed_websocket_bearer_auth
+```
+
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
+## Websockets
+
+The SDK supports WebSocket connections for real-time communication. Use the generated channel clients to connect, send, and receive messages.
+
+```rust
+use seed_websocket_bearer_auth::api::websocket::RealtimeNoAuthClient;
+
+let mut client = RealtimeNoAuthClient::connect(
+    "wss://api.example.com",
+    "session_id",
+    None,
+).await.expect("Failed to connect");
+
+// Send a message
+client.send_send(&NoAuthSendEvent { /* fields */ }).await.expect("Failed to send");
+
+// Receive messages
+while let Some(Ok(message)) = client.recv().await {
+    println!("{:?}", message);
+}
+
+// Close the connection
+client.close().await.expect("Failed to close");
+```
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!

--- a/seed/rust-sdk/websocket-bearer-auth/src/api/mod.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api/mod.rs
@@ -7,9 +7,11 @@
 //!
 //! - [`resources`] - Service clients and endpoints
 //! - [`types`] - Request, response, and model types
+//! - [`websocket`] - WebSocket channel clients
 
 pub mod resources;
 pub mod types;
+pub mod websocket;
 
 pub use resources::{RealtimeClient, RealtimeNoAuthClient, WebsocketBearerAuthClient};
 pub use types::*;

--- a/seed/rust-sdk/websocket-bearer-auth/src/api/resources/mod.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api/resources/mod.rs
@@ -5,18 +5,23 @@
 //! - **RealtimeNoAuth**
 //! - **Realtime**
 
+use crate::api::websocket::{RealtimeConnector, RealtimeNoAuthConnector};
 use crate::{ApiError, ClientConfig};
 
 pub mod realtime;
 pub mod realtime_no_auth;
 pub struct WebsocketBearerAuthClient {
     pub config: ClientConfig,
+    pub realtime_no_auth: RealtimeNoAuthConnector,
+    pub realtime: RealtimeConnector,
 }
 
 impl WebsocketBearerAuthClient {
     pub fn new(config: ClientConfig) -> Result<Self, ApiError> {
         Ok(Self {
             config: config.clone(),
+            realtime_no_auth: RealtimeNoAuthConnector::new(config.base_url.clone()),
+            realtime: RealtimeConnector::new(config.base_url.clone()),
         })
     }
 }

--- a/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/mod.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/mod.rs
@@ -3,6 +3,8 @@
 pub mod realtime;
 pub mod realtime_no_auth;
 pub use realtime::RealtimeClient;
+pub use realtime::RealtimeConnector;
 pub use realtime::RealtimeServerMessage;
 pub use realtime_no_auth::RealtimeNoAuthClient;
+pub use realtime_no_auth::RealtimeNoAuthConnector;
 pub use realtime_no_auth::RealtimeNoAuthServerMessage;

--- a/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/mod.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/mod.rs
@@ -1,0 +1,8 @@
+//! WebSocket channel clients
+
+pub mod realtime;
+pub mod realtime_no_auth;
+pub use realtime::RealtimeClient;
+pub use realtime::RealtimeServerMessage;
+pub use realtime_no_auth::RealtimeNoAuthClient;
+pub use realtime_no_auth::RealtimeNoAuthServerMessage;

--- a/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/realtime.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/realtime.rs
@@ -77,3 +77,23 @@ impl RealtimeClient {
         self.ws.close().await
     }
 }
+/// Connector for the Realtime WebSocket channel.
+/// Provides access to the WebSocket channel through the root client.
+pub struct RealtimeConnector {
+    base_url: String,
+}
+
+impl RealtimeConnector {
+    pub fn new(base_url: String) -> Self {
+        Self { base_url }
+    }
+
+    pub async fn connect(
+        &self,
+        session_id: &str,
+        model: Option<&str>,
+        temperature: Option<&str>,
+    ) -> Result<RealtimeClient, ApiError> {
+        RealtimeClient::connect(&self.base_url, session_id, model, temperature).await
+    }
+}

--- a/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/realtime.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/realtime.rs
@@ -1,0 +1,79 @@
+use crate::prelude::*;
+use crate::{ApiError, WebSocketClient, WebSocketMessage, WebSocketOptions};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum RealtimeServerMessage {
+    #[serde(rename = "receive")]
+    ReceiveEvent(ReceiveEvent),
+    #[serde(rename = "receive_snake_case")]
+    ReceiveSnakeCase(ReceiveSnakeCase),
+    #[serde(rename = "receive2")]
+    ReceiveEvent2(ReceiveEvent2),
+    #[serde(rename = "receive3")]
+    ReceiveEvent3(ReceiveEvent3),
+}
+pub struct RealtimeClient {
+    ws: WebSocketClient,
+    incoming_rx: mpsc::UnboundedReceiver<Result<WebSocketMessage, ApiError>>,
+}
+impl RealtimeClient {
+    pub async fn connect(
+        url: &str,
+        session_id: &str,
+        model: Option<&str>,
+        temperature: Option<&str>,
+    ) -> Result<Self, ApiError> {
+        let full_url = format!("{}/realtime/{session_id}", url);
+        let mut options = WebSocketOptions::default();
+
+        if let Some(v) = model {
+            options
+                .query_params
+                .push(("model".to_string(), v.to_string()));
+        }
+        if let Some(v) = temperature {
+            options
+                .query_params
+                .push(("temperature".to_string(), v.to_string()));
+        }
+        let (ws, incoming_rx) = WebSocketClient::connect(&full_url, options).await?;
+        Ok(Self { ws, incoming_rx })
+    }
+
+    pub async fn send_send(&self, message: &SendEvent) -> Result<(), ApiError> {
+        self.ws.send_json(message).await
+    }
+
+    pub async fn send_send_snake_case(&self, message: &SendSnakeCase) -> Result<(), ApiError> {
+        self.ws.send_json(message).await
+    }
+
+    pub async fn send_send2(&self, message: &SendEvent2) -> Result<(), ApiError> {
+        self.ws.send_json(message).await
+    }
+
+    pub async fn recv(&mut self) -> Option<Result<RealtimeServerMessage, ApiError>> {
+        loop {
+            match self.incoming_rx.recv().await {
+                Some(Ok(WebSocketMessage::Text(raw))) => {
+                    return Some(
+                        serde_json::from_str::<RealtimeServerMessage>(&raw)
+                            .map_err(ApiError::Serialization),
+                    );
+                }
+                Some(Ok(WebSocketMessage::Binary(_))) => {
+                    continue;
+                }
+                Some(Err(e)) => return Some(Err(e)),
+                None => return None,
+            }
+        }
+    }
+
+    pub async fn close(&self) -> Result<(), ApiError> {
+        self.ws.close().await
+    }
+}

--- a/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/realtime_no_auth.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/realtime_no_auth.rs
@@ -1,0 +1,59 @@
+use crate::prelude::*;
+use crate::{ApiError, WebSocketClient, WebSocketMessage, WebSocketOptions};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum RealtimeNoAuthServerMessage {
+    #[serde(rename = "receive")]
+    NoAuthReceiveEvent(NoAuthReceiveEvent),
+}
+pub struct RealtimeNoAuthClient {
+    ws: WebSocketClient,
+    incoming_rx: mpsc::UnboundedReceiver<Result<WebSocketMessage, ApiError>>,
+}
+impl RealtimeNoAuthClient {
+    pub async fn connect(
+        url: &str,
+        session_id: &str,
+        model: Option<&str>,
+    ) -> Result<Self, ApiError> {
+        let full_url = format!("{}/realtime-no-auth/{session_id}", url);
+        let mut options = WebSocketOptions::default();
+
+        if let Some(v) = model {
+            options
+                .query_params
+                .push(("model".to_string(), v.to_string()));
+        }
+        let (ws, incoming_rx) = WebSocketClient::connect(&full_url, options).await?;
+        Ok(Self { ws, incoming_rx })
+    }
+
+    pub async fn send_send(&self, message: &NoAuthSendEvent) -> Result<(), ApiError> {
+        self.ws.send_json(message).await
+    }
+
+    pub async fn recv(&mut self) -> Option<Result<RealtimeNoAuthServerMessage, ApiError>> {
+        loop {
+            match self.incoming_rx.recv().await {
+                Some(Ok(WebSocketMessage::Text(raw))) => {
+                    return Some(
+                        serde_json::from_str::<RealtimeNoAuthServerMessage>(&raw)
+                            .map_err(ApiError::Serialization),
+                    );
+                }
+                Some(Ok(WebSocketMessage::Binary(_))) => {
+                    continue;
+                }
+                Some(Err(e)) => return Some(Err(e)),
+                None => return None,
+            }
+        }
+    }
+
+    pub async fn close(&self) -> Result<(), ApiError> {
+        self.ws.close().await
+    }
+}

--- a/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/realtime_no_auth.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api/websocket/realtime_no_auth.rs
@@ -57,3 +57,22 @@ impl RealtimeNoAuthClient {
         self.ws.close().await
     }
 }
+/// Connector for the RealtimeNoAuth WebSocket channel.
+/// Provides access to the WebSocket channel through the root client.
+pub struct RealtimeNoAuthConnector {
+    base_url: String,
+}
+
+impl RealtimeNoAuthConnector {
+    pub fn new(base_url: String) -> Self {
+        Self { base_url }
+    }
+
+    pub async fn connect(
+        &self,
+        session_id: &str,
+        model: Option<&str>,
+    ) -> Result<RealtimeNoAuthClient, ApiError> {
+        RealtimeNoAuthClient::connect(&self.base_url, session_id, model).await
+    }
+}

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/mod.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/mod.rs
@@ -8,9 +8,15 @@ mod oauth_token_provider;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
+#[cfg(feature = "websocket")]
+mod websocket;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;
+#[cfg(feature = "websocket")]
+pub use websocket::{
+    parse_websocket_message, WebSocketClient, WebSocketMessage, WebSocketOptions, WebSocketState,
+};

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/websocket.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/websocket.rs
@@ -1,0 +1,380 @@
+use crate::ApiError;
+use futures::{
+    stream::{SplitSink, SplitStream},
+    SinkExt, StreamExt,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::sync::{mpsc, Mutex, Notify};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{
+        client::IntoClientRequest,
+        http::{HeaderName, HeaderValue, Uri},
+        protocol::Message,
+    },
+    MaybeTlsStream, WebSocketStream,
+};
+
+type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+type WsSink = SplitSink<WsStream, Message>;
+type WsSource = SplitStream<WsStream>;
+
+#[derive(Debug, Clone)]
+pub enum WebSocketMessage {
+    Text(String),
+    Binary(Vec<u8>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebSocketState {
+    Connecting,
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(Debug, Clone)]
+pub struct WebSocketOptions {
+    pub headers: HashMap<String, String>,
+    pub query_params: Vec<(String, String)>,
+    pub reconnect: bool,
+    pub max_reconnect_attempts: u32,
+    pub reconnect_interval: Duration,
+    pub connection_timeout: Duration,
+}
+
+impl Default for WebSocketOptions {
+    fn default() -> Self {
+        Self {
+            headers: HashMap::new(),
+            query_params: Vec::new(),
+            reconnect: true,
+            max_reconnect_attempts: 5,
+            reconnect_interval: Duration::from_secs(1),
+            connection_timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+pub struct WebSocketClient {
+    url: String,
+    options: WebSocketOptions,
+    sink: Arc<Mutex<Option<WsSink>>>,
+    state: Arc<Mutex<WebSocketState>>,
+    close_notify: Arc<Notify>,
+}
+
+impl WebSocketClient {
+    pub async fn connect(
+        url: &str,
+        options: WebSocketOptions,
+    ) -> Result<
+        (
+            Self,
+            mpsc::UnboundedReceiver<Result<WebSocketMessage, ApiError>>,
+        ),
+        ApiError,
+    > {
+        let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
+
+        let client = Self {
+            url: url.to_string(),
+            options: options.clone(),
+            sink: Arc::new(Mutex::new(None)),
+            state: Arc::new(Mutex::new(WebSocketState::Connecting)),
+            close_notify: Arc::new(Notify::new()),
+        };
+
+        let read = client.establish_connection().await?;
+
+        let sink = client.sink.clone();
+        let state = client.state.clone();
+        let close_notify = client.close_notify.clone();
+        let url_clone = client.url.clone();
+        let options_clone = client.options.clone();
+
+        tokio::spawn(async move {
+            Self::read_loop(
+                read,
+                sink,
+                state,
+                close_notify,
+                incoming_tx,
+                url_clone,
+                options_clone,
+            )
+            .await;
+        });
+
+        Ok((client, incoming_rx))
+    }
+
+    async fn establish_connection(&self) -> Result<WsSource, ApiError> {
+        let uri: Uri = self.build_url().parse().map_err(
+            |e: tokio_tungstenite::tungstenite::http::uri::InvalidUri| {
+                ApiError::WebSocketError(format!("Invalid URL: {}", e))
+            },
+        )?;
+
+        let mut request = uri
+            .into_client_request()
+            .map_err(|e| ApiError::WebSocketError(format!("Failed to build request: {}", e)))?;
+
+        let headers = request.headers_mut();
+        for (key, value) in &self.options.headers {
+            let header_name: HeaderName = key.parse().map_err(|_| ApiError::InvalidHeader)?;
+            let header_value: HeaderValue = value.parse().map_err(|_| ApiError::InvalidHeader)?;
+            headers.insert(header_name, header_value);
+        }
+
+        let connect_future = connect_async(request);
+        let (ws_stream, _response) =
+            tokio::time::timeout(self.options.connection_timeout, connect_future)
+                .await
+                .map_err(|_| ApiError::WebSocketError("Connection timed out".to_string()))?
+                .map_err(|e| ApiError::WebSocketError(format!("Connection failed: {}", e)))?;
+
+        let (write, read) = ws_stream.split();
+
+        {
+            let mut sink = self.sink.lock().await;
+            *sink = Some(write);
+        }
+
+        {
+            let mut state = self.state.lock().await;
+            *state = WebSocketState::Open;
+        }
+
+        Ok(read)
+    }
+
+    fn build_url(&self) -> String {
+        if self.options.query_params.is_empty() {
+            return self.url.clone();
+        }
+        let query: String = self
+            .options
+            .query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+        format!("{}?{}", self.url, query)
+    }
+
+    pub async fn send_json<T: Serialize>(&self, message: &T) -> Result<(), ApiError> {
+        let json = serde_json::to_string(message).map_err(ApiError::Serialization)?;
+        self.send_raw(json).await
+    }
+
+    pub async fn send_raw(&self, message: String) -> Result<(), ApiError> {
+        let mut sink_guard = self.sink.lock().await;
+        match sink_guard.as_mut() {
+            Some(sink) => sink
+                .send(Message::Text(message))
+                .await
+                .map_err(|e| ApiError::WebSocketError(format!("Send failed: {}", e))),
+            None => Err(ApiError::WebSocketError(
+                "WebSocket is not connected".to_string(),
+            )),
+        }
+    }
+
+    pub async fn send_binary(&self, data: &[u8]) -> Result<(), ApiError> {
+        let mut sink_guard = self.sink.lock().await;
+        match sink_guard.as_mut() {
+            Some(sink) => sink
+                .send(Message::Binary(data.to_vec()))
+                .await
+                .map_err(|e| ApiError::WebSocketError(format!("Send failed: {}", e))),
+            None => Err(ApiError::WebSocketError(
+                "WebSocket is not connected".to_string(),
+            )),
+        }
+    }
+
+    pub async fn close(&self) -> Result<(), ApiError> {
+        {
+            let mut state = self.state.lock().await;
+            *state = WebSocketState::Closing;
+        }
+
+        let mut sink_guard = self.sink.lock().await;
+        if let Some(sink) = sink_guard.as_mut() {
+            let _ = sink.send(Message::Close(None)).await;
+        }
+
+        {
+            let mut state = self.state.lock().await;
+            *state = WebSocketState::Closed;
+        }
+
+        self.close_notify.notify_waiters();
+        Ok(())
+    }
+
+    pub async fn state(&self) -> WebSocketState {
+        *self.state.lock().await
+    }
+
+    async fn read_loop(
+        mut read: WsSource,
+        sink: Arc<Mutex<Option<WsSink>>>,
+        state: Arc<Mutex<WebSocketState>>,
+        close_notify: Arc<Notify>,
+        incoming_tx: mpsc::UnboundedSender<Result<WebSocketMessage, ApiError>>,
+        url: String,
+        options: WebSocketOptions,
+    ) {
+        let mut reconnect_attempts: u32 = 0;
+
+        loop {
+            tokio::select! {
+                _ = close_notify.notified() => {
+                    break;
+                }
+                msg = read.next() => {
+                    match msg {
+                        Some(Ok(Message::Text(text))) => {
+                            reconnect_attempts = 0;
+                            if incoming_tx.send(Ok(WebSocketMessage::Text(text))).is_err() {
+                                break;
+                            }
+                        }
+                        Some(Ok(Message::Binary(data))) => {
+                            reconnect_attempts = 0;
+                            if incoming_tx.send(Ok(WebSocketMessage::Binary(data))).is_err() {
+                                break;
+                            }
+                        }
+                        Some(Ok(Message::Close(_))) => {
+                            let mut s = state.lock().await;
+                            *s = WebSocketState::Closed;
+                            break;
+                        }
+                        Some(Ok(Message::Ping(_))) | Some(Ok(Message::Pong(_))) | Some(Ok(Message::Frame(_))) => {
+                            // Protocol frames handled automatically by tungstenite
+                        }
+                        Some(Err(e)) => {
+                            let error = ApiError::WebSocketError(format!("Read error: {}", e));
+                            if !options.reconnect || reconnect_attempts >= options.max_reconnect_attempts {
+                                let _ = incoming_tx.send(Err(error));
+                                let mut s = state.lock().await;
+                                *s = WebSocketState::Closed;
+                                break;
+                            }
+
+                            reconnect_attempts += 1;
+                            {
+                                let mut s = state.lock().await;
+                                *s = WebSocketState::Connecting;
+                            }
+
+                            tokio::time::sleep(options.reconnect_interval).await;
+
+                            match Self::reconnect(&url, &options, &sink).await {
+                                Ok(new_read) => {
+                                    read = new_read;
+                                    let mut s = state.lock().await;
+                                    *s = WebSocketState::Open;
+                                }
+                                Err(reconnect_err) => {
+                                    let _ = incoming_tx.send(Err(reconnect_err));
+                                    let mut s = state.lock().await;
+                                    *s = WebSocketState::Closed;
+                                    break;
+                                }
+                            }
+                        }
+                        None => {
+                            // Stream ended
+                            if !options.reconnect || reconnect_attempts >= options.max_reconnect_attempts {
+                                let mut s = state.lock().await;
+                                *s = WebSocketState::Closed;
+                                break;
+                            }
+
+                            reconnect_attempts += 1;
+                            {
+                                let mut s = state.lock().await;
+                                *s = WebSocketState::Connecting;
+                            }
+
+                            tokio::time::sleep(options.reconnect_interval).await;
+
+                            match Self::reconnect(&url, &options, &sink).await {
+                                Ok(new_read) => {
+                                    read = new_read;
+                                    let mut s = state.lock().await;
+                                    *s = WebSocketState::Open;
+                                }
+                                Err(reconnect_err) => {
+                                    let _ = incoming_tx.send(Err(reconnect_err));
+                                    let mut s = state.lock().await;
+                                    *s = WebSocketState::Closed;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn reconnect(
+        url: &str,
+        options: &WebSocketOptions,
+        sink: &Arc<Mutex<Option<WsSink>>>,
+    ) -> Result<WsSource, ApiError> {
+        let full_url = if options.query_params.is_empty() {
+            url.to_string()
+        } else {
+            let query: String = options
+                .query_params
+                .iter()
+                .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+            format!("{}?{}", url, query)
+        };
+
+        let uri: Uri = full_url.parse().map_err(
+            |e: tokio_tungstenite::tungstenite::http::uri::InvalidUri| {
+                ApiError::WebSocketError(format!("Invalid URL: {}", e))
+            },
+        )?;
+
+        let mut request = uri
+            .into_client_request()
+            .map_err(|e| ApiError::WebSocketError(format!("Failed to build request: {}", e)))?;
+
+        let headers = request.headers_mut();
+        for (key, value) in &options.headers {
+            let header_name: HeaderName = key.parse().map_err(|_| ApiError::InvalidHeader)?;
+            let header_value: HeaderValue = value.parse().map_err(|_| ApiError::InvalidHeader)?;
+            headers.insert(header_name, header_value);
+        }
+
+        let (ws_stream, _response) =
+            tokio::time::timeout(options.connection_timeout, connect_async(request))
+                .await
+                .map_err(|_| ApiError::WebSocketError("Reconnection timed out".to_string()))?
+                .map_err(|e| ApiError::WebSocketError(format!("Reconnection failed: {}", e)))?;
+
+        let (write, read) = ws_stream.split();
+
+        {
+            let mut sink_guard = sink.lock().await;
+            *sink_guard = Some(write);
+        }
+
+        Ok(read)
+    }
+}
+
+pub fn parse_websocket_message<T: DeserializeOwned>(raw: &str) -> Result<T, ApiError> {
+    serde_json::from_str(raw).map_err(ApiError::Serialization)
+}

--- a/seed/rust-sdk/websocket-bearer-auth/src/error.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/error.rs
@@ -18,6 +18,8 @@ pub enum ApiError {
     StreamTerminated,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
+    #[error("WebSocket error: {0}")]
+    WebSocketError(String),
 }
 
 impl ApiError {

--- a/seed/rust-sdk/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/rust-sdk/websocket-inferred-auth/.fern/metadata.json
@@ -2,5 +2,8 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "latest",
+  "generatorConfig": {
+    "enableWebsockets": true
+  },
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/websocket-inferred-auth/Cargo.toml
+++ b/seed/rust-sdk/websocket-inferred-auth/Cargo.toml
@@ -23,8 +23,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls"], optional = true }
+urlencoding = { version = "2.1", optional = true }
 uuid = { version = "1.0", features = ["serde"] }
 
 [dev-dependencies]
 tokio-test = "0.4"
 
+[features]
+default = ["websocket"]
+websocket = ["tokio-tungstenite", "urlencoding"]

--- a/seed/rust-sdk/websocket-inferred-auth/README.md
+++ b/seed/rust-sdk/websocket-inferred-auth/README.md
@@ -105,23 +105,23 @@ The SDK supports WebSocket connections for real-time communication. Use the gene
 ```rust
 use seed_websocket_auth::api::websocket::RealtimeClient;
 
-let mut client = RealtimeClient::connect(
+let mut realtime = RealtimeClient::connect(
     "wss://api.example.com",
     "session_id",
     None,
     None,
 ).await.expect("Failed to connect");
 
-// Send a message
-client.send_send(&SendEvent { /* fields */ }).await.expect("Failed to send");
-
-// Receive messages
-while let Some(Ok(message)) = client.recv().await {
+// Iterate over messages as they arrive
+while let Some(Ok(message)) = realtime.recv().await {
     println!("{:?}", message);
 }
 
-// Close the connection
-client.close().await.expect("Failed to close");
+// Send a message
+realtime.send_send(&SendEvent { /* fields */ }).await.expect("Failed to send");
+
+// Close the connection when done
+realtime.close().await.expect("Failed to close");
 ```
 
 ## Advanced

--- a/seed/rust-sdk/websocket-inferred-auth/README.md
+++ b/seed/rust-sdk/websocket-inferred-auth/README.md
@@ -12,6 +12,7 @@ The Seed Rust library provides convenient access to the Seed APIs from Rust.
 - [Usage](#usage)
 - [Errors](#errors)
 - [Request Types](#request-types)
+- [Websockets](#websockets)
 - [Advanced](#advanced)
   - [Retries](#retries)
   - [Timeouts](#timeouts)
@@ -95,6 +96,32 @@ use seed_websocket_auth::prelude::{*};
 let request = GetTokenRequest {
     ...
 };
+```
+
+## Websockets
+
+The SDK supports WebSocket connections for real-time communication. Use the generated channel clients to connect, send, and receive messages.
+
+```rust
+use seed_websocket_auth::api::websocket::RealtimeClient;
+
+let mut client = RealtimeClient::connect(
+    "wss://api.example.com",
+    "session_id",
+    None,
+    None,
+).await.expect("Failed to connect");
+
+// Send a message
+client.send_send(&SendEvent { /* fields */ }).await.expect("Failed to send");
+
+// Receive messages
+while let Some(Ok(message)) = client.recv().await {
+    println!("{:?}", message);
+}
+
+// Close the connection
+client.close().await.expect("Failed to close");
 ```
 
 ## Advanced

--- a/seed/rust-sdk/websocket-inferred-auth/README.md
+++ b/seed/rust-sdk/websocket-inferred-auth/README.md
@@ -103,10 +103,16 @@ let request = GetTokenRequest {
 The SDK supports WebSocket connections for real-time communication. Use the generated channel clients to connect, send, and receive messages.
 
 ```rust
-use seed_websocket_auth::api::websocket::RealtimeClient;
+use seed_websocket_auth::prelude::*;
 
-let mut realtime = RealtimeClient::connect(
-    "wss://api.example.com",
+let config = ClientConfig {
+    base_url: " ".to_string(),
+    api_key: Some("your-api-key".to_string())
+};
+let client = WebsocketAuthClient::new(config).expect("Failed to build client");
+
+// Connect to the WebSocket
+let mut realtime = client.realtime.connect(
     "session_id",
     None,
     None,

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/mod.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/mod.rs
@@ -7,9 +7,11 @@
 //!
 //! - [`resources`] - Service clients and endpoints
 //! - [`types`] - Request, response, and model types
+//! - [`websocket`] - WebSocket channel clients
 
 pub mod resources;
 pub mod types;
+pub mod websocket;
 
 pub use resources::{AuthClient, RealtimeClient, WebsocketAuthClient};
 pub use types::*;

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/resources/mod.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/resources/mod.rs
@@ -5,6 +5,7 @@
 //! - **Auth**
 //! - **Realtime**
 
+use crate::api::websocket::RealtimeConnector;
 use crate::{ApiError, ClientConfig};
 
 pub mod auth;
@@ -12,6 +13,7 @@ pub mod realtime;
 pub struct WebsocketAuthClient {
     pub config: ClientConfig,
     pub auth: AuthClient,
+    pub realtime: RealtimeConnector,
 }
 
 impl WebsocketAuthClient {
@@ -19,6 +21,7 @@ impl WebsocketAuthClient {
         Ok(Self {
             config: config.clone(),
             auth: AuthClient::new(config.clone())?,
+            realtime: RealtimeConnector::new(config.base_url.clone()),
         })
     }
 }

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/websocket/mod.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/websocket/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod realtime;
 pub use realtime::RealtimeClient;
+pub use realtime::RealtimeConnector;
 pub use realtime::RealtimeServerMessage;

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/websocket/mod.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/websocket/mod.rs
@@ -1,0 +1,5 @@
+//! WebSocket channel clients
+
+pub mod realtime;
+pub use realtime::RealtimeClient;
+pub use realtime::RealtimeServerMessage;

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/websocket/realtime.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/websocket/realtime.rs
@@ -77,3 +77,23 @@ impl RealtimeClient {
         self.ws.close().await
     }
 }
+/// Connector for the Realtime WebSocket channel.
+/// Provides access to the WebSocket channel through the root client.
+pub struct RealtimeConnector {
+    base_url: String,
+}
+
+impl RealtimeConnector {
+    pub fn new(base_url: String) -> Self {
+        Self { base_url }
+    }
+
+    pub async fn connect(
+        &self,
+        session_id: &str,
+        model: Option<&str>,
+        temperature: Option<&str>,
+    ) -> Result<RealtimeClient, ApiError> {
+        RealtimeClient::connect(&self.base_url, session_id, model, temperature).await
+    }
+}

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/websocket/realtime.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/websocket/realtime.rs
@@ -1,0 +1,79 @@
+use crate::prelude::*;
+use crate::{ApiError, WebSocketClient, WebSocketMessage, WebSocketOptions};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum RealtimeServerMessage {
+    #[serde(rename = "receive")]
+    ReceiveEvent(ReceiveEvent),
+    #[serde(rename = "receive_snake_case")]
+    ReceiveSnakeCase(ReceiveSnakeCase),
+    #[serde(rename = "receive2")]
+    ReceiveEvent2(ReceiveEvent2),
+    #[serde(rename = "receive3")]
+    ReceiveEvent3(ReceiveEvent3),
+}
+pub struct RealtimeClient {
+    ws: WebSocketClient,
+    incoming_rx: mpsc::UnboundedReceiver<Result<WebSocketMessage, ApiError>>,
+}
+impl RealtimeClient {
+    pub async fn connect(
+        url: &str,
+        session_id: &str,
+        model: Option<&str>,
+        temperature: Option<&str>,
+    ) -> Result<Self, ApiError> {
+        let full_url = format!("{}/realtime/{session_id}", url);
+        let mut options = WebSocketOptions::default();
+
+        if let Some(v) = model {
+            options
+                .query_params
+                .push(("model".to_string(), v.to_string()));
+        }
+        if let Some(v) = temperature {
+            options
+                .query_params
+                .push(("temperature".to_string(), v.to_string()));
+        }
+        let (ws, incoming_rx) = WebSocketClient::connect(&full_url, options).await?;
+        Ok(Self { ws, incoming_rx })
+    }
+
+    pub async fn send_send(&self, message: &SendEvent) -> Result<(), ApiError> {
+        self.ws.send_json(message).await
+    }
+
+    pub async fn send_send_snake_case(&self, message: &SendSnakeCase) -> Result<(), ApiError> {
+        self.ws.send_json(message).await
+    }
+
+    pub async fn send_send2(&self, message: &SendEvent2) -> Result<(), ApiError> {
+        self.ws.send_json(message).await
+    }
+
+    pub async fn recv(&mut self) -> Option<Result<RealtimeServerMessage, ApiError>> {
+        loop {
+            match self.incoming_rx.recv().await {
+                Some(Ok(WebSocketMessage::Text(raw))) => {
+                    return Some(
+                        serde_json::from_str::<RealtimeServerMessage>(&raw)
+                            .map_err(ApiError::Serialization),
+                    );
+                }
+                Some(Ok(WebSocketMessage::Binary(_))) => {
+                    continue;
+                }
+                Some(Err(e)) => return Some(Err(e)),
+                None => return None,
+            }
+        }
+    }
+
+    pub async fn close(&self) -> Result<(), ApiError> {
+        self.ws.close().await
+    }
+}

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/mod.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/mod.rs
@@ -8,9 +8,15 @@ mod oauth_token_provider;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
+#[cfg(feature = "websocket")]
+mod websocket;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;
+#[cfg(feature = "websocket")]
+pub use websocket::{
+    parse_websocket_message, WebSocketClient, WebSocketMessage, WebSocketOptions, WebSocketState,
+};

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/websocket.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/websocket.rs
@@ -1,0 +1,380 @@
+use crate::ApiError;
+use futures::{
+    stream::{SplitSink, SplitStream},
+    SinkExt, StreamExt,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::sync::{mpsc, Mutex, Notify};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{
+        client::IntoClientRequest,
+        http::{HeaderName, HeaderValue, Uri},
+        protocol::Message,
+    },
+    MaybeTlsStream, WebSocketStream,
+};
+
+type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+type WsSink = SplitSink<WsStream, Message>;
+type WsSource = SplitStream<WsStream>;
+
+#[derive(Debug, Clone)]
+pub enum WebSocketMessage {
+    Text(String),
+    Binary(Vec<u8>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebSocketState {
+    Connecting,
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(Debug, Clone)]
+pub struct WebSocketOptions {
+    pub headers: HashMap<String, String>,
+    pub query_params: Vec<(String, String)>,
+    pub reconnect: bool,
+    pub max_reconnect_attempts: u32,
+    pub reconnect_interval: Duration,
+    pub connection_timeout: Duration,
+}
+
+impl Default for WebSocketOptions {
+    fn default() -> Self {
+        Self {
+            headers: HashMap::new(),
+            query_params: Vec::new(),
+            reconnect: true,
+            max_reconnect_attempts: 5,
+            reconnect_interval: Duration::from_secs(1),
+            connection_timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+pub struct WebSocketClient {
+    url: String,
+    options: WebSocketOptions,
+    sink: Arc<Mutex<Option<WsSink>>>,
+    state: Arc<Mutex<WebSocketState>>,
+    close_notify: Arc<Notify>,
+}
+
+impl WebSocketClient {
+    pub async fn connect(
+        url: &str,
+        options: WebSocketOptions,
+    ) -> Result<
+        (
+            Self,
+            mpsc::UnboundedReceiver<Result<WebSocketMessage, ApiError>>,
+        ),
+        ApiError,
+    > {
+        let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
+
+        let client = Self {
+            url: url.to_string(),
+            options: options.clone(),
+            sink: Arc::new(Mutex::new(None)),
+            state: Arc::new(Mutex::new(WebSocketState::Connecting)),
+            close_notify: Arc::new(Notify::new()),
+        };
+
+        let read = client.establish_connection().await?;
+
+        let sink = client.sink.clone();
+        let state = client.state.clone();
+        let close_notify = client.close_notify.clone();
+        let url_clone = client.url.clone();
+        let options_clone = client.options.clone();
+
+        tokio::spawn(async move {
+            Self::read_loop(
+                read,
+                sink,
+                state,
+                close_notify,
+                incoming_tx,
+                url_clone,
+                options_clone,
+            )
+            .await;
+        });
+
+        Ok((client, incoming_rx))
+    }
+
+    async fn establish_connection(&self) -> Result<WsSource, ApiError> {
+        let uri: Uri = self.build_url().parse().map_err(
+            |e: tokio_tungstenite::tungstenite::http::uri::InvalidUri| {
+                ApiError::WebSocketError(format!("Invalid URL: {}", e))
+            },
+        )?;
+
+        let mut request = uri
+            .into_client_request()
+            .map_err(|e| ApiError::WebSocketError(format!("Failed to build request: {}", e)))?;
+
+        let headers = request.headers_mut();
+        for (key, value) in &self.options.headers {
+            let header_name: HeaderName = key.parse().map_err(|_| ApiError::InvalidHeader)?;
+            let header_value: HeaderValue = value.parse().map_err(|_| ApiError::InvalidHeader)?;
+            headers.insert(header_name, header_value);
+        }
+
+        let connect_future = connect_async(request);
+        let (ws_stream, _response) =
+            tokio::time::timeout(self.options.connection_timeout, connect_future)
+                .await
+                .map_err(|_| ApiError::WebSocketError("Connection timed out".to_string()))?
+                .map_err(|e| ApiError::WebSocketError(format!("Connection failed: {}", e)))?;
+
+        let (write, read) = ws_stream.split();
+
+        {
+            let mut sink = self.sink.lock().await;
+            *sink = Some(write);
+        }
+
+        {
+            let mut state = self.state.lock().await;
+            *state = WebSocketState::Open;
+        }
+
+        Ok(read)
+    }
+
+    fn build_url(&self) -> String {
+        if self.options.query_params.is_empty() {
+            return self.url.clone();
+        }
+        let query: String = self
+            .options
+            .query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+        format!("{}?{}", self.url, query)
+    }
+
+    pub async fn send_json<T: Serialize>(&self, message: &T) -> Result<(), ApiError> {
+        let json = serde_json::to_string(message).map_err(ApiError::Serialization)?;
+        self.send_raw(json).await
+    }
+
+    pub async fn send_raw(&self, message: String) -> Result<(), ApiError> {
+        let mut sink_guard = self.sink.lock().await;
+        match sink_guard.as_mut() {
+            Some(sink) => sink
+                .send(Message::Text(message))
+                .await
+                .map_err(|e| ApiError::WebSocketError(format!("Send failed: {}", e))),
+            None => Err(ApiError::WebSocketError(
+                "WebSocket is not connected".to_string(),
+            )),
+        }
+    }
+
+    pub async fn send_binary(&self, data: &[u8]) -> Result<(), ApiError> {
+        let mut sink_guard = self.sink.lock().await;
+        match sink_guard.as_mut() {
+            Some(sink) => sink
+                .send(Message::Binary(data.to_vec()))
+                .await
+                .map_err(|e| ApiError::WebSocketError(format!("Send failed: {}", e))),
+            None => Err(ApiError::WebSocketError(
+                "WebSocket is not connected".to_string(),
+            )),
+        }
+    }
+
+    pub async fn close(&self) -> Result<(), ApiError> {
+        {
+            let mut state = self.state.lock().await;
+            *state = WebSocketState::Closing;
+        }
+
+        let mut sink_guard = self.sink.lock().await;
+        if let Some(sink) = sink_guard.as_mut() {
+            let _ = sink.send(Message::Close(None)).await;
+        }
+
+        {
+            let mut state = self.state.lock().await;
+            *state = WebSocketState::Closed;
+        }
+
+        self.close_notify.notify_waiters();
+        Ok(())
+    }
+
+    pub async fn state(&self) -> WebSocketState {
+        *self.state.lock().await
+    }
+
+    async fn read_loop(
+        mut read: WsSource,
+        sink: Arc<Mutex<Option<WsSink>>>,
+        state: Arc<Mutex<WebSocketState>>,
+        close_notify: Arc<Notify>,
+        incoming_tx: mpsc::UnboundedSender<Result<WebSocketMessage, ApiError>>,
+        url: String,
+        options: WebSocketOptions,
+    ) {
+        let mut reconnect_attempts: u32 = 0;
+
+        loop {
+            tokio::select! {
+                _ = close_notify.notified() => {
+                    break;
+                }
+                msg = read.next() => {
+                    match msg {
+                        Some(Ok(Message::Text(text))) => {
+                            reconnect_attempts = 0;
+                            if incoming_tx.send(Ok(WebSocketMessage::Text(text))).is_err() {
+                                break;
+                            }
+                        }
+                        Some(Ok(Message::Binary(data))) => {
+                            reconnect_attempts = 0;
+                            if incoming_tx.send(Ok(WebSocketMessage::Binary(data))).is_err() {
+                                break;
+                            }
+                        }
+                        Some(Ok(Message::Close(_))) => {
+                            let mut s = state.lock().await;
+                            *s = WebSocketState::Closed;
+                            break;
+                        }
+                        Some(Ok(Message::Ping(_))) | Some(Ok(Message::Pong(_))) | Some(Ok(Message::Frame(_))) => {
+                            // Protocol frames handled automatically by tungstenite
+                        }
+                        Some(Err(e)) => {
+                            let error = ApiError::WebSocketError(format!("Read error: {}", e));
+                            if !options.reconnect || reconnect_attempts >= options.max_reconnect_attempts {
+                                let _ = incoming_tx.send(Err(error));
+                                let mut s = state.lock().await;
+                                *s = WebSocketState::Closed;
+                                break;
+                            }
+
+                            reconnect_attempts += 1;
+                            {
+                                let mut s = state.lock().await;
+                                *s = WebSocketState::Connecting;
+                            }
+
+                            tokio::time::sleep(options.reconnect_interval).await;
+
+                            match Self::reconnect(&url, &options, &sink).await {
+                                Ok(new_read) => {
+                                    read = new_read;
+                                    let mut s = state.lock().await;
+                                    *s = WebSocketState::Open;
+                                }
+                                Err(reconnect_err) => {
+                                    let _ = incoming_tx.send(Err(reconnect_err));
+                                    let mut s = state.lock().await;
+                                    *s = WebSocketState::Closed;
+                                    break;
+                                }
+                            }
+                        }
+                        None => {
+                            // Stream ended
+                            if !options.reconnect || reconnect_attempts >= options.max_reconnect_attempts {
+                                let mut s = state.lock().await;
+                                *s = WebSocketState::Closed;
+                                break;
+                            }
+
+                            reconnect_attempts += 1;
+                            {
+                                let mut s = state.lock().await;
+                                *s = WebSocketState::Connecting;
+                            }
+
+                            tokio::time::sleep(options.reconnect_interval).await;
+
+                            match Self::reconnect(&url, &options, &sink).await {
+                                Ok(new_read) => {
+                                    read = new_read;
+                                    let mut s = state.lock().await;
+                                    *s = WebSocketState::Open;
+                                }
+                                Err(reconnect_err) => {
+                                    let _ = incoming_tx.send(Err(reconnect_err));
+                                    let mut s = state.lock().await;
+                                    *s = WebSocketState::Closed;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn reconnect(
+        url: &str,
+        options: &WebSocketOptions,
+        sink: &Arc<Mutex<Option<WsSink>>>,
+    ) -> Result<WsSource, ApiError> {
+        let full_url = if options.query_params.is_empty() {
+            url.to_string()
+        } else {
+            let query: String = options
+                .query_params
+                .iter()
+                .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+            format!("{}?{}", url, query)
+        };
+
+        let uri: Uri = full_url.parse().map_err(
+            |e: tokio_tungstenite::tungstenite::http::uri::InvalidUri| {
+                ApiError::WebSocketError(format!("Invalid URL: {}", e))
+            },
+        )?;
+
+        let mut request = uri
+            .into_client_request()
+            .map_err(|e| ApiError::WebSocketError(format!("Failed to build request: {}", e)))?;
+
+        let headers = request.headers_mut();
+        for (key, value) in &options.headers {
+            let header_name: HeaderName = key.parse().map_err(|_| ApiError::InvalidHeader)?;
+            let header_value: HeaderValue = value.parse().map_err(|_| ApiError::InvalidHeader)?;
+            headers.insert(header_name, header_value);
+        }
+
+        let (ws_stream, _response) =
+            tokio::time::timeout(options.connection_timeout, connect_async(request))
+                .await
+                .map_err(|_| ApiError::WebSocketError("Reconnection timed out".to_string()))?
+                .map_err(|e| ApiError::WebSocketError(format!("Reconnection failed: {}", e)))?;
+
+        let (write, read) = ws_stream.split();
+
+        {
+            let mut sink_guard = sink.lock().await;
+            *sink_guard = Some(write);
+        }
+
+        Ok(read)
+    }
+}
+
+pub fn parse_websocket_message<T: DeserializeOwned>(raw: &str) -> Result<T, ApiError> {
+    serde_json::from_str(raw).map_err(ApiError::Serialization)
+}

--- a/seed/rust-sdk/websocket-inferred-auth/src/error.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/error.rs
@@ -18,6 +18,8 @@ pub enum ApiError {
     StreamTerminated,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
+    #[error("WebSocket error: {0}")]
+    WebSocketError(String),
 }
 
 impl ApiError {

--- a/seed/rust-sdk/websocket/README.md
+++ b/seed/rust-sdk/websocket/README.md
@@ -38,12 +38,12 @@ The SDK supports WebSocket connections for real-time communication. Use the gene
 ```rust
 use seed_websocket::api::websocket::EmptyRealtimeClient;
 
-let mut client = EmptyRealtimeClient::connect(
+let mut empty_realtime = EmptyRealtimeClient::connect(
     "wss://api.example.com",
 ).await.expect("Failed to connect");
 
-// Close the connection
-client.close().await.expect("Failed to close");
+// Close the connection when done
+empty_realtime.close().await.expect("Failed to close");
 ```
 
 ## Contributing

--- a/seed/rust-sdk/websocket/README.md
+++ b/seed/rust-sdk/websocket/README.md
@@ -1,0 +1,57 @@
+# Seed Rust Library
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FRust)
+[![crates.io shield](https://img.shields.io/crates/v/seed_websocket)](https://crates.io/crates/seed_websocket)
+
+The Seed Rust library provides convenient access to the Seed APIs from Rust.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Reference](#reference)
+- [Websockets](#websockets)
+- [Contributing](#contributing)
+
+## Installation
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+seed_websocket = "0.0.1"
+```
+
+Or install via cargo:
+
+```sh
+cargo add seed_websocket
+```
+
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
+## Websockets
+
+The SDK supports WebSocket connections for real-time communication. Use the generated channel clients to connect, send, and receive messages.
+
+```rust
+use seed_websocket::api::websocket::EmptyRealtimeClient;
+
+let mut client = EmptyRealtimeClient::connect(
+    "wss://api.example.com",
+).await.expect("Failed to connect");
+
+// Close the connection
+client.close().await.expect("Failed to close");
+```
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!

--- a/seed/rust-sdk/websocket/README.md
+++ b/seed/rust-sdk/websocket/README.md
@@ -36,11 +36,16 @@ A full reference for this library is available [here](./reference.md).
 The SDK supports WebSocket connections for real-time communication. Use the generated channel clients to connect, send, and receive messages.
 
 ```rust
-use seed_websocket::api::websocket::EmptyRealtimeClient;
+use seed_websocket::prelude::*;
 
-let mut empty_realtime = EmptyRealtimeClient::connect(
-    "wss://api.example.com",
-).await.expect("Failed to connect");
+let config = ClientConfig {
+    base_url: " ".to_string(),
+    api_key: Some("your-api-key".to_string())
+};
+let client = WebsocketClient::new(config).expect("Failed to build client");
+
+// Connect to the WebSocket
+let mut empty_realtime = client.empty_realtime.connect().await.expect("Failed to connect");
 
 // Close the connection when done
 empty_realtime.close().await.expect("Failed to close");

--- a/seed/rust-sdk/websocket/src/api/resources/mod.rs
+++ b/seed/rust-sdk/websocket/src/api/resources/mod.rs
@@ -5,18 +5,23 @@
 //! - **Empty**
 //! - **Realtime**
 
+use crate::api::websocket::{EmptyRealtimeConnector, RealtimeConnector};
 use crate::{ApiError, ClientConfig};
 
 pub mod empty;
 pub mod realtime;
 pub struct WebsocketClient {
     pub config: ClientConfig,
+    pub empty_realtime: EmptyRealtimeConnector,
+    pub realtime: RealtimeConnector,
 }
 
 impl WebsocketClient {
     pub fn new(config: ClientConfig) -> Result<Self, ApiError> {
         Ok(Self {
             config: config.clone(),
+            empty_realtime: EmptyRealtimeConnector::new(config.base_url.clone()),
+            realtime: RealtimeConnector::new(config.base_url.clone()),
         })
     }
 }

--- a/seed/rust-sdk/websocket/src/api/websocket/empty_realtime.rs
+++ b/seed/rust-sdk/websocket/src/api/websocket/empty_realtime.rs
@@ -22,3 +22,18 @@ impl EmptyRealtimeClient {
         self.ws.close().await
     }
 }
+/// Connector for the EmptyRealtime WebSocket channel.
+/// Provides access to the WebSocket channel through the root client.
+pub struct EmptyRealtimeConnector {
+    base_url: String,
+}
+
+impl EmptyRealtimeConnector {
+    pub fn new(base_url: String) -> Self {
+        Self { base_url }
+    }
+
+    pub async fn connect(&self) -> Result<EmptyRealtimeClient, ApiError> {
+        EmptyRealtimeClient::connect(&self.base_url).await
+    }
+}

--- a/seed/rust-sdk/websocket/src/api/websocket/mod.rs
+++ b/seed/rust-sdk/websocket/src/api/websocket/mod.rs
@@ -3,5 +3,7 @@
 pub mod empty_realtime;
 pub mod realtime;
 pub use empty_realtime::EmptyRealtimeClient;
+pub use empty_realtime::EmptyRealtimeConnector;
 pub use realtime::RealtimeClient;
+pub use realtime::RealtimeConnector;
 pub use realtime::RealtimeServerMessage;

--- a/seed/rust-sdk/websocket/src/api/websocket/realtime.rs
+++ b/seed/rust-sdk/websocket/src/api/websocket/realtime.rs
@@ -83,3 +83,31 @@ impl RealtimeClient {
         self.ws.close().await
     }
 }
+/// Connector for the Realtime WebSocket channel.
+/// Provides access to the WebSocket channel through the root client.
+pub struct RealtimeConnector {
+    base_url: String,
+}
+
+impl RealtimeConnector {
+    pub fn new(base_url: String) -> Self {
+        Self { base_url }
+    }
+
+    pub async fn connect(
+        &self,
+        session_id: &str,
+        model: Option<&str>,
+        temperature: Option<&str>,
+        language_code: Option<&str>,
+    ) -> Result<RealtimeClient, ApiError> {
+        RealtimeClient::connect(
+            &self.base_url,
+            session_id,
+            model,
+            temperature,
+            language_code,
+        )
+        .await
+    }
+}


### PR DESCRIPTION
## Description

Refs: Requested by @iamnamananand996
Link to Devin Session: https://app.devin.ai/sessions/5d39b24dcd814ff2ba711bf26fe88851

When `enableWebsockets: true` is set in the Rust SDK generator config, the generated SDK now:
1. **Generates WebSocket connector structs** (e.g., `RealtimeConnector`) that wrap `base_url` and delegate to the underlying `XxxClient::connect()` methods
2. **Adds connector fields to the root client** so WebSocket channels are accessible via `client.realtime.connect(...)` — matching the Python and Java generators' access patterns
3. **Includes a Websockets section in README.md** with usage examples showing the root-client-based connection pattern

Previously, WebSocket clients were standalone (required hardcoded URLs), and README generation produced no WebSocket documentation.

### Updates since last revision

**Refactored shared logic to eliminate duplication risks** (addresses former checklist items #1 and #4):

- Extracted `buildConnectParams(channel)` — single method that derives the connect parameter list (path params → headers → query params) from IR. Both `generateConnectMethod()` and `generateConnectorStruct()` now call this instead of duplicating the iteration logic.
- Extracted `getConnectorName(clientName)` — single source of truth for the `${clientName.replace(/Client$/, "")}Connector` naming pattern. Used by `getConnectorInfo()`, `generateWebSocketModFile()`, and `generateConnectorStruct()`.

## Changes Made

- **`features.yml`**: Added `WEBSOCKETS` feature definition for the README feature framework
- **`WebSocketChannelGenerator.ts`**:
  - Added `getConnectorInfo()` to expose connector metadata to `RootClientGenerator`
  - Added `generateConnectorStruct()` to generate `XxxConnector` wrappers with delegating `connect()` methods
  - Added `buildConnectParams()` — shared parameter derivation used by both `generateConnectMethod()` and `generateConnectorStruct()` to keep signatures in sync
  - Added `getConnectorName()` — single source of truth for connector naming used across all three call sites
  - Updated `generateWebSocketModFile()` to re-export connector types
  - Updated `generateChannelFile()` to include connector struct in each channel file
- **`RootClientGenerator.ts`**:
  - Added `wsConnectors` property populated from `WebSocketChannelGenerator.getConnectorInfo()`
  - Updated `generateFields()` to add connector fields alongside HTTP sub-clients
  - Updated `generateConstructor()` to initialize connectors with `config.base_url.clone()`
  - Updated `generateImports()` to import connector types from `crate::api::websocket`
  - Added `getUniqueWsConnectors()` for collision avoidance with HTTP sub-clients
- **`ReadmeSnippetBuilder.ts`**:
  - Made `defaultEndpointId` optional so the constructor no longer throws for WebSocket-only SDKs
  - Added `buildWebSocketSnippets()` using `ClientConfig` + root client pattern with AST expressions
  - Added `getExampleWebSocketChannel()` mirroring Python's `_get_example_websocket_channel()`
  - Added helper methods for channel name mapping and message method name derivation
  - Updated `buildUsageSnippets()` and `getEndpointsForFeature()` to handle undefined `defaultEndpointId`
- **`SdkGeneratorCli.ts`**: Modified `generateReadme()` to proceed with README generation when WebSocket channels exist, even if there are no HTTP endpoints
- **`seed.yml`**: Added `websocket-bearer-auth` and `websocket-inferred-auth` fixtures with `enableWebsockets: true`
- **Seed snapshots**: Updated for all 3 websocket fixtures (`websocket`, `websocket-bearer-auth`, `websocket-inferred-auth`)

## ⚠️ Human Review Checklist

1. ~~**Connector parameter forwarding**~~: ✅ **Addressed** — Both `generateConnectMethod()` and `generateConnectorStruct()` now call the shared `buildConnectParams(channel)` method, ensuring parameter lists stay in sync automatically.

2. **README snippet placeholder values**: The `ClientConfig` in WebSocket snippets uses `base_url: " ".to_string()` (a single space) and always includes `api_key: Some("your-api-key".to_string())` regardless of auth requirements. These are artifacts of reusing `getClientConfigStruct("error")`. The hardcoded `api_key` appears even in the basic `websocket` fixture which has no authentication. Consider making this auth-aware as a follow-up.

3. **Collision detection scope**: `getUniqueWsConnectors()` only checks field name equality with HTTP sub-clients. Module-level collisions (if a WS connector and HTTP sub-client have different field names but same module path) are not detected. Current IR structure makes this scenario unlikely, but worth noting.

4. ~~**Connector re-export duplication risk**~~: ✅ **Addressed** — All three call sites (`getConnectorInfo()`, `generateWebSocketModFile()`, `generateConnectorStruct()`) now use the shared `getConnectorName(clientName)` method as the single source of truth.

5. **`defaultEndpointId` optional change**: Verified safe — all usages handle `undefined` correctly (`buildUsageSnippets` and `getEndpointsForFeature` both explicitly check for null/undefined and return empty arrays). WebSocket-only SDKs confirmed working.

6. **Subpackage iteration order**: `getExampleWebSocketChannel()` iterates `Object.keys(this.context.ir.subpackages)` and picks the first match. If the IR serialization order changes, a different channel may be selected for the README snippet. This is consistent with how Python handles it but worth noting.

## Testing

- [x] Built Rust SDK generator locally (`pnpm turbo run dist:cli --filter @fern-api/rust-sdk`)
- [x] Ran local seed tests for `websocket`, `websocket-bearer-auth`, `websocket-inferred-auth` — all 3 pass
- [x] Ran `simple-api` seed test for regression check — passes
- [x] Lint checks pass (`pnpm run check`)
- [x] Verified refactor produces identical output (git diff shows only `.ts` source changed, no snapshot files)
- [x] Verified generated output:
  - WebSocket-only SDK (`websocket`): Root client has `empty_realtime: EmptyRealtimeConnector` and `realtime: RealtimeConnector` fields, README uses `client.empty_realtime.connect()`
  - Mixed HTTP + WebSocket SDK (`websocket-bearer-auth`): Root client has both HTTP sub-clients and connector fields, README shows WebSocket section with `client.realtime_no_auth.connect()`
  - Connector structs generated with proper delegation to underlying client `connect()` methods
  - Connectors re-exported from websocket `mod.rs` and imported into root client
- [ ] End-to-end test against real API definition (`immix-fern-config`) pending CI completion