### PR TITLE
fix(typescript, csharp, python, ruby, go, swift, rust, php): improve error logging for doc generation failures

### DIFF
--- a/generators/csharp/sdk/src/SdkGeneratorCli.ts
+++ b/generators/csharp/sdk/src/SdkGeneratorCli.ts
@@ -287,13 +287,23 @@ export class SdkGeneratorCLI extends AbstractCsharpGeneratorCli {
                     endpointSnippets: snippets.endpoints
                 });
             } catch (e) {
-                context.logger.warn("Failed to generate README.md, this is OK.");
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const errorStack = e instanceof Error ? e.stack : undefined;
+                context.logger.warn(`Failed to generate README.md: ${errorMessage}`);
+                if (errorStack) {
+                    context.logger.debug(`README.md generation error stack: ${errorStack}`);
+                }
             }
 
             try {
                 await this.generateReference({ context });
             } catch (e) {
-                context.logger.warn("Failed to generate reference.md, this is OK.");
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const errorStack = e instanceof Error ? e.stack : undefined;
+                context.logger.warn(`Failed to generate reference.md: ${errorMessage}`);
+                if (errorStack) {
+                    context.logger.debug(`reference.md generation error stack: ${errorStack}`);
+                }
             }
         }
         context.logger.debug(`[TIMING] code generation took ${Date.now() - generateStartTime}ms`);

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.24.1
+  changelogEntry:
+    - summary: |
+        Improve error logging for README.md and reference.md generation failures.
+        The generator now logs the actual error message and stack trace instead
+        of a generic "this is OK" message, making it easier to diagnose generation issues.
+      type: chore
+  createdAt: "2026-03-09"
+  irVersion: 65
+
 - version: 2.24.0
   changelogEntry:
     - summary: |

--- a/generators/go-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorCli.ts
@@ -83,10 +83,11 @@ export class SdkGeneratorCLI extends AbstractGoGeneratorCli<SdkCustomConfigSchem
         try {
             await this.generateReference({ context });
         } catch (error) {
-            context.logger.warn("Failed to generate reference.md, this is OK.");
-            if (error instanceof Error) {
-                context.logger.warn((error as Error)?.message);
-                context.logger.warn((error as Error)?.stack ?? "");
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorStack = error instanceof Error ? error.stack : undefined;
+            context.logger.warn(`Failed to generate reference.md: ${errorMessage}`);
+            if (errorStack) {
+                context.logger.debug(`reference.md generation error stack: ${errorStack}`);
             }
         }
 

--- a/generators/go-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorCli.ts
@@ -72,10 +72,11 @@ export class SdkGeneratorCLI extends AbstractGoGeneratorCli<SdkCustomConfigSchem
                     endpointSnippets
                 });
             } catch (e) {
-                context.logger.error("Failed to generate README.md");
-                if (e instanceof Error) {
-                    context.logger.debug(e.message);
-                    context.logger.debug(e.stack ?? "");
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const errorStack = e instanceof Error ? e.stack : undefined;
+                context.logger.warn(`Failed to generate README.md: ${errorMessage}`);
+                if (errorStack) {
+                    context.logger.debug(`README.md generation error stack: ${errorStack}`);
                 }
             }
         }

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.28.5
+  changelogEntry:
+    - summary: |
+        Improve error logging for reference.md generation failures. The generator
+        now logs the actual error message and stack trace instead of a generic
+        "this is OK" message, making it easier to diagnose generation issues.
+      type: chore
+  createdAt: "2026-03-09"
+  irVersion: 61
+
 - version: 1.28.4
   changelogEntry:
     - summary: |

--- a/generators/php/sdk/src/SdkGeneratorCli.ts
+++ b/generators/php/sdk/src/SdkGeneratorCli.ts
@@ -79,18 +79,24 @@ export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSche
                     endpointSnippets: snippets
                 });
             } catch (e) {
-                context.logger.warn(
-                    `Failed to generate README.md: ${e instanceof Error ? e.message : "Unknown error"}. This is non-critical and generation will continue.`
-                );
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const errorStack = e instanceof Error ? e.stack : undefined;
+                context.logger.warn(`Failed to generate README.md: ${errorMessage}`);
+                if (errorStack) {
+                    context.logger.debug(`README.md generation error stack: ${errorStack}`);
+                }
             }
 
             try {
                 await context.snippetGenerator.populateSnippetsCache();
                 await this.generateReference({ context });
             } catch (e) {
-                context.logger.warn(
-                    `Failed to generate reference.md: ${e instanceof Error ? e.message : "Unknown error"}. This is non-critical and generation will continue.`
-                );
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const errorStack = e instanceof Error ? e.stack : undefined;
+                context.logger.warn(`Failed to generate reference.md: ${errorMessage}`);
+                if (errorStack) {
+                    context.logger.debug(`reference.md generation error stack: ${errorStack}`);
+                }
             }
         }
 

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.7
+  changelogEntry:
+    - summary: |
+        Improve error logging for README.md and reference.md generation failures.
+        The generator now logs the actual error message and stack trace instead
+        of a generic message, making it easier to diagnose generation issues.
+      type: chore
+  createdAt: "2026-03-09"
+  irVersion: 62
+
 - version: 2.1.6
   changelogEntry:
     - summary: |

