### PR TITLE
chore(rust): update changelog entry for WebSocket connector pattern and README snippets

### DIFF
--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
-- version: 0.18.4
+- version: 0.19.0
   changelogEntry:
     - summary: |
         Add WebSocket connector pattern and README code snippets when `enableWebsockets: true`.

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.18.4
+  changelogEntry:
+    - summary: |
+        Add WebSocket connector pattern and README code snippets when `enableWebsockets: true`.
+        WebSocket channels are now accessible through the root client via connector structs
+        (e.g., `client.realtime.connect(...)`) matching Python and Java generator patterns.
+        Generated README includes a Websockets section with connect, send, receive, and close examples.
+      type: feat
+  createdAt: "2026-03-06"
+  irVersion: 62
+
 - version: 0.18.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Requested by @iamnamananand996
Link to Devin Session: https://app.devin.ai/sessions/5d39b24dcd814ff2ba711bf26fe88851

Adds the missing `versions.yml` changelog entry for the WebSocket connector pattern and README snippets feature that was merged in #13193.

## Changes Made

- Added v0.19.0 entry to `generators/rust/sdk/versions.yml` with `type: feat`

### Updates since last revision

- Bumped version from 0.18.4 → 0.19.0, since `feat` types follow the project convention of minor version bumps (not patch)

## ⚠️ Human Review Checklist

1. **Changelog accuracy**: Verify the summary correctly describes what shipped in #13193 (WebSocket connector structs on root client + README Websockets section)
2. **Version sequence**: Confirm 0.19.0 is the correct next version after 0.18.3 (minor bump for `feat` type, matching project convention)

## Testing

- N/A — changelog-only change, validated by CI's `Validate versions.yml files` check