### PR TITLE
chore(seed): replace sleep 3 with dockerd readiness check in DinD entrypoints

### DIFF
--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -18,10 +18,10 @@ RUN mkdir -p "${GOPATH}/src" "${GOPATH}/bin"
 ENV GOLANGCI_LINT_VERSION=v2.10.1
 RUN wget -O- -nv https://golangci-lint.run/install.sh | sh -s -- -b /usr/local/bin ${GOLANGCI_LINT_VERSION}
 
-# Create entrypoint script to start dockerd and execute commands
+# Create entrypoint script to start dockerd and wait until it is ready
 RUN echo '#!/bin/sh' > /entrypoint.sh && \
     echo 'dockerd &' >> /entrypoint.sh && \
-    echo 'sleep 3' >> /entrypoint.sh && \
+    echo 'for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 0.1; done' >> /entrypoint.sh && \
     echo 'exec "$@"' >> /entrypoint.sh && \
     chmod +x /entrypoint.sh
 

--- a/docker/seed/Dockerfile.php
+++ b/docker/seed/Dockerfile.php
@@ -23,10 +23,10 @@ RUN apk add --no-cache \
 # Create symlink for php command
 RUN ln -sf /usr/bin/php83 /usr/bin/php
 
-# Create entrypoint script to start dockerd and execute commands
+# Create entrypoint script to start dockerd and wait until it is ready
 RUN echo '#!/bin/sh' > /entrypoint.sh && \
     echo 'dockerd &' >> /entrypoint.sh && \
-    echo 'sleep 3' >> /entrypoint.sh && \
+    echo 'for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 0.1; done' >> /entrypoint.sh && \
     echo 'exec "$@"' >> /entrypoint.sh && \
     chmod +x /entrypoint.sh
 

--- a/docker/seed/Dockerfile.python
+++ b/docker/seed/Dockerfile.python
@@ -8,10 +8,10 @@ RUN apk add --no-cache python3 py3-pip \
 ENV POETRY_VERSION=1.8.5
 RUN pip install --no-cache-dir --break-system-packages poetry==${POETRY_VERSION}
 
-# Create entrypoint script to start dockerd and execute commands
+# Create entrypoint script to start dockerd and wait until it is ready
 RUN echo '#!/bin/sh' > /entrypoint.sh && \
     echo 'dockerd &' >> /entrypoint.sh && \
-    echo 'sleep 3' >> /entrypoint.sh && \
+    echo 'for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 0.1; done' >> /entrypoint.sh && \
     echo 'exec "$@"' >> /entrypoint.sh && \
     chmod +x /entrypoint.sh
 


### PR DESCRIPTION
## Description

Refs: Devin session https://app.devin.ai/sessions/1497f56fd9f5442aa8729e09945a1280
Requested by: @Swimburger

Replaces the fixed `sleep 3` in DinD seed container entrypoints with a polling loop that waits for `dockerd` to actually be ready, saving ~2s on average per container start.

## Changes Made

- Replaced `sleep 3` with `for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 0.1; done` in the entrypoint scripts of:
  - `docker/seed/Dockerfile.go`
  - `docker/seed/Dockerfile.python`
  - `docker/seed/Dockerfile.php`
- Fixed missing newline at end of file in `Dockerfile.go` and `Dockerfile.python`

The readiness loop polls `docker info` every 100ms, up to 30 times (3s max). It breaks immediately once `dockerd` is responsive, so typical startup (~0.5-1s) no longer incurs the full 3s fixed delay.

## Review Checklist

- [ ] Verify `sleep 0.1` (fractional seconds) works in Alpine's busybox — it should, but worth confirming
- [ ] Consider whether a log/warning should be emitted if the loop exhausts all 30 iterations without `dockerd` becoming ready (current behavior: silently proceeds, same as the old `sleep 3`)
- [ ] Confirm seed Docker images are rebuilt and wire tests still pass in CI

## Testing

- [ ] Manual testing not performed (requires privileged DinD environment)
- [ ] Relies on CI seed test runs to validate
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