--- a/generators/python-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/python-v2/sdk/src/SdkGeneratorCli.ts
@@ -64,10 +64,11 @@ export class SdkGeneratorCli extends AbstractPythonGeneratorCli<SdkCustomConfigS
             try {
                 await this.generateReadme({ context, endpointSnippets });
             } catch (error) {
-                context.logger.error("Failed to generate README.md");
-                if (error instanceof Error) {
-                    context.logger.debug(error.message);
-                    context.logger.debug(error.stack ?? "");
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                const errorStack = error instanceof Error ? error.stack : undefined;
+                context.logger.warn(`Failed to generate README.md: ${errorMessage}`);
+                if (errorStack) {
+                    context.logger.debug(`README.md generation error stack: ${errorStack}`);
                 }
             }
         }

--- a/generators/python-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/python-v2/sdk/src/SdkGeneratorCli.ts
@@ -76,10 +76,11 @@ export class SdkGeneratorCli extends AbstractPythonGeneratorCli<SdkCustomConfigS
         try {
             await this.generateReference({ context, endpointSnippets });
         } catch (error) {
-            context.logger.warn("Failed to generate reference.md, this is OK.");
-            if (error instanceof Error) {
-                context.logger.debug(error.message);
-                context.logger.debug(error.stack ?? "");
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorStack = error instanceof Error ? error.stack : undefined;
+            context.logger.warn(`Failed to generate reference.md: ${errorMessage}`);
+            if (errorStack) {
+                context.logger.debug(`reference.md generation error stack: ${errorStack}`);
             }
         }
 

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.62.2
+  changelogEntry:
+    - summary: |
+        Improve error logging for reference.md generation failures. The generator
+        now logs the actual error message and stack trace instead of a generic
+        "this is OK" message, making it easier to diagnose generation issues.
+      type: chore
+  createdAt: "2026-03-09"
+  irVersion: 65
+
 - version: 4.62.1
   changelogEntry:
     - summary: |

--- a/generators/ruby-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/ruby-v2/sdk/src/SdkGeneratorCli.ts
@@ -128,10 +128,11 @@ export class SdkGeneratorCLI extends AbstractRubyGeneratorCli<SdkCustomConfigSch
         try {
             await this.generateReference({ context });
         } catch (error) {
-            context.logger.warn("Failed to generate reference.md, this is OK.");
-            if (error instanceof Error) {
-                context.logger.warn((error as Error)?.message);
-                context.logger.warn((error as Error)?.stack ?? "");
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorStack = error instanceof Error ? error.stack : undefined;
+            context.logger.warn(`Failed to generate reference.md: ${errorMessage}`);
+            if (errorStack) {
+                context.logger.debug(`reference.md generation error stack: ${errorStack}`);
             }
         }
 

--- a/generators/ruby-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/ruby-v2/sdk/src/SdkGeneratorCli.ts
@@ -117,10 +117,11 @@ export class SdkGeneratorCLI extends AbstractRubyGeneratorCli<SdkCustomConfigSch
                 });
                 context.logger.debug("Generated readme!");
             } catch (e) {
-                context.logger.error("Failed to generate README.md");
-                if (e instanceof Error) {
-                    context.logger.debug(e.message);
-                    context.logger.debug(e.stack ?? "");
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const errorStack = e instanceof Error ? e.stack : undefined;
+                context.logger.warn(`Failed to generate README.md: ${errorMessage}`);
+                if (errorStack) {
+                    context.logger.debug(`README.md generation error stack: ${errorStack}`);
                 }
             }
         }

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.6
+  changelogEntry:
+    - summary: |
+        Improve error logging for reference.md generation failures. The generator
+        now logs the actual error message and stack trace instead of a generic
+        "this is OK" message, making it easier to diagnose generation issues.
+      type: chore
+  createdAt: "2026-03-09"
+  irVersion: 61
+
 - version: 1.0.5
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -783,9 +783,12 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
 
             context.logger.debug("Successfully added README.md to project");
         } catch (error) {
-            const errorMsg = extractErrorMessage(error);
-            context.logger.debug(`README generation failed: ${errorMsg}`);
-            throw new Error(`Failed to generate README.md: ${errorMsg}`);
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorStack = error instanceof Error ? error.stack : undefined;
+            context.logger.warn(`Failed to generate README.md: ${errorMessage}`);
+            if (errorStack) {
+                context.logger.debug(`README.md generation error stack: ${errorStack}`);
+            }
         }
     }
 
