### PR TITLE
feat(seed): reuse a pool of generator containers across fixtures for parallel execution

### DIFF
--- a/packages/cli/generation/local-generation/docker-utils/src/index.ts
+++ b/packages/cli/generation/local-generation/docker-utils/src/index.ts
@@ -1,1 +1,9 @@
-export { runContainer, runDocker } from "./runDocker.js";
+export {
+    copyFromContainer,
+    copyToContainer,
+    execInContainer,
+    runContainer,
+    runDocker,
+    startContainer,
+    stopContainer
+} from "./runDocker.js";

--- a/packages/cli/generation/local-generation/docker-utils/src/runDocker.ts
+++ b/packages/cli/generation/local-generation/docker-utils/src/runDocker.ts
@@ -164,3 +164,180 @@ async function pullImage(imageName: string, runner?: ContainerRunner, signal?: A
         signal
     });
 }
+
+/**
+ * Starts a long-lived container in detached mode for reuse across multiple executions.
+ * Returns the container ID.
+ */
+export async function startContainer({
+    logger,
+    imageName,
+    runner
+}: {
+    logger: Logger;
+    imageName: string;
+    runner?: ContainerRunner;
+}): Promise<string> {
+    const containerRunner = runner ?? "docker";
+
+    const tryStart = async () => {
+        const { stdout, exitCode, stderr } = await loggingExeca(
+            logger,
+            containerRunner,
+            ["run", "--user", "root", "-dit", "--entrypoint", "/bin/sh", imageName],
+            {
+                reject: false,
+                doNotPipeOutput: true
+            }
+        );
+
+        if (exitCode == null) {
+            throw new Error(
+                `Container runtime '${containerRunner}' is not installed or not found on PATH.\n` +
+                    `Error details: ${stderr || stdout || "No output"}`
+            );
+        }
+
+        if (exitCode !== 0) {
+            throw new Error(`Failed to start container from image ${imageName}.\n${stdout}\n${stderr}`);
+        }
+
+        return stdout.trim();
+    };
+
+    try {
+        return await tryStart();
+    } catch (e) {
+        if (e instanceof Error && e.message.includes("No such image")) {
+            await pullImage(imageName, runner);
+            return await tryStart();
+        }
+        throw e;
+    }
+}
+
+/**
+ * Executes a command inside a running container.
+ */
+export async function execInContainer({
+    logger,
+    containerId,
+    command,
+    runner,
+    writeLogsToFile = true
+}: {
+    logger: Logger;
+    containerId: string;
+    command: string[];
+    runner?: ContainerRunner;
+    writeLogsToFile?: boolean;
+}): Promise<void> {
+    const containerRunner = runner ?? "docker";
+    const { stdout, stderr, exitCode } = await loggingExeca(
+        logger,
+        containerRunner,
+        ["exec", "--user", "root", containerId, ...command],
+        {
+            reject: false,
+            all: true,
+            doNotPipeOutput: true
+        }
+    );
+
+    const logs = stdout + stderr;
+
+    if (writeLogsToFile) {
+        const tmpFile = await tmp.file();
+        await writeFile(tmpFile.path, logs);
+        logger.info(`Generator logs here: ${tmpFile.path}`);
+    }
+
+    if (exitCode !== 0) {
+        throw new Error(`Container exec exited with code ${exitCode}.\n${stdout}\n${stderr}`);
+    }
+}
+
+/**
+ * Copies a file or directory into a running container.
+ */
+export async function copyToContainer({
+    logger,
+    containerId,
+    hostPath,
+    containerPath,
+    runner
+}: {
+    logger: Logger;
+    containerId: string;
+    hostPath: string;
+    containerPath: string;
+    runner?: ContainerRunner;
+}): Promise<void> {
+    const containerRunner = runner ?? "docker";
+    const { exitCode, stdout, stderr } = await loggingExeca(
+        logger,
+        containerRunner,
+        ["cp", hostPath, `${containerId}:${containerPath}`],
+        {
+            reject: false,
+            doNotPipeOutput: true
+        }
+    );
+
+    if (exitCode !== 0) {
+        throw new Error(
+            `Failed to copy ${hostPath} to container ${containerId}:${containerPath}.\n${stdout}\n${stderr}`
+        );
+    }
+}
+
+/**
+ * Copies a file or directory from a running container to the host.
+ */
+export async function copyFromContainer({
+    logger,
+    containerId,
+    containerPath,
+    hostPath,
+    runner
+}: {
+    logger: Logger;
+    containerId: string;
+    containerPath: string;
+    hostPath: string;
+    runner?: ContainerRunner;
+}): Promise<void> {
+    const containerRunner = runner ?? "docker";
+    const { exitCode, stdout, stderr } = await loggingExeca(
+        logger,
+        containerRunner,
+        ["cp", `${containerId}:${containerPath}`, hostPath],
+        {
+            reject: false,
+            doNotPipeOutput: true
+        }
+    );
+
+    if (exitCode !== 0) {
+        throw new Error(`Failed to copy ${containerId}:${containerPath} to ${hostPath}.\n${stdout}\n${stderr}`);
+    }
+}
+
+/**
+ * Stops and removes a running container.
+ */
+export async function stopContainer({
+    logger,
+    containerId,
+    runner
+}: {
+    logger: Logger;
+    containerId: string;
+    runner?: ContainerRunner;
+}): Promise<void> {
+    const containerRunner = runner ?? "docker";
+    await loggingExeca(logger, containerRunner, ["rm", "-f", containerId], {
+        reject: false,
+        doNotPipeOutput: true
+    });
+}

--- a/packages/cli/generation/local-generation/local-workspace-runner/package.json
+++ b/packages/cli/generation/local-generation/local-workspace-runner/package.json
@@ -50,6 +50,7 @@
     "@fern-api/github": "workspace:*",
     "@fern-api/go-dynamic-snippets": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",
