### PR TITLE
fix(seed): replace slow git fetch --deepen with targeted commit fetch

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -126,18 +126,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Determine base ref for affected detection.
-          # The checkout is shallow (depth=1), so we must deepen to make
-          # the base commit reachable — otherwise turbo marks ALL packages
-          # as affected.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # The checkout creates a merge commit (PR head into base branch tip).
-            # Deepen by 1 to fetch its parents, then use the first parent
-            # (the actual base branch tip) as the base ref.  This is more
-            # reliable than the event payload's base.sha, which can drift
-            # when new commits land on main between PR open and CI run.
-            git fetch --no-tags --deepen=1 origin 2>/dev/null || true
-            BASE_REF=$(git rev-parse HEAD^1 2>/dev/null || echo "${{ github.event.pull_request.base.sha }}")
-            echo "Using PR merge-base: $BASE_REF"
+            # Use the PR base SHA from the event payload and fetch only that
+            # specific commit. This is much faster than `git fetch --deepen=1`
+            # which negotiates the entire repo graph (~4 min on this repo).
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+            echo "Using PR base SHA: $BASE_REF"
+            # Fetch just the base commit so git diff can reach it
+            git fetch --no-tags --depth=1 origin "$BASE_REF" 2>/dev/null || true
           else
             # For push/dispatch/workflow_call: use last successful run SHA
             LAST_SUCCESS_SHA=$(gh api \
@@ -146,8 +142,8 @@ jobs:
             if [[ -n "$LAST_SUCCESS_SHA" ]]; then
               BASE_REF="$LAST_SUCCESS_SHA"
               echo "Using last successful run SHA: $BASE_REF"
-              # Deepen to reach the last successful run (typically a few commits back)
-              git fetch --no-tags --deepen=50 origin 2>/dev/null || true
+              # Fetch just the target commit
+              git fetch --no-tags --depth=1 origin "$LAST_SUCCESS_SHA" 2>/dev/null || true
             else
               BASE_REF="origin/main"
               echo "No successful run found, using origin/main"

--- a/packages/seed/src/__test__/affected.test.ts
+++ b/packages/seed/src/__test__/affected.test.ts
@@ -57,7 +57,7 @@ const ALL_FIXTURES = ["imdb", "exhaustive", "alias", "basic-auth", "file-upload"
 
 describe("detectAffected", () => {
     describe("fallback behavior", () => {
-        it("skips all seed tests when no changed files (e.g. git diff failure)", () => {
+        it("skips all seed tests when no changed files detected", () => {
             const result = detectAffected([], ALL_GENERATORS);
 
             expect(result.allGeneratorsAffected).toBe(false);

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -108,21 +108,18 @@ export function getChangedFiles(baseRef: string, repoRoot: string): string[] {
             .filter((line) => line.length > 0);
     } catch (error) {
         console.error("git diff --merge-base failed, trying fallback:", error);
-        // Fallback: try without --merge-base (for cases where merge-base doesn't work)
-        try {
-            const output = execFileSync("git", ["diff", "--name-only", baseRef], {
-                cwd: repoRoot,
-                encoding: "utf-8",
-                timeout: 30000
-            });
-            return output
-                .trim()
-                .split("\n")
-                .filter((line) => line.length > 0);
-        } catch (innerError) {
-            console.error("Failed to get changed files from git.", innerError);
-            return [];
-        }
+        // Fallback: try without --merge-base (for cases where merge-base doesn't work,
+        // e.g. disconnected shallow commits). If this also fails, let the error propagate
+        // so the CLI exits non-zero and the workflow falls back to "run everything".
+        const output = execFileSync("git", ["diff", "--name-only", baseRef], {
+            cwd: repoRoot,
+            encoding: "utf-8",
+            timeout: 30000
+        });
+        return output
+            .trim()
+            .split("\n")
+            .filter((line) => line.length > 0);
     }
 }
 


### PR DESCRIPTION
## Description

Refs: [Devin session](https://app.devin.ai/sessions/f7188efe012a4fc7b3559b3cb782cf68)
Requested by: @Swimburger

The "Detect affected generators and fixtures" step in the `seed.yml` workflow was taking **~3m 48s**. CI logs show the bottleneck was `git fetch --no-tags --deepen=1 origin`, which negotiates the entire repo graph (161K files) just to deepen the shallow clone by one commit. The actual affected detection node command took only ~1.7s.

## Changes Made

- **PR path**: Replace `git fetch --deepen=1 origin` with `git fetch --depth=1 origin <sha>`, fetching only the specific base commit needed for `git diff`. Use `github.event.pull_request.base.sha` directly instead of deepening + `git rev-parse HEAD^1`.
- **Push/dispatch path**: Replace `git fetch --deepen=50 origin` with `git fetch --depth=1 origin <sha>` targeting just the last successful run commit.
- **Error propagation fix**: Remove the inner try-catch in `getChangedFiles` so that if both `git diff --merge-base` and the fallback `git diff --name-only` fail, the error propagates up. This causes the CLI to exit non-zero, which triggers the workflow's existing `|| echo '...run everything...'` fallback (safe default). Previously, a complete git diff failure would silently return empty files, causing `detectAffected` to skip all tests instead of running everything.

Expected reduction: ~3m48s → seconds for the git fetch portion of this step.

## Updates since last revision

Addressed the silent failure concern from the review checklist: previously, if the git fetch failed *and* both git diff attempts also failed, `getChangedFiles` caught the error and returned `[]`. This flowed into `detectAffected` as "no changed files → skip all seed tests" — the opposite of the intended "run everything" safe fallback. Now the error propagates, the CLI exits non-zero, and the workflow's `|| echo` fallback correctly runs everything.

## Human Review Checklist

- [ ] **`git diff --merge-base` with disconnected history**: The base commit is fetched as a disconnected shallow commit (not connected to HEAD's history). `git diff --name-only --merge-base <sha>` fails in this scenario ("fatal: no merge base found"), but the seed CLI falls back to `git diff --name-only <sha>` (without `--merge-base`). In CI, HEAD is a merge commit (PR head into base tip), so this fallback diff correctly shows only the PR's changes.
- [ ] **`github.event.pull_request.base.sha` drift**: The old code preferred `HEAD^1` over the event payload SHA because the payload SHA "can drift when new commits land on main." The new code uses the payload SHA directly. If it drifts, the diff would show *more* changed files (safe direction — runs more tests, not fewer). Confirm this tradeoff is acceptable.
- [ ] **Failure cascade is now safe**: If fetch fails → `git diff --merge-base` fails → fallback `git diff --name-only` also fails → error propagates → CLI exits non-zero → workflow `|| echo` runs everything. Verify this chain is the desired behavior.

## Testing

- [ ] This is a CI-only change — the PR's own CI run serves as the real test
- [ ] Verify the `get-all-test-matrices` job timing after CI completes
- [ ] Unit tests updated and passing (50 tests in `affected.test.ts`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