@@ -850,9 +853,12 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             context.project.addSourceFiles(referenceFile);
             context.logger.debug("Successfully added reference.md to project");
         } catch (error) {
-            const errorMsg = extractErrorMessage(error);
-            context.logger.debug(`Reference generation failed: ${errorMsg}`);
-            throw new Error(`Failed to generate reference.md: ${errorMsg}`);
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorStack = error instanceof Error ? error.stack : undefined;
+            context.logger.warn(`Failed to generate reference.md: ${errorMessage}`);
+            if (errorStack) {
+                context.logger.debug(`reference.md generation error stack: ${errorStack}`);
+            }
         }
     }
 

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -1,5 +1,4 @@
 import { GeneratorNotificationService } from "@fern-api/base-generator";
-import { extractErrorMessage } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import {
     AbstractRustGeneratorCli,

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.19.1
+  changelogEntry:
+    - summary: |
+        Improve error logging for README.md and reference.md generation failures.
+        The generator now logs the actual error message and stack trace instead
+        of crashing the entire generation, making it easier to diagnose issues.
+      type: fix
+  createdAt: "2026-03-09"
+  irVersion: 62
+
 - version: 0.19.0
   changelogEntry:
     - summary: |

--- a/generators/swift/sdk/src/SdkGeneratorCli.ts
+++ b/generators/swift/sdk/src/SdkGeneratorCli.ts
@@ -1,5 +1,5 @@
 import { File, GeneratorNotificationService } from "@fern-api/base-generator";
-import { assertNever, entries, extractErrorMessage, noop } from "@fern-api/core-utils";
+import { assertNever, entries, noop } from "@fern-api/core-utils";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
 import { AbstractSwiftGeneratorCli, SourceTemplateFiles, TestTemplateFiles } from "@fern-api/swift-base";
 import { sanitizeSelf, swift } from "@fern-api/swift-codegen";

--- a/generators/swift/sdk/src/SdkGeneratorCli.ts
+++ b/generators/swift/sdk/src/SdkGeneratorCli.ts
@@ -98,7 +98,12 @@ export class SdkGeneratorCLI extends AbstractSwiftGeneratorCli<SdkCustomConfigSc
             });
             context.project.addRootFiles(new File("README.md", RelativeFilePath.of(""), content));
         } catch (e) {
-            throw new Error(`Failed to generate README.md: ${extractErrorMessage(e)}`);
+            const errorMessage = e instanceof Error ? e.message : String(e);
+            const errorStack = e instanceof Error ? e.stack : undefined;
+            context.logger.warn(`Failed to generate README.md: ${errorMessage}`);
+            if (errorStack) {
+                context.logger.debug(`README.md generation error stack: ${errorStack}`);
+            }
         }
     }
 
@@ -108,7 +113,12 @@ export class SdkGeneratorCLI extends AbstractSwiftGeneratorCli<SdkCustomConfigSc
             const content = await context.generatorAgent.generateReference(builder);
             context.project.addRootFiles(new File("reference.md", RelativeFilePath.of(""), content));
         } catch (e) {
-            throw new Error(`Failed to generate reference.md: ${extractErrorMessage(e)}`);
+            const errorMessage = e instanceof Error ? e.message : String(e);
+            const errorStack = e instanceof Error ? e.stack : undefined;
+            context.logger.warn(`Failed to generate reference.md: ${errorMessage}`);
+            if (errorStack) {
+                context.logger.debug(`reference.md generation error stack: ${errorStack}`);
+            }
         }
     }
 

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.27.1
+  changelogEntry:
+    - summary: |
+        Improve error logging for README.md and reference.md generation failures.
+        The generator now logs the actual error message and stack trace instead
+        of crashing the entire generation, making it easier to diagnose issues.
+      type: fix
+  createdAt: "2026-03-09"
+  irVersion: 61
+
 - version: 0.27.0
   changelogEntry:
     - type: feat

