### PR TITLE
chore(seed): pre-pull wiremock image into DinD seed containers at build time

### DIFF
--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -1,4 +1,15 @@
+# Stage 1: Pull wiremock image as tar (no daemon needed)
+FROM alpine:3.22 AS wiremock-pull
+RUN apk add --no-cache curl && \
+    ARCH=$(uname -m) && if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
+    curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
+    crane pull wiremock/wiremock:3.9.1 /wiremock.tar
+
+# Stage 2: Build the seed image
 FROM docker:28.4.0-dind-alpine3.22
+
+# Copy pre-pulled wiremock image
+COPY --from=wiremock-pull /wiremock.tar /wiremock.tar
 
 # Install Go
 ENV GO_VERSION=1.23.8
@@ -22,6 +33,7 @@ RUN wget -O- -nv https://golangci-lint.run/install.sh | sh -s -- -b /usr/local/b
 RUN echo '#!/bin/sh' > /entrypoint.sh && \
     echo 'dockerd &' >> /entrypoint.sh && \
     echo 'for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 0.1; done' >> /entrypoint.sh && \
+    echo 'if [ -f /wiremock.tar ]; then docker load < /wiremock.tar && rm -f /wiremock.tar; fi' >> /entrypoint.sh && \
     echo 'exec "$@"' >> /entrypoint.sh && \
     chmod +x /entrypoint.sh
 

--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -2,7 +2,7 @@
 FROM alpine:3.22 AS wiremock-pull
 RUN apk add --no-cache curl && \
     ARCH=$(uname -m) && if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
-    curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
+    curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
 # Stage 2: Build the seed image

--- a/docker/seed/Dockerfile.php
+++ b/docker/seed/Dockerfile.php
@@ -1,4 +1,15 @@
+# Stage 1: Pull wiremock image as tar (no daemon needed)
+FROM alpine:3.22 AS wiremock-pull
+RUN apk add --no-cache curl && \
+    ARCH=$(uname -m) && if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
+    curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
+    crane pull wiremock/wiremock:3.9.1 /wiremock.tar
+
+# Stage 2: Build the seed image
 FROM docker:28.4.0-dind-alpine3.22
+
+# Copy pre-pulled wiremock image
+COPY --from=wiremock-pull /wiremock.tar /wiremock.tar
 
 # Install PHP, Composer, and required extensions
 RUN apk add --no-cache \
@@ -27,6 +38,7 @@ RUN ln -sf /usr/bin/php83 /usr/bin/php
 RUN echo '#!/bin/sh' > /entrypoint.sh && \
     echo 'dockerd &' >> /entrypoint.sh && \
     echo 'for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 0.1; done' >> /entrypoint.sh && \
+    echo 'if [ -f /wiremock.tar ]; then docker load < /wiremock.tar && rm -f /wiremock.tar; fi' >> /entrypoint.sh && \
     echo 'exec "$@"' >> /entrypoint.sh && \
     chmod +x /entrypoint.sh
 

--- a/docker/seed/Dockerfile.php
+++ b/docker/seed/Dockerfile.php
@@ -2,7 +2,7 @@
 FROM alpine:3.22 AS wiremock-pull
 RUN apk add --no-cache curl && \
     ARCH=$(uname -m) && if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
-    curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
+    curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
 # Stage 2: Build the seed image

--- a/docker/seed/Dockerfile.python
+++ b/docker/seed/Dockerfile.python
@@ -1,4 +1,15 @@
+# Stage 1: Pull wiremock image as tar (no daemon needed)
+FROM alpine:3.22 AS wiremock-pull
+RUN apk add --no-cache curl && \
+    ARCH=$(uname -m) && if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
+    curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
+    crane pull wiremock/wiremock:3.9.1 /wiremock.tar
+
+# Stage 2: Build the seed image
 FROM docker:28.4.0-dind-alpine3.22
+
+# Copy pre-pulled wiremock image
+COPY --from=wiremock-pull /wiremock.tar /wiremock.tar
 
 # Install Python and Poetry
 RUN apk add --no-cache python3 py3-pip \
@@ -12,6 +23,7 @@ RUN pip install --no-cache-dir --break-system-packages poetry==${POETRY_VERSION}
 RUN echo '#!/bin/sh' > /entrypoint.sh && \
     echo 'dockerd &' >> /entrypoint.sh && \
     echo 'for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 0.1; done' >> /entrypoint.sh && \
+    echo 'if [ -f /wiremock.tar ]; then docker load < /wiremock.tar && rm -f /wiremock.tar; fi' >> /entrypoint.sh && \
     echo 'exec "$@"' >> /entrypoint.sh && \
     chmod +x /entrypoint.sh
 

--- a/docker/seed/Dockerfile.python
+++ b/docker/seed/Dockerfile.python
@@ -2,7 +2,7 @@
 FROM alpine:3.22 AS wiremock-pull
 RUN apk add --no-cache curl && \
     ARCH=$(uname -m) && if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
-    curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
+    curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
 # Stage 2: Build the seed image


### PR DESCRIPTION
## Description

Refs: [Devin session](https://app.devin.ai/sessions/1497f56fd9f5442aa8729e09945a1280)
Requested by: @Swimburger

Pre-pulls `wiremock/wiremock:3.9.1` into the Go, Python, and PHP DinD seed containers at build time so wire tests don't need to pull it over the network on every CI run.

## Changes Made

- Converted `Dockerfile.go`, `Dockerfile.python`, and `Dockerfile.php` to multi-stage builds
- Stage 1 (`wiremock-pull`): uses Alpine + [crane](https://github.com/google/go-containerregistry) v0.21.2 to pull the wiremock image as a tar (no Docker daemon needed)
- Stage 2: copies the tar into the DinD image; entrypoint runs `docker load` after dockerd is ready, then deletes the tar
- Architecture-aware crane download (`x86_64` / `arm64` via `uname -m` detection)

## Things for reviewers to consider

- **Image size increase**: the wiremock tar adds ~277MB to each seed image. It's removed at runtime after `docker load`, but it exists in the image layer.
- **Startup cost**: `docker load` runs synchronously on every fresh container start. Locally this took ~24s with the VFS storage driver; should be faster in CI with overlay2, but still non-trivial. The tradeoff is this vs. pulling over the network on every wire test run.
- **Hardcoded wiremock version**: `3.9.1` is hardcoded in the Dockerfiles. If `docker-compose.test.yml` files are updated to a newer version, these Dockerfiles must be updated in lockstep.
- **`tar xz -C /usr/local/bin crane` syntax**: verify this correctly extracts just the `crane` binary from the archive using Alpine's busybox tar.
- **Every DinD container pays the `docker load` cost**, not just wire-test fixtures. Since each fresh container has its own empty Docker daemon storage, the load must happen on every start. User confirmed this is acceptable since seed images are dedicated for testing.

## Updates since last revision

- Pinned crane version from `/releases/latest/` to `v0.21.2` to avoid potential breakage from upstream changes.

## Testing

- [x] Built `Dockerfile.python` locally and verified `docker load` succeeds
- [x] Confirmed `docker images wiremock/wiremock` shows `3.9.1` inside the running container
- [ ] CI — Dockerfile-only changes; seed tests in CI run against already-published images. Actual validation happens after merge when `seed-dockers.yml` rebuilds images.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
