### PR TITLE
feat(cli): add `fern check` rule to detect colliding component schemas

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.16.0
+  changelogEntry:
+    - summary: |
+        Add `fern check` validation rule to detect component schema collisions
+        across multiple OpenAPI specs. When two specs define
+        `components/schemas` with the same name, one silently overwrites the
+        other during merge. The new `no-component-schema-collisions` rule now
+        reports this as an error, unless `resolve-schema-collisions` is enabled.
+      type: feat
+  createdAt: "2026-03-09"
+  irVersion: 65
+
 - version: 4.15.5
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -6,7 +6,7 @@
         across multiple OpenAPI specs. When two specs define
         `components/schemas` with the same name, one silently overwrites the
         other during merge. The new `no-component-schema-collisions` rule now
-        reports this as an error, unless `resolve-schema-collisions` is enabled.
+        reports this as a warning, unless `resolve-schema-collisions` is enabled.
       type: feat
   createdAt: "2026-03-09"
   irVersion: 65

--- a/packages/cli/workspace/oss-validator/src/getAllRules.ts
+++ b/packages/cli/workspace/oss-validator/src/getAllRules.ts
@@ -1,8 +1,14 @@
 import { Rule } from "./Rule.js";
+import { NoComponentSchemaCollisionsRule } from "./rules/no-component-schema-collisions/index.js";
 import { NoDuplicateAuthHeaderParametersRule } from "./rules/no-duplicate-auth-header-parameters/index.js";
 import { NoDuplicateOverridesRule } from "./rules/no-duplicate-overrides/index.js";
 import { NoSchemaTitleCollisionsRule } from "./rules/no-schema-title-collisions/index.js";
 
 export function getAllRules(): Rule[] {
-    return [NoDuplicateAuthHeaderParametersRule, NoDuplicateOverridesRule, NoSchemaTitleCollisionsRule];
+    return [
+        NoDuplicateAuthHeaderParametersRule,
+        NoDuplicateOverridesRule,
+        NoSchemaTitleCollisionsRule,
+        NoComponentSchemaCollisionsRule
+    ];
 }

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision-resolved/generators.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision-resolved/generators.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ./openapi/api1.yml
+      settings:
+        resolve-schema-collisions: true
+    - openapi: ./openapi/api2.yml
+      settings:
+        resolve-schema-collisions: true

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision-resolved/openapi/api1.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision-resolved/openapi/api1.yml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: API 1
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      summary: Get users
+      operationId: getUsers
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision-resolved/openapi/api2.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision-resolved/openapi/api2.yml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: API 2
+  version: 1.0.0
+paths:
+  /orders:
+    get:
+      summary: Get orders
+      operationId: getOrders
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        email:
+          type: string

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision/generators.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision/generators.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ./openapi/api1.yml
+    - openapi: ./openapi/api2.yml

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision/openapi/api1.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision/openapi/api1.yml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: API 1
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      summary: Get users
+      operationId: getUsers
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision/openapi/api2.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-collision/openapi/api2.yml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: API 2
+  version: 1.0.0
+paths:
+  /orders:
+    get:
+      summary: Get orders
+      operationId: getOrders
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        email:
+          type: string

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-no-collision/generators.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-no-collision/generators.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ./openapi/api1.yml
+    - openapi: ./openapi/api2.yml

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-no-collision/openapi/api1.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-no-collision/openapi/api1.yml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: API 1
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      summary: Get users
+      operationId: getUsers
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-no-collision/openapi/api2.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/multi-spec-no-collision/openapi/api2.yml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: API 2
+  version: 1.0.0
+paths:
+  /orders:
+    get:
+      summary: Get orders
+      operationId: getOrders
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+        total:
+          type: number

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/single-spec-no-collision/generators.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/single-spec-no-collision/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ./openapi/openapi.yml

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/single-spec-no-collision/openapi/openapi.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/fixtures/single-spec-no-collision/openapi/openapi.yml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      summary: Get users
+      operationId: getUsers
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/no-component-schema-collisions.test.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/no-component-schema-collisions.test.ts
@@ -15,7 +15,7 @@ describe("no-component-schema-collisions", () => {
         });
 
         expect(violations.length).toBe(1);
