### PR TITLE
fix(internal): disable commit signing in AutoVersioningService tests

### DIFF
--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
@@ -1255,6 +1255,7 @@ describe("AutoVersioningService", () => {
             await runCommand(["git", "init"], tempDir);
             await runCommand(["git", "config", "user.name", "Test User"], tempDir);
             await runCommand(["git", "config", "user.email", "test@example.com"], tempDir);
+            await runCommand(["git", "config", "commit.gpgsign", "false"], tempDir);
 
             // Create initial files
             await fs.writeFile(path.join(tempDir, "package.json"), '{\n  "name": "test-sdk",\n  "version": "1.0.0"\n}');
@@ -1291,6 +1292,7 @@ describe("AutoVersioningService", () => {
             await runCommand(["git", "init"], tempDir);
             await runCommand(["git", "config", "user.name", "Test User"], tempDir);
             await runCommand(["git", "config", "user.email", "test@example.com"], tempDir);
+            await runCommand(["git", "config", "commit.gpgsign", "false"], tempDir);
 
             await fs.writeFile(path.join(tempDir, "package.json"), '{\n  "name": "test-sdk",\n  "version": "1.0.0"\n}');
             await fs.mkdir(path.join(tempDir, ".fern"), { recursive: true });
@@ -1329,6 +1331,7 @@ describe("AutoVersioningService", () => {
             await runCommand(["git", "init"], tempDir);
             await runCommand(["git", "config", "user.name", "Test User"], tempDir);
             await runCommand(["git", "config", "user.email", "test@example.com"], tempDir);
+            await runCommand(["git", "config", "commit.gpgsign", "false"], tempDir);
 
             await fs.mkdir(path.join(tempDir, ".fern"), { recursive: true });
             await fs.writeFile(path.join(tempDir, ".fern", "metadata.json"), '{"cliVersion": "0.40.0"}');


### PR DESCRIPTION
## Description

Fixes interactive 1Password SSH fingerprint prompts that block `pnpm test:update --continue=always` for developers with SSH-based commit signing enabled globally.

[Link to Devin Session](https://app.devin.ai/sessions/91b0784932034155a8b2c517cb4684a6) | Requested by @Swimburger

## Changes Made

- Added `git config commit.gpgsign false` to 3 test functions in `AutoVersioningService.test.ts` that create temporary git repos and run real `git commit` commands

These tests (`testGenerateDiff_excludesFernMetadataJson`, `testGenerateDiff_includesOtherChangesAlongsideFernMetadata`, `testGenerateDiff_includesOtherFernDirectoryFiles`) were missing the `commit.gpgsign=false` config that is already used in production code paths (e.g., `PersistedTypescriptProject.ts:456`, `replay-init.ts:105`).

Without this, if a developer has `commit.gpgsign=true` and `gpg.format=ssh` in their global git config (common with 1Password SSH agent), every `git commit` in the test triggers an interactive fingerprint prompt.

## Review Checklist

- [x] Confirm these are the only active tests doing real `git commit` during `test:update` (they are — the `@fern-api/github` package's `cloneRepository.test.ts` does not have a `test:update` script)
- [x] Note: 2 commented-out tests (~lines 1373, 1432) also have `git commit` without `gpgsign=false` — not fixed since they're inactive

## Testing

- [x] Lint passes (`pnpm run check`)
- [ ] Manual testing requires 1Password SSH agent + global commit signing to reproduce
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
