### PR TITLE
fix(cli): Consistent formatting across check commands

### DIFF
--- a/packages/cli/cli-v2/src/commands/api/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/api/check/command.ts
@@ -50,9 +50,8 @@ export class CheckCommand {
 
         if (result.violations.length > 0) {
             for (const v of result.violations) {
-                process.stderr.write(
-                    `${chalk.red(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`
-                );
+                const color = v.severity === "warning" ? chalk.yellow : chalk.red;
+                process.stderr.write(`${color(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`);
             }
         }
 
@@ -61,6 +60,7 @@ export class CheckCommand {
         }
 
         if (result.warningCount > 0) {
+            context.stderr.info(`${Icons.warning} ${chalk.yellow(`Found ${result.warningCount} warnings`)}`);
             context.stderr.info(chalk.dim("  Run 'fern api check --strict' to treat warnings as errors"));
             return;
         }

--- a/packages/cli/cli-v2/src/commands/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/check/command.ts
@@ -70,7 +70,7 @@ export class CheckCommand {
             context,
             cliVersion: workspace.cliVersion
         });
-        const apiCheckResult = await apiChecker.check({ workspace });
+        const apiCheckResult = await apiChecker.check({ workspace, strict: args.strict });
 
         const sdkChecker = new SdkChecker({ context });
         const sdkCheckResult = await sdkChecker.check({ workspace });
@@ -90,10 +90,17 @@ export class CheckCommand {
     }
 
     private displayViolations(
-        violations: Array<{ displayRelativeFilepath: string; line: number; column: number; message: string }>
+        violations: Array<{
+            displayRelativeFilepath: string;
+            line: number;
+            column: number;
+            message: string;
+            severity: string;
+        }>
     ): void {
         for (const v of violations) {
-            process.stderr.write(`${chalk.red(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`);
+            const color = v.severity === "warning" ? chalk.yellow : chalk.red;
+            process.stderr.write(`${color(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`);
         }
     }
 

--- a/packages/cli/cli-v2/src/commands/sdk/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/check/command.ts
@@ -37,9 +37,8 @@ export class CheckCommand {
 
         if (result.violations.length > 0) {
             for (const v of result.violations) {
-                process.stderr.write(
-                    `${chalk.red(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`
-                );
+                const color = v.severity === "warning" ? chalk.yellow : chalk.red;
+                process.stderr.write(`${color(`${v.displayRelativeFilepath}:${v.line}:${v.column}: ${v.message}`)}\n`);
             }
         }
 
@@ -48,6 +47,7 @@ export class CheckCommand {
         }
 
         if (result.warningCount > 0) {
+            context.stderr.info(`${Icons.warning} ${chalk.yellow(`Found ${result.warningCount} warnings`)}`);
             context.stderr.info(chalk.dim("  Run 'fern sdk check --strict' to treat warnings as errors"));
             return;
         }


### PR DESCRIPTION
## Description

This fixes the output of `fern check`, `fern api check`, and `fern sdk check` to use consistent warning report formatting.
