### PR TITLE
fix(cli): deduplicate package coordinates in remote generation output

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.15.5
+  changelogEntry:
+    - summary: |
+        Fix duplicate package coordinates in remote generation output. When the
+        server returned duplicate package entries, the "Published" log line and
+        the summary subtitle were printed multiple times. Coordinates are now
+        deduplicated before display.
+      type: fix
+  createdAt: "2026-03-08"
+  irVersion: 65
+
 - version: 4.15.4
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
@@ -49,17 +49,22 @@ export class RemoteTaskHandler {
             this.context.failAndThrow("Task is missing on job status");
         }
 
-        const coordinates = remoteTask.packages.map((p) => {
-            return p.coordinate._visit({
-                npm: (npmPackage) => `${npmPackage.name}@${npmPackage.version}`,
-                maven: (mavenPackage) => `${mavenPackage.group}:${mavenPackage.artifact}:${mavenPackage.version}`,
-                pypi: (pypiPackage) => `${pypiPackage.name} ${pypiPackage.version}`,
-                ruby: (rubyGem) => `${rubyGem.name}:${rubyGem.version}`,
-                nuget: (nugetPackage) => `${nugetPackage.name} ${nugetPackage.version}`,
-                crates: (cratesPackage) => `${cratesPackage.name} ${cratesPackage.version}`,
-                _other: () => "<unknown package>"
-            });
-        });
+        const coordinates = [
+            ...new Set(
+                remoteTask.packages.map((p) => {
+                    return p.coordinate._visit({
+                        npm: (npmPackage) => `${npmPackage.name}@${npmPackage.version}`,
+                        maven: (mavenPackage) =>
+                            `${mavenPackage.group}:${mavenPackage.artifact}:${mavenPackage.version}`,
+                        pypi: (pypiPackage) => `${pypiPackage.name} ${pypiPackage.version}`,
+                        ruby: (rubyGem) => `${rubyGem.name}:${rubyGem.version}`,
+                        nuget: (nugetPackage) => `${nugetPackage.name} ${nugetPackage.version}`,
+                        crates: (cratesPackage) => `${cratesPackage.name} ${cratesPackage.version}`,
+                        _other: () => "<unknown package>"
+                    });
+                })
+            )
+        ];
 
         // extract actual version from the first package for dynamic IR upload
         if (remoteTask.packages.length > 0 && this.#actualVersion == null) {


### PR DESCRIPTION
## Description

Fixes a bug where `fern generate` prints the same "Published" log line and summary coordinate multiple times when the remote generation server returns duplicate package entries.

**Before:**
```
[ir-types-v64]: fernapi/fern-typescript-sdk Published @fern-fern/ir-v64-sdk@0.0.1
[ir-types-v64]: fernapi/fern-typescript-sdk Published @fern-fern/ir-v64-sdk@0.0.1
[ir-types-v64]: fernapi/fern-typescript-sdk Published @fern-fern/ir-v64-sdk@0.0.1
┌─
│ ✓  fernapi/fern-typescript-sdk
│    ◦ @fern-fern/ir-v64-sdk@0.0.1
│    ◦ @fern-fern/ir-v64-sdk@0.0.1
│    ◦ @fern-fern/ir-v64-sdk@0.0.1
└─
```

**After:** Each coordinate appears exactly once.

## Changes Made

- Wrap the `coordinates` array derivation in `RemoteTaskHandler.processUpdate()` with `[...new Set(...)]` to deduplicate identical coordinate strings before they are used for logging and subtitle display
- Added changelog entry (v4.15.5)

## Review Checklist

- [ ] Verify that `Set` deduplication on string coordinates is appropriate (note: the `_other` fallback returns a fixed `"<unknown package>"` string, so multiple truly-different unknown packages would collapse — pre-existing behavior concern, not introduced by this PR)
- [ ] Consider whether the server-side duplicate should also be investigated as a root cause

## Testing

- [x] `pnpm run check` (biome lint) passes
- [ ] No unit tests added — change is display-only deduplication in a polling handler

---

Link to Devin session: https://app.devin.ai/sessions/925234db0d41417186a6eaf828814076
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
