### PR TITLE
chore(internal): combine cleanup + mkdir into single docker exec

### DIFF
--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -154,22 +154,18 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
         const entrypoint = this.entrypoint;
         const logger = context.logger;
 
-        // Clean the entire /fern directory and /tmp/LICENSE to ensure no state leaks between fixtures.
+        // Clean the entire /fern directory and /tmp/LICENSE to ensure no state leaks between fixtures,
+        // then recreate /fern/output in a single exec to reduce round-trips.
         // This is critical — generators may write to any path under /fern (output, generators, sources, etc.)
         // and we need a fresh environment for each fixture.
         await execInContainer({
             logger,
             containerId,
-            command: ["rm", "-rf", CONTAINER_FERN_DIRECTORY, "/tmp/LICENSE"],
-            runner: this.runner,
-            writeLogsToFile: false
-        });
-
-        // Recreate /fern and /fern/output
-        await execInContainer({
-            logger,
-            containerId,
-            command: ["mkdir", "-p", CONTAINER_CODEGEN_OUTPUT_DIRECTORY],
+            command: [
+                "sh",
+                "-c",
+                `rm -rf ${CONTAINER_FERN_DIRECTORY} /tmp/LICENSE && mkdir -p ${CONTAINER_CODEGEN_OUTPUT_DIRECTORY}`
+            ],
             runner: this.runner,
             writeLogsToFile: false
         });


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger

Combines two sequential `execInContainer` calls (cleanup + directory creation) into a single `docker exec` invocation to reduce container round-trips in `ReusableContainerExecutionEnvironment`.

[Link to Devin Session](https://app.devin.ai/sessions/0d89f324c99b4cb2b7c9a807d2e8968d)

## Changes Made

- Merged the `rm -rf /fern /tmp/LICENSE` and `mkdir -p /fern/output` calls into a single `sh -c "rm -rf ... && mkdir -p ..."` exec, eliminating one docker exec round-trip per fixture run

## Review Checklist

- [ ] Verify `CONTAINER_FERN_DIRECTORY` and `CONTAINER_CODEGEN_OUTPUT_DIRECTORY` constants don't contain shell-special characters (they are `/fern` and `/fern/output` respectively, so this is safe)
- [ ] Confirm `&&` preserves the sequential guarantee — `mkdir` only runs after successful `rm`

## Testing

- [ ] Lint passes (`pnpm run check`)
- No unit test changes needed — behavioral change is purely an optimization (one exec instead of two)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
