### PR TITLE
fix(internal): retry git clone with SSL verification disabled in Docker containers

### DIFF
--- a/packages/commons/github/src/cloneRepository.ts
+++ b/packages/commons/github/src/cloneRepository.ts
@@ -60,6 +60,18 @@ function getGitDiagnostics(): string {
 }
 
 /**
+ * Checks if the error message indicates an SSL certificate verification failure.
+ * This commonly occurs in Docker containers that lack CA certificates.
+ */
+function isSSLCertificateError(errorMessage: string): boolean {
+    return (
+        errorMessage.includes("server certificate verification failed") ||
+        errorMessage.includes("SSL certificate problem") ||
+        errorMessage.includes("unable to get local issuer certificate")
+    );
+}
+
+/**
  * Clones the repository to the local file system.
  * @param githubRepository a string that can be parsed into a RepositoryReference (e.g. 'owner/repo')
  */
@@ -94,13 +106,15 @@ export async function cloneRepository({
         );
     }
 
+    const timeoutConfig =
+        timeoutMs != null
+            ? {
+                  block: timeoutMs // Kill the process if no data is received for the specified time
+              }
+            : undefined;
+
     const git = simpleGit(clonePath, {
-        timeout:
-            timeoutMs != null
-                ? {
-                      block: timeoutMs // Kill the process if no data is received for the specified time
-                  }
-                : undefined
+        timeout: timeoutConfig
     });
 
     const startTime = Date.now();
@@ -109,6 +123,34 @@ export async function cloneRepository({
     } catch (error) {
         const elapsed = Date.now() - startTime;
         const errorMessage = error instanceof Error ? error.message : String(error);
+
+        // SSL certificate verification failure - retry with SSL verification disabled.
+        // This commonly occurs in Docker containers that lack CA certificates.
+        if (isSSLCertificateError(errorMessage)) {
+            const retryClonePath = targetDirectory ?? (await tmp.dir()).path;
+            const gitWithoutSsl = simpleGit(retryClonePath, {
+                timeout: timeoutConfig,
+                config: ["http.sslVerify=false"]
+            });
+            try {
+                await gitWithoutSsl.clone(cloneUrl, ".");
+                return new ClonedRepository({
+                    clonePath: retryClonePath,
+                    git: gitWithoutSsl
+                });
+            } catch (retryError) {
+                const retryElapsed = Date.now() - startTime;
+                const retryErrorMessage = retryError instanceof Error ? retryError.message : String(retryError);
+                throw new Error(
+                    `Failed to clone repository: SSL certificate verification failed, ` +
+                        `and retry with SSL verification disabled also failed. ` +
+                        `URL: ${sanitizedUrl}. ` +
+                        `Elapsed: ${retryElapsed}ms. ` +
+                        `Original error: ${errorMessage}. ` +
+                        `Retry error: ${retryErrorMessage}`
+                );
+            }
+        }
 
         // Git binary not found
         if (errorMessage.includes("ENOENT") || errorMessage.includes("spawn git")) {

--- a/packages/commons/github/src/cloneRepository.ts
+++ b/packages/commons/github/src/cloneRepository.ts
@@ -127,7 +127,14 @@ export async function cloneRepository({
         // SSL certificate verification failure - retry with SSL verification disabled.
         // This commonly occurs in Docker containers that lack CA certificates.
         if (isSSLCertificateError(errorMessage)) {
-            const retryClonePath = targetDirectory ?? (await tmp.dir()).path;
+            console.warn(
+                `SSL certificate verification failed when cloning ${sanitizedUrl}. ` +
+                    `Retrying with SSL verification disabled. ` +
+                    `This commonly occurs in Docker containers that lack CA certificates.`
+            );
+            // Always use a fresh temp directory for the retry to avoid conflicts
+            // with any partial .git state left by the failed first clone attempt.
+            const retryClonePath = (await tmp.dir()).path;
             const gitWithoutSsl = simpleGit(retryClonePath, {
                 timeout: timeoutConfig,
                 config: ["http.sslVerify=false"]


### PR DESCRIPTION
## Description

Fixes README generation failures in Docker containers that lack CA certificates. The `cloneRepository` function (used by `ReadmeGenerator.getOriginalReadmeContent()` to fetch existing READMEs for merging) was failing with:

```
fatal: unable to access '...': server certificate verification failed. CAfile: none CRLfile: none
```

[Link to Devin Session](https://app.devin.ai/sessions/6c7ab73f6eec4e63a9e34b1abb425056)
Requested by: @dsinghvi

## Changes Made

- Added `isSSLCertificateError()` helper to detect SSL certificate verification failures (matches `server certificate verification failed`, `SSL certificate problem`, `unable to get local issuer certificate`)
- When an SSL error is detected during `git clone`, automatically retries with `http.sslVerify=false` via simple-git's `config` option
- Logs a `console.warn` before retrying so the SSL fallback is visible in logs
- Always uses a fresh temp directory for the retry to avoid conflicts with partial `.git` state from the failed first clone
- If the retry also fails, throws a descriptive error including both the original and retry error messages
- Extracted `timeoutConfig` to a variable for reuse between the initial and retry git instances

## Human Review Checklist

- [ ] **simple-git `config` option**: Confirm `config: ["http.sslVerify=false"]` correctly passes `-c http.sslVerify=false` to git commands — this is the mechanism that makes the retry work
- [ ] **Fresh temp dir on retry**: The retry always clones into a new `tmp.dir()`, even if the caller passed `targetDirectory`. This is intentional to avoid dirty-directory failures, but means the result won't be in the caller's requested directory. Current callers (README generation) don't pass `targetDirectory`, so this should be fine, but worth noting.
- [ ] **Security**: SSL verification is only disabled as a fallback after the initial attempt fails with a certificate error — never by default. A `console.warn` is emitted, and the logged URL has tokens redacted.

## Testing

- [x] Lint/format checks pass (`pnpm run check`)
- [ ] No new unit tests added (existing tests are integration tests against real repos; the SSL retry path would require mocking simple-git)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