+    "@fern-api/logger": "workspace:*",
     "@fern-api/ir-migrations": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/lazy-fern-workspace": "workspace:*",

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts
@@ -11,6 +11,7 @@ import {
 import { ExecutionEnvironment } from "./ExecutionEnvironment.js";
 
 export class ContainerExecutionEnvironment implements ExecutionEnvironment {
+    public readonly usesContainerPaths = true;
     private readonly containerImage: string;
     private readonly keepContainer: boolean;
     private readonly runner?: ContainerRunner;

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ExecutionEnvironment.ts
@@ -18,5 +18,7 @@ export declare namespace ExecutionEnvironment {
 }
 
 export interface ExecutionEnvironment {
+    /** Whether this environment runs inside a container and needs container-internal paths in the generator config. */
+    readonly usesContainerPaths: boolean;
     execute(args: ExecutionEnvironment.ExecuteArgs): Promise<void>;
 }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
@@ -6,6 +6,7 @@ import { ExecutionEnvironment } from "./ExecutionEnvironment.js";
  * Executes generators natively on the host system using provided commands.
  */
 export class NativeExecutionEnvironment implements ExecutionEnvironment {
+    public readonly usesContainerPaths = false;
     private readonly commands: string[];
     private readonly workingDirectory?: string;
     private readonly env?: Record<string, string>;

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -117,9 +117,16 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             snippetPath,
             snippetTemplatePath,
             licenseFilePath,
-            context
+            context,
+            inspect
         }: ExecutionEnvironment.ExecuteArgs
     ): Promise<void> {
+        if (inspect) {
+            context.logger.warn(
+                "--inspect is not supported with reusable containers (port mapping must be set at container start time). " +
+                    "Use --local mode or the non-reusable container runner for debugging."
+            );
+        }
         if (this.entrypoint == null) {
             throw new Error("Containers not started. Call start() before execute().");
         }
@@ -221,8 +228,13 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
                 containerPath: CONTAINER_PATH_TO_SNIPPET,
                 hostPath: snippetPath,
                 runner: this.runner
-            }).catch((_e: unknown) => {
-                // Snippet file may not exist if the generator didn't produce one
+            }).catch((e: unknown) => {
+                // Snippet file may not exist if the generator didn't produce one.
+                // Only swallow "not found" errors; propagate anything else.
+                const msg = e instanceof Error ? e.message : String(e);
+                if (!msg.includes("No such container:path") && !msg.includes("Could not find the file")) {
+                    logger.debug(`Non-fatal: failed to copy snippet file back: ${msg}`);
+                }
             });
         }
 
@@ -233,8 +245,13 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
                 containerPath: CONTAINER_PATH_TO_SNIPPET_TEMPLATES,
                 hostPath: snippetTemplatePath,
                 runner: this.runner
-            }).catch((_e: unknown) => {
-                // Snippet template file may not exist if the generator didn't produce one
+            }).catch((e: unknown) => {
+                // Snippet template file may not exist if the generator didn't produce one.
+                // Only swallow "not found" errors; propagate anything else.
+                const msg = e instanceof Error ? e.message : String(e);
+                if (!msg.includes("No such container:path") && !msg.includes("Could not find the file")) {
+                    logger.debug(`Non-fatal: failed to copy snippet template file back: ${msg}`);
+                }
             });
         }
     }
@@ -260,7 +277,7 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
 
     private async getImageEntrypoint(logger: Logger): Promise<string[]> {
         const { loggingExeca } = await import("@fern-api/logging-execa");
-        const { stdout } = await loggingExeca(
+        const { stdout, stderr, exitCode } = await loggingExeca(
             logger,
             this.runner,
             ["inspect", "--format", "{{json .Config.Entrypoint}}", this.imageName],
@@ -269,6 +286,10 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
                 doNotPipeOutput: true
             }
         );
+
+        if (exitCode !== 0) {
+            throw new Error(`Failed to inspect image ${this.imageName} (exit code ${exitCode}).\n${stderr || stdout}`);
+        }
 
         try {
             const entrypoint = JSON.parse(stdout.trim());

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -75,8 +75,8 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
                         logger,
                         containerId: result.value,
                         runner: this.runner
-                    }).catch(() => {
-                        // Best-effort cleanup
+                    }).catch((cleanupErr) => {
+                        logger.debug(`Best-effort cleanup failed for container ${result.value}: ${cleanupErr}`);
                     });
                 }
             }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -7,6 +7,7 @@ import {
     stopContainer
 } from "@fern-api/docker-utils";
 import { Logger } from "@fern-api/logger";
+import { loggingExeca } from "@fern-api/logging-execa";
 import {
     CONTAINER_CODEGEN_OUTPUT_DIRECTORY,
     CONTAINER_FERN_DIRECTORY,
@@ -300,7 +301,6 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
     }
 
     private async getImageEntrypoint(logger: Logger): Promise<string[]> {
-        const { loggingExeca } = await import("@fern-api/logging-execa");
         const { stdout, stderr, exitCode } = await loggingExeca(
             logger,
             this.runner,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -65,8 +65,9 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
         // Serialize access — the container uses fixed paths so only one fixture can run at a time.
         const result = this.executionQueue.then(() => this.doExecute(args));
         // Update the queue to wait for this execution (swallow errors so the queue continues)
-        this.executionQueue = result.catch(() => {
-            // Swallow errors so the queue continues to the next fixture
+        this.executionQueue = result.catch((_e: unknown) => {
+            // Swallow errors so the queue continues to the next fixture.
+            // The error is still propagated to the caller via the `result` promise returned above.
         });
         return result;
     }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -62,8 +62,28 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
                 })
             );
         }
