### PR TITLE
chore(csharp): optimize context construction with incremental path building and lazy formatter init

### DIFF
--- a/generators/csharp/base/src/context/GeneratorContext.ts
+++ b/generators/csharp/base/src/context/GeneratorContext.ts
@@ -1,5 +1,10 @@
 import { fail } from "node:assert";
-import { AbstractGeneratorContext, FernGeneratorExec, GeneratorNotificationService } from "@fern-api/base-generator";
+import {
+    AbstractFormatter,
+    AbstractGeneratorContext,
+    FernGeneratorExec,
+    GeneratorNotificationService
+} from "@fern-api/base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { ast, CsharpConfigSchema, Generation } from "@fern-api/csharp-codegen";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
@@ -74,6 +79,14 @@ export abstract class GeneratorContext extends AbstractGeneratorContext {
             ast.convertReadOnlyPrimitiveTypes(this.settings.readOnlyMemoryTypes)
         );
     }
+
+    /**
+     * Backing field for the lazily-initialized formatter.
+     * Declared here so that sibling subclasses (SdkGeneratorContext,
+     * ModelGeneratorContext) share a single property declaration and
+     * remain structurally compatible in TypeScript.
+     */
+    protected _formatter: AbstractFormatter | undefined;
 
     private allNamespaceSegments?: Set<string>;
     private allTypeClassReferences?: Map<string, Set<Namespace>>;

--- a/generators/csharp/codegen/src/context/model-navigator.ts
+++ b/generators/csharp/codegen/src/context/model-navigator.ts
@@ -83,11 +83,29 @@ export type Origin = IrNode | Provenance;
  * @example
  * trim("types.User.name.pascalCase") → "types.User"
  */
