### PR TITLE
fix: strip unnecessary milliseconds from datetime query/header values in wiremock stubs

### DIFF
--- a/packages/commons/mock-utils/index.ts
+++ b/packages/commons/mock-utils/index.ts
@@ -336,7 +336,7 @@ export class WireMock {
     private exampleToQueryOrHeaderValue({ value }: { value: FernIr.ExampleTypeReference }): string | undefined {
         if (typeof value.jsonExample === "string") {
             const maybeDatetime = this.getDateTime(value);
-            return maybeDatetime != null ? maybeDatetime.toISOString() : value.jsonExample;
+            return maybeDatetime != null ? maybeDatetime.toISOString().replace(/\.000Z$/, "Z") : value.jsonExample;
         }
         if (typeof value.jsonExample === "number") {
             return value.jsonExample.toString();


### PR DESCRIPTION
## Description

Refs https://github.com/fern-demo/immix-rust-sdk/pull/3

Fixes a datetime format mismatch between generated WireMock stubs and SDK query parameter serialization that causes wire tests to fail at runtime.

Link to Devin Session: https://app.devin.ai/sessions/4d8af7daf05a43bda73cfe49dd711f34
Requested by: @iamnamananand996

## Problem

`exampleToQueryOrHeaderValue` in `@fern-api/mock-utils` uses JavaScript's `Date.toISOString()` to format datetime values for WireMock stub query/header parameters. `toISOString()` always includes milliseconds (e.g., `2024-01-01T00:00:00.000Z`), even when they are zero.

Most SDKs serialize datetimes **without** fractional seconds when they are zero:
- **Rust**: `chrono::SecondsFormat::Secs` → `2024-01-01T00:00:00Z`
- **Go**: `time.Format(time.RFC3339)` → `2024-01-01T00:00:00Z`
- **Ruby**: `Time#iso8601` → `2024-01-01T00:00:00Z`

Since WireMock uses exact-match (`equalTo`) for query parameters, this mismatch causes stubs to not match, returning 404s and failing wire tests (e.g., 3 `test_balances_history_*` tests in `fern-demo/immix-rust-sdk`).

## Changes Made

- Strip `.000Z` suffix from `toISOString()` output, replacing it with `Z`, so datetime query/header values in WireMock stubs match what SDKs actually send

## Review Checklist

- [ ] Confirm the regex `\.000Z$` correctly targets only zero-millisecond datetimes (non-zero like `.123Z` are preserved)
- [ ] Verify this change is safe for all generators that consume `mock-utils` (Go, Python, PHP, Ruby, etc.)
- [ ] Consider whether a dedicated test case with datetime query parameters should be added to the mock-utils test suite

## Testing

- [x] Existing mock-utils unit tests pass (4/4)
- [x] `pnpm run check` (Biome lint) passes
- [ ] No new test added for this specific edge case — existing fixtures don't include datetime query parameters