### PR TITLE
fix(typescript): revert union safeName rename and qualify shadowed global types

### DIFF
--- a/generators/typescript/model/type-generator/src/union/ParsedSingleUnionTypeForUnion.ts
+++ b/generators/typescript/model/type-generator/src/union/ParsedSingleUnionTypeForUnion.ts
@@ -79,7 +79,7 @@ export class ParsedSingleUnionTypeForUnion<Context extends BaseContext> extends 
     }
 
     public getTypeName(): string {
-        return sanitizeIdentifier(this.singleUnionTypeFromUnion.discriminantValue.name.pascalCase.safeName);
+        return sanitizeIdentifier(this.singleUnionTypeFromUnion.discriminantValue.name.pascalCase.unsafeName);
     }
 
     public needsRequestResponse(context: Context): { request: boolean; response: boolean } {

--- a/generators/typescript/model/union-generator/src/GeneratedUnionImpl.ts
+++ b/generators/typescript/model/union-generator/src/GeneratedUnionImpl.ts
@@ -935,7 +935,8 @@ function qualifyShadowedGlobalTypes(
     for (const globalType of shadowedGlobalTypes) {
         // Replace standalone occurrences of the global type name with globalThis-qualified version.
         // Uses word boundaries to avoid replacing partial matches (e.g., "DateRange" stays unchanged).
-        const pattern = new RegExp(`\\b${globalType}\\b`, "g");
+        // Negative lookbehind `(?<!\.)` prevents matching already-qualified references (e.g., "SeedApi.Date").
+        const pattern = new RegExp(`(?<!\\.)\\b${globalType}\\b`, "g");
         typeText = typeText.replace(pattern, `globalThis.${globalType}`);
     }
 

--- a/generators/typescript/model/union-generator/src/GeneratedUnionImpl.ts
+++ b/generators/typescript/model/union-generator/src/GeneratedUnionImpl.ts
@@ -431,6 +431,14 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
             singleUnionType.getInterfaceDeclaration(context, this)
         );
 
+        // Collect interface names that shadow global TypeScript types.
+        // These interfaces are inside a namespace so they don't actually conflict at the
+        // top level, but property type references within sibling interfaces would resolve
+        // to the local interface instead of the global type (e.g., `value: Date` resolving
+        // to the union's `Date` variant instead of `globalThis.Date`).
+        const interfaceNames = new Set(interfaces.map((i) => i.name));
+        const shadowedGlobalTypes = GLOBAL_TS_TYPES.filter((t) => interfaceNames.has(t));
+
         for (const interface_ of interfaces) {
             const hasBaseInterfaces = this.hasBaseInterfaces(context);
             if (hasBaseInterfaces.normal) {
@@ -469,7 +477,9 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
                 name: interface_.name,
                 isExported: true,
                 extends: interface_.extends.map((e) => getTextOfTsNode(e.typeNode)),
-                properties: interface_.properties.map((p) => p.property)
+                properties: interface_.properties.map((p) =>
+                    qualifyShadowedGlobalTypes(p.property, shadowedGlobalTypes)
+                )
             });
             if (interface_.module) {
                 statements.push(interface_.module);
@@ -501,7 +511,9 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
                             name: "Request",
                             isExported: true,
                             extends: requestExtends.map((e) => getTextOfTsNode(e)),
-                            properties: requestProperties.map((p) => p.requestProperty ?? p.property)
+                            properties: requestProperties.map((p) =>
+                                qualifyShadowedGlobalTypes(p.requestProperty ?? p.property, shadowedGlobalTypes)
+                            )
                         });
                     }
                     if (anyResponseExtends || anyWriteonlyProperties || anyResponseProperties) {
@@ -510,7 +522,9 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
                             name: "Response",
                             isExported: true,
                             extends: responseExtends.map((e) => getTextOfTsNode(e)),
-                            properties: responseProperties.map((p) => p.responseProperty ?? p.property)
+                            properties: responseProperties.map((p) =>
+                                qualifyShadowedGlobalTypes(p.responseProperty ?? p.property, shadowedGlobalTypes)
+                            )
                         });
                     }
 
@@ -892,4 +906,42 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
         }
         return singleUnionType;
     }
