### PR TITLE
feat(internal): weight fixture grouping by variant count for balanced CI

### DIFF
--- a/packages/seed/src/__test__/getAvailableFixtures.test.ts
+++ b/packages/seed/src/__test__/getAvailableFixtures.test.ts
@@ -459,9 +459,7 @@ describe("splitFixturesIntoGroups", () => {
             expect(result).toHaveLength(4);
 
             // Heavy variants should be distributed across groups
-            const heavyCountPerGroup = result.map(
-                (g) => g.fixtures.filter((f) => f.startsWith("heavy:")).length
-            );
+            const heavyCountPerGroup = result.map((g) => g.fixtures.filter((f) => f.startsWith("heavy:")).length);
             // 10 heavy variants / 4 groups → between 2-3 per group
             heavyCountPerGroup.forEach((count) => {
                 expect(count).toBeGreaterThanOrEqual(1);
@@ -487,12 +485,8 @@ describe("splitFixturesIntoGroups", () => {
             expect(result).toHaveLength(3);
 
             // Both multi-variant families should be spread across groups
-            const exhaustivePerGroup = result.map(
-                (g) => g.fixtures.filter((f) => f.startsWith("exhaustive:")).length
-            );
-            const enumPerGroup = result.map(
-                (g) => g.fixtures.filter((f) => f.startsWith("enum:")).length
-            );
+            const exhaustivePerGroup = result.map((g) => g.fixtures.filter((f) => f.startsWith("exhaustive:")).length);
+            const enumPerGroup = result.map((g) => g.fixtures.filter((f) => f.startsWith("enum:")).length);
 
             // Exhaustive (5 variants, weight=5) should be distributed
             expect(Math.max(...exhaustivePerGroup)).toBeLessThanOrEqual(3);
@@ -569,13 +563,7 @@ describe("getFixtureWeights", () => {
     });
 
     it("assigns higher weight to multi-variant fixtures", () => {
-        const fixtures = [
-            "alias",
-            "exhaustive:v1",
-            "exhaustive:v2",
-            "exhaustive:v3",
-            "basic-auth"
-        ];
+        const fixtures = ["alias", "exhaustive:v1", "exhaustive:v2", "exhaustive:v3", "basic-auth"];
         const weights = getFixtureWeights(fixtures);
 
         // Simple fixtures get weight 1
@@ -588,14 +576,7 @@ describe("getFixtureWeights", () => {
     });
 
     it("handles multiple multi-variant families", () => {
-        const fixtures = [
-            "exhaustive:v1",
-            "exhaustive:v2",
-            "enum:a",
-            "enum:b",
-            "enum:c",
-            "simple"
-        ];
+        const fixtures = ["exhaustive:v1", "exhaustive:v2", "enum:a", "enum:b", "enum:c", "simple"];
         const weights = getFixtureWeights(fixtures);
 
         expect(weights.get("exhaustive:v1")).toBe(2);

--- a/packages/seed/src/__test__/getAvailableFixtures.test.ts
+++ b/packages/seed/src/__test__/getAvailableFixtures.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import {
     calculateRecommendedGroups,
     getAvailableFixturesFromList,
+    getBaseFixtureName,
+    getFixtureWeights,
     splitFixturesIntoGroups
 } from "../commands/list-test-fixtures/getAvailableFixtures";
 import { GeneratorWorkspace } from "../loadGeneratorWorkspaces";
@@ -237,22 +239,22 @@ describe("splitFixturesIntoGroups", () => {
             expect(result[2]?.fixtures).toHaveLength(10);
         });
 
-        it("handles uneven splits with ceiling division", () => {
+        it("handles uneven splits with balanced distribution", () => {
             const fixtures = Array.from({ length: 25 }, (_, i) => `fixture${i}`);
 
             const result = splitFixturesIntoGroups(fixtures, 3);
 
-            // 25 / 3 = 8.33, ceiling = 9
-            // Group 1: 0-8 (9 fixtures)
-            // Group 2: 9-17 (9 fixtures)
-            // Group 3: 18-24 (7 fixtures)
+            // With greedy bin-packing (uniform weights), distribution is balanced:
+            // One group gets 9 fixtures, two groups get 8 fixtures
             expect(result).toHaveLength(3);
-            expect(result[0]?.fixtures).toHaveLength(9);
-            expect(result[1]?.fixtures).toHaveLength(9);
-            expect(result[2]?.fixtures).toHaveLength(7);
+            const sizes = result.map((g) => g.fixtures.length).sort((a, b) => a - b);
+            expect(sizes).toEqual([8, 8, 9]);
+            // All fixtures are present
+            const allFixtures = result.flatMap((g) => g.fixtures).sort();
+            expect(allFixtures).toEqual(fixtures.slice().sort());
         });
 
-        it("preserves fixture order within groups", () => {
+        it("distributes all fixtures across groups", () => {
             const fixtures = [
                 "a",
                 "b",
@@ -280,24 +282,29 @@ describe("splitFixturesIntoGroups", () => {
             const result = splitFixturesIntoGroups(fixtures, 3);
 
             // 21 fixtures / 3 groups = 7 per group
-            expect(result[0]?.fixtures).toEqual(["a", "b", "c", "d", "e", "f", "g"]);
-            expect(result[1]?.fixtures).toEqual(["h", "i", "j", "k", "l", "m", "n"]);
-            expect(result[2]?.fixtures).toEqual(["o", "p", "q", "r", "s", "t", "u"]);
+            expect(result).toHaveLength(3);
+            result.forEach((group) => {
+                expect(group.fixtures).toHaveLength(7);
+            });
+            // All fixtures are present across all groups
+            const allFixtures = result.flatMap((g) => g.fixtures).sort();
+            expect(allFixtures).toEqual(fixtures.slice().sort());
         });
 
-        it("handles more groups than fixtures", () => {
+        it("handles more groups than needed", () => {
             const fixtures = Array.from({ length: 25 }, (_, i) => `fixture${i}`);
 
             const result = splitFixturesIntoGroups(fixtures, 10);
 
-            // 25 / 10 = 2.5, ceiling = 3
-            // Should create groups with 3 fixtures each, some groups may be empty
+            // With greedy bin-packing, all groups should get fixtures
             const totalFixtures = result.reduce((sum, g) => sum + g.fixtures.length, 0);
             expect(totalFixtures).toBe(25);
             // All groups should have fixtures (no empty groups)
             result.forEach((group) => {
                 expect(group.fixtures.length).toBeGreaterThan(0);
             });
+            // All 10 groups should be used
+            expect(result).toHaveLength(10);
         });
 
         it("handles exactly 21 fixtures (just over threshold)", () => {
@@ -390,6 +397,113 @@ describe("splitFixturesIntoGroups", () => {
             expect(result).toHaveLength(15);
         });
     });
+
+    describe("weight-balanced distribution", () => {
+        it("distributes multi-variant fixtures across groups", () => {
+            // Simulate a fixture list with one multi-variant fixture (exhaustive with 6 variants)
+            // and several simple fixtures
+            const fixtures = [
+                "alias",
+                "basic-auth",
+                "exhaustive:v1",
+                "exhaustive:v2",
+                "exhaustive:v3",
+                "exhaustive:v4",
+                "exhaustive:v5",
+                "exhaustive:v6",
+                "file-upload",
+                "enum",
+                "pagination",
+                "validation",
+                "streaming",
+                "websocket",
+                "oauth",
+                "idempotency",
+                "audiences",
+                "trace",
+                "imdb",
+                "response-property",
+                "custom-auth"
+            ];
+
+            const result = splitFixturesIntoGroups(fixtures, 3);
+
+            expect(result).toHaveLength(3);
+
+            // The 6 exhaustive variants (weight=6 each) should be spread across groups,
+            // not all concentrated in one group
+            const exhaustiveCountPerGroup = result.map(
+                (g) => g.fixtures.filter((f) => f.startsWith("exhaustive:")).length
+            );
+            // Each group should get at most 2 exhaustive variants (6 variants / 3 groups = 2)
+            exhaustiveCountPerGroup.forEach((count) => {
+                expect(count).toBeLessThanOrEqual(3);
+                expect(count).toBeGreaterThanOrEqual(1);
+            });
+
+            // All fixtures are present
+            const allFixtures = result.flatMap((g) => g.fixtures).sort();
+            expect(allFixtures).toEqual(fixtures.slice().sort());
+        });
+
+        it("balances groups by weight not just count", () => {
+            // 30 simple fixtures + 10 variants of "heavy" fixture = 40 items
+            // Without weighting: might put all heavy:* variants in same group
+            // With weighting: heavy:* variants (weight=10 each) spread across groups
+            const simpleFixtures = Array.from({ length: 30 }, (_, i) => `simple${i}`);
+            const heavyVariants = Array.from({ length: 10 }, (_, i) => `heavy:variant${i}`);
+            const fixtures = [...simpleFixtures, ...heavyVariants];
+
+            const result = splitFixturesIntoGroups(fixtures, 4);
+
+            expect(result).toHaveLength(4);
+
+            // Heavy variants should be distributed across groups
+            const heavyCountPerGroup = result.map(
+                (g) => g.fixtures.filter((f) => f.startsWith("heavy:")).length
+            );
+            // 10 heavy variants / 4 groups → between 2-3 per group
+            heavyCountPerGroup.forEach((count) => {
+                expect(count).toBeGreaterThanOrEqual(1);
+                expect(count).toBeLessThanOrEqual(4);
+            });
+
+            // All fixtures are present
+            const allFixtures = result.flatMap((g) => g.fixtures).sort();
+            expect(allFixtures).toEqual(fixtures.slice().sort());
+        });
+
+        it("handles multiple multi-variant fixture families", () => {
+            // Two multi-variant fixtures: exhaustive (5 variants) and enum (3 variants)
+            // Plus 15 simple fixtures = 23 total
+            const fixtures = [
+                ...Array.from({ length: 15 }, (_, i) => `simple${i}`),
+                ...Array.from({ length: 5 }, (_, i) => `exhaustive:v${i}`),
+                ...Array.from({ length: 3 }, (_, i) => `enum:v${i}`)
+            ];
+
+            const result = splitFixturesIntoGroups(fixtures, 3);
+
+            expect(result).toHaveLength(3);
+
+            // Both multi-variant families should be spread across groups
+            const exhaustivePerGroup = result.map(
+                (g) => g.fixtures.filter((f) => f.startsWith("exhaustive:")).length
+            );
+            const enumPerGroup = result.map(
+                (g) => g.fixtures.filter((f) => f.startsWith("enum:")).length
+            );
+
+            // Exhaustive (5 variants, weight=5) should be distributed
+            expect(Math.max(...exhaustivePerGroup)).toBeLessThanOrEqual(3);
+            // Enum (3 variants, weight=3) should be distributed
+            expect(Math.max(...enumPerGroup)).toBeLessThanOrEqual(2);
+
+            // All fixtures are present
+            const allFixtures = result.flatMap((g) => g.fixtures).sort();
+            expect(allFixtures).toEqual(fixtures.slice().sort());
+        });
+    });
 });
 
 describe("calculateRecommendedGroups", () => {
@@ -421,5 +535,79 @@ describe("calculateRecommendedGroups", () => {
     it("handles edge case of exactly 21 fixtures", () => {
         // 21 / 10 = 2.1, ceiling = 3
         expect(calculateRecommendedGroups(21)).toBe(3);
+    });
+});
+
+describe("getBaseFixtureName", () => {
+    it("returns the base name for fixture:outputFolder format", () => {
+        expect(getBaseFixtureName("exhaustive:no-custom-config")).toBe("exhaustive");
+        expect(getBaseFixtureName("enum:forward-compatible")).toBe("enum");
+    });
+
+    it("returns the fixture name as-is when no colon is present", () => {
+        expect(getBaseFixtureName("alias")).toBe("alias");
+        expect(getBaseFixtureName("basic-auth")).toBe("basic-auth");
+    });
+
+    it("handles fixture names with multiple colons", () => {
+        expect(getBaseFixtureName("fixture:folder:subfolder")).toBe("fixture");
+    });
+
+    it("handles empty string", () => {
+        expect(getBaseFixtureName("")).toBe("");
+    });
+});
+
+describe("getFixtureWeights", () => {
+    it("assigns weight 1 to simple fixtures with no variants", () => {
+        const fixtures = ["alias", "basic-auth", "file-upload"];
+        const weights = getFixtureWeights(fixtures);
+
+        expect(weights.get("alias")).toBe(1);
+        expect(weights.get("basic-auth")).toBe(1);
+        expect(weights.get("file-upload")).toBe(1);
+    });
+
+    it("assigns higher weight to multi-variant fixtures", () => {
+        const fixtures = [
+            "alias",
+            "exhaustive:v1",
+            "exhaustive:v2",
+            "exhaustive:v3",
+            "basic-auth"
+        ];
+        const weights = getFixtureWeights(fixtures);
+
+        // Simple fixtures get weight 1
+        expect(weights.get("alias")).toBe(1);
+        expect(weights.get("basic-auth")).toBe(1);
+        // Exhaustive variants get weight 3 (3 variants share the same base)
+        expect(weights.get("exhaustive:v1")).toBe(3);
+        expect(weights.get("exhaustive:v2")).toBe(3);
+        expect(weights.get("exhaustive:v3")).toBe(3);
+    });
+
+    it("handles multiple multi-variant families", () => {
+        const fixtures = [
+            "exhaustive:v1",
+            "exhaustive:v2",
+            "enum:a",
+            "enum:b",
+            "enum:c",
+            "simple"
+        ];
+        const weights = getFixtureWeights(fixtures);
+
+        expect(weights.get("exhaustive:v1")).toBe(2);
+        expect(weights.get("exhaustive:v2")).toBe(2);
+        expect(weights.get("enum:a")).toBe(3);
+        expect(weights.get("enum:b")).toBe(3);
+        expect(weights.get("enum:c")).toBe(3);
+        expect(weights.get("simple")).toBe(1);
+    });
+
+    it("handles empty fixture list", () => {
+        const weights = getFixtureWeights([]);
+        expect(weights.size).toBe(0);
     });
 });

--- a/packages/seed/src/commands/list-test-fixtures/getAvailableFixtures.ts
+++ b/packages/seed/src/commands/list-test-fixtures/getAvailableFixtures.ts
@@ -186,7 +186,5 @@ export function splitFixturesIntoGroups(fixtures: string[], numGroups: number): 
     }
 
     // Filter out empty groups and return fixture lists only
-    return groups
-        .filter((g) => g.fixtures.length > 0)
-        .map((g) => ({ fixtures: g.fixtures }));
+    return groups.filter((g) => g.fixtures.length > 0).map((g) => ({ fixtures: g.fixtures }));
 }

--- a/packages/seed/src/commands/list-test-fixtures/getAvailableFixtures.ts
+++ b/packages/seed/src/commands/list-test-fixtures/getAvailableFixtures.ts
@@ -70,6 +70,42 @@ export interface FixtureGroup {
 }
 
 /**
+ * Parse the base fixture name from a fixture string.
+ * For "exhaustive:config-a", returns "exhaustive".
+ * For "alias", returns "alias".
+ */
+export function getBaseFixtureName(fixture: string): string {
+    const colonIndex = fixture.indexOf(":");
+    return colonIndex >= 0 ? fixture.substring(0, colonIndex) : fixture;
+}
+
+/**
+ * Calculate the weight of each fixture based on its base fixture's variant count.
+ * Fixtures belonging to a base fixture with many variants are weighted higher,
+ * reflecting that multi-variant fixtures tend to be more complex and slower to run.
+ *
+ * @param fixtures - Array of fixture names (may include "fixture:outputFolder" format)
+ * @returns Map from fixture name to its weight
+ */
+export function getFixtureWeights(fixtures: string[]): Map<string, number> {
+    // Count variants per base fixture
+    const variantCounts = new Map<string, number>();
+    for (const fixture of fixtures) {
+        const base = getBaseFixtureName(fixture);
+        variantCounts.set(base, (variantCounts.get(base) ?? 0) + 1);
+    }
+
+    // Weight each fixture by its base fixture's variant count
+    const weights = new Map<string, number>();
+    for (const fixture of fixtures) {
+        const base = getBaseFixtureName(fixture);
+        weights.set(fixture, variantCounts.get(base) ?? 1);
+    }
+
+    return weights;
+}
+
+/**
  * Calculate the recommended number of groups for a generator based on fixture count.
  * Uses a heuristic: 1 group per 10 fixtures, with a minimum of 1 and maximum of 15.
  * Returns 0 if the fixture count is small enough to run in a single job.
@@ -89,7 +125,16 @@ export function calculateRecommendedGroups(fixtureCount: number): number {
 }
 
 /**
- * Split fixtures into groups for parallel test execution.
+ * Split fixtures into groups for parallel test execution using weight-balanced
+ * bin-packing. Each fixture is weighted by its base fixture's variant count,
+ * so fixtures with many variants (which tend to be more complex) are distributed
+ * evenly across groups. This prevents CI imbalance where one job gets all the
+ * heavy fixtures and takes much longer than others.
+ *
+ * Uses a greedy LPT (Longest Processing Time) algorithm: fixtures are sorted by
+ * weight descending, then each is assigned to the group with the lowest current
+ * total weight.
+ *
  * If numGroups is 0 or fixtures.length <= 20, returns a single group with ["all"].
  *
  * @param fixtures - Array of fixture names to split
@@ -105,21 +150,43 @@ export function splitFixturesIntoGroups(fixtures: string[], numGroups: number): 
         return [{ fixtures: ["all"] }];
     }
 
-    // Calculate fixtures per group (ceiling division)
-    const fixturesPerGroup = Math.ceil(fixtures.length / effectiveNumGroups);
+    // Calculate weight for each fixture based on its base fixture's variant count
+    const weights = getFixtureWeights(fixtures);
 
-    // Create groups by splitting fixtures evenly
-    const groups: FixtureGroup[] = [];
+    // Create indexed fixture list sorted by weight descending (LPT scheduling)
+    // For equal weights, preserve original order for determinism
+    const indexedFixtures = fixtures.map((fixture, index) => ({
+        fixture,
+        weight: weights.get(fixture) ?? 1,
+        originalIndex: index
+    }));
+    indexedFixtures.sort((a, b) => b.weight - a.weight || a.originalIndex - b.originalIndex);
+
+    // Initialize groups with weight tracking
+    const groups: { fixtures: string[]; totalWeight: number }[] = [];
     for (let i = 0; i < effectiveNumGroups; i++) {
-        const start = i * fixturesPerGroup;
-        const end = start + fixturesPerGroup;
-        const groupFixtures = fixtures.slice(start, end);
+        groups.push({ fixtures: [], totalWeight: 0 });
+    }
 
-        // Skip empty groups
-        if (groupFixtures.length > 0) {
-            groups.push({ fixtures: groupFixtures });
+    // Greedy bin-packing: assign each fixture to the group with lowest total weight
+    for (const { fixture, weight } of indexedFixtures) {
+        let lightestIdx = 0;
+        for (let i = 1; i < groups.length; i++) {
+            const current = groups[i];
+            const lightest = groups[lightestIdx];
+            if (current != null && lightest != null && current.totalWeight < lightest.totalWeight) {
+                lightestIdx = i;
+            }
+        }
+        const targetGroup = groups[lightestIdx];
+        if (targetGroup != null) {
+            targetGroup.fixtures.push(fixture);
+            targetGroup.totalWeight += weight;
         }
     }
 
-    return groups;
+    // Filter out empty groups and return fixture lists only
+    return groups
+        .filter((g) => g.fixtures.length > 0)
+        .map((g) => ({ fixtures: g.fixtures }));
 }

--- a/packages/seed/src/commands/list-test-fixtures/index.ts
+++ b/packages/seed/src/commands/list-test-fixtures/index.ts
@@ -3,5 +3,7 @@ export {
     calculateRecommendedGroups,
     getAvailableFixtures,
     getAvailableFixturesFromList,
+    getBaseFixtureName,
+    getFixtureWeights,
     splitFixturesIntoGroups
 } from "./getAvailableFixtures";


### PR DESCRIPTION
## Description

Refs: Fixture grouping heuristic improvement for CI load balancing

Replaces the naive sequential chunking in `splitFixturesIntoGroups` with a weight-balanced greedy bin-packing algorithm (LPT scheduling). Fixtures with many variants (e.g., `exhaustive` with 30+ output folders) are now distributed evenly across CI groups instead of being clustered together, reducing tail latency from unbalanced jobs.

[Link to Devin Session](https://app.devin.ai/sessions/30df5c6bc68941dbaf7880b5a7fbcb5c)
Requested by: @Swimburger

## Changes Made

- **`splitFixturesIntoGroups`**: Replaced sequential slice-based splitting with a greedy LPT bin-packing algorithm. Fixtures are weighted by their base fixture's variant count, sorted by weight descending, then each assigned to the group with the lowest current total weight.
- **`getBaseFixtureName`** (new): Parses base fixture name from `fixture:outputFolder` format (e.g., `"exhaustive:config-a"` → `"exhaustive"`).
- **`getFixtureWeights`** (new): Calculates weight for each fixture based on how many items share the same base fixture name.
- **`index.ts`**: Exports the two new helper functions.
- `calculateRecommendedGroups` is **unchanged** — it already receives the expanded fixture count.

## Testing

- [x] Unit tests updated for changed distribution behavior (less strict about exact group composition, validates balanced distribution properties instead)
- [x] New test suite: `weight-balanced distribution` — verifies multi-variant fixtures spread across groups
- [x] New test suites for `getBaseFixtureName` and `getFixtureWeights`
- [x] All 48 tests pass

## Human Review Checklist

- **Weight heuristic**: Each expanded fixture item gets `weight = variant_count_of_base_fixture`. So each of 30 `exhaustive:*` variants gets weight 30 (total weight contribution = 900). This effectively makes the algorithm strongly prefer spreading variants across groups. Verify this quadratic weighting effect is acceptable vs. a linear alternative (e.g., weight = 1 for all items, but use round-robin distribution).
- **Ordering change**: Groups no longer contain contiguous fixtures. Confirm no downstream consumer depends on fixture ordering within groups.
- **No change to `calculateRecommendedGroups`**: The group count heuristic (1 per 10 items, min 2, max 15) is unchanged since it already receives the expanded list. Confirm this is sufficient or if it should also factor in total weight.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
