### PR TITLE
feat(seed): increase default local parallelism to match CPU count

### DIFF
--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -1,10 +1,10 @@
-import os from "os";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { LOG_LEVELS, LogLevel } from "@fern-api/logger";
 import { askToLogin } from "@fern-api/login";
 import { FernRegistryClient as FdrClient } from "@fern-fern/generators-sdk";
 import { writeFile } from "fs/promises";
 import { minimatch } from "minimatch";
+import os from "os";
 import yargs, { Argv } from "yargs";
 import { hideBin } from "yargs/helpers";
 import {

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { LOG_LEVELS, LogLevel } from "@fern-api/logger";
 import { askToLogin } from "@fern-api/login";
@@ -99,7 +100,7 @@ function addTestCommand(cli: Argv) {
                 })
                 .option("parallel", {
                     type: "number",
-                    default: 4,
+                    default: Math.min(os.cpus().length, 16),
                     alias: "p"
                 })
                 .option("fixture", {
@@ -402,7 +403,7 @@ function addTestRemoteLocalCommand(cli: Argv) {
                 })
                 .option("parallel", {
                     type: "number",
-                    default: 4,
+                    default: Math.min(os.cpus().length, 16),
                     alias: "p",
                     description: "Number of parallel test cases to run"
                 })

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -100,7 +100,7 @@ function addTestCommand(cli: Argv) {
                 })
                 .option("parallel", {
                     type: "number",
-                    default: Math.min(os.cpus().length, 16),
+                    default: Math.max(1, Math.min(os.cpus().length, 16)),
                     alias: "p"
                 })
                 .option("fixture", {
@@ -403,7 +403,7 @@ function addTestRemoteLocalCommand(cli: Argv) {
                 })
                 .option("parallel", {
                     type: "number",
-                    default: Math.min(os.cpus().length, 16),
+                    default: Math.max(1, Math.min(os.cpus().length, 16)),
                     alias: "p",
                     description: "Number of parallel test cases to run"
                 })


### PR DESCRIPTION
## Description

Increases the default `--parallel` value for local seed test runs from a hardcoded `4` to `Math.max(1, Math.min(os.cpus().length, 16))`, dynamically matching the machine's available CPU cores (capped at 16, which is what CI uses). A floor of 1 guards against `os.cpus()` returning an empty array in restricted environments (e.g. some Docker containers or CI runners with limited `/proc` access).

Most developer machines have 8-16+ cores, so the previous default of 4 was leaving significant performance on the table for local runs.

Link to Devin Session: https://app.devin.ai/sessions/3abdef3a8fc942a68c6f2a3e1d9064a7
Requested by: @Swimburger

## Changes Made

- Added `import os from "os"` to `packages/seed/src/cli.ts`
- Updated the default for `--parallel` from `4` to `Math.max(1, Math.min(os.cpus().length, 16))` in both `addTestCommand` and `addTestRemoteLocalCommand`

## Review Checklist

- [ ] **Resource impact**: `os.cpus().length` returns logical cores (including hyperthreads). On an 8-core/16-thread machine this maxes out at 16 containers. Verify this is acceptable given per-container memory usage.
- [ ] **ContainerTestRunner fallback**: `ContainerTestRunner.ts:22` has a separate fallback `args.parallelism ?? 4` — this isn't hit from the CLI path but is a remaining hardcoded `4` that may warrant updating for consistency.
- [ ] **Cap value**: 16 matches CI. Confirm this is the right upper bound.

## Testing

- [x] Built seed CLI locally and verified `test --help` shows `[default: 8]` on an 8-core machine (dynamically computed)
- [x] All 288 CI checks passing
- [ ] Unit tests added/updated — N/A (CLI default change, no new logic)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