+}
+
+/**
+ * Global TypeScript types that can be shadowed by union member interfaces
+ * declared inside a namespace. When a union has a variant named e.g. "Date",
+ * the generated `export interface Date { ... }` inside the namespace shadows
+ * `globalThis.Date`. If a sibling interface references `Date` as a property
+ * type, it would incorrectly resolve to the local interface instead of the
+ * global built-in.
+ */
+const GLOBAL_TS_TYPES: string[] = ["Date", "Error", "Object", "File", "Record", "Map", "Set", "Promise", "Array"];
+
+/**
+ * Post-processes a property signature to qualify any type references that would
+ * be shadowed by sibling union member interfaces. For example, if the union has
+ * a `Date` interface, a property typed as `Date` becomes `globalThis.Date`.
+ */
+function qualifyShadowedGlobalTypes(
+    property: PropertySignatureStructure,
+    shadowedGlobalTypes: string[]
+): PropertySignatureStructure {
+    if (shadowedGlobalTypes.length === 0 || property.type == null || typeof property.type !== "string") {
+        return property;
+    }
+
+    let typeText = property.type;
+    for (const globalType of shadowedGlobalTypes) {
+        // Replace standalone occurrences of the global type name with globalThis-qualified version.
+        // Uses word boundaries to avoid replacing partial matches (e.g., "DateRange" stays unchanged).
+        const pattern = new RegExp(`\\b${globalType}\\b`, "g");
+        typeText = typeText.replace(pattern, `globalThis.${globalType}`);
+    }
+
+    if (typeText === property.type) {
+        return property;
+    }
+
+    return { ...property, type: typeText };
 }

