### PR TITLE
fix(cli): use cross-process file lock to prevent concurrent npm install races

### DIFF
--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -3,7 +3,7 @@ import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import type { Migration, MigrationModule, MigratorResult } from "@fern-api/migrations-base";
-import { mkdir, readFile } from "fs/promises";
+import { mkdir, readdir, readFile, rm } from "fs/promises";
 import { join } from "path";
 import semver from "semver";
 import { pathToFileURL } from "url";
@@ -218,6 +218,11 @@ export class GeneratorMigrator {
 
             const packageEntryPoint = join(packageDir, packageJson.main);
             const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
+
+            // Clean up stale install directories from previous processes.
+            // Fire-and-forget: failures are non-fatal.
+            void GeneratorMigrator.cleanupStaleInstallDirs(cacheDir, installDir);
+
             return migrations as Record<string, MigrationModule>;
         })();
 
@@ -227,6 +232,28 @@ export class GeneratorMigrator {
         });
 
         return this.migrationsInstallPromise;
+    }
+
+    /**
+     * Removes stale install-* directories from the cache dir, keeping only
+     * the current process's directory. This prevents unbounded disk growth.
+     */
+    private static async cleanupStaleInstallDirs(cacheDir: string, currentInstallDir: string): Promise<void> {
+        try {
+            const entries = await readdir(cacheDir, { withFileTypes: true });
+            const removePromises = entries
+                .filter(
+                    (entry) =>
+                        entry.isDirectory() &&
+                        entry.name.startsWith("install-") &&
+                        join(cacheDir, entry.name) !== currentInstallDir
+                )
+                // biome-ignore lint/suspicious/noEmptyBlockStatements: intentionally swallow per-dir removal errors
+                .map((entry) => rm(join(cacheDir, entry.name), { recursive: true, force: true }).catch(() => {}));
+            await Promise.all(removePromises);
+        } catch {
+            // Non-fatal: if we can't list the directory, just skip cleanup.
+        }
     }
 
     /**

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -192,37 +192,28 @@ export class GeneratorMigrator {
             const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
             const packageJsonPath = join(packageDir, "package.json");
 
-            // Acquire cross-process lock before touching node_modules
+            // Acquire cross-process lock so only one process runs npm install
+            // at a time. We always run `npm install @latest` (npm handles
+            // version freshness); the lock prevents concurrent installs from
+            // corrupting each other's node_modules.
             const releaseLock = await GeneratorMigrator.acquireLock(this.logger, cacheDir);
             try {
-                // Check if the package is already installed (by a prior process).
-                let needsInstall = true;
-                try {
-                    await stat(packageJsonPath);
-                    needsInstall = false;
-                    this.logger.debug("Migration package already installed — skipping npm install.");
-                } catch {
-                    // package.json doesn't exist yet — need to install
-                }
-
-                if (needsInstall) {
-                    await loggingExeca(
-                        this.logger,
-                        "npm",
-                        [
-                            "install",
-                            `${MIGRATION_PACKAGE_NAME}@latest`,
-                            "--prefix",
-                            cacheDir,
-                            "--cache",
-                            npmCacheDir,
-                            "--ignore-scripts",
-                            "--no-audit",
-                            "--no-fund"
-                        ],
-                        { doNotPipeOutput: true }
-                    );
-                }
+                await loggingExeca(
+                    this.logger,
+                    "npm",
+                    [
+                        "install",
+                        `${MIGRATION_PACKAGE_NAME}@latest`,
+                        "--prefix",
+                        cacheDir,
+                        "--cache",
+                        npmCacheDir,
+                        "--ignore-scripts",
+                        "--no-audit",
+                        "--no-fund"
+                    ],
+                    { doNotPipeOutput: true }
+                );
             } finally {
                 await releaseLock();
             }
@@ -303,13 +294,15 @@ export class GeneratorMigrator {
                         logger.debug(`Removing stale migration lock (pid=${lockContent.trim()}, age=${lockAge}ms)`);
                         try {
                             await unlink(lockPath);
-                        } catch {
+                        } catch (unlinkErr: unknown) {
                             // Another process may have removed it
+                            logger.debug(`Failed to remove stale lock: ${unlinkErr}`);
                         }
                         continue;
                     }
-                } catch {
+                } catch (vanishErr: unknown) {
                     // Lock file vanished — retry immediately
+                    logger.debug(`Lock file vanished during stale check: ${vanishErr}`);
                     continue;
                 }
 

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -3,7 +3,7 @@ import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import type { Migration, MigrationModule, MigratorResult } from "@fern-api/migrations-base";
-import { close, mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
+import { mkdir, open, readFile, stat, unlink } from "fs/promises";
 import { join } from "path";
 import semver from "semver";
 import { pathToFileURL } from "url";
@@ -272,9 +272,9 @@ export class GeneratorMigrator {
         // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
         while (true) {
             try {
-                const fd = await open(lockPath, "wx");
-                await writeFile(fd, String(process.pid));
-                await close(fd);
+                const fh = await open(lockPath, "wx");
+                await fh.writeFile(String(process.pid));
+                await fh.close();
 
                 return async () => {
                     try {

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -214,21 +214,22 @@ export class GeneratorMigrator {
                     ],
                     { doNotPipeOutput: true }
                 );
+
+                // Read & import while the lock is held so another process cannot
+                // start a concurrent npm install that overwrites node_modules.
+                const packageJsonContent = await readFile(packageJsonPath, "utf-8");
+                const packageJson = JSON.parse(packageJsonContent) as { main?: string };
+
+                if (packageJson.main == null) {
+                    throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
+                }
+
+                const packageEntryPoint = join(packageDir, packageJson.main);
+                const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
+                return migrations as Record<string, MigrationModule>;
             } finally {
                 await releaseLock();
             }
-
-            // Read & import outside the lock — no writes happening here
-            const packageJsonContent = await readFile(packageJsonPath, "utf-8");
-            const packageJson = JSON.parse(packageJsonContent) as { main?: string };
-
-            if (packageJson.main == null) {
-                throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
-            }
-
-            const packageEntryPoint = join(packageDir, packageJson.main);
-            const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
-            return migrations as Record<string, MigrationModule>;
         })();
 
         // Reset the cached promise on failure so the next call can retry.

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -219,9 +219,9 @@ export class GeneratorMigrator {
             const packageEntryPoint = join(packageDir, packageJson.main);
             const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
 
-            // Clean up stale install directories from previous processes.
+            // Clean up stale install directories from dead processes.
             // Fire-and-forget: failures are non-fatal.
-            void GeneratorMigrator.cleanupStaleInstallDirs(cacheDir, installDir);
+            void GeneratorMigrator.cleanupStaleInstallDirs(this.logger, cacheDir, installDir);
 
             return migrations as Record<string, MigrationModule>;
         })();
@@ -235,24 +235,52 @@ export class GeneratorMigrator {
     }
 
     /**
-     * Removes stale install-* directories from the cache dir, keeping only
-     * the current process's directory. This prevents unbounded disk growth.
+     * Returns true if the given PID belongs to a currently running process.
      */
