### PR TITLE
fix(seed): remove turbo dependency from affected detection to speed up CI

### DIFF
--- a/packages/seed/src/__test__/affected.test.ts
+++ b/packages/seed/src/__test__/affected.test.ts
@@ -208,7 +208,6 @@ describe("detectAffected", () => {
             expect(result.affectedGenerators).toEqual(["python-sdk"]);
             expect(result.affectedGenerators).not.toContain("pydantic");
         });
-
     });
 
     describe("seed.yml detection", () => {

--- a/packages/seed/src/__test__/affected.test.ts
+++ b/packages/seed/src/__test__/affected.test.ts
@@ -4,10 +4,8 @@ import { describe, expect, it } from "vitest";
 import {
     type AffectedResult,
     detectAffected,
-    mapTurboPackagesToSeedWorkspaces,
     resolveAffectedFixtures,
-    resolveAffectedGenerators,
-    type TurboPackage
+    resolveAffectedGenerators
 } from "../commands/affected/getAffected";
 import { GeneratorWorkspace } from "../loadGeneratorWorkspaces";
 
@@ -54,14 +52,12 @@ const ALL_GENERATORS: GeneratorWorkspace[] = [
     createGenerator("postman")
 ];
 
-const ALL_GENERATOR_NAMES = ALL_GENERATORS.map((g) => g.workspaceName);
-
 // Standard set of fixtures
 const ALL_FIXTURES = ["imdb", "exhaustive", "alias", "basic-auth", "file-upload", "unions"];
 
 describe("detectAffected", () => {
     describe("fallback behavior", () => {
-        it("runs everything when no changed files and no turbo packages", () => {
+        it("runs everything when no changed files", () => {
             const result = detectAffected([], ALL_GENERATORS);
 
             expect(result.allGeneratorsAffected).toBe(true);
@@ -320,108 +316,6 @@ describe("detectAffected", () => {
             expect(result.allFixturesAffected).toBe(true);
             expect(result.affectedFixtures).toEqual([]);
         });
-    });
-
-    describe("turbo integration", () => {
-        it("detects generator via turbo package path", () => {
-            const turboPackages: TurboPackage[] = [
-                { name: "@fern-api/python-sdk-generator", path: "generators/python/sdk" }
-            ];
-            const result = detectAffected([], ALL_GENERATORS, turboPackages);
-
-            expect(result.affectedGenerators).toContain("python-sdk");
-            expect(result.affectedGenerators).toContain("pydantic");
-            expect(result.affectedGenerators).toContain("fastapi");
-        });
-
-        it("detects global infrastructure via turbo package path", () => {
-            const turboPackages: TurboPackage[] = [{ name: "@fern-api/seed-cli", path: "packages/seed" }];
-            const result = detectAffected([], ALL_GENERATORS, turboPackages);
-
-            expect(result.allGeneratorsAffected).toBe(true);
-            expect(result.allFixturesAffected).toBe(true);
-        });
-
-        it("handles turbo packages for multiple generators", () => {
-            const turboPackages: TurboPackage[] = [
-                { name: "@fern-api/python-sdk-generator", path: "generators/python/sdk" },
-                { name: "@fern-api/java-sdk-generator", path: "generators/java/sdk" }
-            ];
-            const result = detectAffected([], ALL_GENERATORS, turboPackages);
-
-            expect(result.affectedGenerators).toContain("python-sdk");
-            expect(result.affectedGenerators).toContain("java-sdk");
-        });
-    });
-});
-
-describe("mapTurboPackagesToSeedWorkspaces", () => {
-    it("maps generator package paths to seed workspace names", () => {
-        const turboPackages: TurboPackage[] = [{ name: "@fern-api/python-generator", path: "generators/python/sdk" }];
-        const result = mapTurboPackagesToSeedWorkspaces(turboPackages, ALL_GENERATOR_NAMES);
-
-        expect(result.affectedGenerators).toContain("python-sdk");
-        expect(result.affectedGenerators).toContain("pydantic");
-        expect(result.affectedGenerators).toContain("fastapi");
-    });
-
-    it("detects global infrastructure packages", () => {
-        const turboPackages: TurboPackage[] = [{ name: "@fern-api/ir-sdk", path: "packages/ir-sdk" }];
-        const result = mapTurboPackagesToSeedWorkspaces(turboPackages, ALL_GENERATOR_NAMES);
-
-        expect(result.allGeneratorsAffected).toBe(true);
-        expect(result.allFixturesAffected).toBe(true);
-    });
-
-    it("does not false-positive match on prefix collisions", () => {
-        // packages/ir-sdk-v2 should NOT match packages/ir-sdk/
-        const turboPackages: TurboPackage[] = [{ name: "@fern-api/ir-sdk-v2", path: "packages/ir-sdk-v2" }];
-        const result = mapTurboPackagesToSeedWorkspaces(turboPackages, ALL_GENERATOR_NAMES);
-
-        expect(result.allGeneratorsAffected).toBe(false);
-        expect(result.allFixturesAffected).toBe(false);
-    });
-
-    it("matches exact global paths without trailing slash", () => {
-        const turboPackages: TurboPackage[] = [{ name: "@fern-api/seed-cli", path: "packages/seed" }];
-        const result = mapTurboPackagesToSeedWorkspaces(turboPackages, ALL_GENERATOR_NAMES);
-
-        expect(result.allGeneratorsAffected).toBe(true);
-        expect(result.allFixturesAffected).toBe(true);
-    });
-
-    it("matches sub-paths under global paths", () => {
-        const turboPackages: TurboPackage[] = [{ name: "@fern-api/seed-utils", path: "packages/seed/utils" }];
-        const result = mapTurboPackagesToSeedWorkspaces(turboPackages, ALL_GENERATOR_NAMES);
-
-        expect(result.allGeneratorsAffected).toBe(true);
-        expect(result.allFixturesAffected).toBe(true);
-    });
-
-    it("ignores unknown generator directories", () => {
-        const turboPackages: TurboPackage[] = [{ name: "@fern-api/unknown-gen", path: "generators/unknown-lang/sdk" }];
-        const result = mapTurboPackagesToSeedWorkspaces(turboPackages, ALL_GENERATOR_NAMES);
-
-        expect(result.affectedGenerators.size).toBe(0);
-        expect(result.allGeneratorsAffected).toBe(false);
-    });
-
-    it("filters generators not in allGeneratorNames", () => {
-        const turboPackages: TurboPackage[] = [{ name: "@fern-api/python-generator", path: "generators/python/sdk" }];
-        const limitedNames = ["python-sdk"];
-        const result = mapTurboPackagesToSeedWorkspaces(turboPackages, limitedNames);
-
-        expect(result.affectedGenerators).toContain("python-sdk");
-        expect(result.affectedGenerators).not.toContain("pydantic");
-        expect(result.affectedGenerators).not.toContain("fastapi");
-    });
-
-    it("handles empty turbo packages", () => {
-        const result = mapTurboPackagesToSeedWorkspaces([], ALL_GENERATOR_NAMES);
-
-        expect(result.affectedGenerators.size).toBe(0);
-        expect(result.allGeneratorsAffected).toBe(false);
-        expect(result.allFixturesAffected).toBe(false);
     });
 });
 
@@ -724,33 +618,5 @@ describe("end-to-end scenario tests", () => {
             const fixtures = resolveAffectedFixtures(affected, ALL_FIXTURES, gen.workspaceName);
             expect(fixtures).toEqual(ALL_FIXTURES);
         }
-    });
-
-    it("scenario: turbo detects python generator affected", () => {
-        const turboPackages: TurboPackage[] = [{ name: "@fern-api/python-generator", path: "generators/python/sdk" }];
-        const affected = detectAffected([], ALL_GENERATORS, turboPackages);
-
-        const generators = resolveAffectedGenerators(affected, ALL_GENERATORS);
-        const names = generators.map((g) => g.workspaceName);
-        expect(names).toContain("python-sdk");
-        expect(names).toContain("pydantic");
-        expect(names).toContain("fastapi");
-        expect(names).not.toContain("ts-sdk");
-    });
-
-    it("scenario: turbo + fixture change (precise union)", () => {
-        const turboPackages: TurboPackage[] = [{ name: "@fern-api/python-generator", path: "generators/python/sdk" }];
-        const changedFiles = ["test-definitions/fern/apis/imdb/definition/types.yml"];
-        const affected = detectAffected(changedFiles, ALL_GENERATORS, turboPackages);
-
-        // All generators should run (fixture changed)
-        const generators = resolveAffectedGenerators(affected, ALL_GENERATORS);
-        expect(generators).toHaveLength(ALL_GENERATORS.length);
-
-        // Python generators get all fixtures (source changed via turbo)
-        expect(resolveAffectedFixtures(affected, ALL_FIXTURES, "python-sdk")).toEqual(ALL_FIXTURES);
-
-        // Others get only imdb
-        expect(resolveAffectedFixtures(affected, ALL_FIXTURES, "ts-sdk")).toEqual(["imdb"]);
     });
 });

--- a/packages/seed/src/__test__/affected.test.ts
+++ b/packages/seed/src/__test__/affected.test.ts
@@ -67,13 +67,6 @@ describe("detectAffected", () => {
             expect(result.affectedFixtures).toEqual([]);
         });
 
-        it("runs everything when no changed files and empty turbo packages", () => {
-            const result = detectAffected([], ALL_GENERATORS, []);
-
-            expect(result.allGeneratorsAffected).toBe(true);
-            expect(result.allFixturesAffected).toBe(true);
-        });
-
         it("runs everything when changed files don't match any known pattern", () => {
             const result = detectAffected(["README.md", "docs/guide.md", ".github/workflows/ci.yml"], ALL_GENERATORS);
 
@@ -118,33 +111,6 @@ describe("detectAffected", () => {
 
             expect(result.allGeneratorsAffected).toBe(true);
             expect(result.allFixturesAffected).toBe(true);
-        });
-    });
-
-    describe("global infrastructure changes (with turbo)", () => {
-        it("still detects packages/ir-sdk/ via git diff even when turbo is available", () => {
-            // Turbo can't detect ir-sdk changes because generators depend on published npm package
-            const turboPackages: TurboPackage[] = [];
-            const result = detectAffected(["packages/ir-sdk/src/types.ts"], ALL_GENERATORS, turboPackages);
-
-            expect(result.allGeneratorsAffected).toBe(true);
-            expect(result.allFixturesAffected).toBe(true);
-        });
-
-        it("does NOT use generators/base/ as a global path when turbo is available", () => {
-            // When turbo is available, generators/base/ is NOT in GLOBAL_AFFECT_PATHS
-            // (turbo handles it via transitive deps). But if the file doesn't match
-            // any other pattern, it falls back to "run everything".
-            const turboPackages: TurboPackage[] = [];
-            const result = detectAffected(["generators/base/src/utils.ts"], ALL_GENERATORS, turboPackages);
-
-            // Even though generators/base/ is not in GLOBAL_AFFECT_PATHS when turbo is available,
-            // the file doesn't match any other pattern either, so the "no recognized changes"
-            // fallback runs everything. This is the safe/correct behavior.
-            expect(result.allGeneratorsAffected).toBe(true);
-            expect(result.allFixturesAffected).toBe(true);
-            // Verify it's from the fallback, not from the global path detection
-            expect(result.summary).toContain("No recognized changes detected \u2014 running everything as fallback.");
         });
     });
 
@@ -243,14 +209,6 @@ describe("detectAffected", () => {
             expect(result.affectedGenerators).not.toContain("pydantic");
         });
 
-        it("skips git diff generator detection when turbo is available", () => {
-            const turboPackages: TurboPackage[] = [];
-            const result = detectAffected(["generators/python/src/some-file.ts"], ALL_GENERATORS, turboPackages);
-
-            // With empty turbo packages and no global paths hit, no generators detected
-            // (turbo path is used but returned empty, git diff fallback is skipped)
-            expect(result.affectedGenerators).toEqual([]);
-        });
     });
 
     describe("seed.yml detection", () => {

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -11,7 +11,6 @@ import {
     detectAffected,
     findRepoRoot,
     getChangedFiles,
-    getTurboAffectedPackages,
     resolveAffectedFixtures,
     resolveAffectedGenerators
 } from "./commands/affected/index.js";
@@ -174,9 +173,7 @@ function addTestCommand(cli: Argv) {
             if (isGeneratorAffected || isFixtureAffected) {
                 const repoRoot = findRepoRoot();
                 const changedFiles = getChangedFiles(argv.baseRef, repoRoot);
-                // Try turbo for generator detection (handles transitive deps like generators/base/)
-                const turboPackages = getTurboAffectedPackages(repoRoot, argv.baseRef);
-                affectedResult = detectAffected(changedFiles, generators, turboPackages);
+                affectedResult = detectAffected(changedFiles, generators);
 
                 // Log the detection summary
                 console.log("\n=== Affected Detection ===");
@@ -781,9 +778,7 @@ function addAffectedCommand(cli: Argv) {
             const generators = await loadGeneratorWorkspaces();
             const repoRoot = findRepoRoot();
             const changedFiles = getChangedFiles(argv.baseRef, repoRoot);
-            // Try turbo for generator detection (handles transitive deps like generators/base/)
-            const turboPackages = getTurboAffectedPackages(repoRoot, argv.baseRef);
-            const affected = detectAffected(changedFiles, generators, turboPackages);
+            const affected = detectAffected(changedFiles, generators);
 
             if (argv.json) {
                 const resolvedGenerators = resolveAffectedGenerators(affected, generators);

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -28,17 +28,14 @@ export interface AffectedResult {
 
 /**
  * Paths that, when changed, affect ALL generators and ALL fixtures.
- * These are infrastructure-level changes that turbo cannot detect
- * (generators depend on the published npm @fern-fern/ir-sdk, not the local workspace).
+ * These are infrastructure-level changes. Includes shared base packages
+ * (generators/base/, generators/browser-compatible-base/) since all generators
+ * depend on them.
  */
-const GLOBAL_AFFECT_PATHS = ["packages/ir-sdk/", "packages/seed/", "packages/cli/generation/ir-generator/"];
-
-/**
- * Extended global paths used when turbo is unavailable as fallback.
- * Includes shared base packages that turbo would normally handle via dependency graph.
- */
-const GLOBAL_AFFECT_PATHS_WITH_BASE = [
-    ...GLOBAL_AFFECT_PATHS,
+const GLOBAL_AFFECT_PATHS = [
+    "packages/ir-sdk/",
+    "packages/seed/",
+    "packages/cli/generation/ir-generator/",
     "generators/base/",
     "generators/browser-compatible-base/"
 ];
@@ -49,32 +46,8 @@ const GLOBAL_AFFECT_PATHS_WITH_BASE = [
 const TEST_DEFINITION_PATHS = ["test-definitions/fern/apis/", "test-definitions-openapi/fern/apis/"];
 
 /**
- * Maps generator directory prefixes (under generators/) to seed workspace names.
- * Used to convert turbo's affected package paths to seed workspace names.
- * Turbo handles transitive dependencies automatically (e.g. generators/base/ changes
- * will cause all dependent generator packages to appear as affected).
- */
-const GENERATOR_DIR_TO_SEED_WORKSPACES: Record<string, string[]> = {
-    typescript: ["ts-sdk", "ts-express"],
-    "typescript-v2": ["ts-sdk", "ts-express"],
-    python: ["python-sdk", "pydantic", "fastapi"],
-    "python-v2": ["python-sdk", "pydantic", "pydantic-v2", "fastapi"],
-    java: ["java-sdk", "java-model", "java-spring"],
-    "java-v2": ["java-sdk", "java-model", "java-spring"],
-    go: ["go-sdk", "go-model"],
-    "go-v2": ["go-sdk", "go-model"],
-    "ruby-v2": ["ruby-sdk", "ruby-sdk-v2"],
-    csharp: ["csharp-sdk", "csharp-model"],
-    php: ["php-sdk", "php-model"],
-    swift: ["swift-sdk"],
-    rust: ["rust-sdk", "rust-model"],
-    openapi: ["openapi"],
-    postman: ["postman"]
-};
-
-/**
- * Fallback: Maps generator workspace names to their source code paths.
- * Used when turbo detection is not available.
+ * Maps generator workspace names to their source code paths.
+ * Used to detect which generators are affected by file changes.
  */
 const GENERATOR_SOURCE_PATHS: Record<string, string[]> = {
     "ts-sdk": ["generators/typescript/", "generators/typescript-v2/"],
@@ -100,105 +73,6 @@ const GENERATOR_SOURCE_PATHS: Record<string, string[]> = {
     openapi: ["generators/openapi/"],
     postman: ["generators/postman/"]
 };
-
-export interface TurboPackage {
-    name: string;
-    path: string;
-}
-
-interface TurboLsOutput {
-    packages: {
-        count: number;
-        items: TurboPackage[];
-    };
-}
-
-/**
- * Get affected packages using turbo's built-in dependency graph analysis.
- * Turbo automatically resolves transitive dependencies, so if a shared base package
- * (like generators/base/) changes, all dependent generator packages are reported.
- *
- * @param repoRoot - The root directory of the repository
- * @param baseRef - The git ref to diff against (passed via TURBO_SCM_BASE env var)
- * @returns Array of affected packages, or null if turbo detection fails
- */
-export function getTurboAffectedPackages(repoRoot: string, baseRef: string): TurboPackage[] | null {
-    try {
-        const output = execFileSync("pnpm", ["turbo", "ls", "--affected", "--output=json"], {
-            cwd: repoRoot,
-            encoding: "utf-8",
-            timeout: 60000,
-            env: {
-                ...process.env,
-                TURBO_SCM_BASE: baseRef
-            }
-        });
-
-        // turbo may output non-JSON lines (e.g. update notices) before the JSON
-        const jsonStart = output.indexOf("{");
-        if (jsonStart === -1) {
-            console.error("No JSON found in turbo output");
-            return null;
-        }
-
-        const parsed = JSON.parse(output.slice(jsonStart)) as TurboLsOutput;
-        return parsed.packages.items;
-    } catch (error) {
-        console.error("turbo ls --affected failed, falling back to git diff detection:", error);
-        return null;
-    }
-}
-
-/**
- * Map turbo affected package paths to seed workspace names.
- */
-export function mapTurboPackagesToSeedWorkspaces(
-    turboPackages: TurboPackage[],
-    allGeneratorNames: string[]
-): {
-    affectedGenerators: Set<string>;
-    allGeneratorsAffected: boolean;
-    allFixturesAffected: boolean;
-    summary: string[];
-} {
-    const affectedGenerators = new Set<string>();
-    const summary: string[] = [];
-    let allGeneratorsAffected = false;
-    let allFixturesAffected = false;
-
-    for (const pkg of turboPackages) {
-        // Check if this is a global infrastructure package
-        for (const globalPath of GLOBAL_AFFECT_PATHS) {
-            if (pkg.path === globalPath.replace(/\/$/, "") || pkg.path.startsWith(globalPath)) {
-                allGeneratorsAffected = true;
-                allFixturesAffected = true;
-                summary.push(`Global infrastructure package affected (turbo): ${pkg.name} (${pkg.path})`);
-                break;
-            }
-        }
-
-        // Check if this is a generator package
-        if (pkg.path.startsWith("generators/")) {
-            const parts = pkg.path.split("/");
-            if (parts.length >= 2) {
-                const generatorDir = parts[1];
-                if (generatorDir != null) {
-                    const seedWorkspaces = GENERATOR_DIR_TO_SEED_WORKSPACES[generatorDir];
-                    if (seedWorkspaces != null) {
-                        for (const workspace of seedWorkspaces) {
-                            if (allGeneratorNames.includes(workspace)) {
-                                affectedGenerators.add(workspace);
-                            }
-                        }
-                        summary.push(`Generator package affected (turbo): ${pkg.name} -> ${seedWorkspaces.join(", ")}`);
-                    }
-                }
-            }
-        }
-    }
-
-    return { affectedGenerators, allGeneratorsAffected, allFixturesAffected, summary };
-}
 
 /**
  * Get the list of changed files by running git diff against a base ref.
@@ -241,20 +115,13 @@ export function getChangedFiles(baseRef: string, repoRoot: string): string[] {
 
 /**
  * Detect which generators and fixtures are affected based on changed files.
- * Uses turbo for generator detection when available (handles transitive dependencies
- * like generators/base/ automatically), with git diff path matching as fallback.
- * Always uses git diff for test definitions and seed.yml changes.
+ * Uses git diff path matching to determine affected generators and fixtures.
  *
  * @param changedFiles - Array of changed file paths relative to repo root
  * @param allGenerators - All available generator workspaces
- * @param turboPackages - Optional turbo affected packages (null if turbo unavailable)
  * @returns AffectedResult describing what needs to run
  */
-export function detectAffected(
-    changedFiles: string[],
-    allGenerators: GeneratorWorkspace[],
-    turboPackages?: TurboPackage[] | null
-): AffectedResult {
+export function detectAffected(changedFiles: string[], allGenerators: GeneratorWorkspace[]): AffectedResult {
     const summary: string[] = [];
     const affectedGeneratorSet = new Set<string>();
     const affectedFixtureSet = new Set<string>();
@@ -262,7 +129,7 @@ export function detectAffected(
     let allFixturesAffected = false;
     const allGeneratorNames = allGenerators.map((g) => g.workspaceName);
 
-    if (changedFiles.length === 0 && (turboPackages == null || turboPackages.length === 0)) {
+    if (changedFiles.length === 0) {
         summary.push("No changed files detected — running everything as fallback.");
         return {
             allGeneratorsAffected: true,
@@ -274,29 +141,9 @@ export function detectAffected(
         };
     }
 
-    // === GENERATOR DETECTION ===
-    // Use turbo if available (handles transitive deps like generators/base/ automatically)
-    if (turboPackages != null) {
-        summary.push("Using turbo for generator affected detection (transitive dependency support).");
-        const turboResult = mapTurboPackagesToSeedWorkspaces(turboPackages, allGeneratorNames);
-        if (turboResult.allGeneratorsAffected) {
-            allGeneratorsAffected = true;
-        }
-        if (turboResult.allFixturesAffected) {
-            allFixturesAffected = true;
-        }
-        for (const gen of turboResult.affectedGenerators) {
-            affectedGeneratorSet.add(gen);
-        }
-        summary.push(...turboResult.summary);
-    }
-
     // Check git diff for infrastructure paths
-    // (needed even with turbo because generators depend on published @fern-fern/ir-sdk,
-    // not the local workspace, so turbo won't detect ir-sdk changes as affecting generators)
-    const globalPaths = turboPackages != null ? GLOBAL_AFFECT_PATHS : GLOBAL_AFFECT_PATHS_WITH_BASE;
     for (const file of changedFiles) {
-        for (const globalPath of globalPaths) {
+        for (const globalPath of GLOBAL_AFFECT_PATHS) {
             if (file.startsWith(globalPath)) {
                 allGeneratorsAffected = true;
                 allFixturesAffected = true;
@@ -335,20 +182,17 @@ export function detectAffected(
         }
     }
 
-    // === FALLBACK GENERATOR DETECTION (git diff, only when turbo unavailable) ===
-    if (turboPackages == null) {
-        summary.push("Turbo unavailable — using git diff for generator detection.");
-        for (const file of changedFiles) {
-            for (const [generatorName, sourcePaths] of Object.entries(GENERATOR_SOURCE_PATHS)) {
-                if (!allGeneratorNames.includes(generatorName)) {
-                    continue;
-                }
-                for (const sourcePath of sourcePaths) {
-                    if (file.startsWith(sourcePath)) {
-                        affectedGeneratorSet.add(generatorName);
-                        summary.push(`Generator source changed: ${generatorName} (from ${file})`);
-                        break;
-                    }
+    // === GENERATOR DETECTION (git diff path matching) ===
+    for (const file of changedFiles) {
+        for (const [generatorName, sourcePaths] of Object.entries(GENERATOR_SOURCE_PATHS)) {
+            if (!allGeneratorNames.includes(generatorName)) {
+                continue;
+            }
+            for (const sourcePath of sourcePaths) {
+                if (file.startsWith(sourcePath)) {
+                    affectedGeneratorSet.add(generatorName);
+                    summary.push(`Generator source changed: ${generatorName} (from ${file})`);
+                    break;
                 }
             }
         }

--- a/packages/seed/src/commands/affected/index.ts
+++ b/packages/seed/src/commands/affected/index.ts
@@ -3,9 +3,6 @@ export {
     detectAffected,
     findRepoRoot,
     getChangedFiles,
-    getTurboAffectedPackages,
-    mapTurboPackagesToSeedWorkspaces,
     resolveAffectedFixtures,
-    resolveAffectedGenerators,
-    type TurboPackage
+    resolveAffectedGenerators
 } from "./getAffected.js";


### PR DESCRIPTION
## Description

Refs: Reported via [Devin session](https://app.devin.ai/sessions/f7188efe012a4fc7b3559b3cb782cf68)
Requested by: @Swimburger

The "Determine base ref for affected detection" CI step was taking **3m 51s**, almost entirely due to `pnpm turbo ls --affected` which provides no practical value—every generator depends on `generators/base/` or `generators/browser-compatible-base/`, so turbo's transitive dependency analysis just re-discovers what simple path matching already handles.

This PR removes turbo from affected detection entirely and relies solely on git diff path matching, which should reduce this step from ~4 minutes to seconds.

## Changes Made

- **Removed turbo functions**: `getTurboAffectedPackages()`, `mapTurboPackagesToSeedWorkspaces()`, `TurboPackage` type, `GENERATOR_DIR_TO_SEED_WORKSPACES` mapping
- **Consolidated global paths**: Merged `GLOBAL_AFFECT_PATHS` and `GLOBAL_AFFECT_PATHS_WITH_BASE` into a single `GLOBAL_AFFECT_PATHS` that includes `generators/base/` and `generators/browser-compatible-base/`
- **Simplified `detectAffected()`**: Removed `turboPackages` parameter and turbo code path; git diff is now the only detection method
- **Updated CLI call sites**: Removed `getTurboAffectedPackages` calls in `addTestCommand` and `addAffectedCommand`
- **Updated tests**: Removed turbo-specific test suites (`turbo integration`, `mapTurboPackagesToSeedWorkspaces`, turbo scenario tests)

## Testing

- [x] Unit tests updated (removed turbo-specific tests, all remaining tests cover git-diff-based detection)
- [x] Lint/format passes (`biome check`)
- [x] All required CI checks passing (compile, biome, lint, test, test-ete, depcheck, validate versions.yml)

## Human Review Checklist

- **Behavioral equivalence**: Verify that `GENERATOR_SOURCE_PATHS` covers the same generators as the removed `GENERATOR_DIR_TO_SEED_WORKSPACES` (it does — checked manually)
- **Global path coverage**: Confirm that adding `generators/base/` and `generators/browser-compatible-base/` to `GLOBAL_AFFECT_PATHS` is correct—these should indeed trigger all generators (they are shared dependencies). Note: this is actually *more conservative* than before—previously these paths only triggered all generators when turbo was unavailable.
- **CI workflow**: The `.github/workflows/seed.yml` workflow still sets `TURBO_SCM_BASE` env var which is now unused but harmless. Consider removing it in a follow-up if desired.
- **Seed workflow behavior**: Once CI runs on this PR, verify the affected detection still works correctly and the step time is significantly reduced

> **Note:** The "Lint PR title" check fails because updating the PR title requires GitHub API access not available from the build environment. Please update the title to `fix(seed): remove turbo dependency from affected detection to speed up CI` when merging.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
