### PR TITLE
feat(seed): add smart affected detection for --generator affected --fixture affected

### DIFF
--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -6,6 +6,13 @@ import { writeFile } from "fs/promises";
 import { minimatch } from "minimatch";
 import yargs, { Argv } from "yargs";
 import { hideBin } from "yargs/helpers";
+import {
+    detectAffected,
+    findRepoRoot,
+    getChangedFiles,
+    resolveAffectedFixtures,
+    resolveAffectedGenerators
+} from "./commands/affected/index.js";
 import { cleanOrphanedSeedFolders } from "./commands/clean/index.js";
 import { generateCliChangelog } from "./commands/generate/generateCliChangelog.js";
 import { generateGeneratorChangelog } from "./commands/generate/generateGeneratorChangelog.js";
@@ -65,6 +72,7 @@ export async function tryRunCli(): Promise<void> {
     addImgCommand(cli);
     addGetAvailableFixturesCommand(cli);
     addListTestFixturesCommand(cli);
+    addAffectedCommand(cli);
     addCleanCommand(cli);
     addRegisterCommands(cli);
     addPublishCommands(cli);
@@ -143,10 +151,61 @@ function addTestCommand(cli: Argv) {
                     choices: ["docker", "podman"],
                     demandOption: false,
                     description: "Explicitly specify which container runtime to use (docker or podman)"
+                })
+                .option("base-ref", {
+                    type: "string",
+                    demandOption: false,
+                    default: "origin/main",
+                    description: 'Git ref to diff against when using "affected" mode (default: origin/main)'
                 }),
         async (argv) => {
             const generators = await loadGeneratorWorkspaces();
-            if (argv.generator != null) {
+
+            // Handle "affected" mode for --generator and --fixture
+            const isGeneratorAffected =
+                argv.generator != null && argv.generator.length === 1 && argv.generator[0] === "affected";
+            const isFixtureAffected =
+                argv.fixture != null && argv.fixture.length === 1 && argv.fixture[0] === "affected";
+
+            let affectedResult = undefined;
+            if (isGeneratorAffected || isFixtureAffected) {
+                const repoRoot = findRepoRoot();
+                const changedFiles = getChangedFiles(argv.baseRef, repoRoot);
+                affectedResult = detectAffected(changedFiles, generators);
+
+                // Log the detection summary
+                console.log("\n=== Affected Detection ===");
+                for (const line of affectedResult.summary) {
+                    console.log(`  ${line}`);
+                }
+
+                if (isGeneratorAffected) {
+                    const affectedGenerators = resolveAffectedGenerators(affectedResult, generators);
+                    if (affectedGenerators.length === 0) {
+                        console.log("No affected generators detected. Nothing to run.");
+                        return;
+                    }
+                    argv.generator = affectedGenerators.map((g) => g.workspaceName);
+                    console.log(`Affected generators: ${argv.generator.join(", ")}`);
+                }
+
+                if (isFixtureAffected) {
+                    if (affectedResult.allFixturesAffected) {
+                        // Let the per-generator fixture resolution handle it (will use all fixtures)
+                        argv.fixture = undefined;
+                        console.log("All fixtures affected.");
+                    } else if (affectedResult.affectedFixtures.length === 0) {
+                        console.log("No affected fixtures detected. Nothing to run.");
+                        return;
+                    } else {
+                        argv.fixture = affectedResult.affectedFixtures;
+                        console.log(`Affected fixtures: ${argv.fixture.join(", ")}`);
+                    }
+                }
+                console.log("==========================\n");
+            }
+
+            if (argv.generator != null && !isGeneratorAffected) {
                 throwIfGeneratorDoesNotExist({ seedWorkspaces: generators, generators: argv.generator });
             }
 
@@ -165,6 +224,16 @@ function addTestCommand(cli: Argv) {
                 // If no fixtures passed in, use all available fixtures (without output folders)
                 if (argv.fixture == null) {
                     argv.fixture = getAvailableFixtures(generator, false);
+                } else if (isFixtureAffected && affectedResult != null && !affectedResult.allFixturesAffected) {
+                    // In affected mode, resolve fixtures per-generator (filter by what's available)
+                    const available = getAvailableFixtures(generator, false);
+                    argv.fixture = resolveAffectedFixtures(affectedResult, available);
+                    if (argv.fixture.length === 0) {
+                        console.log(
+                            `No affected fixtures available for generator ${generator.workspaceName}. Skipping.`
+                        );
+                        continue;
+                    }
                 } else {
                     const availableFixturesForGlobbing = getAvailableFixtures(generator, false);
                     argv.fixture = expandFixtureGlobs(argv.fixture, availableFixturesForGlobbing);
@@ -649,6 +718,71 @@ function addListTestFixturesCommand(cli: Argv) {
 
             // Output JSON to stdout (can be piped or captured directly)
             console.log(JSON.stringify({ generators: result }));
+        }
+    );
+}
+
+function addAffectedCommand(cli: Argv) {
+    cli.command(
+        "affected",
+        "Detect which generators and fixtures are affected by changes in the current branch",
+        (yargs) =>
+            yargs
+                .option("base-ref", {
+                    type: "string",
+                    demandOption: false,
+                    default: "origin/main",
+                    description: "Git ref to diff against (default: origin/main)"
+                })
+                .option("json", {
+                    type: "boolean",
+                    demandOption: false,
+                    default: false,
+                    description: "Output results as JSON"
+                }),
+        async (argv) => {
+            const generators = await loadGeneratorWorkspaces();
+            const repoRoot = findRepoRoot();
+            const changedFiles = getChangedFiles(argv.baseRef, repoRoot);
+            const affected = detectAffected(changedFiles, generators);
+
+            if (argv.json) {
+                const resolvedGenerators = resolveAffectedGenerators(affected, generators);
+                console.log(
+                    JSON.stringify(
+                        {
+                            allGeneratorsAffected: affected.allGeneratorsAffected,
+                            allFixturesAffected: affected.allFixturesAffected,
+                            generators: resolvedGenerators.map((g) => g.workspaceName),
+                            fixtures: affected.affectedFixtures,
+                            summary: affected.summary
+                        },
+                        null,
+                        2
+                    )
+                );
+            } else {
+                console.log("\n=== Affected Detection ===");
+                for (const line of affected.summary) {
+                    console.log(`  ${line}`);
+                }
+
+                const resolvedGenerators = resolveAffectedGenerators(affected, generators);
+                console.log(`\nAffected generators (${resolvedGenerators.length}):`);
+                for (const gen of resolvedGenerators) {
+                    console.log(`  - ${gen.workspaceName}`);
+                }
+
+                if (!affected.allFixturesAffected && affected.affectedFixtures.length > 0) {
+                    console.log(`\nAffected fixtures (${affected.affectedFixtures.length}):`);
+                    for (const fixture of affected.affectedFixtures) {
+                        console.log(`  - ${fixture}`);
+                    }
+                } else if (affected.allFixturesAffected) {
+                    console.log("\nAll fixtures affected.");
+                }
+                console.log("==========================\n");
+            }
         }
     );
 }

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -197,12 +197,26 @@ function addTestCommand(cli: Argv) {
                         // Let the per-generator fixture resolution handle it (will use all fixtures)
                         argv.fixture = undefined;
                         console.log("All fixtures affected.");
-                    } else if (affectedResult.affectedFixtures.length === 0) {
+                    } else if (
+                        affectedResult.affectedFixtures.length === 0 &&
+                        affectedResult.generatorsWithAllFixtures.length === 0
+                    ) {
                         console.log("No affected fixtures detected. Nothing to run.");
                         return;
                     } else {
-                        argv.fixture = affectedResult.affectedFixtures;
-                        console.log(`Affected fixtures: ${argv.fixture.join(", ")}`);
+                        // Keep argv.fixture non-null so the per-generator loop enters
+                        // the affected resolution branch (not the "all fixtures" branch).
+                        // resolveAffectedFixtures handles per-generator logic:
+                        // generators with source changes get all fixtures,
+                        // others get only the changed fixtures.
+                        if (affectedResult.affectedFixtures.length > 0) {
+                            console.log(`Changed fixtures: ${affectedResult.affectedFixtures.join(", ")}`);
+                        }
+                        if (affectedResult.generatorsWithAllFixtures.length > 0) {
+                            console.log(
+                                `Generators needing all fixtures: ${affectedResult.generatorsWithAllFixtures.join(", ")}`
+                            );
+                        }
                     }
                 }
                 console.log("==========================\n");
@@ -230,9 +244,11 @@ function addTestCommand(cli: Argv) {
                 if (argv.fixture == null) {
                     fixturesForGenerator = getAvailableFixtures(generator, false);
                 } else if (isFixtureAffected && affectedResult != null && !affectedResult.allFixturesAffected) {
-                    // In affected mode, resolve fixtures per-generator (filter by what's available)
+                    // In affected mode, resolve fixtures per-generator:
+                    // - Generators whose source changed get ALL their fixtures
+                    // - Other generators get only the changed fixtures
                     const available = getAvailableFixtures(generator, false);
-                    fixturesForGenerator = resolveAffectedFixtures(affectedResult, available);
+                    fixturesForGenerator = resolveAffectedFixtures(affectedResult, available, generator.workspaceName);
                     if (fixturesForGenerator.length === 0) {
                         console.log(
                             `No affected fixtures available for generator ${generator.workspaceName}. Skipping.`
@@ -762,6 +778,7 @@ function addAffectedCommand(cli: Argv) {
                             allGeneratorsAffected: affected.allGeneratorsAffected,
                             allFixturesAffected: affected.allFixturesAffected,
                             generators: resolvedGenerators.map((g) => g.workspaceName),
+                            generatorsWithAllFixtures: affected.generatorsWithAllFixtures,
                             fixtures: affected.affectedFixtures,
                             summary: affected.summary
                         },
@@ -778,11 +795,12 @@ function addAffectedCommand(cli: Argv) {
                 const resolvedGenerators = resolveAffectedGenerators(affected, generators);
                 console.log(`\nAffected generators (${resolvedGenerators.length}):`);
                 for (const gen of resolvedGenerators) {
-                    console.log(`  - ${gen.workspaceName}`);
+                    const needsAllFixtures = affected.generatorsWithAllFixtures.includes(gen.workspaceName);
+                    console.log(`  - ${gen.workspaceName}${needsAllFixtures ? " (all fixtures)" : ""}`);
                 }
 
                 if (!affected.allFixturesAffected && affected.affectedFixtures.length > 0) {
-                    console.log(`\nAffected fixtures (${affected.affectedFixtures.length}):`);
+                    console.log(`\nChanged fixtures — all generators run these (${affected.affectedFixtures.length}):`);
                     for (const fixture of affected.affectedFixtures) {
                         console.log(`  - ${fixture}`);
                     }

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -10,6 +10,7 @@ import {
     detectAffected,
     findRepoRoot,
     getChangedFiles,
+    getTurboAffectedPackages,
     resolveAffectedFixtures,
     resolveAffectedGenerators
 } from "./commands/affected/index.js";
@@ -171,7 +172,9 @@ function addTestCommand(cli: Argv) {
             if (isGeneratorAffected || isFixtureAffected) {
                 const repoRoot = findRepoRoot();
                 const changedFiles = getChangedFiles(argv.baseRef, repoRoot);
-                affectedResult = detectAffected(changedFiles, generators);
+                // Try turbo for generator detection (handles transitive deps like generators/base/)
+                const turboPackages = getTurboAffectedPackages(repoRoot, argv.baseRef);
+                affectedResult = detectAffected(changedFiles, generators, turboPackages);
 
                 // Log the detection summary
                 console.log("\n=== Affected Detection ===");
@@ -747,7 +750,9 @@ function addAffectedCommand(cli: Argv) {
             const generators = await loadGeneratorWorkspaces();
             const repoRoot = findRepoRoot();
             const changedFiles = getChangedFiles(argv.baseRef, repoRoot);
-            const affected = detectAffected(changedFiles, generators);
+            // Try turbo for generator detection (handles transitive deps like generators/base/)
+            const turboPackages = getTurboAffectedPackages(repoRoot, argv.baseRef);
+            const affected = detectAffected(changedFiles, generators, turboPackages);
 
             if (argv.json) {
                 const resolvedGenerators = resolveAffectedGenerators(affected, generators);

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -221,14 +221,16 @@ function addTestCommand(cli: Argv) {
                 let testRunner: TestRunner;
                 let scriptRunner: ScriptRunner;
 
-                // If no fixtures passed in, use all available fixtures (without output folders)
+                // Resolve fixtures per-generator using a local variable to avoid leaking
+                // one generator's fixtures to the next iteration
+                let fixturesForGenerator: string[];
                 if (argv.fixture == null) {
-                    argv.fixture = getAvailableFixtures(generator, false);
+                    fixturesForGenerator = getAvailableFixtures(generator, false);
                 } else if (isFixtureAffected && affectedResult != null && !affectedResult.allFixturesAffected) {
                     // In affected mode, resolve fixtures per-generator (filter by what's available)
                     const available = getAvailableFixtures(generator, false);
-                    argv.fixture = resolveAffectedFixtures(affectedResult, available);
-                    if (argv.fixture.length === 0) {
+                    fixturesForGenerator = resolveAffectedFixtures(affectedResult, available);
+                    if (fixturesForGenerator.length === 0) {
                         console.log(
                             `No affected fixtures available for generator ${generator.workspaceName}. Skipping.`
                         );
@@ -236,14 +238,14 @@ function addTestCommand(cli: Argv) {
                     }
                 } else {
                     const availableFixturesForGlobbing = getAvailableFixtures(generator, false);
-                    argv.fixture = expandFixtureGlobs(argv.fixture, availableFixturesForGlobbing);
+                    fixturesForGenerator = expandFixtureGlobs(argv.fixture, availableFixturesForGlobbing);
                 }
 
                 // Get both formats of fixtures and check if the fixtures passed in are of one of the two formats allowed
                 const availableFixtures = getAvailableFixtures(generator, false);
                 const availableFixturesWithOutputFolders = getAvailableFixtures(generator, true);
 
-                for (const fixture of argv.fixture) {
+                for (const fixture of fixturesForGenerator) {
                     if (!availableFixtures.includes(fixture) && !availableFixturesWithOutputFolders.includes(fixture)) {
                         throw new Error(
                             `Fixture ${fixture} not found. Please make sure that it is a valid fixture for the generator ${generator.workspaceName}.`
@@ -254,7 +256,8 @@ function addTestCommand(cli: Argv) {
                 // Verify if there are multiple fixtures passed in or a fixture has a colon separated output folder, that
                 // the flag for the output folder is not also used
                 if (
-                    (argv.fixture.length > 1 || argv.fixture.some((fixture) => fixture.includes(":"))) &&
+                    (fixturesForGenerator.length > 1 ||
+                        fixturesForGenerator.some((fixture) => fixture.includes(":"))) &&
                     argv.outputFolder != null
                 ) {
                     throw new Error(
@@ -333,7 +336,7 @@ function addTestCommand(cli: Argv) {
                     testGenerator({
                         generator,
                         runner: testRunner,
-                        fixtures: argv.fixture,
+                        fixtures: fixturesForGenerator,
                         outputFolder: argv.outputFolder,
                         inspect: argv.inspect
                     })

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
 import { GeneratorWorkspace } from "../../loadGeneratorWorkspaces.js";
 
@@ -67,7 +67,7 @@ const GENERATOR_SOURCE_PATHS: Record<string, string[]> = {
  */
 export function getChangedFiles(baseRef: string, repoRoot: string): string[] {
     try {
-        const output = execSync(`git diff --name-only --merge-base ${baseRef}`, {
+        const output = execFileSync("git", ["diff", "--name-only", "--merge-base", baseRef], {
             cwd: repoRoot,
             encoding: "utf-8",
             timeout: 30000
@@ -76,10 +76,11 @@ export function getChangedFiles(baseRef: string, repoRoot: string): string[] {
             .trim()
             .split("\n")
             .filter((line) => line.length > 0);
-    } catch {
+    } catch (error) {
+        console.error("git diff --merge-base failed, trying fallback:", error);
         // Fallback: try without --merge-base (for cases where merge-base doesn't work)
         try {
-            const output = execSync(`git diff --name-only ${baseRef}`, {
+            const output = execFileSync("git", ["diff", "--name-only", baseRef], {
                 cwd: repoRoot,
                 encoding: "utf-8",
                 timeout: 30000
@@ -88,8 +89,8 @@ export function getChangedFiles(baseRef: string, repoRoot: string): string[] {
                 .trim()
                 .split("\n")
                 .filter((line) => line.length > 0);
-        } catch {
-            console.error("Failed to get changed files from git. Falling back to running everything.");
+        } catch (innerError) {
+            console.error("Failed to get changed files from git. Falling back to running everything.", innerError);
             return [];
         }
     }
@@ -265,12 +266,13 @@ export function resolveAffectedFixtures(affected: AffectedResult, availableFixtu
  */
 export function findRepoRoot(): string {
     try {
-        const root = execSync("git rev-parse --show-toplevel", {
+        const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
             encoding: "utf-8",
             timeout: 5000
         }).trim();
         return root;
-    } catch {
+    } catch (error) {
+        console.error("Failed to find repo root via git, falling back to cwd:", error);
         return process.cwd();
     }
 }

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -22,7 +22,13 @@ export interface AffectedResult {
  * Paths that, when changed, affect ALL generators and ALL fixtures.
  * These are infrastructure-level changes.
  */
-const GLOBAL_AFFECT_PATHS = ["packages/ir-sdk/", "packages/seed/", "packages/cli/generation/ir-generator/"];
+const GLOBAL_AFFECT_PATHS = [
+    "packages/ir-sdk/",
+    "packages/seed/",
+    "packages/cli/generation/ir-generator/",
+    "generators/base/",
+    "generators/browser-compatible-base/"
+];
 
 /**
  * Paths for test definitions. Changes here affect specific fixtures.

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -169,7 +169,7 @@ function mapTurboPackagesToSeedWorkspaces(
     for (const pkg of turboPackages) {
         // Check if this is a global infrastructure package
         for (const globalPath of GLOBAL_AFFECT_PATHS) {
-            if (pkg.path.startsWith(globalPath.replace(/\/$/, ""))) {
+            if (pkg.path === globalPath.replace(/\/$/, "") || pkg.path.startsWith(globalPath)) {
                 allGeneratorsAffected = true;
                 allFixturesAffected = true;
                 summary.push(`Global infrastructure package affected (turbo): ${pkg.name} (${pkg.path})`);

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -1,0 +1,277 @@
+import { execSync } from "child_process";
+import path from "path";
+
+import { GeneratorWorkspace } from "../../loadGeneratorWorkspaces.js";
+
+/**
+ * Result of affected detection — which generators and fixtures need to run.
+ */
+export interface AffectedResult {
+    /** If true, ALL generators are affected (e.g. IR/seed infrastructure changed) */
+    allGeneratorsAffected: boolean;
+    /** If true, ALL fixtures are affected for the affected generators */
+    allFixturesAffected: boolean;
+    /** Specific generator workspace names that are affected (empty if allGeneratorsAffected) */
+    affectedGenerators: string[];
+    /** Specific fixture names that are affected (empty if allFixturesAffected) */
+    affectedFixtures: string[];
+    /** Summary of what was detected, for logging */
+    summary: string[];
+}
+
+/**
+ * Paths that, when changed, affect ALL generators and ALL fixtures.
+ * These are infrastructure-level changes.
+ */
+const GLOBAL_AFFECT_PATHS = ["packages/ir-sdk/", "packages/seed/", "packages/cli/generation/ir-generator/"];
+
+/**
+ * Paths for test definitions. Changes here affect specific fixtures.
+ */
+const TEST_DEFINITION_PATHS = ["test-definitions/fern/apis/", "test-definitions-openapi/fern/apis/"];
+
+/**
+ * Maps generator workspace names to their source code paths.
+ * When files under these paths change, the corresponding generator is affected.
+ */
+const GENERATOR_SOURCE_PATHS: Record<string, string[]> = {
+    "ts-sdk": ["generators/typescript/", "generators/typescript-v2/"],
+    "ts-express": ["generators/typescript/", "generators/typescript-v2/"],
+    "python-sdk": ["generators/python/", "generators/python-v2/"],
+    pydantic: ["generators/python/", "generators/python-v2/"],
+    "pydantic-v2": ["generators/python-v2/"],
+    fastapi: ["generators/python/", "generators/python-v2/"],
+    "java-sdk": ["generators/java/", "generators/java-v2/"],
+    "java-model": ["generators/java/", "generators/java-v2/"],
+    "java-spring": ["generators/java/", "generators/java-v2/"],
+    "go-sdk": ["generators/go/", "generators/go-v2/"],
+    "go-model": ["generators/go/", "generators/go-v2/"],
+    "ruby-sdk-v2": ["generators/ruby-v2/"],
+    "csharp-sdk": ["generators/csharp/"],
+    "csharp-model": ["generators/csharp/"],
+    "php-sdk": ["generators/php/"],
+    "php-model": ["generators/php/"],
+    "swift-sdk": ["generators/swift/"],
+    "rust-sdk": ["generators/rust/"],
+    "rust-model": ["generators/rust/"],
+    openapi: ["generators/openapi/"],
+    postman: ["generators/postman/"]
+};
+
+/**
+ * Get the list of changed files by running git diff against a base ref.
+ *
+ * @param baseRef - The git ref to diff against (e.g. "origin/main", a SHA, etc.)
+ *                  If not provided, defaults to "origin/main"
+ * @param repoRoot - The root directory of the repository
+ * @returns Array of changed file paths relative to the repo root
+ */
+export function getChangedFiles(baseRef: string, repoRoot: string): string[] {
+    try {
+        const output = execSync(`git diff --name-only --merge-base ${baseRef}`, {
+            cwd: repoRoot,
+            encoding: "utf-8",
+            timeout: 30000
+        });
+        return output
+            .trim()
+            .split("\n")
+            .filter((line) => line.length > 0);
+    } catch {
+        // Fallback: try without --merge-base (for cases where merge-base doesn't work)
+        try {
+            const output = execSync(`git diff --name-only ${baseRef}`, {
+                cwd: repoRoot,
+                encoding: "utf-8",
+                timeout: 30000
+            });
+            return output
+                .trim()
+                .split("\n")
+                .filter((line) => line.length > 0);
+        } catch {
+            console.error("Failed to get changed files from git. Falling back to running everything.");
+            return [];
+        }
+    }
+}
+
+/**
+ * Detect which generators and fixtures are affected based on changed files.
+ *
+ * @param changedFiles - Array of changed file paths relative to repo root
+ * @param allGenerators - All available generator workspaces
+ * @returns AffectedResult describing what needs to run
+ */
+export function detectAffected(changedFiles: string[], allGenerators: GeneratorWorkspace[]): AffectedResult {
+    const summary: string[] = [];
+    const affectedGeneratorSet = new Set<string>();
+    const affectedFixtureSet = new Set<string>();
+    let allGeneratorsAffected = false;
+    let allFixturesAffected = false;
+
+    if (changedFiles.length === 0) {
+        summary.push("No changed files detected — running everything as fallback.");
+        return {
+            allGeneratorsAffected: true,
+            allFixturesAffected: true,
+            affectedGenerators: [],
+            affectedFixtures: [],
+            summary
+        };
+    }
+
+    // Check for global infrastructure changes
+    for (const file of changedFiles) {
+        for (const globalPath of GLOBAL_AFFECT_PATHS) {
+            if (file.startsWith(globalPath)) {
+                allGeneratorsAffected = true;
+                allFixturesAffected = true;
+                summary.push(`Global infrastructure change detected: ${file}`);
+                break;
+            }
+        }
+        if (allGeneratorsAffected) {
+            break;
+        }
+    }
+
+    // If global changes detected, we're done — everything needs to run
+    if (allGeneratorsAffected && allFixturesAffected) {
+        return {
+            allGeneratorsAffected: true,
+            allFixturesAffected: true,
+            affectedGenerators: [],
+            affectedFixtures: [],
+            summary
+        };
+    }
+
+    // Check for test definition changes → specific fixtures affected
+    for (const file of changedFiles) {
+        for (const testDefPath of TEST_DEFINITION_PATHS) {
+            if (file.startsWith(testDefPath)) {
+                // Extract fixture name from path like "test-definitions/fern/apis/<fixture-name>/..."
+                const relativePath = file.slice(testDefPath.length);
+                const fixtureName = relativePath.split("/")[0];
+                if (fixtureName != null && fixtureName.length > 0) {
+                    affectedFixtureSet.add(fixtureName);
+                    summary.push(`Test definition changed: ${fixtureName} (from ${file})`);
+                }
+            }
+        }
+    }
+
+    // Check for generator source changes → specific generators affected
+    const allGeneratorNames = allGenerators.map((g) => g.workspaceName);
+    for (const file of changedFiles) {
+        for (const [generatorName, sourcePaths] of Object.entries(GENERATOR_SOURCE_PATHS)) {
+            // Only consider generators that actually exist
+            if (!allGeneratorNames.includes(generatorName)) {
+                continue;
+            }
+            for (const sourcePath of sourcePaths) {
+                if (file.startsWith(sourcePath)) {
+                    affectedGeneratorSet.add(generatorName);
+                    summary.push(`Generator source changed: ${generatorName} (from ${file})`);
+                    break;
+                }
+            }
+        }
+
+        // Also check for seed.yml changes → that specific generator is affected
+        if (file.startsWith("seed/") && file.endsWith("/seed.yml")) {
+            // Extract generator name from path like "seed/<generator>/seed.yml"
+            const parts = file.split("/");
+            if (parts.length >= 2) {
+                const generatorName = parts[1];
+                if (generatorName != null && allGeneratorNames.includes(generatorName)) {
+                    affectedGeneratorSet.add(generatorName);
+                    allFixturesAffected = true;
+                    summary.push(`seed.yml changed for generator: ${generatorName}`);
+                }
+            }
+        }
+    }
+
+    // If test definitions changed but no specific generators, all generators are affected
+    // (since test definitions feed into all generators)
+    if (affectedFixtureSet.size > 0 && affectedGeneratorSet.size === 0) {
+        allGeneratorsAffected = true;
+        summary.push(
+            "Test definitions changed but no generator source changed — all generators affected for changed fixtures."
+        );
+    }
+
+    // If generator source changed but no specific fixtures, all fixtures are affected for those generators
+    if (affectedGeneratorSet.size > 0 && affectedFixtureSet.size === 0) {
+        allFixturesAffected = true;
+        summary.push(
+            "Generator source changed but no test definitions changed — all fixtures affected for changed generators."
+        );
+    }
+
+    // If nothing was detected as affected, fall back to running everything
+    if (!allGeneratorsAffected && affectedGeneratorSet.size === 0 && affectedFixtureSet.size === 0) {
+        summary.push("No recognized changes detected — running everything as fallback.");
+        return {
+            allGeneratorsAffected: true,
+            allFixturesAffected: true,
+            affectedGenerators: [],
+            affectedFixtures: [],
+            summary
+        };
+    }
+
+    return {
+        allGeneratorsAffected,
+        allFixturesAffected,
+        affectedGenerators: [...affectedGeneratorSet],
+        affectedFixtures: [...affectedFixtureSet],
+        summary
+    };
+}
+
+/**
+ * Resolve affected generators to actual GeneratorWorkspace objects.
+ * Returns the filtered list of generators that need to run.
+ */
+export function resolveAffectedGenerators(
+    affected: AffectedResult,
+    allGenerators: GeneratorWorkspace[]
+): GeneratorWorkspace[] {
+    if (affected.allGeneratorsAffected) {
+        return allGenerators;
+    }
+    return allGenerators.filter((g) => affected.affectedGenerators.includes(g.workspaceName));
+}
+
+/**
+ * Resolve affected fixtures for a given generator.
+ * Returns the filtered list of fixture names that need to run.
+ */
+export function resolveAffectedFixtures(affected: AffectedResult, availableFixtures: string[]): string[] {
+    if (affected.allFixturesAffected) {
+        return availableFixtures;
+    }
+    return availableFixtures.filter((f) => {
+        // Handle "fixture:outputFolder" format
+        const fixtureName = f.includes(":") ? f.split(":")[0] : f;
+        return fixtureName != null && affected.affectedFixtures.includes(fixtureName);
+    });
+}
+
+/**
+ * Find the repository root by looking for the .git directory.
+ */
+export function findRepoRoot(): string {
+    try {
+        const root = execSync("git rev-parse --show-toplevel", {
+            encoding: "utf-8",
+            timeout: 5000
+        }).trim();
+        return root;
+    } catch {
+        return process.cwd();
+    }
+}

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -45,6 +45,7 @@ const GENERATOR_SOURCE_PATHS: Record<string, string[]> = {
     "java-spring": ["generators/java/", "generators/java-v2/"],
     "go-sdk": ["generators/go/", "generators/go-v2/"],
     "go-model": ["generators/go/", "generators/go-v2/"],
+    "ruby-sdk": ["generators/ruby-v2/"],
     "ruby-sdk-v2": ["generators/ruby-v2/"],
     "csharp-sdk": ["generators/csharp/"],
     "csharp-model": ["generators/csharp/"],

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -1,5 +1,4 @@
 import { execSync } from "child_process";
-import path from "path";
 
 import { GeneratorWorkspace } from "../../loadGeneratorWorkspaces.js";
 

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -124,7 +124,7 @@ interface TurboLsOutput {
  */
 export function getTurboAffectedPackages(repoRoot: string, baseRef: string): TurboPackage[] | null {
     try {
-        const output = execFileSync("npx", ["turbo", "ls", "--affected", "--output=json"], {
+        const output = execFileSync("pnpm", ["turbo", "ls", "--affected", "--output=json"], {
             cwd: repoRoot,
             encoding: "utf-8",
             timeout: 60000,

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -386,8 +386,8 @@ export function detectAffected(
     return {
         allGeneratorsAffected,
         allFixturesAffected,
-        affectedGenerators: [...affectedGeneratorSet],
-        affectedFixtures: [...affectedFixtureSet],
+        affectedGenerators: allGeneratorsAffected ? [] : [...affectedGeneratorSet],
+        affectedFixtures: allFixturesAffected ? [] : [...affectedFixtureSet],
         summary
     };
 }

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -20,12 +20,17 @@ export interface AffectedResult {
 
 /**
  * Paths that, when changed, affect ALL generators and ALL fixtures.
- * These are infrastructure-level changes.
+ * These are infrastructure-level changes that turbo cannot detect
+ * (generators depend on the published npm @fern-fern/ir-sdk, not the local workspace).
  */
-const GLOBAL_AFFECT_PATHS = [
-    "packages/ir-sdk/",
-    "packages/seed/",
-    "packages/cli/generation/ir-generator/",
+const GLOBAL_AFFECT_PATHS = ["packages/ir-sdk/", "packages/seed/", "packages/cli/generation/ir-generator/"];
+
+/**
+ * Extended global paths used when turbo is unavailable as fallback.
+ * Includes shared base packages that turbo would normally handle via dependency graph.
+ */
+const GLOBAL_AFFECT_PATHS_WITH_BASE = [
+    ...GLOBAL_AFFECT_PATHS,
     "generators/base/",
     "generators/browser-compatible-base/"
 ];
@@ -36,8 +41,32 @@ const GLOBAL_AFFECT_PATHS = [
 const TEST_DEFINITION_PATHS = ["test-definitions/fern/apis/", "test-definitions-openapi/fern/apis/"];
 
 /**
- * Maps generator workspace names to their source code paths.
- * When files under these paths change, the corresponding generator is affected.
+ * Maps generator directory prefixes (under generators/) to seed workspace names.
+ * Used to convert turbo's affected package paths to seed workspace names.
+ * Turbo handles transitive dependencies automatically (e.g. generators/base/ changes
+ * will cause all dependent generator packages to appear as affected).
+ */
+const GENERATOR_DIR_TO_SEED_WORKSPACES: Record<string, string[]> = {
+    typescript: ["ts-sdk", "ts-express"],
+    "typescript-v2": ["ts-sdk", "ts-express"],
+    python: ["python-sdk", "pydantic", "fastapi"],
+    "python-v2": ["python-sdk", "pydantic", "pydantic-v2", "fastapi"],
+    java: ["java-sdk", "java-model", "java-spring"],
+    "java-v2": ["java-sdk", "java-model", "java-spring"],
+    go: ["go-sdk", "go-model"],
+    "go-v2": ["go-sdk", "go-model"],
+    "ruby-v2": ["ruby-sdk", "ruby-sdk-v2"],
+    csharp: ["csharp-sdk", "csharp-model"],
+    php: ["php-sdk", "php-model"],
+    swift: ["swift-sdk"],
+    rust: ["rust-sdk", "rust-model"],
+    openapi: ["openapi"],
+    postman: ["postman"]
+};
+
+/**
+ * Fallback: Maps generator workspace names to their source code paths.
+ * Used when turbo detection is not available.
  */
 const GENERATOR_SOURCE_PATHS: Record<string, string[]> = {
     "ts-sdk": ["generators/typescript/", "generators/typescript-v2/"],
@@ -63,6 +92,105 @@ const GENERATOR_SOURCE_PATHS: Record<string, string[]> = {
     openapi: ["generators/openapi/"],
     postman: ["generators/postman/"]
 };
+
+export interface TurboPackage {
+    name: string;
+    path: string;
+}
+
+interface TurboLsOutput {
+    packages: {
+        count: number;
+        items: TurboPackage[];
+    };
+}
+
+/**
+ * Get affected packages using turbo's built-in dependency graph analysis.
+ * Turbo automatically resolves transitive dependencies, so if a shared base package
+ * (like generators/base/) changes, all dependent generator packages are reported.
+ *
+ * @param repoRoot - The root directory of the repository
+ * @param baseRef - The git ref to diff against (passed via TURBO_SCM_BASE env var)
+ * @returns Array of affected packages, or null if turbo detection fails
+ */
+export function getTurboAffectedPackages(repoRoot: string, baseRef: string): TurboPackage[] | null {
+    try {
+        const output = execFileSync("npx", ["turbo", "ls", "--affected", "--output=json"], {
+            cwd: repoRoot,
+            encoding: "utf-8",
+            timeout: 60000,
+            env: {
+                ...process.env,
+                TURBO_SCM_BASE: baseRef
+            }
+        });
+
+        // turbo may output non-JSON lines (e.g. update notices) before the JSON
+        const jsonStart = output.indexOf("{");
+        if (jsonStart === -1) {
+            console.error("No JSON found in turbo output");
+            return null;
+        }
+
+        const parsed = JSON.parse(output.slice(jsonStart)) as TurboLsOutput;
+        return parsed.packages.items;
+    } catch (error) {
+        console.error("turbo ls --affected failed, falling back to git diff detection:", error);
+        return null;
+    }
+}
+
+/**
+ * Map turbo affected package paths to seed workspace names.
+ */
+function mapTurboPackagesToSeedWorkspaces(
+    turboPackages: TurboPackage[],
+    allGeneratorNames: string[]
+): {
+    affectedGenerators: Set<string>;
+    allGeneratorsAffected: boolean;
+    allFixturesAffected: boolean;
+    summary: string[];
+} {
+    const affectedGenerators = new Set<string>();
+    const summary: string[] = [];
+    let allGeneratorsAffected = false;
+    let allFixturesAffected = false;
+
+    for (const pkg of turboPackages) {
+        // Check if this is a global infrastructure package
+        for (const globalPath of GLOBAL_AFFECT_PATHS) {
+            if (pkg.path.startsWith(globalPath.replace(/\/$/, ""))) {
+                allGeneratorsAffected = true;
+                allFixturesAffected = true;
+                summary.push(`Global infrastructure package affected (turbo): ${pkg.name} (${pkg.path})`);
+                break;
+            }
+        }
+
+        // Check if this is a generator package
+        if (pkg.path.startsWith("generators/")) {
+            const parts = pkg.path.split("/");
+            if (parts.length >= 2) {
+                const generatorDir = parts[1];
+                if (generatorDir != null) {
+                    const seedWorkspaces = GENERATOR_DIR_TO_SEED_WORKSPACES[generatorDir];
+                    if (seedWorkspaces != null) {
+                        for (const workspace of seedWorkspaces) {
+                            if (allGeneratorNames.includes(workspace)) {
+                                affectedGenerators.add(workspace);
+                            }
+                        }
+                        summary.push(`Generator package affected (turbo): ${pkg.name} -> ${seedWorkspaces.join(", ")}`);
+                    }
+                }
+            }
+        }
+    }
+
+    return { affectedGenerators, allGeneratorsAffected, allFixturesAffected, summary };
+}
 
 /**
  * Get the list of changed files by running git diff against a base ref.
@@ -105,19 +233,28 @@ export function getChangedFiles(baseRef: string, repoRoot: string): string[] {
 
 /**
  * Detect which generators and fixtures are affected based on changed files.
+ * Uses turbo for generator detection when available (handles transitive dependencies
+ * like generators/base/ automatically), with git diff path matching as fallback.
+ * Always uses git diff for test definitions and seed.yml changes.
  *
  * @param changedFiles - Array of changed file paths relative to repo root
  * @param allGenerators - All available generator workspaces
+ * @param turboPackages - Optional turbo affected packages (null if turbo unavailable)
  * @returns AffectedResult describing what needs to run
  */
-export function detectAffected(changedFiles: string[], allGenerators: GeneratorWorkspace[]): AffectedResult {
+export function detectAffected(
+    changedFiles: string[],
+    allGenerators: GeneratorWorkspace[],
+    turboPackages?: TurboPackage[] | null
+): AffectedResult {
     const summary: string[] = [];
     const affectedGeneratorSet = new Set<string>();
     const affectedFixtureSet = new Set<string>();
     let allGeneratorsAffected = false;
     let allFixturesAffected = false;
+    const allGeneratorNames = allGenerators.map((g) => g.workspaceName);
 
-    if (changedFiles.length === 0) {
+    if (changedFiles.length === 0 && (turboPackages == null || turboPackages.length === 0)) {
         summary.push("No changed files detected — running everything as fallback.");
         return {
             allGeneratorsAffected: true,
@@ -128,9 +265,29 @@ export function detectAffected(changedFiles: string[], allGenerators: GeneratorW
         };
     }
 
-    // Check for global infrastructure changes
+    // === GENERATOR DETECTION ===
+    // Use turbo if available (handles transitive deps like generators/base/ automatically)
+    if (turboPackages != null) {
+        summary.push("Using turbo for generator affected detection (transitive dependency support).");
+        const turboResult = mapTurboPackagesToSeedWorkspaces(turboPackages, allGeneratorNames);
+        if (turboResult.allGeneratorsAffected) {
+            allGeneratorsAffected = true;
+        }
+        if (turboResult.allFixturesAffected) {
+            allFixturesAffected = true;
+        }
+        for (const gen of turboResult.affectedGenerators) {
+            affectedGeneratorSet.add(gen);
+        }
+        summary.push(...turboResult.summary);
+    }
+
+    // Check git diff for infrastructure paths
+    // (needed even with turbo because generators depend on published @fern-fern/ir-sdk,
+    // not the local workspace, so turbo won't detect ir-sdk changes as affecting generators)
+    const globalPaths = turboPackages != null ? GLOBAL_AFFECT_PATHS : GLOBAL_AFFECT_PATHS_WITH_BASE;
     for (const file of changedFiles) {
-        for (const globalPath of GLOBAL_AFFECT_PATHS) {
+        for (const globalPath of globalPaths) {
             if (file.startsWith(globalPath)) {
                 allGeneratorsAffected = true;
                 allFixturesAffected = true;
@@ -138,7 +295,7 @@ export function detectAffected(changedFiles: string[], allGenerators: GeneratorW
                 break;
             }
         }
-        if (allGeneratorsAffected) {
+        if (allGeneratorsAffected && allFixturesAffected) {
             break;
         }
     }
@@ -154,11 +311,10 @@ export function detectAffected(changedFiles: string[], allGenerators: GeneratorW
         };
     }
 
-    // Check for test definition changes → specific fixtures affected
+    // === FIXTURE DETECTION (always via git diff) ===
     for (const file of changedFiles) {
         for (const testDefPath of TEST_DEFINITION_PATHS) {
             if (file.startsWith(testDefPath)) {
-                // Extract fixture name from path like "test-definitions/fern/apis/<fixture-name>/..."
                 const relativePath = file.slice(testDefPath.length);
                 const fixtureName = relativePath.split("/")[0];
                 if (fixtureName != null && fixtureName.length > 0) {
@@ -169,26 +325,28 @@ export function detectAffected(changedFiles: string[], allGenerators: GeneratorW
         }
     }
 
-    // Check for generator source changes → specific generators affected
-    const allGeneratorNames = allGenerators.map((g) => g.workspaceName);
-    for (const file of changedFiles) {
-        for (const [generatorName, sourcePaths] of Object.entries(GENERATOR_SOURCE_PATHS)) {
-            // Only consider generators that actually exist
-            if (!allGeneratorNames.includes(generatorName)) {
-                continue;
-            }
-            for (const sourcePath of sourcePaths) {
-                if (file.startsWith(sourcePath)) {
-                    affectedGeneratorSet.add(generatorName);
-                    summary.push(`Generator source changed: ${generatorName} (from ${file})`);
-                    break;
+    // === FALLBACK GENERATOR DETECTION (git diff, only when turbo unavailable) ===
+    if (turboPackages == null) {
+        summary.push("Turbo unavailable — using git diff for generator detection.");
+        for (const file of changedFiles) {
+            for (const [generatorName, sourcePaths] of Object.entries(GENERATOR_SOURCE_PATHS)) {
+                if (!allGeneratorNames.includes(generatorName)) {
+                    continue;
+                }
+                for (const sourcePath of sourcePaths) {
+                    if (file.startsWith(sourcePath)) {
+                        affectedGeneratorSet.add(generatorName);
+                        summary.push(`Generator source changed: ${generatorName} (from ${file})`);
+                        break;
+                    }
                 }
             }
         }
+    }
 
-        // Also check for seed.yml changes → that specific generator is affected
+    // === SEED.YML DETECTION (always via git diff) ===
+    for (const file of changedFiles) {
         if (file.startsWith("seed/") && file.endsWith("/seed.yml")) {
-            // Extract generator name from path like "seed/<generator>/seed.yml"
             const parts = file.split("/");
             if (parts.length >= 2) {
                 const generatorName = parts[1];

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -4,15 +4,23 @@ import { GeneratorWorkspace } from "../../loadGeneratorWorkspaces.js";
 
 /**
  * Result of affected detection — which generators and fixtures need to run.
+ *
+ * Supports granular per-generator fixture resolution:
+ * - If a generator's source changed, it needs ALL its fixtures → listed in generatorsWithAllFixtures
+ * - If a test definition changed, ALL generators need that fixture → listed in affectedFixtures
+ * - When both happen, each generator gets the union: generators with source changes run all fixtures,
+ *   other generators run only the changed fixtures (no unnecessary full cross-product)
  */
 export interface AffectedResult {
-    /** If true, ALL generators are affected (e.g. IR/seed infrastructure changed) */
+    /** If true, ALL generators are affected (e.g. IR/seed infrastructure changed, or test defs changed) */
     allGeneratorsAffected: boolean;
-    /** If true, ALL fixtures are affected for the affected generators */
+    /** If true, ALL fixtures are affected for ALL generators (e.g. global infrastructure changed) */
     allFixturesAffected: boolean;
     /** Specific generator workspace names that are affected (empty if allGeneratorsAffected) */
     affectedGenerators: string[];
-    /** Specific fixture names that are affected (empty if allFixturesAffected) */
+    /** Generators whose source code changed — these need ALL their fixtures run */
+    generatorsWithAllFixtures: string[];
+    /** Specific fixture names that changed — ALL generators need to run these */
     affectedFixtures: string[];
     /** Summary of what was detected, for logging */
     summary: string[];
@@ -260,6 +268,7 @@ export function detectAffected(
             allGeneratorsAffected: true,
             allFixturesAffected: true,
             affectedGenerators: [],
+            generatorsWithAllFixtures: [],
             affectedFixtures: [],
             summary
         };
@@ -306,6 +315,7 @@ export function detectAffected(
             allGeneratorsAffected: true,
             allFixturesAffected: true,
             affectedGenerators: [],
+            generatorsWithAllFixtures: [],
             affectedFixtures: [],
             summary
         };
@@ -345,6 +355,9 @@ export function detectAffected(
     }
 
     // === SEED.YML DETECTION (always via git diff) ===
+    // When a generator's seed.yml changes, that generator needs all its fixtures.
+    // The generator is added to affectedGeneratorSet which flows into generatorsWithAllFixtures,
+    // so resolveAffectedFixtures will return all fixtures for that specific generator.
     for (const file of changedFiles) {
         if (file.startsWith("seed/") && file.endsWith("/seed.yml")) {
             const parts = file.split("/");
@@ -352,23 +365,21 @@ export function detectAffected(
                 const generatorName = parts[1];
                 if (generatorName != null && allGeneratorNames.includes(generatorName)) {
                     affectedGeneratorSet.add(generatorName);
-                    allFixturesAffected = true;
-                    summary.push(`seed.yml changed for generator: ${generatorName}`);
+                    summary.push(`seed.yml changed for generator: ${generatorName} (needs all fixtures)`);
                 }
             }
         }
     }
 
-    // If test definitions changed, all generators need to run those fixtures
+    // If test definitions changed, all generators need to run those specific fixtures
     if (affectedFixtureSet.size > 0) {
         allGeneratorsAffected = true;
-        summary.push("Test definitions changed — all generators affected for changed fixtures.");
+        summary.push("Test definitions changed — all generators need to run changed fixtures.");
     }
 
-    // If generator source changed, all fixtures need to run for those generators
+    // Generators whose source changed need all their fixtures
     if (affectedGeneratorSet.size > 0) {
-        allFixturesAffected = true;
-        summary.push("Generator source changed — all fixtures affected for changed generators.");
+        summary.push(`Generator source changed — ${[...affectedGeneratorSet].join(", ")} need all fixtures.`);
     }
 
     // If nothing was detected as affected, fall back to running everything
@@ -378,6 +389,7 @@ export function detectAffected(
             allGeneratorsAffected: true,
             allFixturesAffected: true,
             affectedGenerators: [],
+            generatorsWithAllFixtures: [],
             affectedFixtures: [],
             summary
         };
@@ -387,6 +399,7 @@ export function detectAffected(
         allGeneratorsAffected,
         allFixturesAffected,
         affectedGenerators: allGeneratorsAffected ? [] : [...affectedGeneratorSet],
+        generatorsWithAllFixtures: [...affectedGeneratorSet],
         affectedFixtures: allFixturesAffected ? [] : [...affectedFixtureSet],
         summary
     };
@@ -408,10 +421,20 @@ export function resolveAffectedGenerators(
 
 /**
  * Resolve affected fixtures for a given generator.
- * Returns the filtered list of fixture names that need to run.
+ * If the generator's source changed (it's in generatorsWithAllFixtures), run ALL its fixtures.
+ * Otherwise, run only the specific fixtures that changed (affectedFixtures).
+ * This avoids the full cross-product when both generators and fixtures change.
  */
-export function resolveAffectedFixtures(affected: AffectedResult, availableFixtures: string[]): string[] {
+export function resolveAffectedFixtures(
+    affected: AffectedResult,
+    availableFixtures: string[],
+    generatorName?: string
+): string[] {
     if (affected.allFixturesAffected) {
+        return availableFixtures;
+    }
+    // If this generator's source changed, it needs all its fixtures
+    if (generatorName != null && affected.generatorsWithAllFixtures.includes(generatorName)) {
         return availableFixtures;
     }
     return availableFixtures.filter((f) => {

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -195,21 +195,16 @@ export function detectAffected(changedFiles: string[], allGenerators: GeneratorW
         }
     }
 
-    // If test definitions changed but no specific generators, all generators are affected
-    // (since test definitions feed into all generators)
-    if (affectedFixtureSet.size > 0 && affectedGeneratorSet.size === 0) {
+    // If test definitions changed, all generators need to run those fixtures
+    if (affectedFixtureSet.size > 0) {
         allGeneratorsAffected = true;
-        summary.push(
-            "Test definitions changed but no generator source changed — all generators affected for changed fixtures."
-        );
+        summary.push("Test definitions changed — all generators affected for changed fixtures.");
     }
 
-    // If generator source changed but no specific fixtures, all fixtures are affected for those generators
-    if (affectedGeneratorSet.size > 0 && affectedFixtureSet.size === 0) {
+    // If generator source changed, all fixtures need to run for those generators
+    if (affectedGeneratorSet.size > 0) {
         allFixturesAffected = true;
-        summary.push(
-            "Generator source changed but no test definitions changed — all fixtures affected for changed generators."
-        );
+        summary.push("Generator source changed — all fixtures affected for changed generators.");
     }
 
     // If nothing was detected as affected, fall back to running everything

--- a/packages/seed/src/commands/affected/index.ts
+++ b/packages/seed/src/commands/affected/index.ts
@@ -1,0 +1,8 @@
+export {
+    type AffectedResult,
+    detectAffected,
+    findRepoRoot,
+    getChangedFiles,
+    resolveAffectedFixtures,
+    resolveAffectedGenerators
+} from "./getAffected.js";

--- a/packages/seed/src/commands/affected/index.ts
+++ b/packages/seed/src/commands/affected/index.ts
@@ -3,6 +3,8 @@ export {
     detectAffected,
     findRepoRoot,
     getChangedFiles,
+    getTurboAffectedPackages,
     resolveAffectedFixtures,
-    resolveAffectedGenerators
+    resolveAffectedGenerators,
+    type TurboPackage
 } from "./getAffected.js";


### PR DESCRIPTION
## Description

Refs: [Devin Session](https://app.devin.ai/sessions/a6541cd4a96a46e7b3a8942f302d3d02)
Requested by: @Swimburger

Adds a smart detection system to the seed CLI that automatically determines which generators and test fixtures were changed, so you can run only what's needed instead of everything. Uses **Turborepo's dependency graph** when available for accurate transitive dependency resolution (e.g. `generators/base/` changes propagate to all dependent generators), with a **git diff fallback** when turbo is unavailable.

**Key feature:** When both generator source AND test definitions change simultaneously, the system computes the **precise union** instead of the full cross-product:
- Generators whose source changed run ALL their fixtures
- Other generators run ONLY the changed fixtures

**Usage:**
```bash
pnpm seed test --generator affected --fixture affected
pnpm seed test --generator affected --fixture affected --base-ref origin/main
pnpm seed affected --json   # dry-run: just show what's affected
```

## Changes Made

- **New module `packages/seed/src/commands/affected/`** — core detection logic with a hybrid turbo + git diff approach:
  - **Turbo path (preferred):** Calls `pnpm turbo ls --affected --output=json` with `TURBO_SCM_BASE` env var to get affected packages. Turbo resolves the full dependency graph, so shared base packages are handled automatically.
  - **Git diff path (fallback):** Runs `git diff --name-only --merge-base <base-ref>` via `execFileSync` (argument array, no shell injection risk) and matches changed files against a static `GENERATOR_SOURCE_PATHS` mapping (all 22 generator workspaces covered).
  - **Always via git diff:** Test definition changes (`test-definitions/`, `test-definitions-openapi/`), `seed.yml` config changes, and infrastructure paths (`packages/ir-sdk/`, `packages/seed/`, `packages/cli/generation/ir-generator/`) — these are things turbo doesn't know about.
  - Falls back to running everything when both turbo and git diff fail, or when no recognized changes are detected.

- **Modified `addTestCommand` in `cli.ts`** — when `--generator affected` or `--fixture affected` is passed, calls `getTurboAffectedPackages()` then `detectAffected()` to resolve actual affected generators/fixtures. Uses a local `fixturesForGenerator` variable per loop iteration to avoid leaking one generator's fixtures to subsequent generators. Implements per-generator fixture resolution logic.

- **New `pnpm seed affected` command** — standalone command to inspect what's affected without running tests (supports `--json` output for CI consumption, includes `generatorsWithAllFixtures` field)

- **`AffectedResult` interface extended** — added `generatorsWithAllFixtures` field to track which generators need all fixtures (vs. just specific changed fixtures)

- [ ] Updated README.md generator (if applicable) — N/A, internal tooling

### Detection rules

| Changed path | Detection method | Effect |
|---|---|---|
| `packages/ir-sdk/`, `packages/seed/`, `packages/cli/generation/ir-generator/` | git diff (always) | All generators × all fixtures (infrastructure; turbo can't detect ir-sdk because generators depend on published `@fern-fern/ir-sdk`) |
| `generators/base/`, `generators/browser-compatible-base/` | turbo (transitive deps) or git diff fallback | All generators × all fixtures (shared base packages) |
| `generators/<lang>/` | turbo (preferred) or git diff fallback | That generator runs all its fixtures |
| `test-definitions/fern/apis/<fixture>/` | git diff (always) | All generators run that fixture |
| `seed/<generator>/seed.yml` | git diff (always) | That generator runs all its fixtures |
| **Both generator source + test definitions** | **hybrid** | **Union: affected generators run all fixtures + all other generators run only changed fixtures** (avoids full cross-product) |

### Updates since last revision

**Latest: Self-review fixes**
- **Fixed `npx turbo` → `pnpm turbo`** (619f69e) — eliminates cold-start overhead since turbo is already a devDependency in this monorepo
- **Fixed turbo path matching to prevent false-positive prefix collisions** (40308b0) — now uses exact equality OR startsWith with trailing slash intact, so `packages/ir-sdk-v2` won't falsely match `packages/ir-sdk/`

**Previous: Granular per-generator fixture resolution (addresses user feedback)**
- **Refactored `AffectedResult` interface** — added `generatorsWithAllFixtures: string[]` field to track which specific generators need all fixtures (vs. all generators needing specific fixtures)
- **Updated `resolveAffectedFixtures()`** — now accepts optional `generatorName` parameter. If that generator is in `generatorsWithAllFixtures`, returns all available fixtures; otherwise returns only `affectedFixtures`
- **Fixed combined generator+fixture case** — when both change, no longer runs the full cross-product. Instead:
  - Generators whose source changed get ALL their fixtures
  - Other generators get ONLY the changed fixtures
  - This is the precise union, not an all-or-nothing expansion
- **Fixed seed.yml detection** — no longer sets global `allFixturesAffected = true`. Instead, the generator is added to `generatorsWithAllFixtures` so only that specific generator gets all fixtures

**Previous: Fixed interface contract violation**
- **Fixed `AffectedResult` interface contract violation** — `affectedGenerators` and `affectedFixtures` arrays are now cleared (set to `[]`) when the corresponding `allGeneratorsAffected`/`allFixturesAffected` boolean flags are true, matching the documented interface contract.

**Previous: Turbo integration for transitive dependency support**
- Added `getTurboAffectedPackages()`, `GENERATOR_DIR_TO_SEED_WORKSPACES` mapping, and `mapTurboPackagesToSeedWorkspaces()` for turbo-based detection
- Split `GLOBAL_AFFECT_PATHS` (turbo-aware) and `GLOBAL_AFFECT_PATHS_WITH_BASE` (fallback)

**Previous fixes:**
- Added shared base package detection
- Added missing `ruby-sdk` mapping
- Fixed `argv.fixture` leak bug
- Fixed shell injection (switched to `execFileSync`)
- Added error logging to all catch blocks

## Testing

- [ ] Unit tests added/updated — not yet; detection logic is pure/testable
- [x] Lint passes (`pnpm run check`)
- [x] Manual testing completed — built seed CLI locally and verified both `pnpm seed affected` and `pnpm seed affected --json` produce correct output

## Human Review Checklist

1. **No unit tests** — The detection logic is complex, pure, and easily testable, but no tests are included. Given the subtle bugs found during implementation (argv.fixture leak, interface contract violations, full cross-product), this is risky for future maintenance. Consider whether tests should be added before merging or in a followup.

2. **Turbo availability and fallback** — The code assumes turbo may be unavailable and gracefully falls back to git diff detection. Verify that the 60s timeout for `pnpm turbo ls --affected` is reasonable for CI environments.

3. **Turbo JSON parsing fragility** — The code finds the first `{` character in turbo's output to skip any non-JSON prefixes (e.g. update notices). This is fragile if turbo outputs JSON on stderr or changes its output format. The catch block handles failures gracefully (falls back to git diff), but the error message would be misleading.

4. **`TURBO_SCM_BASE` env var** — Verify that turbo actually respects this environment variable for specifying the base git ref. This is not a widely documented turbo feature.

5. **`GENERATOR_DIR_TO_SEED_WORKSPACES` mapping still hardcoded** (`getAffected.ts:57-73`) — Still a static map that must be updated when new generators are added. All 22 current generator workspaces are covered.

6. **Granular fixture resolution correctness** — The per-generator logic is complex:
   - When only fixtures change: all generators run those fixtures ✓
   - When only generators change: only those generators run all their fixtures ✓
   - When both change: affected generators run all fixtures, other generators run only changed fixtures ✓
   - Verify the CLI's `argv.fixture` handling correctly enters the per-generator resolution branch (`getAffected.ts:375-383`, `cli.ts:158-220`, `cli.ts:246-261`)

7. **`packages/seed/` in `GLOBAL_AFFECT_PATHS`** — any change to the seed package triggers ALL generators × ALL fixtures. This means this PR's own changes would mark everything as affected. Intentional for safety, but worth confirming.

8. **seed.yml change behavior** — when a generator's `seed.yml` changes, that generator is added to `generatorsWithAllFixtures`, so it runs all fixtures. Other generators are unaffected. Confirm this is the intended granularity (even for comment-only changes to seed.yml).

9. **Shared base packages via turbo** — When turbo is available, `generators/base/` and `generators/browser-compatible-base/` are NOT in `GLOBAL_AFFECT_PATHS` because turbo resolves their transitive dependents automatically. Verify that turbo correctly reports all generator packages as affected when base packages change.

10. **No runtime validation of turbo output** — The `as TurboLsOutput` cast assumes turbo's JSON matches the expected structure. No validation before accessing `parsed.packages.items`. The catch block handles any parsing failure gracefully (falls back to git diff), but the error message would be confusing if turbo changes its output format.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