-    private static async cleanupStaleInstallDirs(cacheDir: string, currentInstallDir: string): Promise<void> {
+    private static isProcessAlive(pid: number): boolean {
+        try {
+            process.kill(pid, 0);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Removes install-* directories from the cache dir that belong to dead
+     * processes. Skips the current process's directory and any directory
+     * whose PID is still alive, so concurrent CLI processes are never
+     * disrupted. This prevents unbounded disk growth.
+     */
+    private static async cleanupStaleInstallDirs(
+        logger: Logger,
+        cacheDir: string,
+        currentInstallDir: string
+    ): Promise<void> {
         try {
             const entries = await readdir(cacheDir, { withFileTypes: true });
             const removePromises = entries
-                .filter(
-                    (entry) =>
-                        entry.isDirectory() &&
-                        entry.name.startsWith("install-") &&
-                        join(cacheDir, entry.name) !== currentInstallDir
-                )
-                // biome-ignore lint/suspicious/noEmptyBlockStatements: intentionally swallow per-dir removal errors
-                .map((entry) => rm(join(cacheDir, entry.name), { recursive: true, force: true }).catch(() => {}));
+                .filter((entry) => {
+                    if (!entry.isDirectory() || !entry.name.startsWith("install-")) {
+                        return false;
+                    }
+                    if (join(cacheDir, entry.name) === currentInstallDir) {
+                        return false;
+                    }
+                    const pid = Number(entry.name.slice("install-".length));
+                    if (Number.isNaN(pid) || GeneratorMigrator.isProcessAlive(pid)) {
+                        return false;
+                    }
+                    return true;
+                })
+                .map((entry) =>
+                    rm(join(cacheDir, entry.name), { recursive: true, force: true }).catch((err: unknown) => {
+                        logger.debug(`Failed to remove stale install dir ${entry.name}: ${err}`);
+                    })
+                );
             await Promise.all(removePromises);
-        } catch {
-            // Non-fatal: if we can't list the directory, just skip cleanup.
+        } catch (err: unknown) {
+            logger.debug(`Failed to clean up stale migration cache dirs: ${err}`);
         }
     }
 

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -248,7 +248,11 @@ export class GeneratorMigrator {
         try {
             process.kill(pid, 0);
             return true;
-        } catch {
+        } catch (e: unknown) {
+            // EPERM means the process exists but we lack permission to signal it
+            if ((e as NodeJS.ErrnoException).code === "EPERM") {
+                return true;
+            }
             return false;
         }
     }
@@ -278,8 +282,9 @@ export class GeneratorMigrator {
                         if (content.trim() === myPid) {
                             unlinkSync(lockPath);
                         }
-                    } catch {
-                        // Lock file already removed or unreadable — nothing to do
+                    } catch (e: unknown) {
+                        // Lock file already removed or unreadable — best-effort cleanup
+                        void e; // Intentionally suppressed: exit handler cannot log asynchronously
                     }
                 };
                 process.on("exit", exitHandler);

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -3,7 +3,7 @@ import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import type { Migration, MigrationModule, MigratorResult } from "@fern-api/migrations-base";
-import { mkdir, readdir, readFile, rm } from "fs/promises";
+import { close, mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
 import { join } from "path";
 import semver from "semver";
 import { pathToFileURL } from "url";
@@ -50,6 +50,10 @@ export class GeneratorMigrator {
      * npm install.
      */
     private migrationsInstallPromise: Promise<Record<string, MigrationModule> | undefined> | undefined;
+
+    private static readonly LOCK_FILENAME = ".install.lock";
+    private static readonly LOCK_POLL_MS = 200;
+    private static readonly LOCK_STALE_MS = 5 * 60 * 1000; // 5 minutes
 
     constructor(config: GeneratorMigrator.Config) {
         this.logger = config.logger;
@@ -165,10 +169,12 @@ export class GeneratorMigrator {
 
     /**
      * Installs the migration package once and returns the full migrations map.
-     * Uses an isolated npm cache to avoid corruption from the system npm cache.
      *
-     * Subsequent calls reuse the cached result, avoiding redundant npm installs
-     * when migrating multiple generators in the same session.
+     * Within a single instance, concurrent calls reuse the same in-flight promise.
+     * Across processes, a file lock serializes npm installs so only one process
+     * writes to the shared --prefix directory at a time. Processes that acquire
+     * the lock after another process has already installed the package will find
+     * it already present and skip the npm install entirely.
      */
     private async ensureMigrationsInstalled(): Promise<Record<string, MigrationModule> | undefined> {
         if (this.migrationsInstallPromise != null) {
@@ -180,35 +186,48 @@ export class GeneratorMigrator {
 
         this.migrationsInstallPromise = (async () => {
             const cacheDir = this.cachePath as string;
-            // Use a process-specific install directory to avoid cross-process
-            // race conditions when multiple CLI processes run npm install to
-            // the same --prefix directory simultaneously.
-            const installDir = join(cacheDir, `install-${process.pid}`);
-            await mkdir(installDir, { recursive: true });
+            await mkdir(cacheDir, { recursive: true });
 
-            // Use a shared npm download cache for fast installs, but a
-            // process-specific --prefix so concurrent CLI processes don't
-            // corrupt each other's node_modules.
             const npmCacheDir = join(cacheDir, ".npm-cache");
-            await loggingExeca(
-                this.logger,
-                "npm",
-                [
-                    "install",
-                    `${MIGRATION_PACKAGE_NAME}@latest`,
-                    "--prefix",
-                    installDir,
-                    "--cache",
-                    npmCacheDir,
-                    "--ignore-scripts",
-                    "--no-audit",
-                    "--no-fund"
-                ],
-                { doNotPipeOutput: true }
-            );
-
-            const packageDir = join(installDir, "node_modules", MIGRATION_PACKAGE_NAME);
+            const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
             const packageJsonPath = join(packageDir, "package.json");
+
+            // Acquire cross-process lock before touching node_modules
+            const releaseLock = await GeneratorMigrator.acquireLock(this.logger, cacheDir);
+            try {
+                // Check if the package is already installed (by a prior process).
+                let needsInstall = true;
+                try {
+                    await stat(packageJsonPath);
+                    needsInstall = false;
+                    this.logger.debug("Migration package already installed — skipping npm install.");
+                } catch {
+                    // package.json doesn't exist yet — need to install
+                }
+
+                if (needsInstall) {
+                    await loggingExeca(
+                        this.logger,
+                        "npm",
+                        [
+                            "install",
+                            `${MIGRATION_PACKAGE_NAME}@latest`,
+                            "--prefix",
+                            cacheDir,
+                            "--cache",
+                            npmCacheDir,
+                            "--ignore-scripts",
+                            "--no-audit",
+                            "--no-fund"
+                        ],
+                        { doNotPipeOutput: true }
+                    );
+                }
+            } finally {
+                await releaseLock();
+            }
+
+            // Read & import outside the lock — no writes happening here
             const packageJsonContent = await readFile(packageJsonPath, "utf-8");
             const packageJson = JSON.parse(packageJsonContent) as { main?: string };
 
@@ -218,11 +237,6 @@ export class GeneratorMigrator {
 
             const packageEntryPoint = join(packageDir, packageJson.main);
             const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
-
-            // Clean up stale install directories from dead processes.
-            // Fire-and-forget: failures are non-fatal.
-            void GeneratorMigrator.cleanupStaleInstallDirs(this.logger, cacheDir, installDir);
-
             return migrations as Record<string, MigrationModule>;
         })();
 
@@ -247,40 +261,60 @@ export class GeneratorMigrator {
     }
 
     /**
-     * Removes install-* directories from the cache dir that belong to dead
-     * processes. Skips the current process's directory and any directory
-     * whose PID is still alive, so concurrent CLI processes are never
-     * disrupted. This prevents unbounded disk growth.
+     * Acquires an exclusive file lock by atomically creating a lock file.
+     * If the lock already exists, polls until it becomes available.
+     * Stale locks (from dead processes or older than LOCK_STALE_MS) are
+     * automatically removed.
      */
-    private static async cleanupStaleInstallDirs(
-        logger: Logger,
-        cacheDir: string,
-        currentInstallDir: string
-    ): Promise<void> {
-        try {
-            const entries = await readdir(cacheDir, { withFileTypes: true });
-            const removePromises = entries
-                .filter((entry) => {
-                    if (!entry.isDirectory() || !entry.name.startsWith("install-")) {
-                        return false;
+    private static async acquireLock(logger: Logger, cacheDir: string): Promise<() => Promise<void>> {
+        const lockPath = join(cacheDir, GeneratorMigrator.LOCK_FILENAME);
+
+        // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
+        while (true) {
+            try {
+                const fd = await open(lockPath, "wx");
+                await writeFile(fd, String(process.pid));
+                await close(fd);
+
+                return async () => {
+                    try {
+                        await unlink(lockPath);
+                    } catch (err: unknown) {
+                        logger.debug(`Failed to release migration lock: ${err}`);
                     }
-                    if (join(cacheDir, entry.name) === currentInstallDir) {
-                        return false;
+                };
+            } catch (err: unknown) {
+                const code = (err as NodeJS.ErrnoException).code;
+                if (code !== "EEXIST") {
+                    throw err;
+                }
+
+                // Lock file exists — check if it's stale
+                try {
+                    const lockContent = await readFile(lockPath, "utf-8");
+                    const lockPid = Number(lockContent.trim());
+                    const lockStat = await stat(lockPath);
+                    const lockAge = Date.now() - lockStat.mtimeMs;
+
+                    if (
+                        lockAge > GeneratorMigrator.LOCK_STALE_MS ||
+                        (Number.isFinite(lockPid) && lockPid > 0 && !GeneratorMigrator.isProcessAlive(lockPid))
+                    ) {
+                        logger.debug(`Removing stale migration lock (pid=${lockContent.trim()}, age=${lockAge}ms)`);
+                        try {
+                            await unlink(lockPath);
+                        } catch {
+                            // Another process may have removed it
+                        }
+                        continue;
                     }
-                    const pid = Number(entry.name.slice("install-".length));
-                    if (Number.isNaN(pid) || GeneratorMigrator.isProcessAlive(pid)) {
-                        return false;
-                    }
-                    return true;
-                })
-                .map((entry) =>
-                    rm(join(cacheDir, entry.name), { recursive: true, force: true }).catch((err: unknown) => {
-                        logger.debug(`Failed to remove stale install dir ${entry.name}: ${err}`);
-                    })
-                );
-            await Promise.all(removePromises);
-        } catch (err: unknown) {
-            logger.debug(`Failed to clean up stale migration cache dirs: ${err}`);
+                } catch {
+                    // Lock file vanished — retry immediately
+                    continue;
+                }
+
+                await new Promise((resolve) => setTimeout(resolve, GeneratorMigrator.LOCK_POLL_MS));
+            }
         }
     }
 

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -3,6 +3,7 @@ import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import type { Migration, MigrationModule, MigratorResult } from "@fern-api/migrations-base";
+import { readFileSync, unlinkSync } from "fs";
 import { mkdir, open, readFile, stat, unlink } from "fs/promises";
 import { join } from "path";
 import semver from "semver";
@@ -260,17 +261,41 @@ export class GeneratorMigrator {
      */
     private static async acquireLock(logger: Logger, cacheDir: string): Promise<() => Promise<void>> {
         const lockPath = join(cacheDir, GeneratorMigrator.LOCK_FILENAME);
+        const myPid = String(process.pid);
 
         // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
         while (true) {
             try {
                 const fh = await open(lockPath, "wx");
-                await fh.writeFile(String(process.pid));
+                await fh.writeFile(myPid);
                 await fh.close();
 
-                return async () => {
+                // Register a synchronous exit handler so the lock is cleaned up
+                // even if the process crashes or is killed (SIGTERM/SIGINT).
+                const exitHandler = (): void => {
                     try {
-                        await unlink(lockPath);
+                        const content = readFileSync(lockPath, "utf-8");
+                        if (content.trim() === myPid) {
+                            unlinkSync(lockPath);
+                        }
+                    } catch {
+                        // Lock file already removed or unreadable — nothing to do
+                    }
+                };
+                process.on("exit", exitHandler);
+
+                return async () => {
+                    process.removeListener("exit", exitHandler);
+                    try {
+                        // Verify we still own the lock before removing it.
+                        const currentContent = await readFile(lockPath, "utf-8");
+                        if (currentContent.trim() === myPid) {
+                            await unlink(lockPath);
+                        } else {
+                            logger.debug(
+                                `Lock file owned by another process (expected pid=${myPid}, found=${currentContent.trim()}); skipping release`
+                            );
+                        }
                     } catch (err: unknown) {
                         logger.debug(`Failed to release migration lock: ${err}`);
                     }

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -180,10 +180,15 @@ export class GeneratorMigrator {
 
         this.migrationsInstallPromise = (async () => {
             const cacheDir = this.cachePath as string;
-            await mkdir(cacheDir, { recursive: true });
+            // Use a process-specific install directory to avoid cross-process
+            // race conditions when multiple CLI processes run npm install to
+            // the same --prefix directory simultaneously.
+            const installDir = join(cacheDir, `install-${process.pid}`);
+            await mkdir(installDir, { recursive: true });
 
-            // Use an isolated npm cache inside the migration cache dir to prevent
-            // corrupt system-level npm cache entries from causing repeated failures.
+            // Use a shared npm download cache for fast installs, but a
+            // process-specific --prefix so concurrent CLI processes don't
+            // corrupt each other's node_modules.
             const npmCacheDir = join(cacheDir, ".npm-cache");
             await loggingExeca(
                 this.logger,
@@ -192,7 +197,7 @@ export class GeneratorMigrator {
                     "install",
                     `${MIGRATION_PACKAGE_NAME}@latest`,
                     "--prefix",
-                    cacheDir,
+                    installDir,
                     "--cache",
                     npmCacheDir,
                     "--ignore-scripts",
@@ -202,7 +207,7 @@ export class GeneratorMigrator {
                 { doNotPipeOutput: true }
             );
 
-            const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
+            const packageDir = join(installDir, "node_modules", MIGRATION_PACKAGE_NAME);
             const packageJsonPath = join(packageDir, "package.json");
             const packageJsonContent = await readFile(packageJsonPath, "utf-8");
             const packageJson = JSON.parse(packageJsonContent) as { main?: string };

--- a/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
@@ -26,16 +26,30 @@ vi.mock("@fern-api/logging-execa", () => ({
 }));
 
 // Mock fs/promises
+// The lock file mechanism uses open/writeFile/close/unlink/stat.
+// We mock open("wx") to succeed (returning a fake fd), and stat to throw
+// ENOENT so that ensureMigrationsInstalled always runs npm install.
+let mockStatShouldSucceed = false;
 vi.mock("fs/promises", () => ({
     mkdir: vi.fn(async () => undefined),
+    open: vi.fn(async () => 42), // fake file descriptor
+    writeFile: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+    unlink: vi.fn(async () => undefined),
+    stat: vi.fn(async () => {
+        if (!mockStatShouldSucceed) {
+            const err = new Error("ENOENT") as NodeJS.ErrnoException;
+            err.code = "ENOENT";
+            throw err;
+        }
+        return { mtimeMs: Date.now() };
+    }),
     readFile: vi.fn(async () =>
         JSON.stringify({
             name: "@fern-api/generator-migrations",
             main: "./dist/index.js"
         })
-    ),
-    readdir: vi.fn(async () => []),
-    rm: vi.fn(async () => undefined)
+    )
 }));
 
 // Mock os.homedir
@@ -95,16 +109,27 @@ describe("Migration loader deduplication", () => {
                 return { stdout: "", stderr: "", exitCode: 0 };
             })
         }));
+        mockStatShouldSucceed = false;
         vi.doMock("fs/promises", () => ({
             mkdir: vi.fn(async () => undefined),
+            open: vi.fn(async () => 42),
+            writeFile: vi.fn(async () => undefined),
+            close: vi.fn(async () => undefined),
+            unlink: vi.fn(async () => undefined),
+            stat: vi.fn(async () => {
+                if (!mockStatShouldSucceed) {
+                    const err = new Error("ENOENT") as NodeJS.ErrnoException;
+                    err.code = "ENOENT";
+                    throw err;
+                }
+                return { mtimeMs: Date.now() };
+            }),
             readFile: vi.fn(async () =>
                 JSON.stringify({
                     name: "@fern-api/generator-migrations",
                     main: "./dist/index.js"
                 })
-            ),
-            readdir: vi.fn(async () => []),
-            rm: vi.fn(async () => undefined)
+            )
         }));
         vi.doMock("os", () => ({
             homedir: vi.fn(() => "/tmp/test-fern-home")
@@ -114,9 +139,9 @@ describe("Migration loader deduplication", () => {
     it("should only run npm install once when called concurrently", async () => {
         // We need to mock the dynamic import that happens inside ensureMigrationsInstalled.
         // The function does: const { migrations } = await import(packageEntryPoint);
-        // The install dir is process-specific: ~/.fern/migration-cache/install-{pid}/
+        // The install dir is the shared cache dir: ~/.fern/migration-cache/
         vi.doMock(
-            `/tmp/test-fern-home/.fern/migration-cache/install-${process.pid}/node_modules/@fern-api/generator-migrations/dist/index.js`,
+            `/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js`,
             () => ({
                 migrations: mockMigrationsMap
             })
@@ -153,7 +178,7 @@ describe("Migration loader deduplication", () => {
 
     it("should retry npm install after a transient failure", async () => {
         vi.doMock(
-            `/tmp/test-fern-home/.fern/migration-cache/install-${process.pid}/node_modules/@fern-api/generator-migrations/dist/index.js`,
+            `/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js`,
             () => ({
                 migrations: mockMigrationsMap
             })
@@ -191,7 +216,7 @@ describe("Migration loader deduplication", () => {
 
     it("should return undefined for unknown generators", async () => {
         vi.doMock(
-            `/tmp/test-fern-home/.fern/migration-cache/install-${process.pid}/node_modules/@fern-api/generator-migrations/dist/index.js`,
+            `/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js`,
             () => ({
                 migrations: mockMigrationsMap
             })

--- a/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
@@ -110,9 +110,9 @@ describe("Migration loader deduplication", () => {
     it("should only run npm install once when called concurrently", async () => {
         // We need to mock the dynamic import that happens inside ensureMigrationsInstalled.
         // The function does: const { migrations } = await import(packageEntryPoint);
-        // We mock the path module to return a predictable path, then mock that path's import.
+        // The install dir is process-specific: ~/.fern/migration-cache/install-{pid}/
         vi.doMock(
-            "/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js",
+            `/tmp/test-fern-home/.fern/migration-cache/install-${process.pid}/node_modules/@fern-api/generator-migrations/dist/index.js`,
             () => ({
                 migrations: mockMigrationsMap
             })
@@ -149,7 +149,7 @@ describe("Migration loader deduplication", () => {
 
     it("should retry npm install after a transient failure", async () => {
         vi.doMock(
-            "/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js",
+            `/tmp/test-fern-home/.fern/migration-cache/install-${process.pid}/node_modules/@fern-api/generator-migrations/dist/index.js`,
             () => ({
                 migrations: mockMigrationsMap
             })
@@ -187,7 +187,7 @@ describe("Migration loader deduplication", () => {
 
     it("should return undefined for unknown generators", async () => {
         vi.doMock(
-            "/tmp/test-fern-home/.fern/migration-cache/node_modules/@fern-api/generator-migrations/dist/index.js",
+            `/tmp/test-fern-home/.fern/migration-cache/install-${process.pid}/node_modules/@fern-api/generator-migrations/dist/index.js`,
             () => ({
                 migrations: mockMigrationsMap
             })

--- a/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
@@ -33,7 +33,9 @@ vi.mock("fs/promises", () => ({
             name: "@fern-api/generator-migrations",
             main: "./dist/index.js"
         })
-    )
+    ),
+    readdir: vi.fn(async () => []),
+    rm: vi.fn(async () => undefined)
 }));
 
 // Mock os.homedir
@@ -100,7 +102,9 @@ describe("Migration loader deduplication", () => {
                     name: "@fern-api/generator-migrations",
                     main: "./dist/index.js"
                 })
-            )
+            ),
+            readdir: vi.fn(async () => []),
+            rm: vi.fn(async () => undefined)
         }));
         vi.doMock("os", () => ({
             homedir: vi.fn(() => "/tmp/test-fern-home")

--- a/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/__test__/deduplication.test.ts
@@ -26,15 +26,14 @@ vi.mock("@fern-api/logging-execa", () => ({
 }));
 
 // Mock fs/promises
-// The lock file mechanism uses open/writeFile/close/unlink/stat.
-// We mock open("wx") to succeed (returning a fake fd), and stat to throw
-// ENOENT so that ensureMigrationsInstalled always runs npm install.
+// The lock file mechanism uses open("wx") which returns a FileHandle with
+// .writeFile() and .close() methods. We also mock stat to throw ENOENT so
+// that ensureMigrationsInstalled always runs npm install.
+const mockFileHandle = { writeFile: vi.fn(async () => undefined), close: vi.fn(async () => undefined) };
 let mockStatShouldSucceed = false;
 vi.mock("fs/promises", () => ({
     mkdir: vi.fn(async () => undefined),
-    open: vi.fn(async () => 42), // fake file descriptor
-    writeFile: vi.fn(async () => undefined),
-    close: vi.fn(async () => undefined),
+    open: vi.fn(async () => mockFileHandle),
     unlink: vi.fn(async () => undefined),
     stat: vi.fn(async () => {
         if (!mockStatShouldSucceed) {
@@ -112,9 +111,7 @@ describe("Migration loader deduplication", () => {
         mockStatShouldSucceed = false;
         vi.doMock("fs/promises", () => ({
             mkdir: vi.fn(async () => undefined),
-            open: vi.fn(async () => 42),
-            writeFile: vi.fn(async () => undefined),
-            close: vi.fn(async () => undefined),
+            open: vi.fn(async () => mockFileHandle),
             unlink: vi.fn(async () => undefined),
             stat: vi.fn(async () => {
                 if (!mockStatShouldSucceed) {

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -16,14 +16,24 @@ import { Migration, MigrationModule, MigratorResult } from "./types.js";
 const MIGRATION_PACKAGE_NAME = "@fern-api/generator-migrations";
 
 /**
- * Gets the cache directory for migration packages.
- * Migrations are installed to ~/.fern/migration-cache/ to avoid polluting the project.
- *
- * Note: npm's @latest tag resolution ensures we always get the current latest version,
- * and npm's global cache (~/.npm) provides fast installs without repeated downloads.
+ * Gets the base cache directory for migration packages.
+ * The shared npm download cache is stored here for fast installs.
  */
 function getMigrationCacheDir(): string {
     return join(homedir(), ".fern", "migration-cache");
+}
+
+/**
+ * Gets a process-specific install directory for the migration package.
+ * Each CLI process gets its own install directory to avoid cross-process
+ * race conditions when multiple CLI processes (e.g., from concurrent tests)
+ * run npm install to the same --prefix directory simultaneously.
+ *
+ * The shared npm download cache (~/.fern/migration-cache/.npm-cache) still
+ * provides fast installs without repeated downloads.
+ */
+function getInstallDir(): string {
+    return join(getMigrationCacheDir(), `install-${process.pid}`);
 }
 
 /**
@@ -53,16 +63,18 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
 
     migrationsInstallPromise = (async () => {
         const cacheDir = getMigrationCacheDir();
-        await mkdir(cacheDir, { recursive: true });
+        const installDir = getInstallDir();
+        await mkdir(installDir, { recursive: true });
 
-        // Use an isolated npm cache inside the migration cache dir to prevent
-        // corrupt system-level npm cache entries from causing repeated failures.
+        // Use a shared npm download cache for fast installs, but a
+        // process-specific --prefix so concurrent CLI processes don't
+        // corrupt each other's node_modules.
         const npmCacheDir = join(cacheDir, ".npm-cache");
         await loggingExeca(logger, "npm", [
             "install",
             `${MIGRATION_PACKAGE_NAME}@latest`,
             "--prefix",
-            cacheDir,
+            installDir,
             "--cache",
             npmCacheDir,
             "--ignore-scripts",
@@ -70,7 +82,7 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
             "--no-fund"
         ]);
 
-        const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
+        const packageDir = join(installDir, "node_modules", MIGRATION_PACKAGE_NAME);
         const packageJsonPath = join(packageDir, "package.json");
         const packageJsonContent = await readFile(packageJsonPath, "utf-8");
         const packageJson = JSON.parse(packageJsonContent) as { main?: string };

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -39,7 +39,11 @@ function isProcessAlive(pid: number): boolean {
     try {
         process.kill(pid, 0);
         return true;
-    } catch {
+    } catch (e: unknown) {
+        // EPERM means the process exists but we lack permission to signal it
+        if ((e as NodeJS.ErrnoException).code === "EPERM") {
+            return true;
+        }
         return false;
     }
 }
@@ -72,8 +76,9 @@ async function acquireLock(logger: Logger, cacheDir: string): Promise<() => Prom
                     if (content.trim() === myPid) {
                         unlinkSync(lockPath);
                     }
-                } catch {
-                    // Lock file already removed or unreadable — nothing to do
+                } catch (e: unknown) {
+                    // Lock file already removed or unreadable — best-effort cleanup
+                    void e; // Intentionally suppressed: exit handler cannot log asynchronously
                 }
             };
             process.on("exit", exitHandler);

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -88,13 +88,15 @@ async function acquireLock(logger: Logger, cacheDir: string): Promise<() => Prom
                     logger.debug(`Removing stale migration lock (pid=${lockContent.trim()}, age=${lockAge}ms)`);
                     try {
                         await unlink(lockPath);
-                    } catch {
+                    } catch (unlinkErr: unknown) {
                         // Another process may have removed it — that's fine
+                        logger.debug(`Failed to remove stale lock: ${unlinkErr}`);
                     }
                     continue;
                 }
-            } catch {
+            } catch (vanishErr: unknown) {
                 // Lock file vanished between open and stat — retry immediately
+                logger.debug(`Lock file vanished during stale check: ${vanishErr}`);
                 continue;
             }
 
@@ -138,34 +140,23 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
         const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
         const packageJsonPath = join(packageDir, "package.json");
 
-        // Acquire cross-process lock before touching node_modules
+        // Acquire cross-process lock so only one process runs npm install at a time.
+        // We always run `npm install @latest` (npm handles version freshness via
+        // registry checks); the lock simply prevents concurrent installs from
+        // corrupting each other's node_modules.
         const releaseLock = await acquireLock(logger, cacheDir);
         try {
-            // Check if the package is already installed (by a prior process).
-            // npm install @latest may have been run by another process while
-            // we waited for the lock — skip the install if package.json exists.
-            let needsInstall = true;
-            try {
-                await stat(packageJsonPath);
-                needsInstall = false;
-                logger.debug("Migration package already installed — skipping npm install.");
-            } catch {
-                // package.json doesn't exist yet — need to install
-            }
-
-            if (needsInstall) {
-                await loggingExeca(logger, "npm", [
-                    "install",
-                    `${MIGRATION_PACKAGE_NAME}@latest`,
-                    "--prefix",
-                    cacheDir,
-                    "--cache",
-                    npmCacheDir,
-                    "--ignore-scripts",
-                    "--no-audit",
-                    "--no-fund"
-                ]);
-            }
+            await loggingExeca(logger, "npm", [
+                "install",
+                `${MIGRATION_PACKAGE_NAME}@latest`,
+                "--prefix",
+                cacheDir,
+                "--cache",
+                npmCacheDir,
+                "--ignore-scripts",
+                "--no-audit",
+                "--no-fund"
+            ]);
         } finally {
             await releaseLock();
         }

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -1,7 +1,7 @@
 import type { generatorsYml } from "@fern-api/configuration";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { mkdir, readFile } from "fs/promises";
+import { mkdir, readdir, readFile, rm } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import semver from "semver";
@@ -93,6 +93,11 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
 
         const packageEntryPoint = join(packageDir, packageJson.main);
         const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
+
+        // Clean up stale install directories from previous processes.
+        // Fire-and-forget: failures are non-fatal.
+        void cleanupStaleInstallDirs(cacheDir, installDir);
+
         return migrations as Record<string, MigrationModule>;
     })();
 
@@ -102,6 +107,29 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
     });
 
     return migrationsInstallPromise;
+}
+
+/**
+ * Removes stale install-* directories from the cache dir, keeping only
+ * the current process's directory. This prevents unbounded disk growth
+ * from accumulated per-process install dirs.
+ */
+async function cleanupStaleInstallDirs(cacheDir: string, currentInstallDir: string): Promise<void> {
+    try {
+        const entries = await readdir(cacheDir, { withFileTypes: true });
+        const removePromises = entries
+            .filter(
+                (entry) =>
+                    entry.isDirectory() &&
+                    entry.name.startsWith("install-") &&
+                    join(cacheDir, entry.name) !== currentInstallDir
+            )
+            // biome-ignore lint/suspicious/noEmptyBlockStatements: intentionally swallow per-dir removal errors
+            .map((entry) => rm(join(cacheDir, entry.name), { recursive: true, force: true }).catch(() => {}));
+        await Promise.all(removePromises);
+    } catch {
+        // Non-fatal: if we can't list the directory, just skip cleanup.
+    }
 }
 
 /**

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -1,7 +1,7 @@
 import type { generatorsYml } from "@fern-api/configuration";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { mkdir, readdir, readFile, rm } from "fs/promises";
+import { close, mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import semver from "semver";
@@ -16,98 +16,20 @@ import { Migration, MigrationModule, MigratorResult } from "./types.js";
 const MIGRATION_PACKAGE_NAME = "@fern-api/generator-migrations";
 
 /**
- * Gets the base cache directory for migration packages.
- * The shared npm download cache is stored here for fast installs.
+ * Gets the cache directory for migration packages.
+ * Migrations are installed to ~/.fern/migration-cache/ to avoid polluting the project.
  */
 function getMigrationCacheDir(): string {
     return join(homedir(), ".fern", "migration-cache");
 }
 
-/**
- * Gets a process-specific install directory for the migration package.
- * Each CLI process gets its own install directory to avoid cross-process
- * race conditions when multiple CLI processes (e.g., from concurrent tests)
- * run npm install to the same --prefix directory simultaneously.
- *
- * The shared npm download cache (~/.fern/migration-cache/.npm-cache) still
- * provides fast installs without repeated downloads.
- */
-function getInstallDir(): string {
-    return join(getMigrationCacheDir(), `install-${process.pid}`);
-}
+// ---------------------------------------------------------------------------
+// Cross-process file lock
+// ---------------------------------------------------------------------------
 
-/**
- * Module-level promise that ensures the migration package is installed only once
- * per CLI process. When multiple workspaces are upgraded concurrently via
- * Promise.all, they all await this single promise instead of racing on
- * concurrent npm installs to the same --prefix directory (which causes
- * TAR_ENTRY_ERROR and missing files).
- */
-let migrationsInstallPromise: Promise<Record<string, MigrationModule> | undefined> | undefined;
-
-/**
- * Installs the migration package once and returns the full migrations map.
- * Uses an isolated npm cache to avoid corruption from the system npm cache.
- *
- * Concurrent calls reuse the same in-flight promise, preventing the race
- * condition where multiple npm installs to the same --prefix directory cause
- * tar extraction failures.
- */
-async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string, MigrationModule> | undefined> {
-    if (migrationsInstallPromise != null) {
-        return migrationsInstallPromise.catch((err) => {
-            migrationsInstallPromise = undefined;
-            throw err;
-        });
-    }
-
-    migrationsInstallPromise = (async () => {
-        const cacheDir = getMigrationCacheDir();
-        const installDir = getInstallDir();
-        await mkdir(installDir, { recursive: true });
-
-        // Use a shared npm download cache for fast installs, but a
-        // process-specific --prefix so concurrent CLI processes don't
-        // corrupt each other's node_modules.
-        const npmCacheDir = join(cacheDir, ".npm-cache");
-        await loggingExeca(logger, "npm", [
-            "install",
-            `${MIGRATION_PACKAGE_NAME}@latest`,
-            "--prefix",
-            installDir,
-            "--cache",
-            npmCacheDir,
-            "--ignore-scripts",
-            "--no-audit",
-            "--no-fund"
-        ]);
-
-        const packageDir = join(installDir, "node_modules", MIGRATION_PACKAGE_NAME);
-        const packageJsonPath = join(packageDir, "package.json");
-        const packageJsonContent = await readFile(packageJsonPath, "utf-8");
-        const packageJson = JSON.parse(packageJsonContent) as { main?: string };
-
-        if (packageJson.main == null) {
-            throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
-        }
-
-        const packageEntryPoint = join(packageDir, packageJson.main);
-        const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
-
-        // Clean up stale install directories from dead processes.
-        // Fire-and-forget: failures are non-fatal.
-        void cleanupStaleInstallDirs(logger, cacheDir, installDir);
-
-        return migrations as Record<string, MigrationModule>;
-    })();
-
-    // Reset the cached promise on failure so the next call can retry.
-    migrationsInstallPromise.catch(() => {
-        migrationsInstallPromise = undefined;
-    });
-
-    return migrationsInstallPromise;
-}
+const LOCK_FILENAME = ".install.lock";
+const LOCK_POLL_MS = 200;
+const LOCK_STALE_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
  * Returns true if the given PID belongs to a currently running process.
@@ -122,38 +44,151 @@ function isProcessAlive(pid: number): boolean {
 }
 
 /**
- * Removes install-* directories from the cache dir that belong to dead
- * processes. Skips the current process's directory and any directory
- * whose PID is still alive, so concurrent CLI processes are never
- * disrupted. This prevents unbounded disk growth from accumulated
- * per-process install dirs.
+ * Acquires an exclusive file lock by atomically creating a lock file.
+ * If the lock already exists, polls until it becomes available.
+ * Stale locks (from dead processes or older than LOCK_STALE_MS) are
+ * automatically removed.
+ *
+ * Returns a release function that MUST be called when done.
  */
-async function cleanupStaleInstallDirs(logger: Logger, cacheDir: string, currentInstallDir: string): Promise<void> {
-    try {
-        const entries = await readdir(cacheDir, { withFileTypes: true });
-        const removePromises = entries
-            .filter((entry) => {
-                if (!entry.isDirectory() || !entry.name.startsWith("install-")) {
-                    return false;
+async function acquireLock(logger: Logger, cacheDir: string): Promise<() => Promise<void>> {
+    const lockPath = join(cacheDir, LOCK_FILENAME);
+
+    // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
+    while (true) {
+        try {
+            // O_CREAT | O_EXCL — fails if file already exists (atomic)
+            const fd = await open(lockPath, "wx");
+            await writeFile(fd, String(process.pid));
+            await close(fd);
+
+            return async () => {
+                try {
+                    await unlink(lockPath);
+                } catch (err: unknown) {
+                    logger.debug(`Failed to release migration lock: ${err}`);
                 }
-                if (join(cacheDir, entry.name) === currentInstallDir) {
-                    return false;
+            };
+        } catch (err: unknown) {
+            const code = (err as NodeJS.ErrnoException).code;
+            if (code !== "EEXIST") {
+                // Unexpected error (permissions, disk full, etc.) — let it propagate
+                throw err;
+            }
+
+            // Lock file exists — check if it's stale
+            try {
+                const lockContent = await readFile(lockPath, "utf-8");
+                const lockPid = Number(lockContent.trim());
+                const lockStat = await stat(lockPath);
+                const lockAge = Date.now() - lockStat.mtimeMs;
+
+                if (lockAge > LOCK_STALE_MS || (Number.isFinite(lockPid) && lockPid > 0 && !isProcessAlive(lockPid))) {
+                    // Stale lock — remove it and retry immediately
+                    logger.debug(`Removing stale migration lock (pid=${lockContent.trim()}, age=${lockAge}ms)`);
+                    try {
+                        await unlink(lockPath);
+                    } catch {
+                        // Another process may have removed it — that's fine
+                    }
+                    continue;
                 }
-                const pid = Number(entry.name.slice("install-".length));
-                if (Number.isNaN(pid) || isProcessAlive(pid)) {
-                    return false;
-                }
-                return true;
-            })
-            .map((entry) =>
-                rm(join(cacheDir, entry.name), { recursive: true, force: true }).catch((err: unknown) => {
-                    logger.debug(`Failed to remove stale install dir ${entry.name}: ${err}`);
-                })
-            );
-        await Promise.all(removePromises);
-    } catch (err: unknown) {
-        logger.debug(`Failed to clean up stale migration cache dirs: ${err}`);
+            } catch {
+                // Lock file vanished between open and stat — retry immediately
+                continue;
+            }
+
+            // Lock is held by a live process — wait and retry
+            await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_MS));
+        }
     }
+}
+
+/**
+ * Module-level promise that ensures the migration package is installed only once
+ * per CLI process. When multiple workspaces are upgraded concurrently via
+ * Promise.all, they all await this single promise instead of racing on
+ * concurrent npm installs to the same --prefix directory (which causes
+ * TAR_ENTRY_ERROR and missing files).
+ */
+let migrationsInstallPromise: Promise<Record<string, MigrationModule> | undefined> | undefined;
+
+/**
+ * Installs the migration package once and returns the full migrations map.
+ *
+ * Within a single process, concurrent calls reuse the same in-flight promise.
+ * Across processes, a file lock serializes npm installs so only one process
+ * writes to the shared --prefix directory at a time. Processes that acquire
+ * the lock after another process has already installed the package will find
+ * it already present and skip the npm install entirely.
+ */
+async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string, MigrationModule> | undefined> {
+    if (migrationsInstallPromise != null) {
+        return migrationsInstallPromise.catch((err) => {
+            migrationsInstallPromise = undefined;
+            throw err;
+        });
+    }
+
+    migrationsInstallPromise = (async () => {
+        const cacheDir = getMigrationCacheDir();
+        await mkdir(cacheDir, { recursive: true });
+
+        const npmCacheDir = join(cacheDir, ".npm-cache");
+        const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
+        const packageJsonPath = join(packageDir, "package.json");
+
+        // Acquire cross-process lock before touching node_modules
+        const releaseLock = await acquireLock(logger, cacheDir);
+        try {
+            // Check if the package is already installed (by a prior process).
+            // npm install @latest may have been run by another process while
+            // we waited for the lock — skip the install if package.json exists.
+            let needsInstall = true;
+            try {
+                await stat(packageJsonPath);
+                needsInstall = false;
+                logger.debug("Migration package already installed — skipping npm install.");
+            } catch {
+                // package.json doesn't exist yet — need to install
+            }
+
+            if (needsInstall) {
+                await loggingExeca(logger, "npm", [
+                    "install",
+                    `${MIGRATION_PACKAGE_NAME}@latest`,
+                    "--prefix",
+                    cacheDir,
+                    "--cache",
+                    npmCacheDir,
+                    "--ignore-scripts",
+                    "--no-audit",
+                    "--no-fund"
+                ]);
+            }
+        } finally {
+            await releaseLock();
+        }
+
+        // Read & import outside the lock — no writes happening here
+        const packageJsonContent = await readFile(packageJsonPath, "utf-8");
+        const packageJson = JSON.parse(packageJsonContent) as { main?: string };
+
+        if (packageJson.main == null) {
+            throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
+        }
+
+        const packageEntryPoint = join(packageDir, packageJson.main);
+        const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
+        return migrations as Record<string, MigrationModule>;
+    })();
+
+    // Reset the cached promise on failure so the next call can retry.
+    migrationsInstallPromise.catch(() => {
+        migrationsInstallPromise = undefined;
+    });
+
+    return migrationsInstallPromise;
 }
 
 /**

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -94,9 +94,9 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
         const packageEntryPoint = join(packageDir, packageJson.main);
         const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
 
-        // Clean up stale install directories from previous processes.
+        // Clean up stale install directories from dead processes.
         // Fire-and-forget: failures are non-fatal.
-        void cleanupStaleInstallDirs(cacheDir, installDir);
+        void cleanupStaleInstallDirs(logger, cacheDir, installDir);
 
         return migrations as Record<string, MigrationModule>;
     })();
@@ -110,25 +110,49 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
 }
 
 /**
- * Removes stale install-* directories from the cache dir, keeping only
- * the current process's directory. This prevents unbounded disk growth
- * from accumulated per-process install dirs.
+ * Returns true if the given PID belongs to a currently running process.
  */
-async function cleanupStaleInstallDirs(cacheDir: string, currentInstallDir: string): Promise<void> {
+function isProcessAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Removes install-* directories from the cache dir that belong to dead
+ * processes. Skips the current process's directory and any directory
+ * whose PID is still alive, so concurrent CLI processes are never
+ * disrupted. This prevents unbounded disk growth from accumulated
+ * per-process install dirs.
+ */
+async function cleanupStaleInstallDirs(logger: Logger, cacheDir: string, currentInstallDir: string): Promise<void> {
     try {
         const entries = await readdir(cacheDir, { withFileTypes: true });
         const removePromises = entries
-            .filter(
-                (entry) =>
-                    entry.isDirectory() &&
-                    entry.name.startsWith("install-") &&
-                    join(cacheDir, entry.name) !== currentInstallDir
-            )
-            // biome-ignore lint/suspicious/noEmptyBlockStatements: intentionally swallow per-dir removal errors
-            .map((entry) => rm(join(cacheDir, entry.name), { recursive: true, force: true }).catch(() => {}));
+            .filter((entry) => {
+                if (!entry.isDirectory() || !entry.name.startsWith("install-")) {
+                    return false;
+                }
+                if (join(cacheDir, entry.name) === currentInstallDir) {
+                    return false;
+                }
+                const pid = Number(entry.name.slice("install-".length));
+                if (Number.isNaN(pid) || isProcessAlive(pid)) {
+                    return false;
+                }
+                return true;
+            })
+            .map((entry) =>
+                rm(join(cacheDir, entry.name), { recursive: true, force: true }).catch((err: unknown) => {
+                    logger.debug(`Failed to remove stale install dir ${entry.name}: ${err}`);
+                })
+            );
         await Promise.all(removePromises);
-    } catch {
-        // Non-fatal: if we can't list the directory, just skip cleanup.
+    } catch (err: unknown) {
+        logger.debug(`Failed to clean up stale migration cache dirs: ${err}`);
     }
 }
 

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -1,7 +1,7 @@
 import type { generatorsYml } from "@fern-api/configuration";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { close, mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
+import { mkdir, open, readFile, stat, unlink } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import semver from "semver";
@@ -58,9 +58,9 @@ async function acquireLock(logger: Logger, cacheDir: string): Promise<() => Prom
     while (true) {
         try {
             // O_CREAT | O_EXCL — fails if file already exists (atomic)
-            const fd = await open(lockPath, "wx");
-            await writeFile(fd, String(process.pid));
-            await close(fd);
+            const fh = await open(lockPath, "wx");
+            await fh.writeFile(String(process.pid));
+            await fh.close();
 
             return async () => {
                 try {

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -157,21 +157,22 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
                 "--no-audit",
                 "--no-fund"
             ]);
+
+            // Read & import while the lock is held so another process cannot
+            // start a concurrent npm install that overwrites node_modules.
+            const packageJsonContent = await readFile(packageJsonPath, "utf-8");
+            const packageJson = JSON.parse(packageJsonContent) as { main?: string };
+
+            if (packageJson.main == null) {
+                throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
+            }
+
+            const packageEntryPoint = join(packageDir, packageJson.main);
+            const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
+            return migrations as Record<string, MigrationModule>;
         } finally {
             await releaseLock();
         }
-
-        // Read & import outside the lock — no writes happening here
-        const packageJsonContent = await readFile(packageJsonPath, "utf-8");
-        const packageJson = JSON.parse(packageJsonContent) as { main?: string };
-
-        if (packageJson.main == null) {
-            throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
-        }
-
-        const packageEntryPoint = join(packageDir, packageJson.main);
-        const { migrations } = await import(pathToFileURL(packageEntryPoint).href);
-        return migrations as Record<string, MigrationModule>;
     })();
 
     // Reset the cached promise on failure so the next call can retry.

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -1,6 +1,7 @@
 import type { generatorsYml } from "@fern-api/configuration";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
+import { readFileSync, unlinkSync } from "fs";
 import { mkdir, open, readFile, stat, unlink } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
@@ -53,18 +54,44 @@ function isProcessAlive(pid: number): boolean {
  */
 async function acquireLock(logger: Logger, cacheDir: string): Promise<() => Promise<void>> {
     const lockPath = join(cacheDir, LOCK_FILENAME);
+    const myPid = String(process.pid);
 
     // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
     while (true) {
         try {
             // O_CREAT | O_EXCL — fails if file already exists (atomic)
             const fh = await open(lockPath, "wx");
-            await fh.writeFile(String(process.pid));
+            await fh.writeFile(myPid);
             await fh.close();
 
-            return async () => {
+            // Register a synchronous exit handler so the lock is cleaned up
+            // even if the process crashes or is killed (SIGTERM/SIGINT).
+            const exitHandler = (): void => {
                 try {
-                    await unlink(lockPath);
+                    const content = readFileSync(lockPath, "utf-8");
+                    if (content.trim() === myPid) {
+                        unlinkSync(lockPath);
+                    }
+                } catch {
+                    // Lock file already removed or unreadable — nothing to do
+                }
+            };
+            process.on("exit", exitHandler);
+
+            return async () => {
+                process.removeListener("exit", exitHandler);
+                try {
+                    // Verify we still own the lock before removing it.
+                    // If the lock was stolen (stale-lock takeover), skip the unlink
+                    // so we don't delete another process's lock.
+                    const currentContent = await readFile(lockPath, "utf-8");
+                    if (currentContent.trim() === myPid) {
+                        await unlink(lockPath);
+                    } else {
+                        logger.debug(
+                            `Lock file owned by another process (expected pid=${myPid}, found=${currentContent.trim()}); skipping release`
+                        );
+                    }
                 } catch (err: unknown) {
                     logger.debug(`Failed to release migration lock: ${err}`);
                 }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -4,9 +4,8 @@
     - summary: |
         Fix `fern generator upgrade` failing with `ENOENT` on `package.json`
         when multiple CLI processes run concurrently (e.g., in parallel tests).
-        Each CLI process now installs the migration package to a
-        process-specific directory, preventing cross-process npm install races
-        on the shared `~/.fern/migration-cache` prefix.
+        A cross-process file lock now serializes npm installs to the shared
+        `~/.fern/migration-cache` prefix, preventing concurrent install races.
       type: fix
   createdAt: "2026-03-07"
   irVersion: 65

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.15.3
+  changelogEntry:
+    - summary: |
+        Fix `fern generator upgrade` failing with `ENOENT` on `package.json`
+        when multiple CLI processes run concurrently (e.g., in parallel tests).
+        Each CLI process now installs the migration package to a
+        process-specific directory, preventing cross-process npm install races
+        on the shared `~/.fern/migration-cache` prefix.
+      type: fix
+  createdAt: "2026-03-07"
+  irVersion: 65
+
 - version: 4.15.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes flaky `fern generator upgrade` tests failing with `ENOENT: no such file or directory` on `package.json` in the migration cache.

[Link to Devin Session](https://app.devin.ai/sessions/303c471eed064d16a076342f0f24a8a3) | Requested by: @Swimburger

## Root Cause

The previous fix (PR #13141) added a module-level singleton promise to deduplicate `npm install` calls **within a single CLI process**. However, the concurrent ETE tests (`it.concurrent(...)`) each spawn **separate** CLI processes, all running `npm install --prefix ~/.fern/migration-cache` simultaneously. Multiple concurrent npm installs to the same `--prefix` directory corrupt each other's `node_modules`, causing `ENOENT` when reading `package.json` immediately after a seemingly successful install.

## Changes Made

### Approach: Cross-process file lock

A file lock (`~/.fern/migration-cache/.install.lock`) serializes concurrent `npm install` calls to the single shared cache directory.

- **`loader.ts` (CLI v1)**: Added `acquireLock()` that atomically creates a lock file using `open(path, "wx")`. The lock is acquired before running `npm install @latest` and held through the read + dynamic import phase. Stale locks are detected via a 5-minute timeout or dead-PID check (`process.kill(pid, 0)`). All catch blocks include `logger.debug()` logging per REVIEW.md rules.
- **`GeneratorMigrator.ts` (CLI v2)**: Same lock file approach, implemented as static methods on the class.
- **`deduplication.test.ts`**: Updated mocks for `fs/promises` — `open` now returns a mock `FileHandle` with `.writeFile()` and `.close()` methods; added `stat` and `unlink` mocks for lock mechanism.
- **`versions.yml`**: Added changelog entry for v4.15.3.

### Crash safety & ownership verification

Two additional safeguards ensure the lock is robust against process crashes and stale-lock takeover:

- **`process.on("exit")` handler**: On lock acquisition, a synchronous exit handler is registered that uses `readFileSync`/`unlinkSync` to clean up the lock file if the process exits unexpectedly (crash, SIGTERM, `process.exit()`). The handler verifies PID ownership before deleting. It is deregistered on normal lock release.
- **PID ownership check on release**: Before unlinking, `releaseLock()` reads the lock file and verifies it still contains the current process's PID. If the lock was stolen via stale-lock takeover, the unlink is skipped to avoid deleting another process's lock.

### How concurrent processes interact

1. Process A acquires lock → runs `npm install @latest` → reads `package.json` → dynamic imports module → releases lock
2. Process B waits (polls every 200ms) → acquires lock → runs `npm install @latest` → reads + imports → releases lock

The entire install-read-import sequence runs under the lock so no process can read `node_modules` while another process is writing to it. Within a single process, the existing module-level singleton promise still deduplicates concurrent calls.

## Key Review Points

- [ ] **Lock scope**: The lock is held during `npm install`, `readFile`, and `import()`. This is intentional — releasing before the read would allow another process's `npm install` to corrupt the files being read. Lock hold time ≈ 700ms from CI logs.
- [ ] **Exit handler uses sync fs operations**: `readFileSync`/`unlinkSync` are used because async operations don't work in `process.on("exit")` handlers. This is the correct pattern for Node.js exit cleanup.
- [ ] **Crash cleanup limitations**: The exit handler fires for normal exits, `process.exit()`, and SIGTERM. It does NOT fire for SIGKILL or OOM killer — those cases are handled by the stale-lock detection (5-min timeout + dead-PID check).
- [ ] **PID ownership TOCTOU race**: Between reading the lock content and unlinking, another process could have removed/recreated the lock. This is extremely unlikely (microsecond window) and benign (results in a debug log message only).
- [ ] **Test coverage gap**: The test mocks cover `fs/promises` but not the `fs` module sync operations used in the exit handler. The exit handler code path is not directly tested.
- [ ] Both CLI v1 and v2 code paths are updated consistently with the same logic.

## Testing

- [x] Lint passes (`pnpm run check`)
- [x] All CI checks pass (including `test-ete` with the concurrent upgrade-generator tests)
- [ ] Not tested locally end-to-end (race condition requires concurrent process execution to reproduce)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
