### PR TITLE
fix(parser): handle wrappers that wrap `readOnly` properties

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly-ref-shared-schema.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly-ref-shared-schema.json
@@ -70,7 +70,7 @@
                 },
                 "content-type": "application/json",
                 "headers": undefined,
-                "name": "OrgDetails",
+                "name": "UpdateOrgDetailsRequest",
                 "path-parameters": undefined,
                 "query-parameters": undefined,
               },
@@ -121,7 +121,6 @@
               "pattern": "^org_[A-Za-z0-9]{16}$",
             },
           },
-          "UpdateOrgDetailsRequest": "OrgDetailsRead",
           "UpdateOrgDetailsResponse": "OrgDetailsRead",
         },
       },
@@ -152,7 +151,7 @@
         openapi: ../openapi.yml
       display-name: Update organization details
       request:
-        name: OrgDetails
+        name: UpdateOrgDetailsRequest
         body:
           properties:
             name:
@@ -195,7 +194,6 @@ types:
     source:
       openapi: ../openapi.yml
   GetOrgDetailsResponse: OrgDetailsRead
-  UpdateOrgDetailsRequest: OrgDetailsRead
   UpdateOrgDetailsResponse: OrgDetailsRead
 ",
     },

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -522,6 +522,9 @@ function getRequest({
         // When respectReadonlySchemas is enabled and the schema has readOnly properties on a write endpoint,
         // inline the properties so readOnly ones can be filtered out
         let shouldInlineForReadonly = false;
+        // When the request schema is a $ref wrapper (e.g., UpdateOrgDetailsRequest -> OrgDetails),
+        // track the wrapper's name so we can use it instead of the underlying schema's name
+        let readonlyWrapperSchemaName: string | undefined;
         if (context.options.respectReadonlySchemas && isWriteMethod(endpoint.method)) {
             let effectiveSchema = resolvedSchema;
             while (effectiveSchema?.type === "reference") {
@@ -529,6 +532,11 @@ function getRequest({
             }
             if (effectiveSchema?.type === "object" && effectiveSchema.properties.some((p) => p.readonly)) {
                 shouldInlineForReadonly = true;
+                // If the resolved schema was a $ref wrapper pointing to the object with readonly props,
+                // preserve the wrapper's name for the request type
+                if (resolvedSchema?.type === "reference") {
+                    readonlyWrapperSchemaName = resolvedSchema.nameOverride ?? resolvedSchema.generatedName;
+                }
                 resolvedSchema = effectiveSchema;
             }
         }
@@ -767,7 +775,11 @@ function getRequest({
         }
 
         const convertedRequestValue: RawSchemas.HttpRequestSchema = {
-            name: requestNameOverride ?? resolvedSchema.nameOverride ?? resolvedSchema.generatedName,
+            name:
+                requestNameOverride ??
+                readonlyWrapperSchemaName ??
+                resolvedSchema.nameOverride ??
+                resolvedSchema.generatedName,
             "path-parameters": pathParameters,
             "query-parameters": queryParameters,
             headers,
@@ -780,7 +792,10 @@ function getRequest({
             convertedRequestValue.docs = request.description;
         }
         return {
-            schemaIdsToExclude: maybeSchemaId != null && !shouldInlineForReadonly ? [maybeSchemaId] : [],
+            schemaIdsToExclude:
+                maybeSchemaId != null && (!shouldInlineForReadonly || readonlyWrapperSchemaName != null)
+                    ? [maybeSchemaId]
+                    : [],
             value: convertedRequestValue
         };
     } else if (request.type === "octetStream") {

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.20.2
+  changelogEntry:
+    - summary: |
+        Fix `respect-readonly-schemas` handling for request bodies that reference
+        a wrapper schema (a `$ref`-only schema pointing to another schema with
+        `readOnly` properties). The wrapper schema name is now preserved as the
+        request name and the stale type alias to the `Read` variant is no longer
+        emitted.
+      type: fix
+  createdAt: "2026-03-09"
+  irVersion: 65
+
 - version: 4.20.1
   changelogEntry:
     - summary: |
@@ -9,7 +21,7 @@
       type: fix
   createdAt: "2026-03-09"
   irVersion: 65
-      
+
 - version: 4.20.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
[Claude-generated PR description, sorry - is accurate though]

When `respect-readonly-schemas` is enabled (nothing in this PR will happen if it isn't) and an endpoint's request body references a wrapper schema (a schema that's just a $ref to another schema, i.e. a type alias), two things were going wrong:

```
  1. Wrong request name. The code followed the $ref chain to find the inner object schema (to check for readOnly
  properties), but then used that inner schema's name as the request name. So if
  UpdateOrganizationDetailsRequestContent was a $ref to OrgDetails, the generated request type was named
  OrgDetails instead of UpdateOrgDetailsRequest.

  2. Stale type alias. The wrapper schema was still being emitted as a type alias pointing to the Read variant
  (e.g. UpdateOrgDetailsRequest: OrgDetailsRead). This is wrong — the Read variant includes readonly properties
  like id, but request types for write endpoints should exclude them. Since the request body gets inlined
  (non-readonly properties copied directly into the request type), this alias was both unnecessary and
  misleading.
```

  The fix tracks the wrapper schema name when traversing the $ref chain, uses it as the request name, and
  suppresses the stale alias from type generation.

## Testing
`readonly-ref-shared-schema` fixture reflects changes.
- [X] Unit tests added/updated
- [X] Manual testing completed
