### PR TITLE
feat(cli): Add 'fern sdk preview' command

### DIFF
--- a/packages/cli/cli-v2/src/__test__/check.test.ts
+++ b/packages/cli/cli-v2/src/__test__/check.test.ts
@@ -3,39 +3,10 @@ import { randomUUID } from "crypto";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import { Writable } from "stream";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CheckCommand } from "../commands/check/command.js";
 import { CheckCommand as SdkCheckCommand } from "../commands/sdk/check/command.js";
-import { Context } from "../context/Context.js";
-
-function createCapturingStream(): { stream: NodeJS.WriteStream; getOutput: () => string } {
-    const chunks: Buffer[] = [];
-    const stream = new Writable({
-        write(chunk, _encoding, callback) {
-            chunks.push(Buffer.from(chunk));
-            callback();
-        }
-    }) as NodeJS.WriteStream;
-    return {
-        stream,
-        getOutput: () => Buffer.concat(chunks as unknown as Uint8Array[]).toString("utf-8")
-    };
-}
-
-function createTestContextWithCapture({ cwd }: { cwd: AbsoluteFilePath }): {
-    context: Context;
-    getStdout: () => string;
-    getStderr: () => string;
-} {
-    const stdout = createCapturingStream();
-    const stderr = createCapturingStream();
-    return {
-        context: new Context({ stdout: stdout.stream, stderr: stderr.stream, cwd }),
-        getStdout: stdout.getOutput,
-        getStderr: stderr.getOutput
-    };
-}
+import { createTestContextWithCapture } from "./utils/createTestContext.js";
 
 describe("fern check --json", () => {
     let testDir: AbsoluteFilePath;

--- a/packages/cli/cli-v2/src/__test__/compile.test.ts
+++ b/packages/cli/cli-v2/src/__test__/compile.test.ts
@@ -2,43 +2,14 @@ import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
 import { randomUUID } from "crypto";
 import { readFile, rm } from "fs/promises";
 import { join } from "path";
-import { Writable } from "stream";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CompileCommand } from "../commands/api/compile/command.js";
-import { Context } from "../context/Context.js";
 import { CliError } from "../errors/CliError.js";
+import { createTestContextWithCapture } from "./utils/createTestContext.js";
 
 const FIXTURES_DIR = AbsoluteFilePath.of(join(__dirname, "fixtures"));
 const SIMPLE_API_DIR = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
 const INVALID_API_DIR = AbsoluteFilePath.of(join(FIXTURES_DIR, "invalid-api"));
-
-function createCapturingStream(): { stream: NodeJS.WriteStream; getOutput: () => string } {
-    const chunks: Buffer[] = [];
-    const stream = new Writable({
-        write(chunk, _encoding, callback) {
-            chunks.push(Buffer.from(chunk));
-            callback();
-        }
-    }) as NodeJS.WriteStream;
-    return {
-        stream,
-        getOutput: () => Buffer.concat(chunks as unknown as Uint8Array[]).toString("utf-8")
-    };
-}
-
-function createTestContextWithCapture({ cwd }: { cwd: AbsoluteFilePath }): {
-    context: Context;
-    getStdout: () => string;
-    getStderr: () => string;
-} {
-    const stdout = createCapturingStream();
-    const stderr = createCapturingStream();
-    return {
-        context: new Context({ stdout: stdout.stream, stderr: stderr.stream, cwd }),
-        getStdout: stdout.getOutput,
-        getStderr: stderr.getOutput
-    };
-}
 
 function baseArgs(overrides?: Partial<CompileCommand.Args>): CompileCommand.Args {
     return {

--- a/packages/cli/cli-v2/src/__test__/utils/createTestContext.ts
+++ b/packages/cli/cli-v2/src/__test__/utils/createTestContext.ts
@@ -17,6 +17,41 @@ export function createTestContext({ cwd }: { cwd: AbsoluteFilePath }): Context {
 }
 
 /**
+ * Create a Context whose stdout/stderr are captured for assertion.
+ */
+export function createTestContextWithCapture({ cwd }: { cwd: AbsoluteFilePath }): {
+    context: Context;
+    getStdout: () => string;
+    getStderr: () => string;
+} {
+    const stdout = createCapturingStream();
+    const stderr = createCapturingStream();
+    return {
+        context: new Context({ stdout: stdout.stream, stderr: stderr.stream, cwd }),
+        getStdout: stdout.getOutput,
+        getStderr: stderr.getOutput
+    };
+}
+
+/**
+ * Create a writable stream that captures all written chunks so they can be
+ * inspected after the test completes.
+ */
+function createCapturingStream(): { stream: NodeJS.WriteStream; getOutput: () => string } {
+    const chunks: Buffer[] = [];
+    const stream = new Writable({
+        write(chunk, _encoding, callback) {
+            chunks.push(Buffer.from(chunk));
+            callback();
+        }
+    }) as NodeJS.WriteStream;
+    return {
+        stream,
+        getOutput: () => Buffer.concat(chunks as unknown as Uint8Array[]).toString("utf-8")
+    };
+}
+
+/**
  * A writable stream that discards all output.
  * Used for testing to suppress console output.
  */

--- a/packages/cli/cli-v2/src/commands/sdk/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/command.ts
@@ -4,6 +4,7 @@ import { commandGroup } from "../_internal/commandGroup.js";
 import { addAddCommand } from "./add/index.js";
 import { addCheckCommand } from "./check/index.js";
 import { addGenerateCommand } from "./generate/index.js";
+import { addPreviewCommand } from "./preview/index.js";
 import { addUpdateCommand } from "./update/index.js";
 
 export function addSdkCommand(cli: Argv<GlobalArgs>): void {
@@ -11,6 +12,7 @@ export function addSdkCommand(cli: Argv<GlobalArgs>): void {
         addAddCommand,
         addCheckCommand,
         addGenerateCommand,
+        addPreviewCommand,
         addUpdateCommand
     ]);
 }

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -33,32 +33,26 @@ export declare namespace GenerateCommand {
         /** Path or URL to an API spec file (enables no-config mode) */
         api?: string;
 
-        /** Organization name (required in no-config mode) */
-        org?: string;
-
-        /** The SDK target to generate */
-        target?: string;
-
-        /** Override the generator version for the target */
-        "target-version"?: string;
-
-        /** Generator group to run (from fern.yml) */
-        group?: string;
-
         /** Filter by audiences */
         audience?: string[];
-
-        /** Whether to run the generator locally in a container */
-        local: boolean;
 
         /** Container engine to use for local generation */
         "container-engine"?: ContainerRunner;
 
+        /** Force generation without prompts */
+        force: boolean;
+
+        /** Generator group to run (from fern.yml) */
+        group?: string;
+
         /** Whether to keep containers after completion */
         "keep-container": boolean;
 
-        /** Preview mode */
-        preview: boolean;
+        /** Whether to run the generator locally in a container */
+        local: boolean;
+
+        /** Organization name (required in no-config mode) */
+        org?: string;
 
         /** Output directory or git URL */
         output?: string;
@@ -66,8 +60,14 @@ export declare namespace GenerateCommand {
         /** Override the version for generated packages */
         "output-version"?: string;
 
-        /** Force generation without prompts */
-        force: boolean;
+        /** The SDK target to generate */
+        target?: string;
+
+        /** Override the generator version for the target */
+        "target-version"?: string;
+
+        /** Preview mode */
+        preview: boolean;
 
         /** Path to .fernignore file */
         fernignore?: string;
@@ -604,45 +604,37 @@ export function addGenerateCommand(cli: Argv<GlobalArgs>, parentPath?: string): 
                     type: "string",
                     description: "Path or URL to an API spec file (enables no-config mode)"
                 })
-                .option("org", {
-                    type: "string",
-                    description: "Organization name (required with --api)"
-                })
-                .option("target", {
-                    type: "string",
-                    description: "The SDK target to generate"
-                })
-                .option("target-version", {
-                    type: "string",
-                    description: "The generator version for the target"
-                })
-                .option("group", {
-                    type: "string",
-                    description: "The SDK group to generate"
-                })
                 .option("audience", {
                     type: "array",
                     string: true,
                     description: "Filter the target API(s) with the given audience(s)"
                 })
-                .option("local", {
-                    type: "boolean",
-                    default: false,
-                    description: "Run the generator locally in a container"
-                })
                 .option("container-engine", {
                     choices: ["docker", "podman"],
                     description: "Choose the container engine to use for local generation"
+                })
+                .option("force", {
+                    type: "boolean",
+                    default: false,
+                    description: "Ignore prompts to confirm generation"
+                })
+                .option("group", {
+                    type: "string",
+                    description: "The SDK group to generate"
                 })
                 .option("keep-container", {
                     type: "boolean",
                     default: false,
                     description: "Prevent auto-deletion of any containers used for local generation"
                 })
-                .option("preview", {
+                .option("local", {
                     type: "boolean",
                     default: false,
-                    description: "Generate a preview of the generated SDK in a local preview directory"
+                    description: "Run the generator locally in a container"
+                })
+                .option("org", {
+                    type: "string",
+                    description: "Organization name (required with --api)"
                 })
                 .option("output", {
                     type: "string",
@@ -652,10 +644,21 @@ export function addGenerateCommand(cli: Argv<GlobalArgs>, parentPath?: string): 
                     type: "string",
                     description: "The version to use for the generated packages (e.g. 1.0.0)"
                 })
-                .option("force", {
+                .option("target", {
+                    type: "string",
+                    description: "The SDK target to generate"
+                })
+                .option("target-version", {
+                    type: "string",
+                    description: "The generator version for the target"
+                })
+                .option("preview", {
+                    // This flag is still accepted for convenience (i.e. users migrating from the original CLI).
+                    // Users should use `fern sdk preview` instead.
                     type: "boolean",
                     default: false,
-                    description: "Ignore prompts to confirm generation"
+                    description: "Generate a preview of the generated SDK in a local preview directory",
+                    hidden: true
                 })
                 .option("fernignore", {
                     type: "string",

--- a/packages/cli/cli-v2/src/commands/sdk/preview/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/preview/command.ts
@@ -1,0 +1,100 @@
+import type { Argv } from "yargs";
+import { GENERATE_COMMAND_TIMEOUT_MS } from "../../../constants.js";
+import type { Context } from "../../../context/Context.js";
+import type { GlobalArgs } from "../../../context/GlobalArgs.js";
+import { CliError } from "../../../errors/CliError.js";
+import { command } from "../../_internal/command.js";
+import { GenerateCommand } from "../generate/command.js";
+
+export declare namespace PreviewCommand {
+    export type Args = Omit<GenerateCommand.Args, "preview">;
+}
+
+export class PreviewCommand {
+    private readonly generateCommand = new GenerateCommand();
+
+    public async handle(context: Context, args: PreviewCommand.Args): Promise<void> {
+        await this.generateCommand.handle(context, {
+            ...args,
+            preview: true
+        });
+    }
+}
+
+export function addPreviewCommand(cli: Argv<GlobalArgs>, parentPath?: string): void {
+    const cmd = new PreviewCommand();
+    command(
+        cli,
+        "preview",
+        "Generate a preview of an SDK",
+        async (context, args) => {
+            const timeout = new Promise<never>((_, reject) => {
+                setTimeout(
+                    () => reject(new CliError({ message: "Preview generation timed out after 10 minutes." })),
+                    GENERATE_COMMAND_TIMEOUT_MS
+                ).unref();
+            });
+            await Promise.race([cmd.handle(context, args as PreviewCommand.Args), timeout]);
+        },
+        (yargs) =>
+            yargs
+                .option("api", {
+                    type: "string",
+                    description: "Path or URL to an API spec file (enables no-config mode)"
+                })
+                .option("audience", {
+                    type: "array",
+                    string: true,
+                    description: "Filter the target API(s) with the given audience(s)"
+                })
+                .option("container-engine", {
+                    choices: ["docker", "podman"],
+                    description: "Choose the container engine to use for local generation"
+                })
+                .option("force", {
+                    type: "boolean",
+                    default: false,
+                    description: "Ignore prompts to confirm generation"
+                })
+                .option("group", {
+                    type: "string",
+                    description: "The SDK group to generate"
+                })
+                .option("keep-container", {
+                    type: "boolean",
+                    default: false,
+                    description: "Prevent auto-deletion of any containers used for local generation"
+                })
+                .option("local", {
+                    type: "boolean",
+                    default: false,
+                    description: "Run the generator locally in a container"
+                })
+                .option("org", {
+                    type: "string",
+                    description: "Organization name (required with --api)"
+                })
+                .option("output", {
+                    type: "string",
+                    description: "Output path or git URL (required with --api; requires --preview in workspace mode)"
+                })
+                .option("output-version", {
+                    type: "string",
+                    description: "The version to use for the generated packages (e.g. 1.0.0)"
+                })
+                .option("target", {
+                    type: "string",
+                    description: "The SDK target to generate"
+                })
+                .option("target-version", {
+                    type: "string",
+                    description: "The generator version for the target"
+                })
+                .option("fernignore", {
+                    type: "string",
+                    description: "Path to .fernignore file",
+                    hidden: true
+                }),
+        parentPath
+    );
+}

--- a/packages/cli/cli-v2/src/commands/sdk/preview/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/preview/command.ts
@@ -74,10 +74,12 @@ export function addPreviewCommand(cli: Argv<GlobalArgs>, parentPath?: string): v
                     type: "string",
                     description: "Organization name (required with --api)"
                 })
+
                 .option("output", {
                     type: "string",
-                    description: "Output path or git URL (required with --api; requires --preview in workspace mode)"
+                    description: "Output path or git URL (required with --api)"
                 })
+
                 .option("output-version", {
                     type: "string",
                     description: "The version to use for the generated packages (e.g. 1.0.0)"

--- a/packages/cli/cli-v2/src/commands/sdk/preview/index.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/preview/index.ts
@@ -1,0 +1,1 @@
+export { addPreviewCommand } from "./command.js";


### PR DESCRIPTION
## Description

This adds the `fern sdk preview` command, which largely acts as the original `fern generate --preview` command. The intention here is that the preview functionality is far more explicit and less prone to fat-fingering a `fern generate` command that actually generates an SDK into a real repository.

The command largely reuses the `GenerateCommand` implementation, but simply sets the parameters required to fulfill the `--preview` contract. We'll use the same approach for the upcoming `fern docs publish` and `fern docs preview` commands.

### Usage

```sh
$ fern sdk preview --target go
```
