### PR TITLE
fix(internal): populate `readOnly` through `$ref`

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
@@ -278,8 +278,11 @@ export function convertObject({
             const audiences = getExtension<string[]>(propertySchema, FernOpenAPIExtension.AUDIENCES) ?? [];
             const availability = convertAvailability(propertySchema);
 
-            const readonly = isReferenceObject(propertySchema) ? false : propertySchema.readOnly;
-            const writeonly = isReferenceObject(propertySchema) ? false : propertySchema.writeOnly;
+            const resolvedPropertySchema = isReferenceObject(propertySchema)
+                ? context.resolveSchemaReference(propertySchema)
+                : propertySchema;
+            const readonly = resolvedPropertySchema.readOnly;
+            const writeonly = resolvedPropertySchema.writeOnly;
 
             const isRequired = allRequired.includes(propertyName) && !readonly;
             const isPropertyOptional = !isRequired;

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/additional-properties-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/additional-properties-edge-cases.json
@@ -1417,9 +1417,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/assembly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/assembly.json
@@ -7989,9 +7989,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -8292,9 +8290,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -8541,9 +8537,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -8679,9 +8673,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -8972,9 +8964,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -8994,9 +8984,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -9754,9 +9742,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -9780,9 +9766,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -10193,9 +10177,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -10455,9 +10437,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -10567,9 +10547,7 @@
                         },
                         "type": "reference"
                       },
-                      "audiences": [],
-                      "readonly": false,
-                      "writeonly": false
+                      "audiences": []
                     },
                     {
                       "conflict": {},
@@ -10665,9 +10643,7 @@
                         },
                         "type": "reference"
                       },
-                      "audiences": [],
-                      "readonly": false,
-                      "writeonly": false
+                      "audiences": []
                     },
                     {
                       "conflict": {},
@@ -11350,9 +11326,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11659,9 +11633,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11842,9 +11814,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -12004,9 +11974,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -12836,9 +12804,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -12979,9 +12945,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -13055,9 +13019,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -13587,9 +13549,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -13998,9 +13958,7 @@
             },
             "audiences": [],
             "conflict": {},
-            "generatedName": "realtimeBaseMessageMessageType",
-            "readonly": false,
-            "writeonly": false
+            "generatedName": "realtimeBaseMessageMessageType"
           }
         ],
         "generatedName": "RealtimeBaseMessage",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/axle.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/axle.json
@@ -125,9 +125,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -205,9 +203,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -485,9 +481,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -790,9 +784,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -811,9 +803,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -1086,9 +1076,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -1107,9 +1095,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -1615,9 +1601,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -1636,9 +1620,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -1886,9 +1868,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -2365,9 +2345,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -2697,9 +2675,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -2974,9 +2950,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -3346,9 +3320,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -3507,9 +3479,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/circular-refs-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/circular-refs-edge-cases.json
@@ -367,9 +367,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -517,9 +515,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -590,9 +586,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -669,9 +663,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -723,9 +715,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -777,9 +767,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -831,9 +819,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -999,9 +985,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/enum-array-references.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/enum-array-references.json
@@ -239,9 +239,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -577,9 +575,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -598,9 +594,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -619,9 +613,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/enum-normalization-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/enum-normalization-edge-cases.json
@@ -36,9 +36,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -57,9 +55,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -78,9 +74,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -99,9 +93,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -120,9 +112,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -141,9 +131,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -162,9 +150,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -183,9 +169,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -204,9 +188,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/example-depth.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/example-depth.json
@@ -118,9 +118,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -140,9 +138,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/examples-null-values.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/examples-null-values.json
@@ -224,9 +224,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -340,9 +338,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -361,9 +357,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/hathora.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/hathora.json
@@ -4381,9 +4381,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -4803,9 +4801,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -5225,9 +5221,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -5679,9 +5673,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -8389,9 +8381,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -9786,9 +9776,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -9853,9 +9841,7 @@
                     },
                     "type": "optional"
                   },
-                  "audiences": [],
-                  "readonly": false,
-                  "writeonly": false
+                  "audiences": []
                 },
                 {
                   "conflict": {},
@@ -9874,9 +9860,7 @@
                     },
                     "type": "optional"
                   },
-                  "audiences": [],
-                  "readonly": false,
-                  "writeonly": false
+                  "audiences": []
                 }
               ],
               "allOfPropertyConflicts": [],
@@ -10091,9 +10075,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -10108,9 +10090,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -10245,9 +10225,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -10262,9 +10240,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -10279,9 +10255,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -10320,9 +10294,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -10401,9 +10373,7 @@
                     },
                     "type": "optional"
                   },
-                  "audiences": [],
-                  "readonly": false,
-                  "writeonly": false
+                  "audiences": []
                 },
                 {
                   "conflict": {},
@@ -10422,9 +10392,7 @@
                     },
                     "type": "optional"
                   },
-                  "audiences": [],
-                  "readonly": false,
-                  "writeonly": false
+                  "audiences": []
                 }
               ],
               "allOfPropertyConflicts": [],
@@ -10565,9 +10533,7 @@
                       },
                       "type": "reference"
                     },
-                    "audiences": [],
-                    "readonly": false,
-                    "writeonly": false
+                    "audiences": []
                   }
                 ],
                 "allOfPropertyConflicts": [],
@@ -10735,9 +10701,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -10752,9 +10716,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -10812,9 +10774,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -10980,9 +10940,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -10997,9 +10955,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11014,9 +10970,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -11449,9 +11403,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11466,9 +11418,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11483,9 +11433,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11500,9 +11448,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -11603,9 +11549,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11620,9 +11564,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -11651,9 +11593,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11668,9 +11608,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11685,9 +11623,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11836,9 +11772,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11873,9 +11807,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11890,9 +11822,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -11921,9 +11851,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -11952,9 +11880,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -11997,9 +11923,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/idiomatic-request-names.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/idiomatic-request-names.json
@@ -525,9 +525,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -677,9 +675,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -698,9 +694,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/non-alphanumeric-characters.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/non-alphanumeric-characters.json
@@ -112,9 +112,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/nullable-types-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/nullable-types-edge-cases.json
@@ -40,9 +40,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -65,9 +63,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -90,9 +86,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             },
             {
               "conflict": {},
@@ -111,9 +105,7 @@
                 },
                 "type": "optional"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/nullable.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/nullable.json
