### PR TITLE
chore(csharp): parallelize file writes with batched concurrency

### DIFF
--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -227,15 +227,11 @@ export class CsharpProject extends AbstractProject<GeneratorContext> {
         this.context.logger.debug(`[TIMING] createTestProject took ${Date.now() - createTestProjectStartTime}ms`);
 
         const writeSourceFilesStartTime = Date.now();
-        for (const file of this.sourceFiles) {
-            await file.write(absolutePathToProjectDirectory);
-        }
+        await this.writeFilesInBatches(this.sourceFiles, absolutePathToProjectDirectory);
         this.context.logger.debug(`[TIMING] writeSourceFiles took ${Date.now() - writeSourceFilesStartTime}ms`);
 
         const writeTestFilesStartTime = Date.now();
-        for (const file of this.testFiles) {
-            await file.write(absolutePathToTestProjectDirectory);
-        }
+        await this.writeFilesInBatches(this.testFiles, absolutePathToTestProjectDirectory);
         this.context.logger.debug(`[TIMING] writeTestFiles took ${Date.now() - writeTestFilesStartTime}ms`);
 
         await this.createRawFiles();
@@ -497,9 +493,7 @@ dotnet_diagnostic.IDE0005.severity = error
         this.context.logger.debug(`mkdir ${absolutePathToCoreDirectory}`);
         await mkdir(absolutePathToCoreDirectory, { recursive: true });
 
-        for (const file of this.coreFiles) {
-            await file.write(absolutePathToCoreDirectory);
-        }
+        await this.writeFilesInBatches(this.coreFiles, absolutePathToCoreDirectory);
 
         return absolutePathToCoreDirectory;
     }
@@ -516,9 +510,7 @@ dotnet_diagnostic.IDE0005.severity = error
         this.context.logger.debug(`mkdir ${absolutePathToCoreTestDirectory}`);
         await mkdir(absolutePathToCoreTestDirectory, { recursive: true });
 
-        for (const file of this.coreTestFiles) {
-            await file.write(absolutePathToCoreTestDirectory);
-        }
+        await this.writeFilesInBatches(this.coreTestFiles, absolutePathToCoreTestDirectory);
 
         return absolutePathToCoreTestDirectory;
     }
@@ -539,9 +531,7 @@ dotnet_diagnostic.IDE0005.severity = error
         this.context.logger.debug(`mkdir ${absolutePathToPublicCoreTestDirectory}`);
         await mkdir(absolutePathToPublicCoreTestDirectory, { recursive: true });
 
-        for (const file of this.publicCoreTestFiles) {
-            await file.write(absolutePathToPublicCoreTestDirectory);
-        }
+        await this.writeFilesInBatches(this.publicCoreTestFiles, absolutePathToPublicCoreTestDirectory);
 
         return absolutePathToPublicCoreTestDirectory;
     }
@@ -558,9 +548,7 @@ dotnet_diagnostic.IDE0005.severity = error
         this.context.logger.debug(`mkdir ${absolutePathToTestUtilsDirectory}`);
         await mkdir(absolutePathToTestUtilsDirectory, { recursive: true });
 
-        for (const file of this.testUtilFiles) {
-            await file.write(absolutePathToTestUtilsDirectory);
-        }
+        await this.writeFilesInBatches(this.testUtilFiles, absolutePathToTestUtilsDirectory);
 
         return absolutePathToTestUtilsDirectory;
     }
@@ -578,9 +566,7 @@ dotnet_diagnostic.IDE0005.severity = error
         this.context.logger.debug(`mkdir ${absolutePathToPublicCoreDirectory}`);
         await mkdir(absolutePathToPublicCoreDirectory, { recursive: true });
 
-        for (const file of this.publicCoreFiles) {
-            await file.write(absolutePathToPublicCoreDirectory);
-        }
+        await this.writeFilesInBatches(this.publicCoreFiles, absolutePathToPublicCoreDirectory);
 
         return absolutePathToPublicCoreDirectory;
     }
@@ -691,6 +677,19 @@ dotnet_diagnostic.IDE0005.severity = error
                 }
             })
         );
+    }
+
+    private static readonly FILE_WRITE_BATCH_SIZE = 100;
+
+    /**
+     * Writes files in batches with bounded concurrency to avoid exhausting file descriptors
+     * while still being significantly faster than sequential writes.
+     */
+    private async writeFilesInBatches(files: File[], directoryPrefix: AbsoluteFilePath): Promise<void> {
+        for (let i = 0; i < files.length; i += CsharpProject.FILE_WRITE_BATCH_SIZE) {
+            const batch = files.slice(i, i + CsharpProject.FILE_WRITE_BATCH_SIZE);
+            await Promise.all(batch.map((file) => file.write(directoryPrefix)));
+        }
     }
 
     private async createRawFiles(): Promise<void> {

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.0.12
+  changelogEntry:
+    - summary: |
+        Parallelize file writes during project persistence using batched concurrency
+        (100 files per batch via `Promise.all`), significantly reducing generation time
+        for large projects with thousands of files.
+      type: chore
+  createdAt: "2026-03-07"
+  irVersion: 62
+
 - version: 0.0.11
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.23.7
+  changelogEntry:
+    - summary: |
+        Parallelize file writes during project persistence using batched concurrency
+        (100 files per batch via `Promise.all`), significantly reducing generation time
+        for large projects with thousands of files.
+      type: chore
+  createdAt: "2026-03-07"
+  irVersion: 62
+
 - version: 2.23.6
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs performance optimization for C# SDK generation.

Replaces sequential `await file.write()` loops in `CsharpProject.ts` with batched concurrent writes using `Promise.all`, targeting the main bottleneck where ~2,000+ files are written one at a time during project persistence.

[Link to Devin Session](https://app.devin.ai/sessions/a2c3d049fe144ef1822365ce46fe31fc)  
Requested by: @Swimburger

## Changes Made

- Added `writeFilesInBatches(files, directoryPrefix)` private method to `CsharpProject` that writes files in batches of 100 via `Promise.all`
- Replaced 7 sequential `for...of` file write loops with calls to `writeFilesInBatches`:
  - `persist()`: source files and test files (the primary bottleneck — ~2,083 files)
  - `createCoreDirectory`, `createCoreTestDirectory`, `createPublicCoreTestDirectory`, `createTestUtilsDirectory`, `createPublicCoreDirectory`
- Updated `versions.yml` for both `csharp/sdk` (2.23.7) and `csharp/model` (0.0.12)

**Not changed**: The `createRawFiles` and as-is file creation loops were intentionally left sequential since they mutate `this.rawFiles`/`this.coreFiles` arrays during iteration.

## Review Checklist

- [ ] Batch size of 100 is appropriate (each `File.write()` calls `mkdir` + `writeFile`, so 100 concurrent open file descriptors is well within typical OS limits)
- [ ] `mkdir({ recursive: true })` is safe when called concurrently for overlapping paths (it is — idempotent by design)
- [ ] No ordering dependencies between file writes within a single directory (files write to distinct paths)
- [ ] Consistent with existing patterns in Swift (`SwiftProject.ts`) and Go (`GoProject.ts`) generators which already use `Promise.all` for file writes

## Testing

- [ ] Lint passes (`biome check`)
- [ ] Existing [TIMING] debug logs will validate actual savings in production runs
- [ ] No unit tests added — this is a transparent performance optimization with no change to generated output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
