### PR TITLE
feat(cli): auto-discover .fernignore for generators with local file system output

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -675,7 +675,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 .option("fernignore", {
                     type: "string",
                     description:
-                        "Path to a custom .fernignore file. For generators with local file system output, the .fernignore in the output directory is used automatically if not specified (remote generation only)"
+                        "Path to a custom .fernignore file. For generators with local file system output, the .fernignore in the output directory is used automatically if not specified"
                 })
                 .option("dynamic-ir-only", {
                     boolean: true,

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -675,7 +675,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 .option("fernignore", {
                     type: "string",
                     description:
-                        "Path to a custom .fernignore file to use instead of the one on the main branch (remote generation only)"
+                        "Path to a custom .fernignore file. For generators with local file system output, the .fernignore in the output directory is used automatically if not specified (remote generation only)"
                 })
                 .option("dynamic-ir-only", {
                     boolean: true,

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.16.0
+  changelogEntry:
+    - summary: |
+        Auto-discover `.fernignore` for generators configured with local file system
+        output. When running `fern generate` without the `--fernignore` flag, the CLI
+        now automatically looks for a `.fernignore` file in the generator's configured
+        output directory and uses it if present. This eliminates the need to explicitly
+        pass `--fernignore` for the common case where the `.fernignore` lives alongside
+        the generated code.
+      type: feat
+  createdAt: "2026-03-09"
+  irVersion: 65
+
 - version: 4.15.5
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/resolveAutoDiscoveredFernignorePath.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/resolveAutoDiscoveredFernignorePath.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@fern-api/configuration", () => ({
+    FERNIGNORE_FILENAME: ".fernignore",
+    generatorsYml: {}
+}));
+
+const mockDoesPathExist = vi.fn<(path: string) => Promise<boolean>>();
+
+vi.mock("@fern-api/fs-utils", () => ({
+    doesPathExist: (...args: unknown[]) => mockDoesPathExist(args[0] as string),
+    join: (...segments: string[]) => segments.join("/"),
+    RelativeFilePath: {
+        of: (p: string) => p
+    }
+}));
+
+import { resolveAutoDiscoveredFernignorePath } from "../resolveAutoDiscoveredFernignorePath.js";
+
+function createMockContext() {
+    return {
+        logger: {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            log: vi.fn(),
+            trace: vi.fn(),
+            disable: vi.fn(),
+            enable: vi.fn()
+        }
+    };
+}
+
+describe("resolveAutoDiscoveredFernignorePath", () => {
+    it("should return undefined when generator has no absolutePathToLocalOutput", async () => {
+        // biome-ignore lint/suspicious/noExplicitAny: mock generator invocation for testing
+        const generatorInvocation = { absolutePathToLocalOutput: undefined } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: mock context for testing
+        const context = createMockContext() as any;
+
+        const result = await resolveAutoDiscoveredFernignorePath({ generatorInvocation, context });
+
+        expect(result).toBeUndefined();
+        expect(mockDoesPathExist).not.toHaveBeenCalled();
+    });
+
+    it("should return undefined when generator has null absolutePathToLocalOutput", async () => {
+        // biome-ignore lint/suspicious/noExplicitAny: mock generator invocation for testing
+        const generatorInvocation = { absolutePathToLocalOutput: null } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: mock context for testing
+        const context = createMockContext() as any;
+
+        const result = await resolveAutoDiscoveredFernignorePath({ generatorInvocation, context });
+
+        expect(result).toBeUndefined();
+        expect(mockDoesPathExist).not.toHaveBeenCalled();
+    });
+
+    it("should return the .fernignore path when it exists in the output directory", async () => {
+        mockDoesPathExist.mockResolvedValue(true);
+
+        // biome-ignore lint/suspicious/noExplicitAny: mock generator invocation for testing
+        const generatorInvocation = { absolutePathToLocalOutput: "/path/to/output" } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: mock context for testing
+        const context = createMockContext() as any;
+
+        const result = await resolveAutoDiscoveredFernignorePath({ generatorInvocation, context });
+
+        expect(result).toBe("/path/to/output/.fernignore");
+        expect(mockDoesPathExist).toHaveBeenCalledWith("/path/to/output/.fernignore");
+        expect(context.logger.debug).toHaveBeenCalledWith(expect.stringContaining("Auto-discovered .fernignore"));
+    });
+
+    it("should return undefined when .fernignore does not exist in the output directory", async () => {
+        mockDoesPathExist.mockResolvedValue(false);
+
+        // biome-ignore lint/suspicious/noExplicitAny: mock generator invocation for testing
+        const generatorInvocation = { absolutePathToLocalOutput: "/path/to/output" } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: mock context for testing
+        const context = createMockContext() as any;
+
+        const result = await resolveAutoDiscoveredFernignorePath({ generatorInvocation, context });
+
+        expect(result).toBeUndefined();
+        expect(mockDoesPathExist).toHaveBeenCalledWith("/path/to/output/.fernignore");
+        expect(context.logger.debug).not.toHaveBeenCalled();
+    });
+
+    it("should check the correct path by joining output directory with .fernignore filename", async () => {
+        mockDoesPathExist.mockResolvedValue(true);
+
+        // biome-ignore lint/suspicious/noExplicitAny: mock generator invocation for testing
+        const generatorInvocation = { absolutePathToLocalOutput: "/some/other/directory" } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: mock context for testing
+        const context = createMockContext() as any;
+
+        await resolveAutoDiscoveredFernignorePath({ generatorInvocation, context });
+
+        expect(mockDoesPathExist).toHaveBeenCalledWith("/some/other/directory/.fernignore");
+    });
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/resolveAutoDiscoveredFernignorePath.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/resolveAutoDiscoveredFernignorePath.ts
@@ -1,0 +1,29 @@
+import { FERNIGNORE_FILENAME, generatorsYml } from "@fern-api/configuration";
+import { doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { TaskContext } from "@fern-api/task-context";
+
+/**
+ * If the generator is configured with local file system output (absolutePathToLocalOutput),
+ * checks whether a .fernignore file exists in that output directory and returns its path.
+ * Returns undefined if the generator has no local output path or no .fernignore file exists.
+ */
+export async function resolveAutoDiscoveredFernignorePath({
+    generatorInvocation,
+    context
+}: {
+    generatorInvocation: generatorsYml.GeneratorInvocation;
+    context: TaskContext;
+}): Promise<string | undefined> {
+    if (generatorInvocation.absolutePathToLocalOutput == null) {
+        return undefined;
+    }
+    const fernignoreFilePath = join(
+        generatorInvocation.absolutePathToLocalOutput,
+        RelativeFilePath.of(FERNIGNORE_FILENAME)
+    );
+    if (await doesPathExist(fernignoreFilePath)) {
+        context.logger.debug(`Auto-discovered ${FERNIGNORE_FILENAME} at ${fernignoreFilePath}`);
+        return fernignoreFilePath;
+    }
+    return undefined;
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -1,7 +1,7 @@
 import { validateAPIWorkspaceAndLogIssues } from "@fern-api/api-workspace-validator";
 import { FernToken } from "@fern-api/auth";
-import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
-import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { FERNIGNORE_FILENAME, fernConfigJson, generatorsYml } from "@fern-api/configuration";
+import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { TaskContext } from "@fern-api/task-context";
 import {
@@ -79,6 +79,15 @@ export async function runRemoteGenerationForAPIWorkspace({
                     });
                 }
 
+                // Auto-discover .fernignore from the generator's local output directory
+                // if not explicitly provided via --fernignore
+                const effectiveFernignorePath =
+                    fernignorePath ??
+                    (await resolveAutoDiscoveredFernignorePath({
+                        generatorInvocation,
+                        context: interactiveTaskContext
+                    }));
+
                 const remoteTaskHandlerResponse = await runRemoteGenerationForGenerator({
                     projectConfig,
                     organization,
@@ -115,7 +124,7 @@ export async function runRemoteGenerationForAPIWorkspace({
                     readme: generatorInvocation.readme,
                     irVersionOverride: generatorInvocation.irVersionOverride,
                     absolutePathToPreview,
-                    fernignorePath,
+                    fernignorePath: effectiveFernignorePath,
                     dynamicIrOnly,
                     retryRateLimited
                 });
@@ -145,4 +154,30 @@ export async function runRemoteGenerationForAPIWorkspace({
     return {
         snippetsProducedBy
     };
+}
+
+/**
+ * If the generator is configured with local file system output (absolutePathToLocalOutput),
+ * checks whether a .fernignore file exists in that output directory and returns its path.
+ * Returns undefined if the generator has no local output path or no .fernignore file exists.
+ */
+async function resolveAutoDiscoveredFernignorePath({
+    generatorInvocation,
+    context
+}: {
+    generatorInvocation: generatorsYml.GeneratorInvocation;
+    context: TaskContext;
+}): Promise<string | undefined> {
+    if (generatorInvocation.absolutePathToLocalOutput == null) {
+        return undefined;
+    }
+    const fernignoreFilePath = join(
+        generatorInvocation.absolutePathToLocalOutput,
+        RelativeFilePath.of(FERNIGNORE_FILENAME)
+    );
+    if (await doesPathExist(fernignoreFilePath)) {
+        context.logger.debug(`Auto-discovered ${FERNIGNORE_FILENAME} at ${fernignoreFilePath}`);
+        return fernignoreFilePath;
+    }
+    return undefined;
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -1,7 +1,7 @@
 import { validateAPIWorkspaceAndLogIssues } from "@fern-api/api-workspace-validator";
 import { FernToken } from "@fern-api/auth";
-import { FERNIGNORE_FILENAME, fernConfigJson, generatorsYml } from "@fern-api/configuration";
-import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { TaskContext } from "@fern-api/task-context";
 import {
@@ -12,6 +12,7 @@ import {
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
 
 import { downloadSnippetsForTask } from "./downloadSnippetsForTask.js";
+import { resolveAutoDiscoveredFernignorePath } from "./resolveAutoDiscoveredFernignorePath.js";
 import { runRemoteGenerationForGenerator } from "./runRemoteGenerationForGenerator.js";
 
 export interface RemoteGenerationForAPIWorkspaceResponse {
@@ -154,30 +155,4 @@ export async function runRemoteGenerationForAPIWorkspace({
     return {
         snippetsProducedBy
     };
-}
-
-/**
- * If the generator is configured with local file system output (absolutePathToLocalOutput),
- * checks whether a .fernignore file exists in that output directory and returns its path.
- * Returns undefined if the generator has no local output path or no .fernignore file exists.
- */
-async function resolveAutoDiscoveredFernignorePath({
-    generatorInvocation,
-    context
-}: {
-    generatorInvocation: generatorsYml.GeneratorInvocation;
-    context: TaskContext;
-}): Promise<string | undefined> {
-    if (generatorInvocation.absolutePathToLocalOutput == null) {
-        return undefined;
-    }
-    const fernignoreFilePath = join(
-        generatorInvocation.absolutePathToLocalOutput,
-        RelativeFilePath.of(FERNIGNORE_FILENAME)
-    );
-    if (await doesPathExist(fernignoreFilePath)) {
-        context.logger.debug(`Auto-discovered ${FERNIGNORE_FILENAME} at ${fernignoreFilePath}`);
-        return fernignoreFilePath;
-    }
-    return undefined;
 }


### PR DESCRIPTION
## Description

When running `fern generate` against a generator configured with local file system output, automatically discover and use the `.fernignore` file from the output directory if `--fernignore` is not explicitly provided.

**Link to Devin Session:** https://app.devin.ai/sessions/37a0928c061242a2a45c496455675b5c
**Requested by:** @Swimburger

## Changes Made

- Added `resolveAutoDiscoveredFernignorePath()` in a new module (`resolveAutoDiscoveredFernignorePath.ts`) — checks for `.fernignore` in a generator's `absolutePathToLocalOutput` directory
- Auto-discovery runs **per-generator** in `runRemoteGenerationForAPIWorkspace.ts` — different generators in a group can have different output paths and each resolves its own `.fernignore`
- Explicit `--fernignore` flag takes precedence over auto-discovered path (via `??` operator)
- Updated `--fernignore` CLI option description to document the auto-discovery behavior (removed outdated "remote generation only" qualifier)
- Added `versions.yml` entry (4.16.0, feat)
- Added unit tests for `resolveAutoDiscoveredFernignorePath` (5 tests covering: no output path, null output path, `.fernignore` exists, `.fernignore` missing, correct path construction)

## Important Review Notes

1. **Scope**: This only affects the **remote generation** code path. Local Docker generation (`--local`/`--runner`) already handles `.fernignore` auto-discovery internally via `LocalTaskHandler.isFernIgnorePresent()`. The explicit `--fernignore` flag remains blocked for local generation (cli.ts:712).
2. **`--lfs-override` compatibility**: When `--lfs-override` is used, it sets `absolutePathToLocalOutput` on the modified generator invocations, so auto-discovery will also work for that flow.
3. **`fernignorePath` type**: The resolved path is returned as `string | undefined` (not `AbsoluteFilePath`) — this matches the existing contract in `createAndStartJob`. A reviewer should verify this is intentional and safe.

## Human Review Checklist

- [ ] Verify that auto-discovery should only trigger for generators with `absolutePathToLocalOutput` set (i.e., `output.location: local-file-system` in generators.yml or `--lfs-override`)
- [ ] Confirm the explicit `--fernignore` flag blocking for local generation (cli.ts:712) is still desired now that the description no longer says "remote generation only"
- [ ] Check that `fernignorePath` being passed as `string` (vs `AbsoluteFilePath`) is consistent with the existing contract in `createAndStartJob`

## Testing

- [x] Unit tests added/updated
- [x] Lint/format passes (`pnpm run check`)
- [ ] Manual testing completed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