-        expect(violations[0]?.severity).toBe("error");
+        expect(violations[0]?.severity).toBe("warning");
         expect(violations[0]?.message).toContain("Component schema collision detected");
         expect(violations[0]?.message).toContain("User");
         expect(violations[0]?.message).toContain("api1.yml");

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/no-component-schema-collisions.test.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/__test__/no-component-schema-collisions.test.ts
@@ -1,0 +1,66 @@
+import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { getViolationsForRule } from "../../../testing-utils/getViolationsForRule";
+import { NoComponentSchemaCollisionsRule } from "../no-component-schema-collisions";
+
+describe("no-component-schema-collisions", () => {
+    it("should detect schema ID collisions across multiple specs", async () => {
+        const violations = await getViolationsForRule({
+            rule: NoComponentSchemaCollisionsRule,
+            absolutePathToWorkspace: join(
+                AbsoluteFilePath.of(__dirname),
+                RelativeFilePath.of("fixtures"),
+                RelativeFilePath.of("multi-spec-collision")
+            ),
+            cliVersion: "0.1.3-rc0"
+        });
+
+        expect(violations.length).toBe(1);
+        expect(violations[0]?.severity).toBe("error");
+        expect(violations[0]?.message).toContain("Component schema collision detected");
+        expect(violations[0]?.message).toContain("User");
+        expect(violations[0]?.message).toContain("api1.yml");
+        expect(violations[0]?.message).toContain("api2.yml");
+    }, 10_000);
+
+    it("should not report violations when specs have different schema names", async () => {
+        const violations = await getViolationsForRule({
+            rule: NoComponentSchemaCollisionsRule,
+            absolutePathToWorkspace: join(
+                AbsoluteFilePath.of(__dirname),
+                RelativeFilePath.of("fixtures"),
+                RelativeFilePath.of("multi-spec-no-collision")
+            ),
+            cliVersion: "0.1.3-rc0"
+        });
+
+        expect(violations).toEqual([]);
+    }, 10_000);
+
+    it("should not report violations when resolve-schema-collisions is true", async () => {
+        const violations = await getViolationsForRule({
+            rule: NoComponentSchemaCollisionsRule,
+            absolutePathToWorkspace: join(
+                AbsoluteFilePath.of(__dirname),
+                RelativeFilePath.of("fixtures"),
+                RelativeFilePath.of("multi-spec-collision-resolved")
+            ),
+            cliVersion: "0.1.3-rc0"
+        });
+
+        expect(violations).toEqual([]);
+    }, 10_000);
+
+    it("should not report violations for a single spec", async () => {
+        const violations = await getViolationsForRule({
+            rule: NoComponentSchemaCollisionsRule,
+            absolutePathToWorkspace: join(
+                AbsoluteFilePath.of(__dirname),
+                RelativeFilePath.of("fixtures"),
+                RelativeFilePath.of("single-spec-no-collision")
+            ),
+            cliVersion: "0.1.3-rc0"
+        });
+
+        expect(violations).toEqual([]);
+    }, 10_000);
+});

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/index.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/index.ts
@@ -1,0 +1,1 @@
+export { NoComponentSchemaCollisionsRule } from "./no-component-schema-collisions";

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/no-component-schema-collisions.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/no-component-schema-collisions.ts
@@ -1,0 +1,77 @@
+import { isOpenAPIV2 } from "@fern-api/api-workspace-commons";
+import { relative } from "@fern-api/fs-utils";
+import { convertOpenAPIV2ToV3, loadOpenAPI } from "@fern-api/lazy-fern-workspace";
+import { readFile } from "fs/promises";
+
+import { Rule } from "../../Rule";
+import { ValidationViolation } from "../../ValidationViolation";
+
+interface SchemaEntry {
+    schemaId: string;
+    specFile: string;
+}
+
+export const NoComponentSchemaCollisionsRule: Rule = {
+    name: "no-component-schema-collisions",
+    run: async ({ workspace, specs, context }) => {
+        const violations: ValidationViolation[] = [];
+
+        // Only relevant when there are multiple specs that could collide
+        const openapiSpecs = specs.filter((spec) => spec.type === "openapi");
+        if (openapiSpecs.length < 2) {
+            return violations;
+        }
+
+        // Check if any spec has resolveSchemaCollisions enabled (auto-resolution mode)
+        const hasResolveEnabled = openapiSpecs.some((spec) => spec.settings?.resolveSchemaCollisions === true);
+        if (hasResolveEnabled) {
+            return violations;
+        }
+
+        // Global schema ID registry across all specs
+        const schemaIdRegistry = new Map<string, SchemaEntry>();
+
+        for (const spec of openapiSpecs) {
+            const contents = (await readFile(spec.absoluteFilepath)).toString();
+            const isAsyncAPI = contents.includes("asyncapi:");
+            const isOpenAPI = contents.includes("openapi") || contents.includes("swagger");
+
+            if (!isOpenAPI && !isAsyncAPI) {
+                continue;
+            }
+
+            const relativeFilepath = relative(workspace.absoluteFilePath, spec.source.file);
+
+            // Load the document (with overrides applied)
+            const document = await loadOpenAPI({
+                absolutePathToOpenAPI: spec.absoluteFilepath,
+                context,
+                absolutePathToOpenAPIOverrides: spec.absoluteFilepathToOverrides,
+                absolutePathToOpenAPIOverlays: spec.absoluteFilepathToOverlays
+            });
+
+            // For OpenAPI v2, convert to v3 first
+            const apiToValidate = isOpenAPIV2(document) ? await convertOpenAPIV2ToV3(document) : document;
+
+            // Check component schemas for ID collisions across specs
+            const schemas = apiToValidate.components?.schemas ?? {};
+
+            for (const schemaId of Object.keys(schemas)) {
+                const existing = schemaIdRegistry.get(schemaId);
+                if (existing != null) {
+                    violations.push({
+                        name: "no-component-schema-collisions",
+                        severity: "error",
+                        relativeFilepath,
+                        nodePath: ["components", "schemas", schemaId],
+                        message: `Component schema collision detected: Schema '${schemaId}' is defined in both '${existing.specFile}' and '${relativeFilepath}'. One will overwrite the other. Rename the schema in one of the specs or use namespaces to avoid conflicts.`
+                    });
+                } else {
+                    schemaIdRegistry.set(schemaId, { schemaId, specFile: relativeFilepath });
+                }
+            }
+        }
+
+        return violations;
+    }
+};

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/no-component-schema-collisions.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/no-component-schema-collisions.ts
@@ -61,7 +61,7 @@ export const NoComponentSchemaCollisionsRule: Rule = {
                 if (existing != null) {
                     violations.push({
                         name: "no-component-schema-collisions",
-                        severity: "error",
+                        severity: "warning",
                         relativeFilepath,
                         nodePath: ["components", "schemas", schemaId],
                         message: `Component schema collision detected: Schema '${schemaId}' is defined in both '${existing.specFile}' and '${relativeFilepath}'. One will overwrite the other. Rename the schema in one of the specs or use namespaces to avoid conflicts.`


### PR DESCRIPTION
## Description

Closes https://github.com/fern-api/fern/issues/11686

When multiple OpenAPI specs are configured in `generators.yml`, two specs can define `components/schemas` with the same name (e.g., both define `User`). During the IR merge in `mergeSchemaMaps`, the second schema silently overwrites the first. This PR adds a new `fern check` validation rule to detect and report these collisions.

Link to Devin Session: https://app.devin.ai/sessions/66062ea64ac74d1980bb9ea74ff41e50
Requested by: @iamnamananand996

## Changes Made

- Added new `no-component-schema-collisions` OSS validation rule in `packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/`
- Registered the rule in `getAllRules.ts`
- Added CLI versions.yml entry (4.17.0, feat)
- Added 4 test fixtures covering: collision detected, no collision (different names), collision with `resolve-schema-collisions: true` (skipped), single spec (skipped)

## Updates since last revision

- **Severity changed from `error` to `warning`** per reviewer feedback — avoids breaking existing users who may have colliding schemas in their specs today
- Version bumped to 4.17.0 (from 4.16.0) to resolve merge conflict with `.fernignore` autodiscovery feature on main
- E2E verified locally: built the CLI and confirmed the rule reports collisions correctly via `fern check --json`

## Testing

- [x] Unit tests added (4 test cases, all passing)
- [x] Biome lint/format passing
- [x] E2E verified with local CLI build against multi-spec fixture with colliding `User` schema

## Items for Reviewer Attention

1. **Severity is `warning`, not `error`**: Collisions won't block CI. If we want to promote this to `error` in a future release, it can be changed in one line.
2. **`resolveSchemaCollisions` skip logic**: The rule skips the *entire* check if *any* spec has `resolve-schema-collisions: true`. If only one of N specs enables it, collisions between the remaining specs won't be caught. Confirm this is the desired behavior vs. per-spec opt-out.
3. **AsyncAPI / namespaced schemas not covered**: The rule only checks OpenAPI spec component schemas at the root level. `mergeSchemaMaps` also merges namespaced and AsyncAPI schemas — collisions there are not detected by this rule.
4. **OSSWorkspace only**: The rule runs via the OSS validator, which requires the workspace to be an `OSSWorkspace` (OpenAPI-only projects). Projects that also have a `definition/` directory load as `LazyFernWorkspace` and won't trigger this rule.
5. **Redundant content-based file type check**: The specs are already filtered to `type === "openapi"`, but the rule also reads file contents to check for `"openapi"` / `"swagger"` strings. This is inherited from the sibling `no-schema-title-collisions` rule but could be simplified.