### PR TITLE
fix(cli): improve error messages for 'fern docs preview list' command

### DIFF
--- a/packages/cli/cli/src/commands/docs-preview/listDocsPreview.ts
+++ b/packages/cli/cli/src/commands/docs-preview/listDocsPreview.ts
@@ -46,11 +46,19 @@ export async function listDocsPreview({
                     return context.failAndThrow(
                         "Unauthorized to list preview deployments. Please run 'fern login' to refresh your credentials, or set the FERN_TOKEN environment variable."
                     );
-                default:
+                default: {
+                    const errorContent =
+                        listResponse.error.content != null &&
+                        typeof listResponse.error.content === "object" &&
+                        "body" in listResponse.error.content
+                            ? listResponse.error.content.body
+                            : listResponse.error.content;
+                    context.logger.debug(`Error fetching preview deployments: ${JSON.stringify(errorContent)}`);
                     return context.failAndThrow(
-                        "Failed to fetch preview deployments. Please check your network connection and try again.",
+                        "Failed to fetch preview deployments. Please ensure you are logged in with 'fern login' or have FERN_TOKEN set, then try again.",
                         listResponse.error
                     );
+                }
             }
         }
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.65.2
+  changelogEntry:
+    - summary: |
+        Improve error messages for `fern docs preview list` command. The default
+        error now suggests checking authentication instead of network connectivity,
+        and the full error response is logged at debug level for easier diagnosis.
+      type: fix
+  createdAt: "2026-04-10"
+  irVersion: 66
+
 - version: 4.65.1
   changelogEntry:
     - summary: |
@@ -1433,6 +1443,7 @@
       type: feat
   createdAt: "2026-03-09"
   irVersion: 65
+
 - version: 4.15.5
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/issues/13139

Companion CLI-side improvement for the server-side fix in https://github.com/fern-api/fern-platform/pull/8202.

The `fern docs preview list` command always fails with *"Please check your network connection and try again"*, which is misleading — the actual cause is an auth-related 500 from the FDR endpoint (`/v2/registry/docs/urls/list`). The server-side fix (fern-platform PR) addresses the root cause by allowing non-Fern org users to list their own preview URLs. This PR improves the CLI error handling so the message is accurate even before/without the server fix.

## Changes Made

- Updated the default error message to suggest checking authentication (`fern login` / `FERN_TOKEN`) instead of network connectivity
- Added debug-level logging of the full error response body for easier diagnosis
- Added `versions.yml` entry (4.65.2)

### Updates since last revision
- Rebased onto latest `main` to resolve merge conflicts in `versions.yml`
- Bumped version entry from 4.15.6 → 4.65.2 (current latest is 4.65.1) and irVersion from 65 → 66

## Testing

- [ ] Manual testing not feasible without the server-side fix deployed
- [x] Lint passes (`pnpm run check`)

## Review Checklist

- [ ] Verify the error content extraction logic (`"body" in listResponse.error.content`) handles all SDK error shapes correctly
- [ ] Confirm debug log does not leak sensitive data (it logs the error body, not the auth token)
- [ ] Note: the **root cause fix** is in [fern-platform#8202](https://github.com/fern-api/fern-platform/pull/8202) — this PR is a UX improvement only

Link to Devin session: https://app.devin.ai/sessions/1e37d95e18374259aedf7c60bf69b1d3
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
