### PR TITLE
chore(csharp): defer AST-to-string conversion to write time in CSharpFile

### DIFF
--- a/generators/csharp/base/src/project/CSharpFile.ts
+++ b/generators/csharp/base/src/project/CSharpFile.ts
@@ -29,6 +29,13 @@ export declare namespace CSharpFile {
 }
 
 export class CSharpFile extends File {
+    private clazz: ast.Class | ast.Enum | ast.Interface;
+    private allNamespaceSegments: Set<string>;
+    private allTypeClassReferences: Map<string, Set<Namespace>>;
+    private generation: Generation;
+    private fileHeader: string | undefined;
+    private resolved: boolean = false;
+
     constructor({
         clazz,
         directory,
@@ -37,17 +44,37 @@ export class CSharpFile extends File {
         generation,
         fileHeader
     }: CSharpFile.Args) {
-        let fileContents = clazz.toString({
-            namespace: clazz.namespace,
-            allNamespaceSegments,
-            allTypeClassReferences,
-            generation
-        });
-        if (fileHeader) {
-            fileContents = `${fileHeader}\n\n${fileContents}`;
-        }
+        super(`${clazz.name}.cs`, directory, "");
+        this.clazz = clazz;
+        this.allNamespaceSegments = allNamespaceSegments;
+        this.allTypeClassReferences = allTypeClassReferences;
+        this.generation = generation;
+        this.fileHeader = fileHeader;
+    }
 
-        super(`${clazz.name}.cs`, directory, fileContents);
+    /**
+     * Lazily resolves the AST to string, caching the result for subsequent calls.
+     */
+    private resolveFileContents(): void {
+        if (this.resolved) {
+            return;
+        }
+        let fileContents = this.clazz.toString({
+            namespace: this.clazz.namespace,
+            allNamespaceSegments: this.allNamespaceSegments,
+            allTypeClassReferences: this.allTypeClassReferences,
+            generation: this.generation
+        });
+        if (this.fileHeader) {
+            fileContents = `${this.fileHeader}\n\n${fileContents}`;
+        }
+        this.fileContents = fileContents;
+        this.resolved = true;
+    }
+
+    public override async write(directoryPrefix: AbsoluteFilePath): Promise<void> {
+        this.resolveFileContents();
+        await super.write(directoryPrefix);
     }
 
     public async tryWrite(directoryPrefix: AbsoluteFilePath): Promise<void> {


### PR DESCRIPTION
## Description

Refs performance optimization backlog

Defers the `clazz.toString()` call in `CSharpFile` from the constructor to `write()` time, so AST-to-string conversion no longer blocks the generation loop.

[Link to Devin Session](https://app.devin.ai/sessions/b3c08a1d091e42a492285940b707ce49) | Requested by @Swimburger

## Changes Made

- Store AST node and rendering parameters (`clazz`, `allNamespaceSegments`, `allTypeClassReferences`, `generation`, `fileHeader`) as private fields instead of eagerly converting in the constructor
- Add `resolveFileContents()` with a `resolved` guard to lazily compute and cache the string content on first call
- Override `write()` to trigger lazy resolution before delegating to `super.write()`
- Constructor passes empty string `""` to parent `File` class as placeholder

## Review Checklist

- [ ] **`fileContents` access before `write()`**: The parent `File.fileContents` is `public`. If any code path reads it before `write()` is called, it will see an empty string. The main path (`CsharpProject.persist()`) only accesses files through `file.write()`, but verify no other consumers depend on reading `fileContents` directly after construction.
- [ ] **Memory**: AST nodes and `allNamespaceSegments`/`allTypeClassReferences` are now held as instance references until after `write()` completes, which could marginally increase peak memory for large generations.

## Testing

- [ ] No new unit tests (behavior is unchanged; existing C# generator snapshot/integration tests cover correctness)
- [ ] Typecheck confirmed no new errors introduced in `CSharpFile.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
