### PR TITLE
fix(seed): fetch base ref in CI so turbo affected detection works

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -143,13 +143,19 @@ jobs:
             fi
           fi
 
-          # Fetch the base ref so turbo and git diff can compare against it.
-          # The default checkout is shallow (depth=1) and doesn't include the base commit,
-          # which causes turbo to report ALL packages as affected.
-          # We fetch only the specific commit (no tags) to keep it fast.
+          # Deepen the shallow clone so the base ref is reachable from HEAD.
+          # The default checkout is depth=1, so turbo can't diff against the base commit
+          # (it marks ALL packages as affected when the base is unreachable).
+          # For PRs: deepen by 1 to include parents of the merge commit (base SHA + PR head).
+          # For pushes: the last-successful-run SHA may be several commits back.
           if [[ "$BASE_REF" != "origin/main" ]]; then
-            echo "Fetching base ref $BASE_REF into shallow clone..."
-            git fetch --no-tags --depth=1 origin "$BASE_REF" 2>/dev/null || echo "Warning: could not fetch base ref $BASE_REF"
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              echo "Deepening shallow clone by 1 to include PR base ref..."
+              git fetch --no-tags --deepen=1 origin 2>/dev/null || true
+            else
+              echo "Deepening shallow clone to reach last successful run SHA..."
+              git fetch --no-tags --deepen=50 origin 2>/dev/null || true
+            fi
           fi
 
           # Force run everything for workflow_dispatch (manual trigger) and metrics collection

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -125,10 +125,19 @@ jobs:
           FORCE_COLOR: "2"
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Determine base ref for affected detection
+          # Determine base ref for affected detection.
+          # The checkout is shallow (depth=1), so we must deepen to make
+          # the base commit reachable — otherwise turbo marks ALL packages
+          # as affected.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE_REF="${{ github.event.pull_request.base.sha }}"
-            echo "Using PR base SHA: $BASE_REF"
+            # The checkout creates a merge commit (PR head into base branch tip).
+            # Deepen by 1 to fetch its parents, then use the first parent
+            # (the actual base branch tip) as the base ref.  This is more
+            # reliable than the event payload's base.sha, which can drift
+            # when new commits land on main between PR open and CI run.
+            git fetch --no-tags --deepen=1 origin 2>/dev/null || true
+            BASE_REF=$(git rev-parse HEAD^1 2>/dev/null || echo "${{ github.event.pull_request.base.sha }}")
+            echo "Using PR merge-base: $BASE_REF"
           else
             # For push/dispatch/workflow_call: use last successful run SHA
             LAST_SUCCESS_SHA=$(gh api \
@@ -137,24 +146,11 @@ jobs:
             if [[ -n "$LAST_SUCCESS_SHA" ]]; then
               BASE_REF="$LAST_SUCCESS_SHA"
               echo "Using last successful run SHA: $BASE_REF"
+              # Deepen to reach the last successful run (typically a few commits back)
+              git fetch --no-tags --deepen=50 origin 2>/dev/null || true
             else
               BASE_REF="origin/main"
               echo "No successful run found, using origin/main"
-            fi
-          fi
-
-          # Deepen the shallow clone so the base ref is reachable from HEAD.
-          # The default checkout is depth=1, so turbo can't diff against the base commit
-          # (it marks ALL packages as affected when the base is unreachable).
-          # For PRs: deepen by 1 to include parents of the merge commit (base SHA + PR head).
-          # For pushes: the last-successful-run SHA may be several commits back.
-          if [[ "$BASE_REF" != "origin/main" ]]; then
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "Deepening shallow clone by 1 to include PR base ref..."
-              git fetch --no-tags --deepen=1 origin 2>/dev/null || true
-            else
-              echo "Deepening shallow clone to reach last successful run SHA..."
-              git fetch --no-tags --deepen=50 origin 2>/dev/null || true
             fi
           fi
 

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -143,6 +143,15 @@ jobs:
             fi
           fi
 
+          # Fetch the base ref so turbo and git diff can compare against it.
+          # The default checkout is shallow (depth=1) and doesn't include the base commit,
+          # which causes turbo to report ALL packages as affected.
+          # We fetch only the specific commit (no tags) to keep it fast.
+          if [[ "$BASE_REF" != "origin/main" ]]; then
+            echo "Fetching base ref $BASE_REF into shallow clone..."
+            git fetch --no-tags --depth=1 origin "$BASE_REF" 2>/dev/null || echo "Warning: could not fetch base ref $BASE_REF"
+          fi
+
           # Force run everything for workflow_dispatch (manual trigger) and metrics collection
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "Manual dispatch — forcing all generators and fixtures to run."


### PR DESCRIPTION
## Description

<!-- Refs: no linear ticket -->

The smart affected detection (shipped in #13211) is currently a no-op in CI — **every run reports all generators × all fixtures as affected**, even for narrow PRs that only touch a single generator or docs files.

**Root cause:** `actions/checkout@v4` defaults to `fetch-depth: 1` (shallow clone). Turbo's `ls --affected` uses `TURBO_SCM_BASE` to diff against a base commit, but that commit doesn't exist in the shallow history. When turbo can't find it, it marks every package as affected — including global infrastructure packages like `@fern-api/ir-sdk` and `@fern-api/seed-cli` — which triggers the "run everything" path.

**Evidence:** For PR #13216 (a docs-only change), turbo locally with a full clone correctly reports 2 affected packages (`@fern-api/cli`, `@fern-api/library-docs-generator`). In CI, turbo reported all ~40+ packages as affected.

## Changes Made

- **PR events:** Run `git fetch --no-tags --deepen=1 origin` to extend the shallow clone by one commit, making the merge commit's parents reachable. Then extract the actual base branch tip via `git rev-parse HEAD^1` (the first parent of the GitHub-created merge commit). This is more reliable than the event payload's `base.sha`, which can drift when new commits land on main between PR creation and CI execution.
- **Push/dispatch events:** Run `git fetch --no-tags --deepen=50 origin` to make the last-successful-run SHA reachable in the shallow history.
- Falls back gracefully on failure (`2>/dev/null || true`): if deepen or rev-parse fails, affected detection will still run everything — same as current behavior.
- Skips deepen when `BASE_REF` is `origin/main` (already available from checkout).

### Why `--deepen` instead of `--depth`

An earlier iteration used `--depth=1` to fetch the base commit directly, but this creates a **disconnected** shallow root that turbo cannot reach from HEAD. `--deepen=N` extends the *existing* shallow boundary, keeping ancestors connected in the git graph so turbo's `git diff` works correctly.

## Testing

- [x] Verified locally that `TURBO_SCM_BASE=<sha> pnpm turbo ls --affected` returns correct results with full clone (2 packages for docs-only PR)
- [x] Confirmed same command returns 0 packages when comparing HEAD to itself (baseline)
- [x] CI logs from 4 recent runs all show turbo over-reporting every package — this PR addresses the root cause
- [x] CI `get-all-test-matrices` job passed: `HEAD^1` correctly resolved to `600df20c2b5eea7aed02481f3fd47020ee81d7b1` (the actual merge base)
- [x] Affected detection produced valid output: `"No recognized changes detected — running everything as fallback."` — correct for this PR since `.github/workflows/seed.yml` is not a recognized generator path
- [ ] Cannot fully test selective detection on this PR (seed.yml changes trigger the fallback). True verification requires a PR that touches only generator-specific files.
- **Note:** 237 CI seed job failures are all `API rate limit exceeded for installation` from `buf-setup-action` (all jobs starting simultaneously overwhelm GitHub's rate limit). Unrelated to this change; the 28 passing seed jobs ran tests successfully.

## Human Review Checklist

- [ ] Verify that `HEAD^1` on the GitHub Actions merge commit reliably points to the base branch tip (not the PR head). GitHub documents this merge commit structure, but worth confirming.
- [ ] Confirm `--deepen=1` is sufficient to make the first parent reachable — could there be edge cases where the merge commit's parents need deeper history?
- [ ] Check that `--deepen=50` is a reasonable heuristic for push events (if last successful run is >50 commits back, falls back to running everything).
- [ ] The `2>/dev/null || true` fallback is silent — acceptable since failure means same "run everything" behavior as today?

---


Link to Devin Session: https://app.devin.ai/sessions/9dc2e1f348da4ff084c51e93e2462fd9  
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