--- a/generators/typescript/sdk/generator/src/SdkGenerator.ts
+++ b/generators/typescript/sdk/generator/src/SdkGenerator.ts
@@ -669,20 +669,35 @@ export class SdkGenerator {
             try {
                 await this.generateReadme();
             } catch (e) {
-                this.context.logger.warn("Failed to generate README.md, this is OK");
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const errorStack = e instanceof Error ? e.stack : undefined;
+                this.context.logger.warn(`Failed to generate README.md: ${errorMessage}`);
+                if (errorStack) {
+                    this.context.logger.debug(`README.md generation error stack: ${errorStack}`);
+                }
             }
 
             try {
                 await this.generateReference();
             } catch (e) {
-                this.context.logger.warn("Failed to generate reference.md, this is OK");
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const errorStack = e instanceof Error ? e.stack : undefined;
+                this.context.logger.warn(`Failed to generate reference.md: ${errorMessage}`);
+                if (errorStack) {
+                    this.context.logger.debug(`reference.md generation error stack: ${errorStack}`);
+                }
             }
 
             if (!this.config.whitelabel) {
                 try {
                     await this.generateContributing();
                 } catch (e) {
-                    this.context.logger.warn("Failed to generate CONTRIBUTING.md, this is OK");
+                    const errorMessage = e instanceof Error ? e.message : String(e);
+                    const errorStack = e instanceof Error ? e.stack : undefined;
+                    this.context.logger.warn(`Failed to generate CONTRIBUTING.md: ${errorMessage}`);
+                    if (errorStack) {
+                        this.context.logger.debug(`CONTRIBUTING.md generation error stack: ${errorStack}`);
+                    }
                 }
             }
         }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.53.8
+  changelogEntry:
+    - summary: |
+        Improve error logging for README.md, reference.md, and CONTRIBUTING.md generation
+        failures. The generator now logs the actual error message and stack trace instead
+        of a generic "this is OK" message, making it easier to diagnose generation issues.
+      type: chore
+  createdAt: "2026-03-09"
+  irVersion: 65
+
 - version: 3.53.7
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Requested by @iamnamananand996
Link to Devin Session: https://app.devin.ai/sessions/415fec7ffce447359ec05a022645be95

When README.md, reference.md, or CONTRIBUTING.md generation fails during SDK generation, the error catch blocks previously logged generic messages (e.g., "this is OK", "Unknown error", or used `logger.error` without the message in the warn), swallowing the actual error. This makes it difficult to diagnose why generation failed. This PR updates **all** generators to use a consistent error logging pattern — the actual error message at `warn` level and stack trace at `debug` level — matching the pattern already used by the java-v2 generator.

Additionally, the **Swift** and **Rust** generators previously _re-threw_ the error on doc generation failure, which would crash the entire SDK generation. These have been fixed to catch and log instead, aligning them with all other generators.

## Changes Made

- **TypeScript SDK generator**: Updated catch blocks for README.md, reference.md, and CONTRIBUTING.md generation to log error message + stack trace
- **C# SDK generator**: Updated catch blocks for README.md and reference.md generation
- **Python-v2 SDK generator**: Updated catch blocks for README.md and reference.md generation (README changed from `logger.error` to `warn` with message; reference changed from generic "this is OK")
- **Ruby-v2 SDK generator**: Updated catch blocks for README.md and reference.md generation (README changed from `logger.error` to `warn` with message; reference changed from generic "this is OK")
- **Go-v2 SDK generator**: Updated catch blocks for README.md and reference.md generation (README changed from `logger.error` to `warn` with message; reference changed from generic "this is OK")
- **PHP SDK generator**: Updated catch blocks for README.md and reference.md generation (changed from `"Unknown error"` fallback with no stack trace to consistent pattern)
- **Swift SDK generator**: Changed README.md and reference.md catch blocks from `throw` to warn+debug logging (fixes generation crash on failure)
- **Rust SDK generator**: Changed README.md and reference.md catch blocks from `throw` to warn+debug logging (fixes generation crash on failure)
- Updated `versions.yml` for all eight generators with patch version bumps

## Human Review Checklist

- [ ] **Swift & Rust behavior change**: These two generators previously threw on doc generation failure, crashing the entire generation. They now catch and continue. Verify this is the desired behavior.
- [ ] **Rust no longer uses `extractErrorMessage`**: The Rust generator previously used a utility function `extractErrorMessage(error)`. The new code uses `error instanceof Error ? error.message : String(error)` inline, matching all other generators. Confirm this handles the same edge cases.
- [ ] **Log level changes**: Python-v2, Go-v2, and Ruby-v2 README catch blocks changed from `logger.error` → `logger.warn`. Go-v2 and Ruby-v2 reference catch blocks changed stack traces from `warn` → `debug` level. Verify these level changes are acceptable.
- [ ] **PHP fallback change**: PHP previously used `"Unknown error"` as the fallback for non-Error exceptions; now uses `String(e)`. This should be equivalent or better but worth a glance.

## Testing

- [ ] No functional behavior changes for TypeScript, C#, PHP — only log message formatting is affected
- [ ] Python-v2, Go-v2, Ruby-v2: Log level for README failure changed from `error` to `warn`; reference stack traces moved from `warn` to `debug`
- [ ] Swift and Rust: Error handling flow changed from fatal to non-fatal; generation now continues on doc failure
- [ ] No unit tests added — changes are in error logging paths that are difficult to trigger in isolation