--- a/generators/typescript/model/union-schema-generator/src/AbstractRawSingleUnionType.ts
+++ b/generators/typescript/model/union-schema-generator/src/AbstractRawSingleUnionType.ts
@@ -26,7 +26,7 @@ export abstract class AbstractRawSingleUnionType<Context> implements RawSingleUn
 
     public generateInterface(context: Context): OptionalKind<InterfaceDeclarationStructure> {
         return {
-            name: sanitizeIdentifier(this.discriminantValueWithAllCasings.name.pascalCase.safeName),
+            name: sanitizeIdentifier(this.discriminantValueWithAllCasings.name.pascalCase.unsafeName),
             extends: this.getExtends(context).map(getTextOfTsNode),
             properties: [
                 {

--- a/generators/typescript/sdk/endpoint-error-union-generator/src/error/ParsedSingleUnionTypeForError.ts
+++ b/generators/typescript/sdk/endpoint-error-union-generator/src/error/ParsedSingleUnionTypeForError.ts
@@ -62,7 +62,7 @@ export class ParsedSingleUnionTypeForError extends AbstractKnownSingleUnionType<
     }
 
     public getTypeName(): string {
-        return sanitizeIdentifier(this.errorDeclaration.discriminantValue.name.pascalCase.safeName);
+        return sanitizeIdentifier(this.errorDeclaration.discriminantValue.name.pascalCase.unsafeName);
     }
 
     public getDiscriminantValue(): string | number {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.53.7
+  changelogEntry:
+    - summary: |
+        Revert union member interface naming from `safeName` back to `unsafeName`.
+        The v3.53.4 change to use `safeName` for union variant interface names (e.g.,
+        `Date_` instead of `Date`, `Error_` instead of `Error`) was a breaking change.
+        Union member interfaces are generated inside a namespace, so they do not
+        shadow global TypeScript types like `Date` or `Error`.
+      type: fix
+  createdAt: "2026-03-08"
+  irVersion: 65
+
 - version: 3.53.6
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -8,6 +8,13 @@
         Union member interfaces are generated inside a namespace, so they do not
         shadow global TypeScript types like `Date` or `Error`.
       type: fix
+    - summary: |
+        Qualify global type references with `globalThis.` inside union namespaces
+        when a sibling interface would shadow them. For example, if a union has both
+        `Date` and `Datetime` variants, the `Datetime` interface's `value: Date`
+        property now generates `value: globalThis.Date` to correctly reference the
+        built-in Date type instead of the local `Date` interface.
+      type: fix
   createdAt: "2026-03-08"
   irVersion: 65
 

--- a/seed/ts-express/trace/no-custom-config/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-express/trace/no-custom-config/api/resources/problem/types/CreateProblemResponse.ts
@@ -2,7 +2,7 @@
 
 import type * as SeedTrace from "../../../index";
 
-export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error_;
+export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error;
 
 export namespace CreateProblemResponse {
     export interface Success {
@@ -10,7 +10,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error_ {
+    export interface Error {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-express/trace/no-custom-config/serialization/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-express/trace/no-custom-config/serialization/resources/problem/types/CreateProblemResponse.ts
@@ -22,14 +22,14 @@ export const CreateProblemResponse: core.serialization.Schema<
     });
 
 export declare namespace CreateProblemResponse {
-    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error_;
+    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error;
 
     export interface Success {
         type: "success";
         value: serializers.ProblemId.Raw;
     }
 
-    export interface Error_ {
+    export interface Error {
         type: "error";
         value: serializers.CreateProblemError.Raw;
     }

--- a/seed/ts-express/trace/no-zurg-trace/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-express/trace/no-zurg-trace/api/resources/problem/types/CreateProblemResponse.ts
@@ -2,7 +2,7 @@
 
 import type * as SeedTrace from "../../../index";
 
-export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error_;
+export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error;
 
 export namespace CreateProblemResponse {
     export interface Success {
@@ -10,7 +10,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error_ {
+    export interface Error {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-express/unions-with-local-date/api/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-express/unions-with-local-date/api/resources/types/types/UnionWithOptionalTime.ts
@@ -27,10 +27,10 @@ import type * as SeedUnions from "../../../index";
  *         value: undefined
  *     }
  */
-export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date_ | SeedUnions.UnionWithOptionalTime.Datetime;
+export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date | SeedUnions.UnionWithOptionalTime.Datetime;
 
 export namespace UnionWithOptionalTime {
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value?: string;
     }

--- a/seed/ts-express/unions-with-local-date/api/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-express/unions-with-local-date/api/resources/types/types/UnionWithTime.ts
@@ -23,7 +23,7 @@ import type * as SeedUnions from "../../../index";
  */
 export type UnionWithTime =
     | SeedUnions.UnionWithTime.Value
-    | SeedUnions.UnionWithTime.Date_
+    | SeedUnions.UnionWithTime.Date
     | SeedUnions.UnionWithTime.Datetime;
 
 export namespace UnionWithTime {
@@ -32,7 +32,7 @@ export namespace UnionWithTime {
         value: number;
     }
 
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value: string;
     }

--- a/seed/ts-express/unions-with-local-date/serialization/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-express/unions-with-local-date/serialization/resources/types/types/UnionWithOptionalTime.ts
@@ -22,9 +22,9 @@ export const UnionWithOptionalTime: core.serialization.Schema<
     });
 
 export declare namespace UnionWithOptionalTime {
-    export type Raw = UnionWithOptionalTime.Date_ | UnionWithOptionalTime.Datetime;
+    export type Raw = UnionWithOptionalTime.Date | UnionWithOptionalTime.Datetime;
 
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value?: string | null;
     }

--- a/seed/ts-express/unions-with-local-date/serialization/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-express/unions-with-local-date/serialization/resources/types/types/UnionWithTime.ts
@@ -23,14 +23,14 @@ export const UnionWithTime: core.serialization.Schema<serializers.UnionWithTime.
         });
 
 export declare namespace UnionWithTime {
-    export type Raw = UnionWithTime.Value | UnionWithTime.Date_ | UnionWithTime.Datetime;
+    export type Raw = UnionWithTime.Value | UnionWithTime.Date | UnionWithTime.Datetime;
 
     export interface Value {
         type: "value";
         value: number;
     }
 
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value: string;
     }

--- a/seed/ts-express/unions/api/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-express/unions/api/resources/types/types/UnionWithOptionalTime.ts
@@ -27,10 +27,10 @@ import type * as SeedUnions from "../../../index";
  *         value: undefined
  *     }
  */
-export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date_ | SeedUnions.UnionWithOptionalTime.Datetime;
+export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date | SeedUnions.UnionWithOptionalTime.Datetime;
 
 export namespace UnionWithOptionalTime {
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value?: string;
     }

--- a/seed/ts-express/unions/api/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-express/unions/api/resources/types/types/UnionWithOptionalTime.ts
@@ -37,6 +37,6 @@ export namespace UnionWithOptionalTime {
 
     export interface Datetime {
         type: "datetime";
-        value?: Date;
+        value?: globalThis.Date;
     }
 }

--- a/seed/ts-express/unions/api/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-express/unions/api/resources/types/types/UnionWithTime.ts
@@ -23,7 +23,7 @@ import type * as SeedUnions from "../../../index";
  */
 export type UnionWithTime =
     | SeedUnions.UnionWithTime.Value
-    | SeedUnions.UnionWithTime.Date_
+    | SeedUnions.UnionWithTime.Date
     | SeedUnions.UnionWithTime.Datetime;
 
 export namespace UnionWithTime {
@@ -32,7 +32,7 @@ export namespace UnionWithTime {
         value: number;
     }
 
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value: string;
     }

--- a/seed/ts-express/unions/api/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-express/unions/api/resources/types/types/UnionWithTime.ts
@@ -39,6 +39,6 @@ export namespace UnionWithTime {
 
     export interface Datetime {
         type: "datetime";
-        value: Date;
+        value: globalThis.Date;
     }
 }

--- a/seed/ts-express/unions/serialization/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-express/unions/serialization/resources/types/types/UnionWithOptionalTime.ts
@@ -22,9 +22,9 @@ export const UnionWithOptionalTime: core.serialization.Schema<
     });
 
 export declare namespace UnionWithOptionalTime {
-    export type Raw = UnionWithOptionalTime.Date_ | UnionWithOptionalTime.Datetime;
+    export type Raw = UnionWithOptionalTime.Date | UnionWithOptionalTime.Datetime;
 
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value?: string | null;
     }

--- a/seed/ts-express/unions/serialization/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-express/unions/serialization/resources/types/types/UnionWithTime.ts
@@ -23,14 +23,14 @@ export const UnionWithTime: core.serialization.Schema<serializers.UnionWithTime.
         });
 
 export declare namespace UnionWithTime {
-    export type Raw = UnionWithTime.Value | UnionWithTime.Date_ | UnionWithTime.Datetime;
+    export type Raw = UnionWithTime.Value | UnionWithTime.Date | UnionWithTime.Datetime;
 
     export interface Value {
         type: "value";
         value: number;
     }
 
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value: string;
     }

--- a/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/types/StreamEvent.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/types/StreamEvent.ts
@@ -2,14 +2,14 @@
 
 import type * as SeedServerSentEvents from "../../../index.js";
 
-export type StreamEvent = SeedServerSentEvents.StreamEvent.Completion | SeedServerSentEvents.StreamEvent.Error_;
+export type StreamEvent = SeedServerSentEvents.StreamEvent.Completion | SeedServerSentEvents.StreamEvent.Error;
 
 export namespace StreamEvent {
     export interface Completion extends SeedServerSentEvents.CompletionEvent {
         event: "completion";
     }
 
-    export interface Error_ extends SeedServerSentEvents.ErrorEvent {
+    export interface Error extends SeedServerSentEvents.ErrorEvent {
         event: "error";
     }
 }

--- a/seed/ts-sdk/trace/exhaustive/src/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/api/resources/problem/types/CreateProblemResponse.ts
@@ -4,7 +4,7 @@ import type * as SeedTrace from "../../../index.js";
 
 export type CreateProblemResponse =
     | SeedTrace.CreateProblemResponse.Success
-    | SeedTrace.CreateProblemResponse.Error_
+    | SeedTrace.CreateProblemResponse.Error
     | SeedTrace.CreateProblemResponse._Unknown;
 
 export namespace CreateProblemResponse {
@@ -13,7 +13,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error_ {
+    export interface Error {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/problem/types/CreateProblemResponse.ts
@@ -2,7 +2,7 @@
 
 import type * as SeedTrace from "../../../index.js";
 
-export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error_;
+export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error;
 
 export namespace CreateProblemResponse {
     export interface Success {
@@ -10,7 +10,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error_ {
+    export interface Error {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/api/resources/problem/types/CreateProblemResponse.ts
@@ -2,7 +2,7 @@
 
 import type * as SeedTrace from "../../../index.js";
 
-export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error_;
+export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error;
 
 export namespace CreateProblemResponse {
     export interface Success {
@@ -10,7 +10,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error_ {
+    export interface Error {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-sdk/trace/serde-no-throwing/src/serialization/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/serialization/resources/problem/types/CreateProblemResponse.ts
@@ -24,14 +24,14 @@ export const CreateProblemResponse: core.serialization.Schema<
     });
 
 export declare namespace CreateProblemResponse {
-    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error_;
+    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error;
 
     export interface Success {
         type: "success";
         value: ProblemId.Raw;
     }
 
-    export interface Error_ {
+    export interface Error {
         type: "error";
         value: CreateProblemError.Raw;
     }

--- a/seed/ts-sdk/trace/serde/src/api/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/problem/types/CreateProblemResponse.ts
@@ -2,7 +2,7 @@
 
 import type * as SeedTrace from "../../../index.js";
 
-export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error_;
+export type CreateProblemResponse = SeedTrace.CreateProblemResponse.Success | SeedTrace.CreateProblemResponse.Error;
 
 export namespace CreateProblemResponse {
     export interface Success {
@@ -10,7 +10,7 @@ export namespace CreateProblemResponse {
         value: SeedTrace.ProblemId;
     }
 
-    export interface Error_ {
+    export interface Error {
         type: "error";
         value: SeedTrace.CreateProblemError;
     }

--- a/seed/ts-sdk/trace/serde/src/serialization/resources/problem/types/CreateProblemResponse.ts
+++ b/seed/ts-sdk/trace/serde/src/serialization/resources/problem/types/CreateProblemResponse.ts
@@ -24,14 +24,14 @@ export const CreateProblemResponse: core.serialization.Schema<
     });
 
 export declare namespace CreateProblemResponse {
-    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error_;
+    export type Raw = CreateProblemResponse.Success | CreateProblemResponse.Error;
 
     export interface Success {
         type: "success";
         value: ProblemId.Raw;
     }
 
-    export interface Error_ {
+    export interface Error {
         type: "error";
         value: CreateProblemError.Raw;
     }

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/types/types/UnionWithOptionalTime.ts
@@ -27,10 +27,10 @@ import type * as SeedUnions from "../../../index.js";
  *         value: undefined
  *     }
  */
-export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date_ | SeedUnions.UnionWithOptionalTime.Datetime;
+export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date | SeedUnions.UnionWithOptionalTime.Datetime;
 
 export namespace UnionWithOptionalTime {
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value?: string;
     }

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/types/types/UnionWithTime.ts
@@ -23,7 +23,7 @@ import type * as SeedUnions from "../../../index.js";
  */
 export type UnionWithTime =
     | SeedUnions.UnionWithTime.Value
-    | SeedUnions.UnionWithTime.Date_
+    | SeedUnions.UnionWithTime.Date
     | SeedUnions.UnionWithTime.Datetime;
 
 export namespace UnionWithTime {
@@ -32,7 +32,7 @@ export namespace UnionWithTime {
         value: number;
     }
 
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value: string;
     }

--- a/seed/ts-sdk/unions/src/api/resources/types/types/UnionWithOptionalTime.ts
+++ b/seed/ts-sdk/unions/src/api/resources/types/types/UnionWithOptionalTime.ts
@@ -27,10 +27,10 @@ import type * as SeedUnions from "../../../index.js";
  *         value: undefined
  *     }
  */
-export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date_ | SeedUnions.UnionWithOptionalTime.Datetime;
+export type UnionWithOptionalTime = SeedUnions.UnionWithOptionalTime.Date | SeedUnions.UnionWithOptionalTime.Datetime;
 
 export namespace UnionWithOptionalTime {
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value?: string;
     }

--- a/seed/ts-sdk/unions/src/api/resources/types/types/UnionWithTime.ts
+++ b/seed/ts-sdk/unions/src/api/resources/types/types/UnionWithTime.ts
@@ -23,7 +23,7 @@ import type * as SeedUnions from "../../../index.js";
  */
 export type UnionWithTime =
     | SeedUnions.UnionWithTime.Value
-    | SeedUnions.UnionWithTime.Date_
+    | SeedUnions.UnionWithTime.Date
     | SeedUnions.UnionWithTime.Datetime;
 
 export namespace UnionWithTime {
@@ -32,7 +32,7 @@ export namespace UnionWithTime {
         value: number;
     }
 
-    export interface Date_ {
+    export interface Date {
         type: "date";
         value: string;
     }


### PR DESCRIPTION
## Description

Reverts the breaking change introduced in v3.53.4 (#13129), which switched union member interface naming from `unsafeName` to `safeName`. That change renamed generated interfaces like `Date` → `Date_` and `Error` → `Error_` inside union namespaces, breaking existing SDK consumers.

Additionally, addresses the underlying shadowing concern non-breakingly: when a union variant interface (e.g., `Date`) would shadow a global TypeScript type, sibling interface property references are now qualified with `globalThis.` (e.g., `value: globalThis.Date`) instead of renaming the interface.

Refs #13129

## Why the original change was unnecessary

Union member interfaces are generated **inside a namespace** (e.g., `ExamplePrimitive.Date`, `CreateProblemResponse.Error`), so they do not shadow global TypeScript types like `Date` or `Error` at the top level. The `safeName` suffixing was solving a problem that didn't exist, while introducing a breaking rename for all union variants whose names collide with built-in types.

However, **within** the namespace, a sibling interface's property type *can* resolve to the local interface instead of the global type (e.g., `Datetime.value: Date` resolving to the union's `Date` variant instead of `globalThis.Date`). The `globalThis.` qualification fix handles this correctly without any breaking rename.

## Changes Made

### Revert (commit 1)
- Reverted `pascalCase.safeName` → `pascalCase.unsafeName` in three generator source files:
  - `ParsedSingleUnionTypeForUnion.ts` (model type generator)
  - `AbstractRawSingleUnionType.ts` (union schema generator)
  - `ParsedSingleUnionTypeForError.ts` (endpoint error union generator)
- Reverted all 22 affected seed test fixtures (`ts-sdk` and `ts-express`) back to pre-v3.53.4 output

### `globalThis` qualification (commit 2)
- Added `qualifyShadowedGlobalTypes` post-processing in `GeneratedUnionImpl.getSingleUnionTypeInterfaces()`:
  - Collects all interface names in the union namespace
  - Detects which names shadow known global TS types (`Date`, `Error`, `Object`, `File`, `Record`, `Map`, `Set`, `Promise`, `Array`)
  - Replaces bare references in sibling interface property types with `globalThis.X` using word-boundary regex
  - Applied to normal, request, and response interface properties
- Updated 2 seed fixtures (`ts-express/unions`) where `value: Date` → `value: globalThis.Date`

### Changelog
- Added `versions.yml` entry for v3.53.7 with both fixes

## Review Checklist

- [ ] Confirm no code added after v3.53.4 depends on the `safeName` behavior for union member interfaces
- [ ] Verify seed fixture diffs are the exact inverse of #13129's seed changes (plus the 2 new `globalThis` qualifications)
- [ ] Review the word-boundary regex in `qualifyShadowedGlobalTypes` — it replaces `\bDate\b` with `globalThis.Date`. Confirm this handles compound types correctly (e.g., `Date | undefined`, `Date[]`, `Map<string, Date>`) and doesn't cause false positives
- [ ] Verify `GLOBAL_TS_TYPES` list is reasonable — currently includes `Date`, `Error`, `Object`, `File`, `Record`, `Map`, `Set`, `Promise`, `Array`

## Testing

- Seed test fixtures updated to reflect the reverted output + `globalThis` qualification
- Ran `pnpm seed test --generator ts-express --fixture unions --skip-scripts` — passed ✅
- Ran `pnpm seed test --generator ts-sdk --fixture unions --skip-scripts` — passed, no output changes ✅ (SDK uses `string` for dates, no shadowing)
- [ ] CI seed tests should pass

---


[Link to Devin Session](https://app.devin.ai/sessions/c676aaae81444df3871a6bc9a7cec974)  
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
