### PR TITLE
chore(csharp): reduce dotnet CLI process spawns during project setup

### DIFF
--- a/generators/csharp/base/src/asIs/test/Template.Test.csproj
+++ b/generators/csharp/base/src/asIs/test/Template.Test.csproj
@@ -30,7 +30,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\<%= projectName%>\<%= projectName%>.csproj" />
+        <ProjectReference Include="<%= projectReferencePath%>" />
     </ItemGroup>
 
     <Import Project="<%= testProjectName%>.Custom.props" Condition="Exists('<%= testProjectName%>.Custom.props')" />

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -3,7 +3,7 @@ import { Generation, WithGeneration } from "@fern-api/csharp-codegen";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { Eta } from "eta";
-import { access, mkdir, readFile, unlink, writeFile } from "fs/promises";
+import { mkdir, readFile, unlink, writeFile } from "fs/promises";
 import path from "path";
 import { AsIsFiles } from "../AsIs.js";
 import { GeneratorContext } from "../context/GeneratorContext.js";
@@ -212,19 +212,22 @@ export class CsharpProject extends AbstractProject<GeneratorContext> {
         const createProjectStartTime = Date.now();
         const absolutePathToProjectDirectory = await this.createProject({
             absolutePathToLibraryDirectory,
-            absolutePathToSolutionDirectory,
-            absolutePathToOtherDirectory,
-            libraryPath,
-            solutionPath
+            absolutePathToOtherDirectory
         });
         this.context.logger.debug(`[TIMING] createProject took ${Date.now() - createProjectStartTime}ms`);
         const createTestProjectStartTime = Date.now();
         const absolutePathToTestProjectDirectory = await this.createTestProject({
             absolutePathToTestDirectory,
-            absolutePathToSolutionDirectory,
             absolutePathToProjectDirectory
         });
         this.context.logger.debug(`[TIMING] createTestProject took ${Date.now() - createTestProjectStartTime}ms`);
+
+        // Generate the .slnx solution file directly as XML instead of using dotnet CLI
+        await this.createSolutionFile({
+            absolutePathToSolutionDirectory,
+            absolutePathToProjectDirectory,
+            absolutePathToTestProjectDirectory
+        });
 
         const writeSourceFilesStartTime = Date.now();
         for (const file of this.sourceFiles) {
@@ -350,30 +353,11 @@ dotnet_diagnostic.IDE0005.severity = error
 
     private async createProject({
         absolutePathToLibraryDirectory,
-        absolutePathToSolutionDirectory,
-        absolutePathToOtherDirectory,
-        libraryPath,
-        solutionPath
+        absolutePathToOtherDirectory
     }: {
         absolutePathToLibraryDirectory: AbsoluteFilePath;
-        absolutePathToSolutionDirectory: AbsoluteFilePath;
         absolutePathToOtherDirectory: AbsoluteFilePath;
-        libraryPath: string;
-        solutionPath: string;
     }): Promise<AbsoluteFilePath> {
-        // Create solution file in the solution directory using absolute paths
-        const solutionFilePath = join(absolutePathToSolutionDirectory, RelativeFilePath.of(`${this.name}.slnx`));
-        await access(solutionFilePath).catch(() =>
-            loggingExeca(
-                this.context.logger,
-                "dotnet",
-                ["new", "sln", "-n", this.name, "-o", absolutePathToSolutionDirectory, "--no-update-check"],
-                {
-                    doNotPipeOutput: true
-                }
-            )
-        );
-
         const absolutePathToProjectDirectory = join(absolutePathToLibraryDirectory, RelativeFilePath.of(this.name));
         this.context.logger.debug(`mkdir ${absolutePathToProjectDirectory}`);
         await mkdir(absolutePathToProjectDirectory, { recursive: true });
@@ -410,39 +394,34 @@ dotnet_diagnostic.IDE0005.severity = error
             (await readFile(getAsIsFilepath(AsIsFiles.CustomProps))).toString()
         );
 
-        // Add library project to solution using absolute paths
-        // Use --in-root to place project at solution root without folder nesting
-        await loggingExeca(
-            this.context.logger,
-            "dotnet",
-            ["sln", solutionFilePath, "add", libraryCsprojPath, "--in-root"],
-            {
-                doNotPipeOutput: true
-            }
-        );
-
         return absolutePathToProjectDirectory;
     }
 
     private async createTestProject({
         absolutePathToTestDirectory,
-        absolutePathToSolutionDirectory,
         absolutePathToProjectDirectory
     }: {
         absolutePathToTestDirectory: AbsoluteFilePath;
-        absolutePathToSolutionDirectory: AbsoluteFilePath;
         absolutePathToProjectDirectory: AbsoluteFilePath;
     }): Promise<AbsoluteFilePath> {
         const testProjectName = this.names.files.testProject;
         const absolutePathToTestProject = join(absolutePathToTestDirectory, RelativeFilePath.of(testProjectName));
         await mkdir(absolutePathToTestProject, { recursive: true });
 
+        // Compute the relative path from the test project to the library .csproj
+        // Use win32.normalize to produce backslash paths matching dotnet CLI conventions
+        const libraryCsprojPath = join(absolutePathToProjectDirectory, RelativeFilePath.of(`${this.name}.csproj`));
+        const projectReferenceRelativePath = path.win32.normalize(
+            path.relative(absolutePathToTestProject, libraryCsprojPath)
+        );
+
         const testCsProjTemplateContents = (
             await readFile(getAsIsFilepath(AsIsFiles.Test.TemplateTestCsProj))
         ).toString();
         const testCsProjContents = eta.renderString(testCsProjTemplateContents, {
             projectName: this.name,
-            testProjectName
+            testProjectName,
+            projectReferencePath: projectReferenceRelativePath
         });
         const testCsprojPath = join(absolutePathToTestProject, RelativeFilePath.of(`${testProjectName}.csproj`));
         await writeFile(testCsprojPath, testCsProjContents);
@@ -451,38 +430,49 @@ dotnet_diagnostic.IDE0005.severity = error
             (await readFile(getAsIsFilepath(AsIsFiles.Test.TestCustomProps))).toString()
         );
 
-        // Add test project to solution using absolute paths
-        // Use --in-root to place project at solution root without folder nesting
-        const solutionFilePath = join(absolutePathToSolutionDirectory, RelativeFilePath.of(`${this.name}.slnx`));
-        await loggingExeca(
-            this.context.logger,
-            "dotnet",
-            ["sln", solutionFilePath, "add", testCsprojPath, "--in-root"],
-            {
-                doNotPipeOutput: true
-            }
+        return absolutePathToTestProject;
+    }
+
+    /**
+     * Generates the .slnx solution file directly as XML, avoiding dotnet CLI overhead.
+     * Computes relative paths from the solution directory to both project .csproj files.
+     */
+    private async createSolutionFile({
+        absolutePathToSolutionDirectory,
+        absolutePathToProjectDirectory,
+        absolutePathToTestProjectDirectory
+    }: {
+        absolutePathToSolutionDirectory: AbsoluteFilePath;
+        absolutePathToProjectDirectory: AbsoluteFilePath;
+        absolutePathToTestProjectDirectory: AbsoluteFilePath;
+    }): Promise<void> {
+        const testProjectName = this.names.files.testProject;
+
+        // Compute relative paths from the solution directory to each .csproj file
+        const libraryCsprojAbsolute = join(
+            absolutePathToProjectDirectory,
+            RelativeFilePath.of(`${this.name}.csproj`)
+        );
+        const testCsprojAbsolute = join(
+            absolutePathToTestProjectDirectory,
+            RelativeFilePath.of(`${testProjectName}.csproj`)
         );
 
-        // Update project reference in test project to point to the library project using absolute paths
-        const libraryCsprojPath = join(absolutePathToProjectDirectory, RelativeFilePath.of(`${this.name}.csproj`));
+        const libraryCsprojRelative = path.posix.normalize(
+            path.relative(absolutePathToSolutionDirectory, libraryCsprojAbsolute)
+        );
+        const testCsprojRelative = path.posix.normalize(
+            path.relative(absolutePathToSolutionDirectory, testCsprojAbsolute)
+        );
 
-        // First remove the old reference (from template), then add the correct one
-        await loggingExeca(
-            this.context.logger,
-            "dotnet",
-            ["remove", testCsprojPath, "reference", `../${this.name}/${this.name}.csproj`],
-            {
-                doNotPipeOutput: true
-            }
-        ).catch(() => {
-            // Ignore error if reference doesn't exist
-        });
+        const slnxContents = `<Solution>
+  <Project Path="${testCsprojRelative}" />
+  <Project Path="${libraryCsprojRelative}" />
+</Solution>
+`;
 
-        await loggingExeca(this.context.logger, "dotnet", ["add", testCsprojPath, "reference", libraryCsprojPath], {
-            doNotPipeOutput: true
-        });
-
-        return absolutePathToTestProject;
+        const solutionFilePath = join(absolutePathToSolutionDirectory, RelativeFilePath.of(`${this.name}.slnx`));
+        await writeFile(solutionFilePath, slnxContents);
     }
 
     private async createCoreDirectory({

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -449,10 +449,7 @@ dotnet_diagnostic.IDE0005.severity = error
         const testProjectName = this.names.files.testProject;
 
         // Compute relative paths from the solution directory to each .csproj file
-        const libraryCsprojAbsolute = join(
-            absolutePathToProjectDirectory,
-            RelativeFilePath.of(`${this.name}.csproj`)
-        );
+        const libraryCsprojAbsolute = join(absolutePathToProjectDirectory, RelativeFilePath.of(`${this.name}.csproj`));
         const testCsprojAbsolute = join(
             absolutePathToTestProjectDirectory,
             RelativeFilePath.of(`${testProjectName}.csproj`)

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -455,12 +455,8 @@ dotnet_diagnostic.IDE0005.severity = error
             RelativeFilePath.of(`${testProjectName}.csproj`)
         );
 
-        const libraryCsprojRelative = path.posix.normalize(
-            path.relative(absolutePathToSolutionDirectory, libraryCsprojAbsolute)
-        );
-        const testCsprojRelative = path.posix.normalize(
-            path.relative(absolutePathToSolutionDirectory, testCsprojAbsolute)
-        );
+        const libraryCsprojRelative = path.relative(absolutePathToSolutionDirectory, libraryCsprojAbsolute).replace(/\\/g, "/");
+        const testCsprojRelative = path.relative(absolutePathToSolutionDirectory, testCsprojAbsolute).replace(/\\/g, "/");
 
         const slnxContents = `<Solution>
   <Project Path="${testCsprojRelative}" />

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -455,8 +455,12 @@ dotnet_diagnostic.IDE0005.severity = error
             RelativeFilePath.of(`${testProjectName}.csproj`)
         );
 
-        const libraryCsprojRelative = path.relative(absolutePathToSolutionDirectory, libraryCsprojAbsolute).replace(/\\/g, "/");
-        const testCsprojRelative = path.relative(absolutePathToSolutionDirectory, testCsprojAbsolute).replace(/\\/g, "/");
+        const libraryCsprojRelative = path
+            .relative(absolutePathToSolutionDirectory, libraryCsprojAbsolute)
+            .replace(/\\/g, "/");
+        const testCsprojRelative = path
+            .relative(absolutePathToSolutionDirectory, testCsprojAbsolute)
+            .replace(/\\/g, "/");
 
         const slnxContents = `<Solution>
   <Project Path="${testCsprojRelative}" />

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.23.7
+  changelogEntry:
+    - summary: |
+        Reduce dotnet CLI process spawns during project setup by generating
+        the `.slnx` solution file and test project reference directly as
+        templates instead of invoking 5 separate `dotnet` CLI commands
+        (`dotnet new sln`, `dotnet sln add` ×2, `dotnet remove reference`,
+        `dotnet add reference`). This eliminates ~5-10s of cold .NET CLI
+        startup overhead per generation run.
+      type: chore
+  createdAt: "2026-03-07"
+  irVersion: 62
+
 - version: 2.23.6
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Performance optimization for C# generator project setup

Replaces 5 separate `dotnet` CLI process spawns during project setup with direct file generation, eliminating ~5-10s of cold .NET CLI startup overhead per generation run.

[Link to Devin Session](https://app.devin.ai/sessions/1a7d4bba3453405f80f1b4a248ca3677) | Requested by: @Swimburger

## Changes Made

- **Generate `.slnx` directly**: New `createSolutionFile()` method writes the solution XML template instead of calling `dotnet new sln` + `dotnet sln add` ×2. Relative paths from the solution directory to each `.csproj` are computed via `path.relative()` with explicit backslash-to-forward-slash conversion for cross-platform safety.
- **Compute test project reference at template time**: Instead of writing the test `.csproj` with a hardcoded sibling path, then running `dotnet remove reference` + `dotnet add reference` to fix it, the correct relative path from the test project to the library `.csproj` is computed upfront and passed as `projectReferencePath` to the Eta template.
- **Simplified `createProject` and `createTestProject` signatures**: Removed solution-related parameters (`absolutePathToSolutionDirectory`, `libraryPath`, `solutionPath`) from these methods since solution file generation is now handled by the dedicated `createSolutionFile` method.
- **Removed unused `access` import** from `fs/promises` (was only used for the `dotnet new sln` existence check).
- Updated `versions.yml` with a new `2.23.8` changelog entry (bumped from `2.23.7` after merging main which already contained `2.23.7` for parallel file writes).
- [ ] Updated README.md generator (if applicable) — N/A

## Human Review Checklist

1. **Path separator conventions**: `.slnx` paths use `.replace(/\\/g, "/")` to ensure forward slashes regardless of OS. `.csproj` `<ProjectReference>` uses `path.win32.normalize` to produce backslashes matching `dotnet` CLI conventions. Verify these conventions match what downstream tooling expects.
2. **Custom `output-path` configs**: The `output-path` setting allows `library`, `test`, and `solution` to be separate directories. The `path.relative()` calls operate on absolute paths, so they should produce correct relative paths regardless of configuration — but this is the highest-risk area since not all config permutations were tested. Seed tests do cover 3 configurations: default (`src/`), custom string (`custom-src/`), and custom object (separate `lib/` + `test/` dirs).
3. **Always-overwrite vs existence check**: The old code skipped `dotnet new sln` if the `.slnx` already existed. The new code always writes the file. This should be fine for generated output but is a behavioral change.
4. **`path.win32.normalize` on Linux**: On Linux, `path.relative()` produces forward-slash paths. `path.win32.normalize()` converts these to backslashes for the `.csproj` `<ProjectReference>`. This matches `dotnet` CLI convention but is worth sanity-checking against the seed snapshot diffs.

## Testing

- [x] Seed tests run for `csharp-sdk` (imdb fixture, 5 configs + all matrix jobs) — all passed with zero diff
- [x] Seed tests run for `csharp-model` (imdb fixture) — passed with zero diff
- [x] `pnpm lint:biome` — passed
- [x] TypeScript compilation — passed
- [x] All 24 C# seed CI matrix jobs pass with zero diff after merge from main
- [ ] No new unit tests added (seed tests serve as integration coverage)

## Updates Since Last Revision

- Merged main branch (resolved `versions.yml` conflict by bumping version to `2.23.8`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