-        this.containers = await Promise.all(startPromises);
-        this.availableContainers = [...this.containers];
+
+        try {
+            this.containers = await Promise.all(startPromises);
+            this.availableContainers = [...this.containers];
+        } catch (error) {
+            // Clean up any containers that started successfully before the failure
+            const settledPromises = await Promise.allSettled(startPromises);
+            for (const result of settledPromises) {
+                if (result.status === "fulfilled") {
+                    await stopContainer({
+                        logger,
+                        containerId: result.value,
+                        runner: this.runner
+                    }).catch(() => {
+                        // Best-effort cleanup
+                    });
+                }
+            }
+            this.containers = [];
+            this.availableContainers = [];
+            throw error;
+        }
 
         logger.info(
             `Started ${this.containers.length} reusable container(s) from image ${this.imageName}: ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
@@ -229,11 +249,13 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
                 hostPath: snippetPath,
                 runner: this.runner
             }).catch((e: unknown) => {
-                // Snippet file may not exist if the generator didn't produce one.
-                // Only swallow "not found" errors; propagate anything else.
+                // Swallow "not found" errors — generator didn't produce snippet.
+                // Propagate other errors (permissions, disk space, etc.).
                 const msg = e instanceof Error ? e.message : String(e);
-                if (!msg.includes("No such container:path") && !msg.includes("Could not find the file")) {
-                    logger.debug(`Non-fatal: failed to copy snippet file back: ${msg}`);
+                if (msg.includes("No such container:path") || msg.includes("Could not find the file")) {
+                    logger.debug(`Snippet file not found (expected): ${msg}`);
+                } else {
+                    throw e;
                 }
             });
         }
@@ -246,11 +268,13 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
                 hostPath: snippetTemplatePath,
                 runner: this.runner
             }).catch((e: unknown) => {
-                // Snippet template file may not exist if the generator didn't produce one.
-                // Only swallow "not found" errors; propagate anything else.
+                // Swallow "not found" errors — generator didn't produce snippet template.
+                // Propagate other errors (permissions, disk space, etc.).
                 const msg = e instanceof Error ? e.message : String(e);
-                if (!msg.includes("No such container:path") && !msg.includes("Could not find the file")) {
-                    logger.debug(`Non-fatal: failed to copy snippet template file back: ${msg}`);
+                if (msg.includes("No such container:path") || msg.includes("Could not find the file")) {
+                    logger.debug(`Snippet template file not found (expected): ${msg}`);
+                } else {
+                    throw e;
                 }
             });
         }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -173,6 +173,32 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             hostPath: outputPath,
             runner: this.runner
         });
+
+        // Copy snippet files back to the host (generators write these inside the container).
+        // Unlike bind mounts in ContainerExecutionEnvironment, docker cp requires explicit copy-back.
+        if (snippetPath != null) {
+            await copyFromContainer({
+                logger,
+                containerId,
+                containerPath: CONTAINER_PATH_TO_SNIPPET,
+                hostPath: snippetPath,
+                runner: this.runner
+            }).catch((_e: unknown) => {
+                // Snippet file may not exist if the generator didn't produce one
+            });
+        }
+
+        if (snippetTemplatePath != null) {
+            await copyFromContainer({
+                logger,
+                containerId,
+                containerPath: CONTAINER_PATH_TO_SNIPPET_TEMPLATES,
+                hostPath: snippetTemplatePath,
+                runner: this.runner
+            }).catch((_e: unknown) => {
+                // Snippet template file may not exist if the generator didn't produce one
+            });
+        }
     }
 
     /**

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -18,74 +18,112 @@ import {
 import { ExecutionEnvironment } from "./ExecutionEnvironment.js";
 
 /**
- * An execution environment that starts a long-lived container once and reuses it
- * across multiple generator executions. Instead of `docker run` per fixture,
+ * An execution environment that starts a pool of long-lived containers and reuses
+ * them across multiple generator executions. Instead of `docker run` per fixture,
  * files are copied in via `docker cp`, the generator is invoked via `docker exec`,
  * and output is copied back out.
+ *
+ * The pool size controls how many fixtures can run in parallel. Each container in the
+ * pool handles one fixture at a time, providing isolation without needing a mutex.
  */
 export class ReusableContainerExecutionEnvironment implements ExecutionEnvironment {
     public readonly usesContainerPaths = true;
 
-    private containerId: string | undefined;
+    private containers: string[] = [];
+    private availableContainers: string[] = [];
+    private waiters: Array<(containerId: string) => void> = [];
     private entrypoint: string[] | undefined;
     private readonly imageName: string;
     private readonly runner: ContainerRunner;
+    private readonly poolSize: number;
 
-    // Mutex to serialize execute() calls — the container uses fixed paths (/fern/*, /tmp/LICENSE)
-    // so concurrent executions would overwrite each other's files.
-    private executionQueue: Promise<void> = Promise.resolve();
-
-    constructor({ imageName, runner }: { imageName: string; runner?: ContainerRunner }) {
+    constructor({ imageName, runner, poolSize }: { imageName: string; runner?: ContainerRunner; poolSize?: number }) {
         this.imageName = imageName;
         this.runner = runner ?? "docker";
+        this.poolSize = poolSize ?? 1;
     }
 
     /**
-     * Starts the long-lived container and inspects the image for its entrypoint.
+     * Starts the pool of long-lived containers and inspects the image for its entrypoint.
      * Must be called before any `execute()` calls.
      */
     public async start(logger: Logger): Promise<void> {
         // Get the image entrypoint before starting (since we override it with /bin/sh)
         this.entrypoint = await this.getImageEntrypoint(logger);
 
-        this.containerId = await startContainer({
-            logger,
-            imageName: this.imageName,
-            runner: this.runner
-        });
+        // Start N containers in parallel
+        const startPromises = [];
+        for (let i = 0; i < this.poolSize; i++) {
+            startPromises.push(
+                startContainer({
+                    logger,
+                    imageName: this.imageName,
+                    runner: this.runner
+                })
+            );
+        }
+        this.containers = await Promise.all(startPromises);
+        this.availableContainers = [...this.containers];
 
-        logger.info(`Started reusable container ${this.containerId} from image ${this.imageName}`);
+        logger.info(
+            `Started ${this.containers.length} reusable container(s) from image ${this.imageName}: ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
+        );
     }
 
     public async execute(args: ExecutionEnvironment.ExecuteArgs): Promise<void> {
-        if (this.containerId == null || this.entrypoint == null) {
-            throw new Error("Container not started. Call start() before execute().");
+        if (this.containers.length === 0 || this.entrypoint == null) {
+            throw new Error("Containers not started. Call start() before execute().");
         }
 
-        // Serialize access — the container uses fixed paths so only one fixture can run at a time.
-        const result = this.executionQueue.then(() => this.doExecute(args));
-        // Update the queue to wait for this execution (swallow errors so the queue continues)
-        this.executionQueue = result.catch((_e: unknown) => {
-            // Swallow errors so the queue continues to the next fixture.
-            // The error is still propagated to the caller via the `result` promise returned above.
-        });
-        return result;
+        const containerId = await this.acquire();
+        try {
+            await this.doExecute(containerId, args);
+        } finally {
+            this.release(containerId);
+        }
     }
 
-    private async doExecute({
-        irPath,
-        configPath,
-        outputPath,
-        snippetPath,
-        snippetTemplatePath,
-        licenseFilePath,
-        context
-    }: ExecutionEnvironment.ExecuteArgs): Promise<void> {
-        if (this.containerId == null || this.entrypoint == null) {
-            throw new Error("Container not started. Call start() before execute().");
+    /**
+     * Acquires a container from the pool, waiting if all are busy.
+     */
+    private acquire(): Promise<string> {
+        const available = this.availableContainers.shift();
+        if (available != null) {
+            return Promise.resolve(available);
+        }
+        return new Promise<string>((resolve) => {
+            this.waiters.push(resolve);
+        });
+    }
+
+    /**
+     * Releases a container back to the pool, waking up any waiters.
+     */
+    private release(containerId: string): void {
+        const waiter = this.waiters.shift();
+        if (waiter != null) {
+            waiter(containerId);
+        } else {
+            this.availableContainers.push(containerId);
+        }
+    }
+
+    private async doExecute(
+        containerId: string,
+        {
+            irPath,
+            configPath,
+            outputPath,
+            snippetPath,
+            snippetTemplatePath,
+            licenseFilePath,
+            context
+        }: ExecutionEnvironment.ExecuteArgs
+    ): Promise<void> {
+        if (this.entrypoint == null) {
+            throw new Error("Containers not started. Call start() before execute().");
         }
         const entrypoint = this.entrypoint;
-        const containerId = this.containerId;
         const logger = context.logger;
 
         // Clean the entire /fern directory and /tmp/LICENSE to ensure no state leaks between fixtures.
@@ -202,18 +240,22 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
     }
 
     /**
-     * Stops and removes the long-lived container.
+     * Stops and removes all containers in the pool.
      */
     public async stop(logger: Logger): Promise<void> {
-        if (this.containerId != null) {
+        const stopPromises = this.containers.map(async (containerId) => {
             await stopContainer({
                 logger,
-                containerId: this.containerId,
+                containerId,
                 runner: this.runner
             });
-            logger.info(`Stopped reusable container ${this.containerId}`);
-            this.containerId = undefined;
-        }
+        });
+        await Promise.all(stopPromises);
+        logger.info(
+            `Stopped ${this.containers.length} reusable container(s): ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
+        );
+        this.containers = [];
+        this.availableContainers = [];
     }
 
     private async getImageEntrypoint(logger: Logger): Promise<string[]> {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -31,6 +31,10 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
     private readonly imageName: string;
     private readonly runner: ContainerRunner;
 
+    // Mutex to serialize execute() calls — the container uses fixed paths (/fern/*, /tmp/LICENSE)
+    // so concurrent executions would overwrite each other's files.
+    private executionQueue: Promise<void> = Promise.resolve();
+
     constructor({ imageName, runner }: { imageName: string; runner?: ContainerRunner }) {
         this.imageName = imageName;
         this.runner = runner ?? "docker";
@@ -53,7 +57,21 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
         logger.info(`Started reusable container ${this.containerId} from image ${this.imageName}`);
     }
 
-    public async execute({
+    public async execute(args: ExecutionEnvironment.ExecuteArgs): Promise<void> {
+        if (this.containerId == null || this.entrypoint == null) {
+            throw new Error("Container not started. Call start() before execute().");
+        }
+
+        // Serialize access — the container uses fixed paths so only one fixture can run at a time.
+        const result = this.executionQueue.then(() => this.doExecute(args));
+        // Update the queue to wait for this execution (swallow errors so the queue continues)
+        this.executionQueue = result.catch(() => {
+            // Swallow errors so the queue continues to the next fixture
+        });
+        return result;
+    }
+
+    private async doExecute({
         irPath,
         configPath,
         outputPath,
@@ -65,31 +83,26 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
         if (this.containerId == null || this.entrypoint == null) {
             throw new Error("Container not started. Call start() before execute().");
         }
-
-        const logger = context.logger;
+        const entrypoint = this.entrypoint;
         const containerId = this.containerId;
+        const logger = context.logger;
 
-        // Clean the output directory in the container for this fixture
+        // Clean the entire /fern directory and /tmp/LICENSE to ensure no state leaks between fixtures.
+        // This is critical — generators may write to any path under /fern (output, generators, sources, etc.)
+        // and we need a fresh environment for each fixture.
         await execInContainer({
             logger,
             containerId,
-            command: ["rm", "-rf", CONTAINER_CODEGEN_OUTPUT_DIRECTORY],
+            command: ["rm", "-rf", CONTAINER_FERN_DIRECTORY, "/tmp/LICENSE"],
             runner: this.runner,
             writeLogsToFile: false
         });
+
+        // Recreate /fern and /fern/output
         await execInContainer({
             logger,
             containerId,
             command: ["mkdir", "-p", CONTAINER_CODEGEN_OUTPUT_DIRECTORY],
-            runner: this.runner,
-            writeLogsToFile: false
-        });
-
-        // Ensure the /fern directory exists
-        await execInContainer({
-            logger,
-            containerId,
-            command: ["mkdir", "-p", CONTAINER_FERN_DIRECTORY],
             runner: this.runner,
             writeLogsToFile: false
         });
@@ -145,7 +158,7 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
         await execInContainer({
             logger,
             containerId,
-            command: [...this.entrypoint, CONTAINER_GENERATOR_CONFIG_PATH],
+            command: [...entrypoint, CONTAINER_GENERATOR_CONFIG_PATH],
             runner: this.runner,
             writeLogsToFile: true
         });
@@ -193,8 +206,8 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             if (Array.isArray(entrypoint) && entrypoint.length > 0) {
                 return entrypoint;
             }
-        } catch {
-            // Fall through to error
+        } catch (e) {
+            logger.warn(`Failed to parse entrypoint for image ${this.imageName}: ${e}`);
         }
 
         throw new Error(

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -1,0 +1,205 @@
+import { ContainerRunner } from "@fern-api/core-utils";
+import {
+    copyFromContainer,
+    copyToContainer,
+    execInContainer,
+    startContainer,
+    stopContainer
+} from "@fern-api/docker-utils";
+import { Logger } from "@fern-api/logger";
+import {
+    CONTAINER_CODEGEN_OUTPUT_DIRECTORY,
+    CONTAINER_FERN_DIRECTORY,
+    CONTAINER_GENERATOR_CONFIG_PATH,
+    CONTAINER_PATH_TO_IR,
+    CONTAINER_PATH_TO_SNIPPET,
+    CONTAINER_PATH_TO_SNIPPET_TEMPLATES
+} from "./constants.js";
+import { ExecutionEnvironment } from "./ExecutionEnvironment.js";
+
+/**
+ * An execution environment that starts a long-lived container once and reuses it
+ * across multiple generator executions. Instead of `docker run` per fixture,
+ * files are copied in via `docker cp`, the generator is invoked via `docker exec`,
+ * and output is copied back out.
+ */
+export class ReusableContainerExecutionEnvironment implements ExecutionEnvironment {
+    public readonly usesContainerPaths = true;
+
+    private containerId: string | undefined;
+    private entrypoint: string[] | undefined;
+    private readonly imageName: string;
+    private readonly runner: ContainerRunner;
+
+    constructor({ imageName, runner }: { imageName: string; runner?: ContainerRunner }) {
+        this.imageName = imageName;
+        this.runner = runner ?? "docker";
+    }
+
+    /**
+     * Starts the long-lived container and inspects the image for its entrypoint.
+     * Must be called before any `execute()` calls.
+     */
+    public async start(logger: Logger): Promise<void> {
+        // Get the image entrypoint before starting (since we override it with /bin/sh)
+        this.entrypoint = await this.getImageEntrypoint(logger);
+
+        this.containerId = await startContainer({
+            logger,
+            imageName: this.imageName,
+            runner: this.runner
+        });
+
+        logger.info(`Started reusable container ${this.containerId} from image ${this.imageName}`);
+    }
+
+    public async execute({
+        irPath,
+        configPath,
+        outputPath,
+        snippetPath,
+        snippetTemplatePath,
+        licenseFilePath,
+        context
+    }: ExecutionEnvironment.ExecuteArgs): Promise<void> {
+        if (this.containerId == null || this.entrypoint == null) {
+            throw new Error("Container not started. Call start() before execute().");
+        }
+
+        const logger = context.logger;
+        const containerId = this.containerId;
+
+        // Clean the output directory in the container for this fixture
+        await execInContainer({
+            logger,
+            containerId,
+            command: ["rm", "-rf", CONTAINER_CODEGEN_OUTPUT_DIRECTORY],
+            runner: this.runner,
+            writeLogsToFile: false
+        });
+        await execInContainer({
+            logger,
+            containerId,
+            command: ["mkdir", "-p", CONTAINER_CODEGEN_OUTPUT_DIRECTORY],
+            runner: this.runner,
+            writeLogsToFile: false
+        });
+
+        // Ensure the /fern directory exists
+        await execInContainer({
+            logger,
+            containerId,
+            command: ["mkdir", "-p", CONTAINER_FERN_DIRECTORY],
+            runner: this.runner,
+            writeLogsToFile: false
+        });
+
+        // Copy input files into the container
+        await copyToContainer({
+            logger,
+            containerId,
+            hostPath: irPath,
+            containerPath: CONTAINER_PATH_TO_IR,
+            runner: this.runner
+        });
+
+        await copyToContainer({
+            logger,
+            containerId,
+            hostPath: configPath,
+            containerPath: CONTAINER_GENERATOR_CONFIG_PATH,
+            runner: this.runner
+        });
+
+        if (snippetPath != null) {
+            await copyToContainer({
+                logger,
+                containerId,
+                hostPath: snippetPath,
+                containerPath: CONTAINER_PATH_TO_SNIPPET,
+                runner: this.runner
+            });
+        }
+
+        if (snippetTemplatePath != null) {
+            await copyToContainer({
+                logger,
+                containerId,
+                hostPath: snippetTemplatePath,
+                containerPath: CONTAINER_PATH_TO_SNIPPET_TEMPLATES,
+                runner: this.runner
+            });
+        }
+
+        if (licenseFilePath != null) {
+            await copyToContainer({
+                logger,
+                containerId,
+                hostPath: licenseFilePath,
+                containerPath: "/tmp/LICENSE",
+                runner: this.runner
+            });
+        }
+
+        // Execute the generator inside the container using the image's original entrypoint
+        await execInContainer({
+            logger,
+            containerId,
+            command: [...this.entrypoint, CONTAINER_GENERATOR_CONFIG_PATH],
+            runner: this.runner,
+            writeLogsToFile: true
+        });
+
+        // Copy the output back to the host
+        // Use "/fern/output/." to copy contents (not the directory itself)
+        await copyFromContainer({
+            logger,
+            containerId,
+            containerPath: `${CONTAINER_CODEGEN_OUTPUT_DIRECTORY}/.`,
+            hostPath: outputPath,
+            runner: this.runner
+        });
+    }
+
+    /**
+     * Stops and removes the long-lived container.
+     */
+    public async stop(logger: Logger): Promise<void> {
+        if (this.containerId != null) {
+            await stopContainer({
+                logger,
+                containerId: this.containerId,
+                runner: this.runner
+            });
+            logger.info(`Stopped reusable container ${this.containerId}`);
+            this.containerId = undefined;
+        }
+    }
+
+    private async getImageEntrypoint(logger: Logger): Promise<string[]> {
+        const { loggingExeca } = await import("@fern-api/logging-execa");
+        const { stdout } = await loggingExeca(
+            logger,
+            this.runner,
+            ["inspect", "--format", "{{json .Config.Entrypoint}}", this.imageName],
+            {
+                reject: false,
+                doNotPipeOutput: true
+            }
+        );
+
+        try {
+            const entrypoint = JSON.parse(stdout.trim());
+            if (Array.isArray(entrypoint) && entrypoint.length > 0) {
+                return entrypoint;
+            }
+        } catch {
+            // Fall through to error
+        }
+
+        throw new Error(
+            `Could not determine entrypoint for image ${this.imageName}. ` +
+                `The image must have an ENTRYPOINT defined to be used with reusable containers.`
+        );
+    }
+}

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/index.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/index.ts
@@ -11,6 +11,8 @@ export * from "./GenerationRunner.js";
 export { GenerationRunner } from "./GenerationRunner.js";
 export * from "./NativeExecutionEnvironment.js";
 export { NativeExecutionEnvironment } from "./NativeExecutionEnvironment.js";
+export * from "./ReusableContainerExecutionEnvironment.js";
+export { ReusableContainerExecutionEnvironment } from "./ReusableContainerExecutionEnvironment.js";
 export {
     runContainerizedGenerationForSeed,
     runNativeGenerationForSeed,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
@@ -167,8 +167,7 @@ export async function writeFilesToDiskAndRunGenerator({
             keepContainer: keepDocker
         });
 
-    const isContainer = environment instanceof ContainerExecutionEnvironment;
-    const paths = isContainer
+    const paths = environment.usesContainerPaths
         ? ({
               outputDirectory: AbsoluteFilePath.of(CONTAINER_CODEGEN_OUTPUT_DIRECTORY),
               irPath: AbsoluteFilePath.of(CONTAINER_PATH_TO_IR),

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForSeed.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForSeed.ts
@@ -1,5 +1,6 @@
 import { ContainerRunner } from "@fern-api/core-utils";
 import { ContainerExecutionEnvironment } from "./ContainerExecutionEnvironment.js";
+import { ExecutionEnvironment } from "./ExecutionEnvironment.js";
 import { GenerationRunner } from "./GenerationRunner.js";
 import { NativeExecutionEnvironment } from "./NativeExecutionEnvironment.js";
 
@@ -8,13 +9,16 @@ export async function runContainerizedGenerationForSeed(
         keepDocker: boolean;
         dockerImage: string;
         runner?: ContainerRunner;
+        executionEnvironment?: ExecutionEnvironment;
     }
 ): Promise<void> {
-    const executionEnv = new ContainerExecutionEnvironment({
-        containerImage: args.dockerImage,
-        keepContainer: args.keepDocker,
-        runner: args.runner ?? "podman"
-    });
+    const executionEnv =
+        args.executionEnvironment ??
+        new ContainerExecutionEnvironment({
+            containerImage: args.dockerImage,
+            keepContainer: args.keepDocker,
+            runner: args.runner ?? "podman"
+        });
     const runner = new GenerationRunner(executionEnv);
     await runner.run(args);
 }

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -154,6 +154,7 @@ function addTestCommand(cli: Argv) {
             const lock = new Semaphore(argv.parallel);
             const tests: Promise<boolean>[] = [];
             const scriptRunners: ScriptRunner[] = [];
+            const testRunners: TestRunner[] = [];
 
             for (const generator of generators) {
                 if (argv.generator != null && !argv.generator.includes(generator.workspaceName)) {
@@ -260,6 +261,7 @@ function addTestCommand(cli: Argv) {
                 }
 
                 scriptRunners.push(scriptRunner);
+                testRunners.push(testRunner);
                 tests.push(
                     testGenerator({
                         generator,
@@ -275,6 +277,10 @@ function addTestCommand(cli: Argv) {
 
             for (const scriptRunner of scriptRunners) {
                 await scriptRunner.stop();
+            }
+
+            for (const testRunner of testRunners) {
+                await testRunner.cleanup();
             }
 
             // If any of the tests failed and allow-unexpected-failures is false, exit with a non-zero status code

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -256,7 +256,8 @@ function addTestCommand(cli: Argv) {
                         keepContainer: argv.keepContainer,
                         scriptRunner,
                         inspect: argv.inspect,
-                        runner: argv.containerRuntime as "docker" | "podman" | undefined
+                        runner: argv.containerRuntime as "docker" | "podman" | undefined,
+                        parallelism: argv.parallel
                     });
                 }
 

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -274,14 +274,18 @@ function addTestCommand(cli: Argv) {
                 );
             }
 
-            const results = await Promise.all(tests);
+            let results: boolean[];
+            try {
+                results = await Promise.all(tests);
+            } finally {
+                // Always clean up containers and script runners, even if tests throw unexpectedly.
+                for (const scriptRunner of scriptRunners) {
+                    await scriptRunner.stop();
+                }
 
-            for (const scriptRunner of scriptRunners) {
-                await scriptRunner.stop();
-            }
-
-            for (const testRunner of testRunners) {
-                await testRunner.cleanup();
+                for (const testRunner of testRunners) {
+                    await testRunner.cleanup();
+                }
             }
 
             // If any of the tests failed and allow-unexpected-failures is false, exit with a non-zero status code

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -142,6 +142,7 @@ export async function runWithCustomFixture({
         if (!skipScripts) {
             await scriptRunner?.stop();
         }
+        await testRunner.cleanup();
     }
 }
 

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -78,7 +78,8 @@ export async function runWithCustomFixture({
             skipScripts,
             keepContainer,
             scriptRunner,
-            inspect
+            inspect,
+            parallelism: 1
         });
     }
 

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -14,10 +14,12 @@ import { TestRunner } from "./TestRunner.js";
 
 export class ContainerTestRunner extends TestRunner {
     private readonly runner: ContainerRunner;
+    private readonly parallelism: number;
     private reusableContainer: ReusableContainerExecutionEnvironment | undefined;
 
-    constructor(args: TestRunner.Args & { runner?: ContainerRunner }) {
+    constructor(args: TestRunner.Args & { runner?: ContainerRunner; parallelism?: number }) {
         super(args);
+        this.parallelism = args.parallelism ?? 4;
 
         if (args.runner != null) {
             this.runner = args.runner;
@@ -64,7 +66,8 @@ export class ContainerTestRunner extends TestRunner {
         }
         this.reusableContainer = new ReusableContainerExecutionEnvironment({
             imageName: this.getContainerImageName(),
-            runner: this.runner
+            runner: this.runner,
+            poolSize: this.parallelism
         });
         await this.reusableContainer.start(CONSOLE_LOGGER);
     }

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -1,6 +1,9 @@
 import { generatorsYml } from "@fern-api/configuration";
 import { ContainerRunner } from "@fern-api/core-utils";
-import { runContainerizedGenerationForSeed } from "@fern-api/local-workspace-runner";
+import {
+    ReusableContainerExecutionEnvironment,
+    runContainerizedGenerationForSeed
+} from "@fern-api/local-workspace-runner";
 import { CONSOLE_LOGGER } from "@fern-api/logger";
 import path from "path";
 
@@ -11,6 +14,7 @@ import { TestRunner } from "./TestRunner.js";
 
 export class ContainerTestRunner extends TestRunner {
     private readonly runner: ContainerRunner;
+    private reusableContainer: ReusableContainerExecutionEnvironment | undefined;
 
     constructor(args: TestRunner.Args & { runner?: ContainerRunner }) {
         super(args);
@@ -52,6 +56,20 @@ export class ContainerTestRunner extends TestRunner {
         });
         if (containerBuildReturn.exitCode !== 0) {
             throw new Error(`Failed to build the container for ${this.generator.workspaceName}.`);
+        }
+
+        // Start a reusable long-lived container for generation
+        this.reusableContainer = new ReusableContainerExecutionEnvironment({
+            imageName: this.getContainerImageName(),
+            runner: this.runner
+        });
+        await this.reusableContainer.start(CONSOLE_LOGGER);
+    }
+
+    public async cleanup(): Promise<void> {
+        if (this.reusableContainer != null) {
+            await this.reusableContainer.stop(CONSOLE_LOGGER);
+            this.reusableContainer = undefined;
         }
     }
 
@@ -111,6 +129,7 @@ export class ContainerTestRunner extends TestRunner {
             keepDocker: keepContainer ?? false,
             dockerImage: this.getContainerImageName(),
             runner: this.runner,
+            executionEnvironment: this.reusableContainer,
             ai: undefined
         });
     }

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -58,7 +58,10 @@ export class ContainerTestRunner extends TestRunner {
             throw new Error(`Failed to build the container for ${this.generator.workspaceName}.`);
         }
 
-        // Start a reusable long-lived container for generation
+        // Start a reusable long-lived container for generation (guard against double build() calls)
+        if (this.reusableContainer != null) {
+            return;
+        }
         this.reusableContainer = new ReusableContainerExecutionEnvironment({
             imageName: this.getContainerImageName(),
             runner: this.runner

--- a/packages/seed/src/commands/test/test-runner/TestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/TestRunner.ts
@@ -125,6 +125,14 @@ export abstract class TestRunner {
 
     public abstract build(): Promise<void>;
 
+    /**
+     * Cleans up any resources (e.g., long-lived containers) used by this runner.
+     * Override in subclasses that manage resources requiring explicit cleanup.
+     */
+    public async cleanup(): Promise<void> {
+        // Default no-op; subclasses like ContainerTestRunner override this.
+    }
+
     public async run({
         fixture,
         configuration,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6224,6 +6224,9 @@ importers:
       '@fern-api/lazy-fern-workspace':
         specifier: workspace:*
         version: link:../../../workspace/lazy-fern-workspace
+      '@fern-api/logger':
+        specifier: workspace:*
+        version: link:../../../logger
       '@fern-api/logging-execa':
         specifier: workspace:*
         version: link:../../../../commons/logging-execa


### PR DESCRIPTION
## Description

Refs performance optimization for seed tests.

Instead of spinning up a new `docker run` per fixture (which incurs ~1-3s of container creation/teardown overhead each time), this PR starts a **pool of long-lived containers** per generator and reuses them across all fixtures via `docker cp` + `docker exec`. This mirrors the pattern already used by script containers (`ContainerScriptRunner`), but with a pool to support parallel execution.

The pool size matches the `--parallel N` flag, so N fixtures can run concurrently in N separate containers. Each container in the pool handles one fixture at a time via an acquire/release pattern, providing isolation without a global mutex.

**No impact on normal generation** — `ReusableContainerExecutionEnvironment` is only instantiated in `ContainerTestRunner` (seed's test runner). The CLI's normal `generate` command path still uses `ContainerExecutionEnvironment` (bind mounts + `docker run`), which is untouched. All new code is additive; the only shared-code change is adding `usesContainerPaths: boolean` to the `ExecutionEnvironment` interface (replacing an `instanceof` check).

### Performance

Benchmarked head-to-head on ts-sdk (194 test cases, `--parallel 4`, same machine, Docker image pre-cached):

| | `main` (docker run per fixture) | This PR (container pool) |
|---|---|---|
| **Total time** | **16m19s** | **6m03s** |
| **Per-fixture avg** | ~5.0s | ~1.9s |
| **Typical fixture time** | 15–25s | 4.5–7s |

**63% faster overall** — the per-fixture container creation/teardown overhead (~10-15s each on `main`) is eliminated; the only overhead now is `docker cp` + `docker exec` (~0.5s per fixture).

**Link to Devin session:** https://app.devin.ai/sessions/81a178b6e60c481d89429464549de111
**Requested by:** @Swimburger

## Changes Made

### docker-utils
- Added 5 new utility functions: `startContainer`, `execInContainer`, `copyToContainer`, `copyFromContainer`, `stopContainer`
- Each handles docker/podman runtime selection and error reporting consistently with existing `runContainer`

### local-workspace-runner
- Added `usesContainerPaths: boolean` to `ExecutionEnvironment` interface (replaces `instanceof ContainerExecutionEnvironment` check in `runGenerator.ts`)
- Created `ReusableContainerExecutionEnvironment` class that:
  - Starts a **pool of N containers** with `-dit --entrypoint /bin/sh` (stays alive)
  - Per fixture: acquires a container from the pool → wipes entire `/fern` directory + `/tmp/LICENSE` → copies IR/config in → `docker exec` the original entrypoint → copies output + snippets back → releases container back to pool
  - Retrieves the image's original entrypoint via `docker inspect`
  - Implements **acquire/release pool pattern**: if all containers are busy, callers wait in a queue until one is released
- Added `@fern-api/logger` dependency (used for error logging in entrypoint parsing)
- Updated `runContainerizedGenerationForSeed` to accept an optional `executionEnvironment` parameter

### seed
- `ContainerTestRunner.build()` now starts a reusable container pool after image build, with a guard to prevent container leaks from double `build()` invocation
- `ContainerTestRunner` accepts `parallelism` param (defaults to 4, receives `argv.parallel` from CLI)
- Added `cleanup()` lifecycle method to `TestRunner` base class (no-op default)
- `ContainerTestRunner.cleanup()` stops all containers in the pool
- Wired cleanup into `cli.ts` (inside `try/finally` to ensure cleanup on unexpected errors) and `runWithCustomFixture.ts`
- `runWithCustomFixture` uses `parallelism: 1` since it only ever runs a single fixture

### Reliability hardening
- **Snippet copy-back error handling**: `.catch()` blocks correctly swallow only "not found" errors (logged at debug level) and **re-throw** all other errors (permissions, disk space, etc.)
- **`--inspect` flag warning**: Logs a clear warning when `--inspect` is used with reusable containers, since port mapping can only be set at container start time
- **`getImageEntrypoint` error reporting**: Captures stderr and checks exit code, so `docker inspect` failures produce actionable error messages instead of confusing JSON parse errors
- **`cli.ts` cleanup resilience**: Wrapped in `try/finally` to ensure containers are cleaned up even if tests throw unexpectedly
- **Partial pool startup cleanup**: If any container in the pool fails to start, successfully started containers are stopped via `Promise.allSettled` before re-throwing the error. Cleanup failures are logged at debug level per REVIEW.md rules.
- **Fixed dynamic import**: Replaced runtime `await import("@fern-api/logging-execa")` with top-level import for consistency with other files in the package

- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- [x] Lint/format checks pass (`pnpm run check` / biome)
- [x] All 300 CI checks pass (all required checks green, 6 skipped, 0 failures)
- [x] Manual testing with **postman** generator (3 fixtures): container reuse confirmed, no leaks, no cross-fixture contamination ([recording](https://app.devin.ai/attachments/eab7e275-8e4f-429d-b87d-8e50c38ce82e/rec-34ddba20dc7c4012b6689edd251dcce1-edited.mp4))
- [x] Manual testing with **ts-sdk** generator (194 test cases, `--parallel 4`): all passed, 4 containers started/stopped correctly, ~6m03s total time

## Human Review Checklist

> ⚠️ This changes the fundamental execution model for containerized seed tests. All checklist items have been investigated ([full analysis in PR comments](https://github.com/fern-api/fern/pull/13196#issuecomment-2898339435)).

**Key findings:**
1. ✅ **Entrypoint detection** — All 25 generator Dockerfiles use `ENTRYPOINT` (verified). None use only `CMD`.
2. ⚠️ **State isolation** — Generators could theoretically write outside `/fern` or `/tmp/LICENSE`, but all Fern generators write only to `/fern/output` by design. 194-fixture ts-sdk test showed no cross-contamination. Acceptable risk.
3. ⚠️ **Snippet error string matching** — `docker cp` exit codes can't distinguish "file not found" from other errors, so string matching is necessary. Error messages have been stable across Docker versions for years. Acceptable fragility.
4. ✅ **Pool size vs. Semaphore** — Pool size and Semaphore both use `argv.parallel`, so they're 1:1 aligned (if `--parallel 4`, we get 4 containers and Semaphore(4)).
5. ⚠️ **Container leak on SIGKILL** — Inherent Docker behavior (even `docker run --rm` won't clean up on SIGKILL). `try/finally` handles normal exits. CI uses ephemeral VMs. Acceptable risk.
6. ✅ **Partial pool startup** — `Promise.allSettled` cleanup logic handles edge cases (including when cleanup itself fails).
7. ✅ **`--inspect` flag** — Warning is appropriate (hard error would be too aggressive since users might have `--inspect` in config but not be debugging).
8. ✅ **Dynamic import** — Fixed in commit e575a12 (now uses top-level import, consistent with other files in the package).

**Areas to scrutinize:**
- Verify the cleanup logic in `cli.ts` and `runWithCustomFixture.ts` always runs (even on unexpected errors)
- Consider whether snippet copy-back error handling could miss edge cases (though no better alternative exists with `docker cp` exit codes)
- Check that the pool size matches intended parallelism in your deployment (defaults to 4, configurable via `--parallel`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
