### PR TITLE
feat(docs): add hide-products layout option to docs.yml schema

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.16.0
+  changelogEntry:
+    - summary: |
+        Add `hide-products` layout option to `docs.yml`. When set to `true`,
+        the docs frontend hides the product switcher dropdown and header tabs,
+        showing only the API reference content. This is useful for docs sites
+        sourced from Postman collections that don't need product navigation.
+      type: feat
+  createdAt: "2026-03-07"
+  irVersion: 65
+
 - version: 4.15.3
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -465,7 +465,8 @@ function convertLayoutConfig(
                 : CjsFdrSdk.docs.v1.commons.HeaderPosition.Fixed,
         disableHeader: layout.disableHeader ?? false,
         hideNavLinks: layout.hideNavLinks ?? false,
-        hideFeedback: layout.hideFeedback ?? false
+        hideFeedback: layout.hideFeedback ?? false,
+        hideProducts: layout.hideProducts ?? false
     };
 }
 

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -294,7 +294,8 @@ export const LayoutConfig = z.object({
     "header-position": HeaderPosition.optional(),
     "disable-header": z.boolean().optional(),
     "hide-nav-links": z.boolean().optional(),
-    "hide-feedback": z.boolean().optional()
+    "hide-feedback": z.boolean().optional(),
+    "hide-products": z.boolean().optional()
 });
 
 // ===== Settings =====


### PR DESCRIPTION
## Description

Refs: Companion to [fern-platform#8182](https://github.com/fern-api/fern-platform/pull/8182)

Adds a new `hide-products` boolean option to the `layout` section of `docs.yml`. When set to `true`, the docs frontend will hide the product switcher dropdown and header tabs, showing only the API reference content. This is useful for Postman-sourced docs sites that don't need product navigation.

## Changes Made

- Added `"hide-products": z.boolean().optional()` to the `LayoutConfig` Zod schema in `DocsYmlSchemas.ts`
- Added `hideProducts: layout.hideProducts ?? false` to the `convertLayoutConfig` return value in `parseDocsConfiguration.ts`

## Testing

- [ ] Unit tests added/updated — no new tests; follows existing pattern of `hide-nav-links` and `hide-feedback` which also lack dedicated tests
- [x] Lint/pre-commit checks pass

## Human Review Checklist

- [ ] Verify the FDR SDK type (`DocsLayoutConfig`) accepts `hideProducts` — this depends on the companion [fern-platform PR](https://github.com/fern-api/fern-platform/pull/8182) being merged first so the SDK type includes the new field
- [ ] Confirm naming consistency: schema uses `hide-products` (kebab-case), parser outputs `hideProducts` (camelCase) — matches existing convention (`hide-feedback` → `hideFeedback`)

[Link to Devin Session](https://app.devin.ai/sessions/e4f77381c77c4b8d8d7fe06b7236a2d0) | Requested by @dsinghvi