### PR TITLE
fix(cli): add collapsed property to api-reference-section-configuration

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -2051,6 +2051,16 @@
             }
           ]
         },
+        "collapsed": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "collapsible": {
           "oneOf": [
             {

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -1339,6 +1339,11 @@ types:
       icon: optional<string>
       hidden: optional<boolean>
       skip-slug: optional<boolean>
+      collapsed:
+        type: optional<boolean>
+        docs: |
+          Deprecated. Use `collapsible` and `collapsed-by-default` instead.
+        availability: deprecated
       collapsible:
         type: optional<boolean>
         docs: Whether the section can be expanded/collapsed by the user in the sidebar.

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.20.3
+  changelogEntry:
+    - summary: |
+        Add support for the `collapsed` property on API reference section
+        configurations. Sections inside an API reference `layout` can now use
+        `collapsed: true` or `collapsed: open-by-default` to control sidebar
+        collapse behavior, matching the existing support on top-level sections
+        and folders.
+      type: fix
+  createdAt: "2026-03-09"
+  irVersion: 65
+
 - version: 4.20.2
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -1248,7 +1248,7 @@ function parseApiReferenceLayoutItem(
             validateCollapsibleConfig({
                 context,
                 sectionTitle: item.section,
-                collapsed: undefined,
+                collapsed: item.collapsed ?? undefined,
                 collapsible: item.collapsible ?? undefined,
                 collapsedByDefault: item.collapsedByDefault ?? undefined
             });
@@ -1266,6 +1266,7 @@ function parseApiReferenceLayoutItem(
                 slug: item.slug,
                 hidden: item.hidden,
                 skipUrlSlug: item.skipSlug,
+                collapsed: item.collapsed ?? undefined,
                 collapsible: item.collapsible ?? undefined,
                 collapsedByDefault: item.collapsedByDefault ?? undefined,
                 availability: item.availability,

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -700,6 +700,7 @@ export const ApiReferenceSectionConfiguration = WithPermissions.merge(WithFeatur
         icon: z.string().optional(),
         hidden: z.boolean().optional(),
         "skip-slug": z.boolean().optional(),
+        collapsed: z.union([z.boolean(), z.literal("open-by-default")]).optional(),
         collapsible: z.boolean().optional(),
         "collapsed-by-default": z.boolean().optional(),
         availability: Availability.optional(),

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -425,6 +425,7 @@ export declare namespace ParsedApiReferenceLayoutItem {
         hidden: boolean | undefined;
         icon: string | AbsoluteFilePath | undefined;
         skipUrlSlug: boolean | undefined;
+        collapsed: boolean | "open-by-default" | undefined;
         collapsible: boolean | undefined;
         collapsedByDefault: boolean | undefined;
         availability: Availability | undefined;

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/ApiReferenceSectionConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/ApiReferenceSectionConfiguration.ts
@@ -16,6 +16,8 @@ export interface ApiReferenceSectionConfiguration
     icon?: string;
     hidden?: boolean;
     skipSlug?: boolean;
+    /** Deprecated. Use `collapsible` and `collapsed-by-default` instead. When set to `"open-by-default"`, the section starts expanded but can be collapsed. */
+    collapsed?: boolean | "open-by-default";
     /** Whether the section can be expanded/collapsed by the user in the sidebar. */
     collapsible?: boolean;
     /** Whether the section starts collapsed. Only meaningful when collapsible is true. */

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/ApiReferenceSectionConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/ApiReferenceSectionConfiguration.ts
@@ -24,6 +24,7 @@ export const ApiReferenceSectionConfiguration: core.serialization.ObjectSchema<
         icon: core.serialization.string().optional(),
         hidden: core.serialization.boolean().optional(),
         skipSlug: core.serialization.property("skip-slug", core.serialization.boolean().optional()),
+        collapsed: core.serialization.undiscriminatedUnion([core.serialization.boolean(), core.serialization.stringLiteral("open-by-default")]).optional(),
         collapsible: core.serialization.boolean().optional(),
         collapsedByDefault: core.serialization.property("collapsed-by-default", core.serialization.boolean().optional()),
         availability: Availability.optional(),
@@ -42,6 +43,7 @@ export declare namespace ApiReferenceSectionConfiguration {
         icon?: string | null;
         hidden?: boolean | null;
         "skip-slug"?: boolean | null;
+        collapsed?: boolean | "open-by-default" | null;
         collapsible?: boolean | null;
         "collapsed-by-default"?: boolean | null;
         availability?: Availability.Raw | null;

--- a/packages/cli/docs-resolver/src/ApiReferenceNodeConverter.ts
+++ b/packages/cli/docs-resolver/src/ApiReferenceNodeConverter.ts
@@ -460,6 +460,7 @@ export class ApiReferenceNodeConverter {
             icon: this.resolveIconFileId(section.icon),
             hidden: this.hideChildren || section.hidden,
             overviewPageId,
+            collapsed: section.collapsed,
             collapsible: section.collapsible,
             collapsedByDefault: section.collapsedByDefault,
             availability: sectionAvailability,

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -2051,6 +2051,16 @@
             }
           ]
         },
+        "collapsed": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "collapsible": {
           "oneOf": [
             {

--- a/packages/cli/yaml/docs-validator/src/docsAst/products-yml.schema.json
+++ b/packages/cli/yaml/docs-validator/src/docsAst/products-yml.schema.json
@@ -957,9 +957,6 @@
               "type": "boolean"
             },
             {
-              "const": "open-by-default"
-            },
-            {
               "type": "null"
             }
           ]

--- a/packages/cli/yaml/docs-validator/src/docsAst/products-yml.schema.json
+++ b/packages/cli/yaml/docs-validator/src/docsAst/products-yml.schema.json
@@ -951,6 +951,19 @@
             }
           ]
         },
+        "collapsed": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "const": "open-by-default"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "collapsible": {
           "oneOf": [
             {

--- a/packages/cli/yaml/docs-validator/src/docsAst/versions-yml.schema.json
+++ b/packages/cli/yaml/docs-validator/src/docsAst/versions-yml.schema.json
@@ -957,9 +957,6 @@
               "type": "boolean"
             },
             {
-              "const": "open-by-default"
-            },
-            {
               "type": "null"
             }
           ]

--- a/packages/cli/yaml/docs-validator/src/docsAst/versions-yml.schema.json
+++ b/packages/cli/yaml/docs-validator/src/docsAst/versions-yml.schema.json
@@ -951,6 +951,19 @@
             }
           ]
         },
+        "collapsed": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "const": "open-by-default"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "collapsible": {
           "oneOf": [
             {

--- a/product-yml.schema.json
+++ b/product-yml.schema.json
@@ -951,6 +951,16 @@
             }
           ]
         },
+        "collapsed": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "collapsible": {
           "oneOf": [
             {

--- a/version-yml.schema.json
+++ b/version-yml.schema.json
@@ -951,6 +951,16 @@
             }
           ]
         },
+        "collapsed": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "collapsible": {
           "oneOf": [
             {


### PR DESCRIPTION
## Description

Refs: Reported via Slack — `fern check` fails with `Invalid object at path $.navigation[1].variants[0].layout[3].layout[0]: does not match any allowed schema (has properties: section, collapsed, contents)` when using `collapsed: open-by-default` inside an API reference section layout.

The `collapsed` property was supported on top-level `SectionConfiguration` and `FolderConfiguration` but was missing from `ApiReferenceSectionConfiguration`, causing schema validation to reject it.

## Changes Made

- Added `collapsed: z.union([z.boolean(), z.literal("open-by-default")]).optional()` to the `ApiReferenceSectionConfiguration` zod schema
- Updated the SDK API type and serialization schema to include the `collapsed` field
- Updated `ParsedDocsConfiguration.ts` to include `collapsed` on the parsed `Section` type
- Updated `parseDocsConfiguration.ts` to read and pass through the `collapsed` value (previously hardcoded to `undefined`)
- Updated `ApiReferenceNodeConverter.ts` to forward `collapsed` to the navigation node
- Added `collapsed` property to `ApiReferenceSectionConfiguration` in both JSON schema files (`products-yml.schema.json`, `versions-yml.schema.json`)
- Added version entry `4.20.3` in `versions.yml`

## Review Checklist

- [ ] Verify that `ApiPackageNodeWithCollapsibleConfig` (the cast target in `ApiReferenceNodeConverter.ts:475`) actually includes a `collapsed` field — the `as` cast could mask a type mismatch
- [ ] Confirm the SDK type/serialization files (`schemas/sdk/api/...` and `schemas/sdk/serialization/...`) are safe to edit manually and aren't regenerated from another source
- [ ] Verify the `collapsed` semantics here are consistent with how it works on `SectionConfiguration`

## Testing

- [x] `pnpm run check` (biome lint) passes
- [ ] No unit tests added — relies on existing test suite and CI

---

Link to Devin Session: https://app.devin.ai/sessions/cffb58323c684d99b4830e89a80b063c
Requested by: Deep Singhvi (@dsinghvi)