@@ -583,9 +583,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -661,9 +659,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -777,9 +773,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -798,9 +792,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/overlay-resolution.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/overlay-resolution.json
@@ -383,9 +383,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -703,9 +701,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -724,9 +720,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -797,9 +791,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/overrides-resolution.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/overrides-resolution.json
@@ -383,9 +383,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -703,9 +701,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -724,9 +720,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -797,9 +791,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/preserve-schema-ids-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/preserve-schema-ids-edge-cases.json
@@ -219,9 +219,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/readonly-ref-shared-schema.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/readonly-ref-shared-schema.json
@@ -1,0 +1,313 @@
+{
+  "title": "Readonly Ref Shared Schema API",
+  "description": "Tests that readOnly on a $ref'd schema propagates correctly when the parent schema is shared between request and response contexts.\n",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "summary": "Get organization details",
+      "audiences": [],
+      "operationId": "getOrgDetails",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetOrgDetailsRequest",
+      "response": {
+        "description": "Organization details",
+        "schema": {
+          "generatedName": "GetOrgDetailsResponse",
+          "schema": "GetOrgDetailsResponse",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "GET",
+      "path": "/orgs/details",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": "id",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "name": {
+                  "value": {
+                    "value": "name",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "display_name": {
+                  "value": {
+                    "value": "display_name",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "summary": "Update organization details",
+      "audiences": [],
+      "operationId": "updateOrgDetails",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "UpdateOrgDetailsRequest",
+      "request": {
+        "schema": {
+          "generatedName": "UpdateOrgDetailsRequest",
+          "schema": "UpdateOrgDetailsRequest",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Updated organization details",
+        "schema": {
+          "generatedName": "UpdateOrgDetailsResponse",
+          "schema": "UpdateOrgDetailsResponse",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "PATCH",
+      "path": "/orgs/details",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {},
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": "id",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "name": {
+                  "value": {
+                    "value": "name",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "display_name": {
+                  "value": {
+                    "value": "display_name",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "OrgId": {
+        "description": "Organization identifier.",
+        "schema": {
+          "pattern": "^org_[A-Za-z0-9]{16}$",
+          "type": "string"
+        },
+        "generatedName": "OrgId",
+        "groupName": [],
+        "type": "primitive"
+      },
+      "OrgDetails": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "orgDetailsId",
+            "key": "id",
+            "schema": {
+              "generatedName": "OrgDetailsId",
+              "value": {
+                "generatedName": "OrgDetailsId",
+                "schema": "OrgId",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": true
+          },
+          {
+            "conflict": {},
+            "generatedName": "orgDetailsName",
+            "key": "name",
+            "schema": {
+              "generatedName": "OrgDetailsName",
+              "description": "The name of this organization.",
+              "value": {
+                "description": "The name of this organization.",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "OrgDetailsName",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "orgDetailsDisplayName",
+            "key": "display_name",
+            "schema": {
+              "generatedName": "OrgDetailsDisplayName",
+              "description": "Friendly name of this organization.",
+              "value": {
+                "description": "Friendly name of this organization.",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "OrgDetailsDisplayName",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "OrgDetails",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "GetOrgDetailsResponse": {
+        "generatedName": "GetOrgDetailsResponse",
+        "schema": "OrgDetails",
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "reference"
+      },
+      "UpdateOrgDetailsRequest": {
+        "generatedName": "UpdateOrgDetailsRequest",
+        "schema": "OrgDetails",
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "reference"
+      },
+      "UpdateOrgDetailsResponse": {
+        "generatedName": "UpdateOrgDetailsResponse",
+        "schema": "OrgDetails",
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "reference"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/readonly-schema-references.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/readonly-schema-references.json
@@ -511,9 +511,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -532,9 +530,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/readonly-writeonly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/readonly-writeonly.json
@@ -396,9 +396,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -529,9 +527,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -550,9 +546,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/readonly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/readonly.json
@@ -382,9 +382,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -495,9 +493,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -516,9 +512,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/speechify.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/speechify.json
@@ -2637,9 +2637,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -2779,9 +2777,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -2936,9 +2932,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/switchboard.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/switchboard.json
@@ -3145,9 +3145,7 @@
                     },
                     "audiences": [],
                     "conflict": {},
-                    "generatedName": "sessionsEventsResponseStatusData",
-                    "readonly": false,
-                    "writeonly": false
+                    "generatedName": "sessionsEventsResponseStatusData"
                   },
                   {
                     "key": "id",
@@ -3220,9 +3218,7 @@
                     },
                     "audiences": [],
                     "conflict": {},
-                    "generatedName": "sessionsEventsResponseErrorData",
-                    "readonly": false,
-                    "writeonly": false
+                    "generatedName": "sessionsEventsResponseErrorData"
                   },
                   {
                     "key": "id",
@@ -5051,9 +5047,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -5093,9 +5087,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -5183,9 +5175,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -5251,9 +5241,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -5468,9 +5456,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -5574,9 +5560,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -5708,9 +5692,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -5750,9 +5732,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -6097,9 +6077,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -6139,9 +6117,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -6305,9 +6281,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -6336,9 +6310,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -6378,9 +6350,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -6479,9 +6449,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -6825,9 +6793,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -6920,9 +6886,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -7022,9 +6986,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -7090,9 +7052,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -7132,9 +7092,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -7189,9 +7147,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -7247,9 +7203,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -7289,9 +7243,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -7594,9 +7546,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -7636,9 +7586,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/union-extension.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/union-extension.json
@@ -103,9 +103,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -235,9 +233,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/url-reference.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/url-reference.json
@@ -364,9 +364,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/valtown.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/valtown.json
@@ -161,9 +161,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -1518,9 +1516,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -2158,9 +2154,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -2677,9 +2671,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -3464,9 +3456,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],
@@ -7782,9 +7772,7 @@
                 },
                 "type": "reference"
               },
-              "audiences": [],
-              "readonly": false,
-              "writeonly": false
+              "audiences": []
             }
           ],
           "allOfPropertyConflicts": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/vellum.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/vellum.json
@@ -4522,9 +4522,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -4567,9 +4565,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -4630,9 +4626,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -4721,9 +4715,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -5657,9 +5649,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -6521,9 +6511,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -6570,9 +6558,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -6591,9 +6577,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -6636,9 +6620,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -6983,9 +6965,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -7357,9 +7337,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -7829,9 +7807,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -7950,9 +7926,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -7967,9 +7941,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -8553,9 +8525,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -8570,9 +8540,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -8975,9 +8943,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -9525,9 +9491,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -9688,9 +9652,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -10014,9 +9976,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -11187,9 +11147,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -11218,9 +11176,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -11808,9 +11764,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -11853,9 +11807,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -11944,9 +11896,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -12013,9 +11963,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           }
         ],
         "allOfPropertyConflicts": [],
@@ -12157,9 +12105,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -12496,9 +12442,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -12646,9 +12590,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -12763,9 +12705,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},
@@ -12878,9 +12818,7 @@
               },
               "type": "reference"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-ignore.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-ignore.json
@@ -238,9 +238,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-pagination.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-pagination.json
@@ -351,9 +351,7 @@
               },
               "type": "optional"
             },
-            "audiences": [],
-            "readonly": false,
-            "writeonly": false
+            "audiences": []
           },
           {
             "conflict": {},

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly-ref-shared-schema.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly-ref-shared-schema.json
@@ -1,0 +1,219 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "getOrgDetails": {
+              "auth": undefined,
+              "display-name": "Get organization details",
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": {
+                      "display_name": "display_name",
+                      "id": "id",
+                      "name": "name",
+                    },
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/orgs/details",
+              "response": {
+                "docs": "Organization details",
+                "status-code": 200,
+                "type": "GetOrgDetailsResponse",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+            "updateOrgDetails": {
+              "auth": undefined,
+              "display-name": "Update organization details",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {},
+                  "response": {
+                    "body": {
+                      "display_name": "display_name",
+                      "id": "id",
+                      "name": "name",
+                    },
+                  },
+                },
+              ],
+              "method": "PATCH",
+              "pagination": undefined,
+              "path": "/orgs/details",
+              "request": {
+                "body": {
+                  "properties": {
+                    "display_name": {
+                      "docs": "Friendly name of this organization.",
+                      "type": "optional<string>",
+                    },
+                    "name": {
+                      "docs": "The name of this organization.",
+                      "type": "optional<string>",
+                    },
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "OrgDetails",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "response": {
+                "docs": "Updated organization details",
+                "status-code": 200,
+                "type": "UpdateOrgDetailsResponse",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "GetOrgDetailsResponse": "OrgDetailsRead",
+          "OrgDetailsRead": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "display_name": {
+                "docs": "Friendly name of this organization.",
+                "type": "optional<string>",
+              },
+              "id": {
+                "access": "read-only",
+                "type": "optional<OrgId>",
+              },
+              "name": {
+                "docs": "The name of this organization.",
+                "type": "optional<string>",
+              },
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "OrgId": {
+            "docs": "Organization identifier.",
+            "type": "string",
+            "validation": {
+              "format": undefined,
+              "maxLength": undefined,
+              "minLength": undefined,
+              "pattern": "^org_[A-Za-z0-9]{16}$",
+            },
+          },
+          "UpdateOrgDetailsRequest": "OrgDetailsRead",
+          "UpdateOrgDetailsResponse": "OrgDetailsRead",
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    getOrgDetails:
+      path: /orgs/details
+      method: GET
+      source:
+        openapi: ../openapi.yml
+      display-name: Get organization details
+      response:
+        docs: Organization details
+        type: GetOrgDetailsResponse
+        status-code: 200
+      examples:
+        - response:
+            body:
+              id: id
+              name: name
+              display_name: display_name
+    updateOrgDetails:
+      path: /orgs/details
+      method: PATCH
+      source:
+        openapi: ../openapi.yml
+      display-name: Update organization details
+      request:
+        name: OrgDetails
+        body:
+          properties:
+            name:
+              type: optional<string>
+              docs: The name of this organization.
+            display_name:
+              type: optional<string>
+              docs: Friendly name of this organization.
+        content-type: application/json
+      response:
+        docs: Updated organization details
+        type: UpdateOrgDetailsResponse
+        status-code: 200
+      examples:
+        - request: {}
+          response:
+            body:
+              id: id
+              name: name
+              display_name: display_name
+  source:
+    openapi: ../openapi.yml
+types:
+  OrgId:
+    type: string
+    docs: Organization identifier.
+    validation:
+      pattern: ^org_[A-Za-z0-9]{16}$
+  OrgDetailsRead:
+    properties:
+      id:
+        type: optional<OrgId>
+        access: read-only
+      name:
+        type: optional<string>
+        docs: The name of this organization.
+      display_name:
+        type: optional<string>
+        docs: Friendly name of this organization.
+    source:
+      openapi: ../openapi.yml
+  GetOrgDetailsResponse: OrgDetailsRead
+  UpdateOrgDetailsRequest: OrgDetailsRead
+  UpdateOrgDetailsResponse: OrgDetailsRead
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Readonly Ref Shared Schema API",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Readonly Ref Shared Schema API
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-ref-shared-schema/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-ref-shared-schema/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "test",
+  "version": "0.0.0"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-ref-shared-schema/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-ref-shared-schema/fern/generators.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml
+      settings:
+        respect-readonly-schemas: true

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-ref-shared-schema/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-ref-shared-schema/openapi.yml
@@ -1,0 +1,70 @@
+openapi: 3.0.0
+info:
+  title: Readonly Ref Shared Schema API
+  description: >
+    Tests that readOnly on a $ref'd schema propagates correctly when the
+    parent schema is shared between request and response contexts.
+  version: 1.0.0
+
+paths:
+  /orgs/details:
+    get:
+      operationId: getOrgDetails
+      summary: Get organization details
+      responses:
+        "200":
+          description: Organization details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetOrgDetailsResponse"
+
+    patch:
+      operationId: updateOrgDetails
+      summary: Update organization details
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateOrgDetailsRequest"
+      responses:
+        "200":
+          description: Updated organization details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateOrgDetailsResponse"
+
+components:
+  schemas:
+    # A string type marked readOnly at the schema level (not property level).
+    # When OrgDetails.$id references this via $ref, the readOnly should propagate.
+    OrgId:
+      type: string
+      description: Organization identifier.
+      readOnly: true
+      pattern: "^org_[A-Za-z0-9]{16}$"
+
+    # Shared schema used in both request and response.
+    # The "id" property references OrgId which is readOnly.
+    OrgDetails:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          $ref: "#/components/schemas/OrgId"
+        name:
+          type: string
+          description: The name of this organization.
+        display_name:
+          type: string
+          description: Friendly name of this organization.
+
+    # All three alias the same shared schema
+    GetOrgDetailsResponse:
+      $ref: "#/components/schemas/OrgDetails"
+    UpdateOrgDetailsRequest:
+      $ref: "#/components/schemas/OrgDetails"
+    UpdateOrgDetailsResponse:
+      $ref: "#/components/schemas/OrgDetails"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -516,13 +516,28 @@ function getRequest({
 }): ConvertedRequest {
     if (request.type === "json" || request.type === "formUrlEncoded") {
         const maybeSchemaId = request.schema.type === "reference" ? request.schema.schema : undefined;
-        const resolvedSchema =
+        let resolvedSchema =
             request.schema.type === "reference" ? context.getSchema(request.schema.schema, namespace) : request.schema;
+
+        // When respectReadonlySchemas is enabled and the schema has readOnly properties on a write endpoint,
+        // inline the properties so readOnly ones can be filtered out
+        let shouldInlineForReadonly = false;
+        if (context.options.respectReadonlySchemas && isWriteMethod(endpoint.method)) {
+            let effectiveSchema = resolvedSchema;
+            while (effectiveSchema?.type === "reference") {
+                effectiveSchema = context.getSchema(effectiveSchema.schema, namespace);
+            }
+            if (effectiveSchema?.type === "object" && effectiveSchema.properties.some((p) => p.readonly)) {
+                shouldInlineForReadonly = true;
+                resolvedSchema = effectiveSchema;
+            }
+        }
+
         // the request body is referenced if it is not an object or if other parts of the spec
         // refer to the same type
         if (
             resolvedSchema?.type !== "object" ||
-            (maybeSchemaId != null && nonRequestReferencedSchemas.includes(maybeSchemaId))
+            (maybeSchemaId != null && nonRequestReferencedSchemas.includes(maybeSchemaId) && !shouldInlineForReadonly)
         ) {
             const requestTypeReference = buildTypeReference({
                 schema: request.schema,
@@ -765,7 +780,7 @@ function getRequest({
             convertedRequestValue.docs = request.description;
         }
         return {
-            schemaIdsToExclude: maybeSchemaId != null ? [maybeSchemaId] : [],
+            schemaIdsToExclude: maybeSchemaId != null && !shouldInlineForReadonly ? [maybeSchemaId] : [],
             value: convertedRequestValue
         };
     } else if (request.type === "octetStream") {

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.15.1
+  changelogEntry:
+    - summary: |
+        Fix `readOnly`/`writeOnly` not being detected on properties that use
+        `$ref` to reference a schema with `readOnly: true`/`writeOnly: true`.
+      type: fix
+  createdAt: "2026-03-06"
+  irVersion: 65
+
 - version: 4.15.0
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/server-sent-event-examples.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/server-sent-event-examples.json
@@ -819,7 +819,115 @@
             "docs": null
         }
     },
-    "errors": {},
+    "errors": {
+        "error_completions:BadRequestError": {
+            "name": {
+                "name": {
+                    "originalName": "BadRequestError",
+                    "camelCase": {
+                        "unsafeName": "badRequestError",
+                        "safeName": "badRequestError"
+                    },
+                    "snakeCase": {
+                        "unsafeName": "bad_request_error",
+                        "safeName": "bad_request_error"
+                    },
+                    "screamingSnakeCase": {
+                        "unsafeName": "BAD_REQUEST_ERROR",
+                        "safeName": "BAD_REQUEST_ERROR"
+                    },
+                    "pascalCase": {
+                        "unsafeName": "BadRequestError",
+                        "safeName": "BadRequestError"
+                    }
+                },
+                "fernFilepath": {
+                    "allParts": [
+                        {
+                            "originalName": "completions",
+                            "camelCase": {
+                                "unsafeName": "completions",
+                                "safeName": "completions"
+                            },
+                            "snakeCase": {
+                                "unsafeName": "completions",
+                                "safeName": "completions"
+                            },
+                            "screamingSnakeCase": {
+                                "unsafeName": "COMPLETIONS",
+                                "safeName": "COMPLETIONS"
+                            },
+                            "pascalCase": {
+                                "unsafeName": "Completions",
+                                "safeName": "Completions"
+                            }
+                        }
+                    ],
+                    "packagePath": [],
+                    "file": {
+                        "originalName": "completions",
+                        "camelCase": {
+                            "unsafeName": "completions",
+                            "safeName": "completions"
+                        },
+                        "snakeCase": {
+                            "unsafeName": "completions",
+                            "safeName": "completions"
+                        },
+                        "screamingSnakeCase": {
+                            "unsafeName": "COMPLETIONS",
+                            "safeName": "COMPLETIONS"
+                        },
+                        "pascalCase": {
+                            "unsafeName": "Completions",
+                            "safeName": "Completions"
+                        }
+                    }
+                },
+                "errorId": "error_completions:BadRequestError"
+            },
+            "discriminantValue": {
+                "name": {
+                    "originalName": "BadRequestError",
+                    "camelCase": {
+                        "unsafeName": "badRequestError",
+                        "safeName": "badRequestError"
+                    },
+                    "snakeCase": {
+                        "unsafeName": "bad_request_error",
+                        "safeName": "bad_request_error"
+                    },
+                    "screamingSnakeCase": {
+                        "unsafeName": "BAD_REQUEST_ERROR",
+                        "safeName": "BAD_REQUEST_ERROR"
+                    },
+                    "pascalCase": {
+                        "unsafeName": "BadRequestError",
+                        "safeName": "BadRequestError"
+                    }
+                },
+                "wireValue": "BadRequestError"
+            },
+            "statusCode": 400,
+            "isWildcardStatusCode": null,
+            "type": {
+                "_type": "primitive",
+                "primitive": {
+                    "v1": "STRING",
+                    "v2": {
+                        "type": "string",
+                        "default": null,
+                        "validation": null
+                    }
+                }
+            },
+            "examples": [],
+            "v2Examples": null,
+            "displayName": null,
+            "headers": [],
+            "docs": null
+        }
+    },
     "services": {
         "service_completions": {
             "availability": null,
@@ -1146,7 +1254,76 @@
                         "docs": null
                     },
                     "v2Responses": null,
-                    "errors": [],
+                    "errors": [
+                        {
+                            "error": {
+                                "name": {
+                                    "originalName": "BadRequestError",
+                                    "camelCase": {
+                                        "unsafeName": "badRequestError",
+                                        "safeName": "badRequestError"
+                                    },
+                                    "snakeCase": {
+                                        "unsafeName": "bad_request_error",
+                                        "safeName": "bad_request_error"
+                                    },
+                                    "screamingSnakeCase": {
+                                        "unsafeName": "BAD_REQUEST_ERROR",
+                                        "safeName": "BAD_REQUEST_ERROR"
+                                    },
+                                    "pascalCase": {
+                                        "unsafeName": "BadRequestError",
+                                        "safeName": "BadRequestError"
+                                    }
+                                },
+                                "fernFilepath": {
+                                    "allParts": [
+                                        {
+                                            "originalName": "completions",
+                                            "camelCase": {
+                                                "unsafeName": "completions",
+                                                "safeName": "completions"
+                                            },
+                                            "snakeCase": {
+                                                "unsafeName": "completions",
+                                                "safeName": "completions"
+                                            },
+                                            "screamingSnakeCase": {
+                                                "unsafeName": "COMPLETIONS",
+                                                "safeName": "COMPLETIONS"
+                                            },
+                                            "pascalCase": {
+                                                "unsafeName": "Completions",
+                                                "safeName": "Completions"
+                                            }
+                                        }
+                                    ],
+                                    "packagePath": [],
+                                    "file": {
+                                        "originalName": "completions",
+                                        "camelCase": {
+                                            "unsafeName": "completions",
+                                            "safeName": "completions"
+                                        },
+                                        "snakeCase": {
+                                            "unsafeName": "completions",
+                                            "safeName": "completions"
+                                        },
+                                        "screamingSnakeCase": {
+                                            "unsafeName": "COMPLETIONS",
+                                            "safeName": "COMPLETIONS"
+                                        },
+                                        "pascalCase": {
+                                            "unsafeName": "Completions",
+                                            "safeName": "Completions"
+                                        }
+                                    }
+                                },
+                                "errorId": "error_completions:BadRequestError"
+                            },
+                            "docs": null
+                        }
+                    ],
                     "userSpecifiedExamples": [
                         {
                             "example": {
@@ -1850,6 +2027,165 @@
                                 "docs": null
                             },
                             "codeSamples": null
+                        },
+                        {
+                            "example": {
+                                "id": "Bad request",
+                                "name": {
+                                    "originalName": "Bad request",
+                                    "camelCase": {
+                                        "unsafeName": "badRequest",
+                                        "safeName": "badRequest"
+                                    },
+                                    "snakeCase": {
+                                        "unsafeName": "bad_request",
+                                        "safeName": "bad_request"
+                                    },
+                                    "screamingSnakeCase": {
+                                        "unsafeName": "BAD_REQUEST",
+                                        "safeName": "BAD_REQUEST"
+                                    },
+                                    "pascalCase": {
+                                        "unsafeName": "BadRequest",
+                                        "safeName": "BadRequest"
+                                    }
+                                },
+                                "url": "/stream",
+                                "rootPathParameters": [],
+                                "endpointPathParameters": [],
+                                "servicePathParameters": [],
+                                "endpointHeaders": [],
+                                "serviceHeaders": [],
+                                "queryParameters": [],
+                                "request": {
+                                    "type": "inlinedRequestBody",
+                                    "properties": [
+                                        {
+                                            "name": {
+                                                "name": {
+                                                    "originalName": "query",
+                                                    "camelCase": {
+                                                        "unsafeName": "query",
+                                                        "safeName": "query"
+                                                    },
+                                                    "snakeCase": {
+                                                        "unsafeName": "query",
+                                                        "safeName": "query"
+                                                    },
+                                                    "screamingSnakeCase": {
+                                                        "unsafeName": "QUERY",
+                                                        "safeName": "QUERY"
+                                                    },
+                                                    "pascalCase": {
+                                                        "unsafeName": "Query",
+                                                        "safeName": "Query"
+                                                    }
+                                                },
+                                                "wireValue": "query"
+                                            },
+                                            "value": {
+                                                "shape": {
+                                                    "type": "primitive",
+                                                    "primitive": {
+                                                        "type": "string",
+                                                        "string": {
+                                                            "original": ""
+                                                        }
+                                                    }
+                                                },
+                                                "jsonExample": ""
+                                            },
+                                            "originalTypeDeclaration": null
+                                        }
+                                    ],
+                                    "extraProperties": null,
+                                    "jsonExample": {
+                                        "query": ""
+                                    }
+                                },
+                                "response": {
+                                    "type": "error",
+                                    "error": {
+                                        "name": {
+                                            "originalName": "BadRequestError",
+                                            "camelCase": {
+                                                "unsafeName": "badRequestError",
+                                                "safeName": "badRequestError"
+                                            },
+                                            "snakeCase": {
+                                                "unsafeName": "bad_request_error",
+                                                "safeName": "bad_request_error"
+                                            },
+                                            "screamingSnakeCase": {
+                                                "unsafeName": "BAD_REQUEST_ERROR",
+                                                "safeName": "BAD_REQUEST_ERROR"
+                                            },
+                                            "pascalCase": {
+                                                "unsafeName": "BadRequestError",
+                                                "safeName": "BadRequestError"
+                                            }
+                                        },
+                                        "fernFilepath": {
+                                            "allParts": [
+                                                {
+                                                    "originalName": "completions",
+                                                    "camelCase": {
+                                                        "unsafeName": "completions",
+                                                        "safeName": "completions"
+                                                    },
+                                                    "snakeCase": {
+                                                        "unsafeName": "completions",
+                                                        "safeName": "completions"
+                                                    },
+                                                    "screamingSnakeCase": {
+                                                        "unsafeName": "COMPLETIONS",
+                                                        "safeName": "COMPLETIONS"
+                                                    },
+                                                    "pascalCase": {
+                                                        "unsafeName": "Completions",
+                                                        "safeName": "Completions"
+                                                    }
+                                                }
+                                            ],
+                                            "packagePath": [],
+                                            "file": {
+                                                "originalName": "completions",
+                                                "camelCase": {
+                                                    "unsafeName": "completions",
+                                                    "safeName": "completions"
+                                                },
+                                                "snakeCase": {
+                                                    "unsafeName": "completions",
+                                                    "safeName": "completions"
+                                                },
+                                                "screamingSnakeCase": {
+                                                    "unsafeName": "COMPLETIONS",
+                                                    "safeName": "COMPLETIONS"
+                                                },
+                                                "pascalCase": {
+                                                    "unsafeName": "Completions",
+                                                    "safeName": "Completions"
+                                                }
+                                            }
+                                        },
+                                        "errorId": "error_completions:BadRequestError"
+                                    },
+                                    "body": {
+                                        "shape": {
+                                            "type": "primitive",
+                                            "primitive": {
+                                                "type": "string",
+                                                "string": {
+                                                    "original": "bad request"
+                                                }
+                                            }
+                                        },
+                                        "jsonExample": "bad request"
+                                    }
+                                },
+                                "docs": null
+                            },
+                            "codeSamples": null
                         }
                     ],
                     "autogeneratedExamples": [
@@ -2228,6 +2564,146 @@
                                 },
                                 "docs": null
                             }
+                        },
+                        {
+                            "example": {
+                                "id": "cbc87cc2",
+                                "url": "/stream",
+                                "name": null,
+                                "endpointHeaders": [],
+                                "endpointPathParameters": [],
+                                "queryParameters": [],
+                                "servicePathParameters": [],
+                                "serviceHeaders": [],
+                                "rootPathParameters": [],
+                                "request": {
+                                    "type": "inlinedRequestBody",
+                                    "properties": [
+                                        {
+                                            "name": {
+                                                "name": {
+                                                    "originalName": "query",
+                                                    "camelCase": {
+                                                        "unsafeName": "query",
+                                                        "safeName": "query"
+                                                    },
+                                                    "snakeCase": {
+                                                        "unsafeName": "query",
+                                                        "safeName": "query"
+                                                    },
+                                                    "screamingSnakeCase": {
+                                                        "unsafeName": "QUERY",
+                                                        "safeName": "QUERY"
+                                                    },
+                                                    "pascalCase": {
+                                                        "unsafeName": "Query",
+                                                        "safeName": "Query"
+                                                    }
+                                                },
+                                                "wireValue": "query"
+                                            },
+                                            "originalTypeDeclaration": null,
+                                            "value": {
+                                                "shape": {
+                                                    "type": "primitive",
+                                                    "primitive": {
+                                                        "type": "string",
+                                                        "string": {
+                                                            "original": "query"
+                                                        }
+                                                    }
+                                                },
+                                                "jsonExample": "query"
+                                            }
+                                        }
+                                    ],
+                                    "extraProperties": null,
+                                    "jsonExample": {
+                                        "query": "query"
+                                    }
+                                },
+                                "response": {
+                                    "type": "error",
+                                    "body": {
+                                        "shape": {
+                                            "type": "primitive",
+                                            "primitive": {
+                                                "type": "string",
+                                                "string": {
+                                                    "original": "string"
+                                                }
+                                            }
+                                        },
+                                        "jsonExample": "string"
+                                    },
+                                    "error": {
+                                        "name": {
+                                            "originalName": "BadRequestError",
+                                            "camelCase": {
+                                                "unsafeName": "badRequestError",
+                                                "safeName": "badRequestError"
+                                            },
+                                            "snakeCase": {
+                                                "unsafeName": "bad_request_error",
+                                                "safeName": "bad_request_error"
+                                            },
+                                            "screamingSnakeCase": {
+                                                "unsafeName": "BAD_REQUEST_ERROR",
+                                                "safeName": "BAD_REQUEST_ERROR"
+                                            },
+                                            "pascalCase": {
+                                                "unsafeName": "BadRequestError",
+                                                "safeName": "BadRequestError"
+                                            }
+                                        },
+                                        "fernFilepath": {
+                                            "allParts": [
+                                                {
+                                                    "originalName": "completions",
+                                                    "camelCase": {
+                                                        "unsafeName": "completions",
+                                                        "safeName": "completions"
+                                                    },
+                                                    "snakeCase": {
+                                                        "unsafeName": "completions",
+                                                        "safeName": "completions"
+                                                    },
+                                                    "screamingSnakeCase": {
+                                                        "unsafeName": "COMPLETIONS",
+                                                        "safeName": "COMPLETIONS"
+                                                    },
+                                                    "pascalCase": {
+                                                        "unsafeName": "Completions",
+                                                        "safeName": "Completions"
+                                                    }
+                                                }
+                                            ],
+                                            "packagePath": [],
+                                            "file": {
+                                                "originalName": "completions",
+                                                "camelCase": {
+                                                    "unsafeName": "completions",
+                                                    "safeName": "completions"
+                                                },
+                                                "snakeCase": {
+                                                    "unsafeName": "completions",
+                                                    "safeName": "completions"
+                                                },
+                                                "screamingSnakeCase": {
+                                                    "unsafeName": "COMPLETIONS",
+                                                    "safeName": "COMPLETIONS"
+                                                },
+                                                "pascalCase": {
+                                                    "unsafeName": "Completions",
+                                                    "safeName": "Completions"
+                                                }
+                                            }
+                                        },
+                                        "errorId": "error_completions:BadRequestError"
+                                    }
+                                },
+                                "docs": null
+                            }
                         }
                     ],
                     "pagination": null,
@@ -2504,7 +2980,76 @@
                         "docs": null
                     },
                     "v2Responses": null,
-                    "errors": [],
+                    "errors": [
+                        {
+                            "error": {
+                                "name": {
+                                    "originalName": "BadRequestError",
+                                    "camelCase": {
+                                        "unsafeName": "badRequestError",
+                                        "safeName": "badRequestError"
+                                    },
+                                    "snakeCase": {
+                                        "unsafeName": "bad_request_error",
+                                        "safeName": "bad_request_error"
+                                    },
+                                    "screamingSnakeCase": {
+                                        "unsafeName": "BAD_REQUEST_ERROR",
+                                        "safeName": "BAD_REQUEST_ERROR"
+                                    },
+                                    "pascalCase": {
+                                        "unsafeName": "BadRequestError",
+                                        "safeName": "BadRequestError"
+                                    }
+                                },
+                                "fernFilepath": {
+                                    "allParts": [
+                                        {
+                                            "originalName": "completions",
+                                            "camelCase": {
+                                                "unsafeName": "completions",
+                                                "safeName": "completions"
+                                            },
+                                            "snakeCase": {
+                                                "unsafeName": "completions",
+                                                "safeName": "completions"
+                                            },
+                                            "screamingSnakeCase": {
+                                                "unsafeName": "COMPLETIONS",
+                                                "safeName": "COMPLETIONS"
+                                            },
+                                            "pascalCase": {
+                                                "unsafeName": "Completions",
+                                                "safeName": "Completions"
+                                            }
+                                        }
+                                    ],
+                                    "packagePath": [],
+                                    "file": {
+                                        "originalName": "completions",
+                                        "camelCase": {
+                                            "unsafeName": "completions",
+                                            "safeName": "completions"
+                                        },
+                                        "snakeCase": {
+                                            "unsafeName": "completions",
+                                            "safeName": "completions"
+                                        },
+                                        "screamingSnakeCase": {
+                                            "unsafeName": "COMPLETIONS",
+                                            "safeName": "COMPLETIONS"
+                                        },
+                                        "pascalCase": {
+                                            "unsafeName": "Completions",
+                                            "safeName": "Completions"
+                                        }
+                                    }
+                                },
+                                "errorId": "error_completions:BadRequestError"
+                            },
+                            "docs": null
+                        }
+                    ],
                     "userSpecifiedExamples": [
                         {
                             "example": {
@@ -2833,6 +3378,165 @@
                                 "docs": null
                             },
                             "codeSamples": null
+                        },
+                        {
+                            "example": {
+                                "id": "Bad request",
+                                "name": {
+                                    "originalName": "Bad request",
+                                    "camelCase": {
+                                        "unsafeName": "badRequest",
+                                        "safeName": "badRequest"
+                                    },
+                                    "snakeCase": {
+                                        "unsafeName": "bad_request",
+                                        "safeName": "bad_request"
+                                    },
+                                    "screamingSnakeCase": {
+                                        "unsafeName": "BAD_REQUEST",
+                                        "safeName": "BAD_REQUEST"
+                                    },
+                                    "pascalCase": {
+                                        "unsafeName": "BadRequest",
+                                        "safeName": "BadRequest"
+                                    }
+                                },
+                                "url": "/stream-events",
+                                "rootPathParameters": [],
+                                "endpointPathParameters": [],
+                                "servicePathParameters": [],
+                                "endpointHeaders": [],
+                                "serviceHeaders": [],
+                                "queryParameters": [],
+                                "request": {
+                                    "type": "inlinedRequestBody",
+                                    "properties": [
+                                        {
+                                            "name": {
+                                                "name": {
+                                                    "originalName": "query",
+                                                    "camelCase": {
+                                                        "unsafeName": "query",
+                                                        "safeName": "query"
+                                                    },
+                                                    "snakeCase": {
+                                                        "unsafeName": "query",
+                                                        "safeName": "query"
+                                                    },
+                                                    "screamingSnakeCase": {
+                                                        "unsafeName": "QUERY",
+                                                        "safeName": "QUERY"
+                                                    },
+                                                    "pascalCase": {
+                                                        "unsafeName": "Query",
+                                                        "safeName": "Query"
+                                                    }
+                                                },
+                                                "wireValue": "query"
+                                            },
+                                            "value": {
+                                                "shape": {
+                                                    "type": "primitive",
+                                                    "primitive": {
+                                                        "type": "string",
+                                                        "string": {
+                                                            "original": ""
+                                                        }
+                                                    }
+                                                },
+                                                "jsonExample": ""
+                                            },
+                                            "originalTypeDeclaration": null
+                                        }
+                                    ],
+                                    "extraProperties": null,
+                                    "jsonExample": {
+                                        "query": ""
+                                    }
+                                },
+                                "response": {
+                                    "type": "error",
+                                    "error": {
+                                        "name": {
+                                            "originalName": "BadRequestError",
+                                            "camelCase": {
+                                                "unsafeName": "badRequestError",
+                                                "safeName": "badRequestError"
+                                            },
+                                            "snakeCase": {
+                                                "unsafeName": "bad_request_error",
+                                                "safeName": "bad_request_error"
+                                            },
+                                            "screamingSnakeCase": {
+                                                "unsafeName": "BAD_REQUEST_ERROR",
+                                                "safeName": "BAD_REQUEST_ERROR"
+                                            },
+                                            "pascalCase": {
+                                                "unsafeName": "BadRequestError",
+                                                "safeName": "BadRequestError"
+                                            }
+                                        },
+                                        "fernFilepath": {
+                                            "allParts": [
+                                                {
+                                                    "originalName": "completions",
+                                                    "camelCase": {
+                                                        "unsafeName": "completions",
+                                                        "safeName": "completions"
+                                                    },
+                                                    "snakeCase": {
+                                                        "unsafeName": "completions",
+                                                        "safeName": "completions"
+                                                    },
+                                                    "screamingSnakeCase": {
+                                                        "unsafeName": "COMPLETIONS",
+                                                        "safeName": "COMPLETIONS"
+                                                    },
+                                                    "pascalCase": {
+                                                        "unsafeName": "Completions",
+                                                        "safeName": "Completions"
+                                                    }
+                                                }
+                                            ],
+                                            "packagePath": [],
+                                            "file": {
+                                                "originalName": "completions",
+                                                "camelCase": {
+                                                    "unsafeName": "completions",
+                                                    "safeName": "completions"
+                                                },
+                                                "snakeCase": {
+                                                    "unsafeName": "completions",
+                                                    "safeName": "completions"
+                                                },
+                                                "screamingSnakeCase": {
+                                                    "unsafeName": "COMPLETIONS",
+                                                    "safeName": "COMPLETIONS"
+                                                },
+                                                "pascalCase": {
+                                                    "unsafeName": "Completions",
+                                                    "safeName": "Completions"
+                                                }
+                                            }
+                                        },
+                                        "errorId": "error_completions:BadRequestError"
+                                    },
+                                    "body": {
+                                        "shape": {
+                                            "type": "primitive",
+                                            "primitive": {
+                                                "type": "string",
+                                                "string": {
+                                                    "original": "bad request"
+                                                }
+                                            }
+                                        },
+                                        "jsonExample": "bad request"
+                                    }
+                                },
+                                "docs": null
+                            },
+                            "codeSamples": null
                         }
                     ],
                     "autogeneratedExamples": [
@@ -3140,6 +3844,146 @@
                                                 "event": "completion"
                                             }
                                         ]
+                                    }
+                                },
+                                "docs": null
+                            }
+                        },
+                        {
+                            "example": {
+                                "id": "cbc87cc2",
+                                "url": "/stream-events",
+                                "name": null,
+                                "endpointHeaders": [],
+                                "endpointPathParameters": [],
+                                "queryParameters": [],
+                                "servicePathParameters": [],
+                                "serviceHeaders": [],
+                                "rootPathParameters": [],
+                                "request": {
+                                    "type": "inlinedRequestBody",
+                                    "properties": [
+                                        {
+                                            "name": {
+                                                "name": {
+                                                    "originalName": "query",
+                                                    "camelCase": {
+                                                        "unsafeName": "query",
+                                                        "safeName": "query"
+                                                    },
+                                                    "snakeCase": {
+                                                        "unsafeName": "query",
+                                                        "safeName": "query"
+                                                    },
+                                                    "screamingSnakeCase": {
+                                                        "unsafeName": "QUERY",
+                                                        "safeName": "QUERY"
+                                                    },
+                                                    "pascalCase": {
+                                                        "unsafeName": "Query",
+                                                        "safeName": "Query"
+                                                    }
+                                                },
+                                                "wireValue": "query"
+                                            },
+                                            "originalTypeDeclaration": null,
+                                            "value": {
+                                                "shape": {
+                                                    "type": "primitive",
+                                                    "primitive": {
+                                                        "type": "string",
+                                                        "string": {
+                                                            "original": "query"
+                                                        }
+                                                    }
+                                                },
+                                                "jsonExample": "query"
+                                            }
+                                        }
+                                    ],
+                                    "extraProperties": null,
+                                    "jsonExample": {
+                                        "query": "query"
+                                    }
+                                },
+                                "response": {
+                                    "type": "error",
+                                    "body": {
+                                        "shape": {
+                                            "type": "primitive",
+                                            "primitive": {
+                                                "type": "string",
+                                                "string": {
+                                                    "original": "string"
+                                                }
+                                            }
+                                        },
+                                        "jsonExample": "string"
+                                    },
+                                    "error": {
+                                        "name": {
+                                            "originalName": "BadRequestError",
+                                            "camelCase": {
+                                                "unsafeName": "badRequestError",
+                                                "safeName": "badRequestError"
+                                            },
+                                            "snakeCase": {
+                                                "unsafeName": "bad_request_error",
+                                                "safeName": "bad_request_error"
+                                            },
+                                            "screamingSnakeCase": {
+                                                "unsafeName": "BAD_REQUEST_ERROR",
+                                                "safeName": "BAD_REQUEST_ERROR"
+                                            },
+                                            "pascalCase": {
+                                                "unsafeName": "BadRequestError",
+                                                "safeName": "BadRequestError"
+                                            }
+                                        },
+                                        "fernFilepath": {
+                                            "allParts": [
+                                                {
+                                                    "originalName": "completions",
+                                                    "camelCase": {
+                                                        "unsafeName": "completions",
+                                                        "safeName": "completions"
+                                                    },
+                                                    "snakeCase": {
+                                                        "unsafeName": "completions",
+                                                        "safeName": "completions"
+                                                    },
+                                                    "screamingSnakeCase": {
+                                                        "unsafeName": "COMPLETIONS",
+                                                        "safeName": "COMPLETIONS"
+                                                    },
+                                                    "pascalCase": {
+                                                        "unsafeName": "Completions",
+                                                        "safeName": "Completions"
+                                                    }
+                                                }
+                                            ],
+                                            "packagePath": [],
+                                            "file": {
+                                                "originalName": "completions",
+                                                "camelCase": {
+                                                    "unsafeName": "completions",
+                                                    "safeName": "completions"
+                                                },
+                                                "snakeCase": {
+                                                    "unsafeName": "completions",
+                                                    "safeName": "completions"
+                                                },
+                                                "screamingSnakeCase": {
+                                                    "unsafeName": "COMPLETIONS",
+                                                    "safeName": "COMPLETIONS"
+                                                },
+                                                "pascalCase": {
+                                                    "unsafeName": "Completions",
+                                                    "safeName": "Completions"
+                                                }
+                                            }
+                                        },
+                                        "errorId": "error_completions:BadRequestError"
                                     }
                                 },
                                 "docs": null
@@ -4177,7 +5021,9 @@
                 "type_completions:ErrorEvent",
                 "type_completions:StreamEvent"
             ],
-            "errors": [],
+            "errors": [
+                "error_completions:BadRequestError"
+            ],
             "subpackages": [],
             "navigationConfig": null,
             "webhooks": null,


### PR DESCRIPTION
## Description
When a property was indirect, i.e. `$ref`erenced some other property, the parser had a fallback that would automatically set `readOnly: false`, which would screw up `respect-readonly-schemas` formatting; now it correctly populates `readOnly` through the reference. (Also does this for `writeOnly`.)

(Note https://spec.openapis.org/oas/v3.0.3#fixed-fields-19's entries on readOnly and writeOnly.)

## Changes Made
`convertObject.ts`, `buildEndpoint.ts` in the `openapi-ir-parser`.

## Testing
A new `openapi-ir-to-fern-test`, `readonly-ref-shared-schema`, to hit this test case. Note that many other `openapi-ir` snapshots have dropped their `readOnly: false`s; this is because we were explicitly setting that to false before and are now just leaving it undefined, which is the same behavior for cheaper.
- [X] Unit tests added/updated
- [X] Manual testing completed
