### PR TITLE
chore(internal): allow `parser`, `ir`, and `cli-v2` in PR titles; cut sonnet as default claude model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,6 +62,5 @@
     "NODE_ENV": "development",
     "PNPM_VERSION": "9.15.9"
   },
-  "includeCoAuthoredBy": true,
-  "model": "claude-sonnet-4-20250514"
+  "includeCoAuthoredBy": true
 }

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -55,6 +55,9 @@ jobs:
             swift
             rust
             generator-cli
+            parser
+            ir
+            cli-v2
           requireScope: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Purely in-repo housekeeping stuff.