-function trim(jsonPath: JsonPath): JsonPath {
-    return jsonPath
-        .split(".")
-        .filter((part) => !["name", "camelCase", "snakeCase", "screamingSnakeCase", "pascalCase"].includes(part))
-        .join(".");
+/**
+ * Set of IR path segments that represent name casing variants.
+ * These segments are "transparent" in path construction - they don't contribute
+ * to the canonical path because all case variants of a name resolve to the same
+ * logical entity. Skipping them during path building avoids the expensive
+ * split/filter/join that the old trim() function performed on every node.
+ */
+const TRIMMED_KEYS = new Set(["name", "camelCase", "snakeCase", "screamingSnakeCase", "pascalCase"]);
+
+/**
+ * Builds a canonical JsonPath by appending a key to a parent path,
+ * skipping keys that are in the TRIMMED_KEYS set.
+ *
+ * This replaces the old trim() function which called split/filter/join
+ * on the entire path string for every node in the IR tree. Since parent
+ * paths are already canonical (built incrementally), we only need to
+ * check the current key.
+ */
+function buildPath(parentPath: string | undefined, key: string): string {
+    if (TRIMMED_KEYS.has(key)) {
+        return parentPath ?? "";
+    }
+    return parentPath ? `${parentPath}.${key}` : key;
 }
 
 /**
@@ -166,16 +184,15 @@ export class ModelNavigator {
      * Recursively builds indexes for all nodes in the IR tree.
      *
      * This private method traverses the entire IR object graph and creates provenance entries
-     * for each node. It handles path collisions by using a trimming strategy - when multiple
-     * paths normalize to the same trimmed path (e.g., "types.User.name.pascalCase" and
-     * "types.User.name.camelCase" both trim to "types.User.name"), only the first encounter
-     * is stored in indexByPath, and subsequent encounters are redirected to the parent provenance.
+     * for each node. It handles path collisions by using an incremental path building strategy -
+     * keys in TRIMMED_KEYS (name casing variants like "camelCase", "pascalCase") are skipped
+     * during path construction, causing them to share the parent's canonical path.
      *
-     * The algorithm:
-     * 1. Trims the current path to normalize it
-     * 2. If the path already exists, map this node to the parent provenance (path collision)
-     * 3. Otherwise, create a new provenance and store it in both indexes
-     * 4. Recursively process all child nodes
+     * Performance optimizations:
+     * - Uses incremental path building (buildPath) instead of split/filter/join on every node
+     * - When a trimmed key's children are also trimmed keys (e.g., name.camelCase, name.pascalCase),
+     *   registers them in indexByObject without recursing further since their children are only
+     *   primitive string values (safeName/unsafeName)
      *
      * @param instance - The current IR node being indexed
      * @param key - The property name/key used to access this node (empty string for root)
@@ -183,7 +200,7 @@ export class ModelNavigator {
      * @returns The provenance for this node (may be parent's provenance if path collision occurred)
      */
     private createIndex(instance: IrNode, key = "", parentProvenance?: Provenance) {
-        const jsonPath = trim(parentProvenance?.jsonPath ? `${parentProvenance.jsonPath}.${key}` : key);
+        const jsonPath = buildPath(parentProvenance?.jsonPath, key);
 
         if (this.indexByPath.has(jsonPath)) {
             // if the name was already taken that means that we've trimmed the path so we're not going to store this node
@@ -197,10 +214,21 @@ export class ModelNavigator {
             // if someone looks up this object, dial them back to the parent provenance
             this.indexByObject.set(instance, parentProvenance);
 
-            // but do continue to process the children nodes
-            for (const [key, value] of Object.entries(instance)) {
-                if (typeof value === "object" && value !== null) {
-                    this.createIndex(value, key, parentProvenance);
+            // Process children, but optimize for trimmed-key branches:
+            // Children of trimmed keys (e.g., "name") that are themselves trimmed keys
+            // (e.g., "camelCase", "pascalCase") only contain primitive string values
+            // (safeName/unsafeName), so we can register them without full recursion.
+            const isTrimmedKey = TRIMMED_KEYS.has(key);
+            for (const [childKey, childValue] of Object.entries(instance)) {
+                if (typeof childValue === "object" && childValue !== null) {
+                    if (isTrimmedKey && TRIMMED_KEYS.has(childKey)) {
+                        // This is a name case variant (e.g., camelCase under name).
+                        // Its children are only strings (safeName/unsafeName),
+                        // so just register the object mapping and skip recursion.
+                        this.indexByObject.set(childValue as IrNode, parentProvenance);
+                    } else {
+                        this.createIndex(childValue as IrNode, childKey, parentProvenance);
+                    }
                 }
             }
 
@@ -218,9 +246,9 @@ export class ModelNavigator {
         this.indexByPath.set(jsonPath, provenance);
 
         // process the children nodes
-        for (const [key, value] of Object.entries(instance)) {
-            if (typeof value === "object" && value !== null) {
-                this.createIndex(value, key, provenance);
+        for (const [childKey, childValue] of Object.entries(instance)) {
+            if (typeof childValue === "object" && childValue !== null) {
+                this.createIndex(childValue as IrNode, childKey, provenance);
             }
         }
 
@@ -265,7 +293,9 @@ export class ModelNavigator {
 
         const element = {
             ...parentProvenance,
-            jsonPath: trim(`${parentProvenance.jsonPath}+${member}`),
+            // The '+' separator means member names won't match TRIMMED_KEYS segments,
+            // so we can directly concatenate without needing to trim.
+            jsonPath: `${parentProvenance.jsonPath}+${member}`,
             name: member,
             node: parentProvenance.node,
             parent: parentProvenance,

--- a/generators/csharp/model/src/ModelGeneratorContext.ts
+++ b/generators/csharp/model/src/ModelGeneratorContext.ts
@@ -13,7 +13,20 @@ type WellKnownProtobufType = FernIr.WellKnownProtobufType;
 const WellKnownProtobufType = FernIr.WellKnownProtobufType;
 
 export class ModelGeneratorContext extends GeneratorContext {
-    public readonly formatter: AbstractFormatter;
+    private _formatter: AbstractFormatter | undefined;
+
+    /**
+     * Lazily initializes the CsharpFormatter on first access.
+     * The formatter resolves the csharpier tool path and is only needed
+     * during code formatting, not during context construction.
+     */
+    public get formatter(): AbstractFormatter {
+        if (this._formatter === undefined) {
+            this._formatter = new CsharpFormatter();
+        }
+        return this._formatter;
+    }
+
     public constructor(
         ir: IntermediateRepresentation,
         config: FernGeneratorExec.config.GeneratorConfig,
@@ -37,7 +50,6 @@ export class ModelGeneratorContext extends GeneratorContext {
                 getChildNamespaceSegments: (fernFilepath: FernFilepath) => this.getChildNamespaceSegments(fernFilepath)
             })
         );
-        this.formatter = new CsharpFormatter();
     }
 
     override getAsyncCoreAsIsFiles(): string[] {

--- a/generators/csharp/model/src/ModelGeneratorContext.ts
+++ b/generators/csharp/model/src/ModelGeneratorContext.ts
@@ -13,8 +13,6 @@ type WellKnownProtobufType = FernIr.WellKnownProtobufType;
 const WellKnownProtobufType = FernIr.WellKnownProtobufType;
 
 export class ModelGeneratorContext extends GeneratorContext {
-    private _formatter: AbstractFormatter | undefined;
-
     /**
      * Lazily initializes the CsharpFormatter on first access.
      * The formatter resolves the csharpier tool path and is only needed

--- a/generators/csharp/sdk/src/SdkGeneratorContext.ts
+++ b/generators/csharp/sdk/src/SdkGeneratorContext.ts
@@ -13,11 +13,24 @@ import { EndpointSnippetsGenerator } from "./endpoint/snippets/EndpointSnippetsG
 import { ReadmeConfigBuilder } from "./readme/ReadmeConfigBuilder.js";
 
 export class SdkGeneratorContext extends GeneratorContext {
-    public readonly formatter: AbstractFormatter;
+    private _formatter: AbstractFormatter | undefined;
     public readonly nopFormatter: AbstractFormatter;
     public readonly endpointGenerator: EndpointGenerator;
     public readonly generatorAgent: CsharpGeneratorAgent;
     public readonly snippetGenerator: EndpointSnippetsGenerator;
+
+    /**
+     * Lazily initializes the CsharpFormatter on first access.
+     * The formatter resolves the csharpier tool path and is only needed
+     * during code formatting, not during context construction.
+     */
+    public get formatter(): AbstractFormatter {
+        if (this._formatter === undefined) {
+            this._formatter = new CsharpFormatter();
+        }
+        return this._formatter;
+    }
+
     public constructor(
         ir: FernIr.IntermediateRepresentation,
         config: FernGeneratorExec.config.GeneratorConfig,
@@ -42,7 +55,6 @@ export class SdkGeneratorContext extends GeneratorContext {
                     this.getChildNamespaceSegments(fernFilepath)
             })
         );
-        this.formatter = new CsharpFormatter();
         this.nopFormatter = new NopFormatter();
         this.endpointGenerator = new EndpointGenerator({ context: this });
         this.generatorAgent = new CsharpGeneratorAgent({

--- a/generators/csharp/sdk/src/SdkGeneratorContext.ts
+++ b/generators/csharp/sdk/src/SdkGeneratorContext.ts
@@ -13,7 +13,6 @@ import { EndpointSnippetsGenerator } from "./endpoint/snippets/EndpointSnippetsG
 import { ReadmeConfigBuilder } from "./readme/ReadmeConfigBuilder.js";
 
 export class SdkGeneratorContext extends GeneratorContext {
-    private _formatter: AbstractFormatter | undefined;
     public readonly nopFormatter: AbstractFormatter;
     public readonly endpointGenerator: EndpointGenerator;
     public readonly generatorAgent: CsharpGeneratorAgent;

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.23.7
+  changelogEntry:
+    - summary: |
+        Optimize context construction performance: replace expensive O(n) string
+        split/filter/join in ModelNavigator's tree indexing with O(1) incremental
+        path building, skip recursion into name-casing variant branches that only
+        contain primitive values, and lazily initialize the CsharpFormatter so
+        the csharpier tool path is only resolved when formatting is actually needed.
+      type: chore
+  createdAt: "2026-03-07"
+  irVersion: 62
+
 - version: 2.23.6
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Performance optimization for C# SDK generator context construction (reported at ~7.2s).

Requested by: @Swimburger
[Link to Devin Session](https://app.devin.ai/sessions/b527e0925f514d6391946ffa16ab045d)

Reduces context construction overhead by optimizing the two most expensive operations: `ModelNavigator.createIndex()` tree traversal and `CsharpFormatter` initialization (which spawns csharpier).

## Changes Made

### 1. ModelNavigator: Incremental path building (`model-navigator.ts`)
- **Replaced `trim()` with `buildPath()`**: The old `trim()` function called `split(".")` → `filter()` → `join(".")` on every single node in the IR tree. The new `buildPath()` does an O(1) `Set.has()` check on only the current key, since parent paths are already canonical.
- **Skip recursion into name-casing variant branches**: When a trimmed key's children are also trimmed keys (e.g., `name.camelCase`, `name.pascalCase`), we register them in `indexByObject` without recursing further, since their children are only primitive string values (`safeName`/`unsafeName`).
- **Remove `trim()` from `explicit()` method**: The `+` separator used in explicit paths means member names can never collide with `TRIMMED_KEYS` segments, so trimming is unnecessary.

### 2. Lazy CsharpFormatter initialization (`SdkGeneratorContext.ts`, `ModelGeneratorContext.ts`, `GeneratorContext.ts`)
- Changed `formatter` from an eagerly-initialized `readonly` field to a lazily-initialized getter backed by `_formatter`.
- The `CsharpFormatter` constructor resolves the csharpier dotnet tool path, which is only needed when formatting actually occurs — not during context construction.
- The `_formatter` backing field is declared in the base `GeneratorContext` class so that sibling subclasses (`SdkGeneratorContext`, `ModelGeneratorContext`) remain structurally compatible in TypeScript's type system. Without this, each class having its own `private _formatter` makes them incompatible where one is passed where the other is expected.

### 3. Changelog
- Added `versions.yml` entry for v2.23.7 documenting the optimization.

## Human Review Checklist

> ⚠️ These are the riskiest areas — no new tests were added since this is intended to be behavior-preserving.

- [ ] **Verify `buildPath` equivalence**: Does incremental path building produce identical canonical paths to the old `trim()` for all IR structures? Specifically, paths like `a.name.camelCase` should still canonicalize to `a`.
- [ ] **Verify the IR structure assumption**: The recursion-skip optimization assumes children of trimmed keys that are themselves trimmed keys (e.g., `name.camelCase`) only ever contain primitive `safeName`/`unsafeName` strings. If the IR ever adds non-primitive children here, they'd be silently skipped from indexing.
- [ ] **Verify `explicit()` trim removal is safe**: The `+` separator in `${parentProvenance.jsonPath}+${member}` means member names won't match TRIMMED_KEYS — confirm no member name could be `"name"`, `"camelCase"`, etc.
- [ ] **Verify base class `_formatter` placement is safe**: The `protected _formatter` field on `GeneratorContext` is only used by the two subclasses' `formatter` getters. Confirm no other subclass or external code is affected.

## Testing
- [x] Lint passes (`pnpm run check`)
- [x] Compilation passes (`pnpm turbo compile --filter=@fern-api/fern-csharp-sdk`)
- [x] Seed tests: `csharp-sdk` and `csharp-model` all passing in CI with zero diffs
- [x] Local seed tests confirmed zero diffs (`imdb`, `exhaustive` fixtures)
- [ ] Unit tests added/updated — not added; behavior-preserving optimization
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
