### PR TITLE
chore(internal): add unit tests for Priority 1 TypeScript SDK generator components

### DIFF
--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -41,8 +41,8 @@
     "ts-poet": "catalog:"
   },
   "devDependencies": {
-    "@fern-api/casings-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
+    "@fern-typescript/test-utils": "workspace:*",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -41,6 +43,7 @@
     "ts-poet": "catalog:"
   },
   "devDependencies": {
+    "@fern-api/casings-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
@@ -1,39 +1,10 @@
-import { constructCasingsGenerator } from "@fern-api/casings-generator";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
+import { createMockTypeContext, createMockTypeSchemaContext, createQueryParameter } from "@fern-typescript/test-utils";
 import { ts } from "ts-morph";
 import { assert, describe, expect, it } from "vitest";
 
 import { GeneratedQueryParams } from "../endpoints/utils/GeneratedQueryParams.js";
-
-const casingsGenerator = constructCasingsGenerator({
-    generationLanguage: undefined,
-    keywords: undefined,
-    smartCasing: false
-});
-
-function createNameAndWireValue(name: string, wireValue?: string): FernIr.NameAndWireValue {
-    return {
-        wireValue: wireValue ?? name,
-        name: casingsGenerator.generateName(name)
-    };
-}
-
-function createQueryParameter(
-    name: string,
-    valueType: FernIr.TypeReference,
-    opts?: { allowMultiple?: boolean; wireValue?: string }
-): FernIr.QueryParameter {
-    return {
-        name: createNameAndWireValue(name, opts?.wireValue),
-        valueType,
-        allowMultiple: opts?.allowMultiple ?? false,
-        v2Examples: undefined,
-        docs: undefined,
-        availability: undefined,
-        explode: undefined
-    };
-}
 
 function createMockContext(opts?: {
     includeSerdeLayer?: boolean;
@@ -44,36 +15,8 @@ function createMockContext(opts?: {
         includeSerdeLayer: opts?.includeSerdeLayer ?? false,
         retainOriginalCasing: opts?.retainOriginalCasing ?? false,
         omitUndefined: opts?.omitUndefined ?? false,
-        type: {
-            // biome-ignore lint/suspicious/noExplicitAny: test mock callback signature
-            stringify: (expr: ts.Expression, _typeRef: FernIr.TypeReference, _opts: any) => {
-                return ts.factory.createCallExpression(
-                    ts.factory.createPropertyAccessExpression(expr, ts.factory.createIdentifier("toString")),
-                    undefined,
-                    []
-                );
-            },
-            getTypeDeclaration: () => ({
-                shape: FernIr.Type.object({
-                    properties: [],
-                    extends: [],
-                    extraProperties: false,
-                    extendedProperties: undefined
-                })
-            }),
-            getReferenceToType: () => ({ isOptional: false })
-        },
-        typeSchema: {
-            getSchemaOfNamedType: () => ({
-                jsonOrThrow: (expr: ts.Expression) => {
-                    return ts.factory.createCallExpression(
-                        ts.factory.createIdentifier("serializer.jsonOrThrow"),
-                        undefined,
-                        [expr]
-                    );
-                }
-            })
-        }
+        type: createMockTypeContext(),
+        typeSchema: createMockTypeSchemaContext({ useSerializerPrefix: true })
         // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
     } as any;
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
@@ -1,3 +1,4 @@
+import { constructCasingsGenerator } from "@fern-api/casings-generator";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
 import { ts } from "ts-morph";
@@ -5,26 +6,16 @@ import { assert, describe, expect, it } from "vitest";
 
 import { GeneratedQueryParams } from "../endpoints/utils/GeneratedQueryParams.js";
 
-function createName(name: string): FernIr.Name {
-    return {
-        originalName: name,
-        camelCase: {
-            unsafeName: name.charAt(0).toLowerCase() + name.slice(1),
-            safeName: name.charAt(0).toLowerCase() + name.slice(1)
-        },
-        pascalCase: {
-            unsafeName: name.charAt(0).toUpperCase() + name.slice(1),
-            safeName: name.charAt(0).toUpperCase() + name.slice(1)
-        },
-        snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
-        screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
-    };
-}
+const casingsGenerator = constructCasingsGenerator({
+    generationLanguage: undefined,
+    keywords: undefined,
+    smartCasing: false
+});
 
 function createNameAndWireValue(name: string, wireValue?: string): FernIr.NameAndWireValue {
     return {
         wireValue: wireValue ?? name,
-        name: createName(name)
+        name: casingsGenerator.generateName(name)
     };
 }
 

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
@@ -1,0 +1,257 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode } from "@fern-typescript/commons";
+import { ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+
+import { GeneratedQueryParams } from "../endpoints/utils/GeneratedQueryParams.js";
+
+function createName(name: string): FernIr.Name {
+    return {
+        originalName: name,
+        camelCase: { unsafeName: name.charAt(0).toLowerCase() + name.slice(1), safeName: name.charAt(0).toLowerCase() + name.slice(1) },
+        pascalCase: { unsafeName: name.charAt(0).toUpperCase() + name.slice(1), safeName: name.charAt(0).toUpperCase() + name.slice(1) },
+        snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
+        screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
+    };
+}
+
+function createNameAndWireValue(name: string, wireValue?: string): FernIr.NameAndWireValue {
+    return {
+        wireValue: wireValue ?? name,
+        name: createName(name)
+    };
+}
+
+function createQueryParameter(
+    name: string,
+    valueType: FernIr.TypeReference,
+    opts?: { allowMultiple?: boolean; wireValue?: string }
+): FernIr.QueryParameter {
+    return {
+        name: createNameAndWireValue(name, opts?.wireValue),
+        valueType,
+        allowMultiple: opts?.allowMultiple ?? false,
+        v2Examples: undefined,
+        docs: undefined,
+        availability: undefined,
+        explode: undefined
+    };
+}
+
+function createMockContext(opts?: { includeSerdeLayer?: boolean; retainOriginalCasing?: boolean; omitUndefined?: boolean }) {
+    return {
+        includeSerdeLayer: opts?.includeSerdeLayer ?? false,
+        retainOriginalCasing: opts?.retainOriginalCasing ?? false,
+        omitUndefined: opts?.omitUndefined ?? false,
+        type: {
+            stringify: (expr: ts.Expression, _typeRef: FernIr.TypeReference, _opts: any) => {
+                return ts.factory.createCallExpression(
+                    ts.factory.createPropertyAccessExpression(
+                        expr,
+                        ts.factory.createIdentifier("toString")
+                    ),
+                    undefined,
+                    []
+                );
+            },
+            getTypeDeclaration: () => ({
+                shape: FernIr.Type.object({
+                    properties: [],
+                    extends: [],
+                    extraProperties: false,
+                    extendedProperties: undefined
+                })
+            }),
+            getReferenceToType: () => ({ isOptional: false })
+        },
+        typeSchema: {
+            getSchemaOfNamedType: () => ({
+                jsonOrThrow: (expr: ts.Expression) => {
+                    return ts.factory.createCallExpression(
+                        ts.factory.createIdentifier("serializer.jsonOrThrow"),
+                        undefined,
+                        [expr]
+                    );
+                }
+            })
+        }
+    } as any;
+}
+
+function defaultReferenceToQueryParameterProperty(queryParameterKey: string) {
+    return ts.factory.createIdentifier(queryParameterKey);
+}
+
+describe("GeneratedQueryParams", () => {
+    describe("getBuildStatements", () => {
+        it("returns empty array when no query parameters", () => {
+            const generator = new GeneratedQueryParams({
+                queryParameters: undefined,
+                referenceToQueryParameterProperty: defaultReferenceToQueryParameterProperty
+            });
+            const result = generator.getBuildStatements(createMockContext());
+            expect(result).toHaveLength(0);
+        });
+
+        it("returns empty array when query parameters is empty array", () => {
+            const generator = new GeneratedQueryParams({
+                queryParameters: [],
+                referenceToQueryParameterProperty: defaultReferenceToQueryParameterProperty
+            });
+            const result = generator.getBuildStatements(createMockContext());
+            expect(result).toHaveLength(0);
+        });
+
+        it("generates query params for single string parameter", () => {
+            const queryParams = [
+                createQueryParameter("name", FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }))
+            ];
+
+            const generator = new GeneratedQueryParams({
+                queryParameters: queryParams,
+                referenceToQueryParameterProperty: defaultReferenceToQueryParameterProperty
+            });
+
+            const statements = generator.getBuildStatements(createMockContext());
+            expect(statements).toHaveLength(1);
+
+            const text = getTextOfTsNode(statements[0]!);
+            expect(text).toMatchSnapshot();
+        });
+
+        it("generates query params for multiple parameters", () => {
+            const queryParams = [
+                createQueryParameter("name", FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })),
+                createQueryParameter("age", FernIr.TypeReference.primitive({ v1: "INTEGER", v2: undefined })),
+                createQueryParameter("active", FernIr.TypeReference.primitive({ v1: "BOOLEAN", v2: undefined }))
+            ];
+
+            const generator = new GeneratedQueryParams({
+                queryParameters: queryParams,
+                referenceToQueryParameterProperty: defaultReferenceToQueryParameterProperty
+            });
+
+            const statements = generator.getBuildStatements(createMockContext());
+            expect(statements).toHaveLength(1);
+
+            const text = getTextOfTsNode(statements[0]!);
+            expect(text).toMatchSnapshot();
+        });
+
+        it("generates query params with wire value different from name", () => {
+            const queryParams = [
+                createQueryParameter("filterBy", FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }), {
+                    wireValue: "filter_by"
+                })
+            ];
+
+            const generator = new GeneratedQueryParams({
+                queryParameters: queryParams,
+                referenceToQueryParameterProperty: (key) => ts.factory.createIdentifier("filterBy")
+            });
+
+            const statements = generator.getBuildStatements(createMockContext());
+            expect(statements).toHaveLength(1);
+
+            const text = getTextOfTsNode(statements[0]!);
+            expect(text).toMatchSnapshot();
+        });
+
+        it("generates query params with allowMultiple and array check", () => {
+            const queryParams = [
+                createQueryParameter(
+                    "tags",
+                    FernIr.TypeReference.container(
+                        FernIr.ContainerType.list(
+                            FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                        )
+                    ),
+                    { allowMultiple: true }
+                )
+            ];
+
+            const generator = new GeneratedQueryParams({
+                queryParameters: queryParams,
+                referenceToQueryParameterProperty: defaultReferenceToQueryParameterProperty
+            });
+
+            const statements = generator.getBuildStatements(createMockContext());
+            expect(statements).toHaveLength(1);
+
+            const text = getTextOfTsNode(statements[0]!);
+            expect(text).toMatchSnapshot();
+        });
+
+        it("generates query params with date-time type needing stringify", () => {
+            const queryParams = [
+                createQueryParameter("createdAfter", FernIr.TypeReference.primitive({ v1: "DATE_TIME", v2: undefined }))
+            ];
+
+            const generator = new GeneratedQueryParams({
+                queryParameters: queryParams,
+                referenceToQueryParameterProperty: defaultReferenceToQueryParameterProperty
+            });
+
+            const statements = generator.getBuildStatements(createMockContext());
+            expect(statements).toHaveLength(1);
+
+            const text = getTextOfTsNode(statements[0]!);
+            expect(text).toMatchSnapshot();
+        });
+
+        it("handles special characters in wire values", () => {
+            const queryParams = [
+                createQueryParameter("filterDate", FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }), {
+                    wireValue: "filter.date"
+                })
+            ];
+
+            const generator = new GeneratedQueryParams({
+                queryParameters: queryParams,
+                referenceToQueryParameterProperty: (key) =>
+                    ts.factory.createPropertyAccessExpression(
+                        ts.factory.createIdentifier("request"),
+                        ts.factory.createIdentifier("filterDate")
+                    )
+            });
+
+            const statements = generator.getBuildStatements(createMockContext());
+            expect(statements).toHaveLength(1);
+
+            const text = getTextOfTsNode(statements[0]!);
+            expect(text).toMatchSnapshot();
+        });
+    });
+
+    describe("getReferenceTo", () => {
+        it("returns spread with query params when parameters exist", () => {
+            const queryParams = [
+                createQueryParameter("name", FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }))
+            ];
+
+            const generator = new GeneratedQueryParams({
+                queryParameters: queryParams,
+                referenceToQueryParameterProperty: defaultReferenceToQueryParameterProperty
+            });
+
+            const result = generator.getReferenceTo();
+            expect(result).toBeDefined();
+
+            const text = getTextOfTsNode(result!);
+            expect(text).toMatchSnapshot();
+        });
+
+        it("returns only requestOptions queryParams when no parameters", () => {
+            const generator = new GeneratedQueryParams({
+                queryParameters: undefined,
+                referenceToQueryParameterProperty: defaultReferenceToQueryParameterProperty
+            });
+
+            const result = generator.getReferenceTo();
+            expect(result).toBeDefined();
+
+            const text = getTextOfTsNode(result!);
+            expect(text).toMatchSnapshot();
+        });
+    });
+});

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
@@ -162,7 +162,7 @@ describe("GeneratedQueryParams", () => {
 
             const generator = new GeneratedQueryParams({
                 queryParameters: queryParams,
-                referenceToQueryParameterProperty: (key) => ts.factory.createIdentifier("filterBy")
+                referenceToQueryParameterProperty: (_key) => ts.factory.createIdentifier("filterBy")
             });
 
             const statements = generator.getBuildStatements(createMockContext());
@@ -230,7 +230,7 @@ describe("GeneratedQueryParams", () => {
 
             const generator = new GeneratedQueryParams({
                 queryParameters: queryParams,
-                referenceToQueryParameterProperty: (key) =>
+                referenceToQueryParameterProperty: (_key) =>
                     ts.factory.createPropertyAccessExpression(
                         ts.factory.createIdentifier("request"),
                         ts.factory.createIdentifier("filterDate")

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
@@ -1,7 +1,7 @@
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
 import { ts } from "ts-morph";
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 
 import { GeneratedQueryParams } from "../endpoints/utils/GeneratedQueryParams.js";
 
@@ -125,10 +125,9 @@ describe("GeneratedQueryParams", () => {
             expect(statements).toHaveLength(1);
 
             const firstStatement = statements[0];
-            if (firstStatement != null) {
-                const text = getTextOfTsNode(firstStatement);
-                expect(text).toMatchSnapshot();
-            }
+            assert(firstStatement != null, "expected at least one build statement for single parameter");
+            const text = getTextOfTsNode(firstStatement);
+            expect(text).toMatchSnapshot();
         });
 
         it("generates query params for multiple parameters", () => {
@@ -147,10 +146,9 @@ describe("GeneratedQueryParams", () => {
             expect(statements).toHaveLength(1);
 
             const firstStatement = statements[0];
-            if (firstStatement != null) {
-                const text = getTextOfTsNode(firstStatement);
-                expect(text).toMatchSnapshot();
-            }
+            assert(firstStatement != null, "expected at least one build statement for multiple parameters");
+            const text = getTextOfTsNode(firstStatement);
+            expect(text).toMatchSnapshot();
         });
 
         it("generates query params with wire value different from name", () => {
@@ -169,10 +167,9 @@ describe("GeneratedQueryParams", () => {
             expect(statements).toHaveLength(1);
 
             const firstStatement = statements[0];
-            if (firstStatement != null) {
-                const text = getTextOfTsNode(firstStatement);
-                expect(text).toMatchSnapshot();
-            }
+            assert(firstStatement != null, "expected at least one build statement for wire value mismatch");
+            const text = getTextOfTsNode(firstStatement);
+            expect(text).toMatchSnapshot();
         });
 
         it("generates query params with allowMultiple and array check", () => {
@@ -195,10 +192,9 @@ describe("GeneratedQueryParams", () => {
             expect(statements).toHaveLength(1);
 
             const firstStatement = statements[0];
-            if (firstStatement != null) {
-                const text = getTextOfTsNode(firstStatement);
-                expect(text).toMatchSnapshot();
-            }
+            assert(firstStatement != null, "expected at least one build statement for allowMultiple");
+            const text = getTextOfTsNode(firstStatement);
+            expect(text).toMatchSnapshot();
         });
 
         it("generates query params with date-time type needing stringify", () => {
@@ -215,10 +211,9 @@ describe("GeneratedQueryParams", () => {
             expect(statements).toHaveLength(1);
 
             const firstStatement = statements[0];
-            if (firstStatement != null) {
-                const text = getTextOfTsNode(firstStatement);
-                expect(text).toMatchSnapshot();
-            }
+            assert(firstStatement != null, "expected at least one build statement for date-time stringify");
+            const text = getTextOfTsNode(firstStatement);
+            expect(text).toMatchSnapshot();
         });
 
         it("handles special characters in wire values", () => {
@@ -241,10 +236,9 @@ describe("GeneratedQueryParams", () => {
             expect(statements).toHaveLength(1);
 
             const firstStatement = statements[0];
-            if (firstStatement != null) {
-                const text = getTextOfTsNode(firstStatement);
-                expect(text).toMatchSnapshot();
-            }
+            assert(firstStatement != null, "expected at least one build statement for special characters");
+            const text = getTextOfTsNode(firstStatement);
+            expect(text).toMatchSnapshot();
         });
     });
 
@@ -260,12 +254,9 @@ describe("GeneratedQueryParams", () => {
             });
 
             const result = generator.getReferenceTo();
-            expect(result).toBeDefined();
-
-            if (result != null) {
-                const text = getTextOfTsNode(result);
-                expect(text).toMatchSnapshot();
-            }
+            assert(result != null, "expected getReferenceTo to return an expression when parameters exist");
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
         });
 
         it("returns only requestOptions queryParams when no parameters", () => {
@@ -275,12 +266,9 @@ describe("GeneratedQueryParams", () => {
             });
 
             const result = generator.getReferenceTo();
-            expect(result).toBeDefined();
-
-            if (result != null) {
-                const text = getTextOfTsNode(result);
-                expect(text).toMatchSnapshot();
-            }
+            assert(result != null, "expected getReferenceTo to return an expression when no parameters");
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
         });
     });
 });

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedQueryParams.test.ts
@@ -8,8 +8,14 @@ import { GeneratedQueryParams } from "../endpoints/utils/GeneratedQueryParams.js
 function createName(name: string): FernIr.Name {
     return {
         originalName: name,
-        camelCase: { unsafeName: name.charAt(0).toLowerCase() + name.slice(1), safeName: name.charAt(0).toLowerCase() + name.slice(1) },
-        pascalCase: { unsafeName: name.charAt(0).toUpperCase() + name.slice(1), safeName: name.charAt(0).toUpperCase() + name.slice(1) },
+        camelCase: {
+            unsafeName: name.charAt(0).toLowerCase() + name.slice(1),
+            safeName: name.charAt(0).toLowerCase() + name.slice(1)
+        },
+        pascalCase: {
+            unsafeName: name.charAt(0).toUpperCase() + name.slice(1),
+            safeName: name.charAt(0).toUpperCase() + name.slice(1)
+        },
         snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
         screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
     };
@@ -38,18 +44,20 @@ function createQueryParameter(
     };
 }
 
-function createMockContext(opts?: { includeSerdeLayer?: boolean; retainOriginalCasing?: boolean; omitUndefined?: boolean }) {
+function createMockContext(opts?: {
+    includeSerdeLayer?: boolean;
+    retainOriginalCasing?: boolean;
+    omitUndefined?: boolean;
+}) {
     return {
         includeSerdeLayer: opts?.includeSerdeLayer ?? false,
         retainOriginalCasing: opts?.retainOriginalCasing ?? false,
         omitUndefined: opts?.omitUndefined ?? false,
         type: {
+            // biome-ignore lint/suspicious/noExplicitAny: test mock callback signature
             stringify: (expr: ts.Expression, _typeRef: FernIr.TypeReference, _opts: any) => {
                 return ts.factory.createCallExpression(
-                    ts.factory.createPropertyAccessExpression(
-                        expr,
-                        ts.factory.createIdentifier("toString")
-                    ),
+                    ts.factory.createPropertyAccessExpression(expr, ts.factory.createIdentifier("toString")),
                     undefined,
                     []
                 );
@@ -75,6 +83,7 @@ function createMockContext(opts?: { includeSerdeLayer?: boolean; retainOriginalC
                 }
             })
         }
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
     } as any;
 }
 
@@ -115,8 +124,11 @@ describe("GeneratedQueryParams", () => {
             const statements = generator.getBuildStatements(createMockContext());
             expect(statements).toHaveLength(1);
 
-            const text = getTextOfTsNode(statements[0]!);
-            expect(text).toMatchSnapshot();
+            const firstStatement = statements[0];
+            if (firstStatement != null) {
+                const text = getTextOfTsNode(firstStatement);
+                expect(text).toMatchSnapshot();
+            }
         });
 
         it("generates query params for multiple parameters", () => {
@@ -134,8 +146,11 @@ describe("GeneratedQueryParams", () => {
             const statements = generator.getBuildStatements(createMockContext());
             expect(statements).toHaveLength(1);
 
-            const text = getTextOfTsNode(statements[0]!);
-            expect(text).toMatchSnapshot();
+            const firstStatement = statements[0];
+            if (firstStatement != null) {
+                const text = getTextOfTsNode(firstStatement);
+                expect(text).toMatchSnapshot();
+            }
         });
 
         it("generates query params with wire value different from name", () => {
@@ -153,8 +168,11 @@ describe("GeneratedQueryParams", () => {
             const statements = generator.getBuildStatements(createMockContext());
             expect(statements).toHaveLength(1);
 
-            const text = getTextOfTsNode(statements[0]!);
-            expect(text).toMatchSnapshot();
+            const firstStatement = statements[0];
+            if (firstStatement != null) {
+                const text = getTextOfTsNode(firstStatement);
+                expect(text).toMatchSnapshot();
+            }
         });
 
         it("generates query params with allowMultiple and array check", () => {
@@ -162,9 +180,7 @@ describe("GeneratedQueryParams", () => {
                 createQueryParameter(
                     "tags",
                     FernIr.TypeReference.container(
-                        FernIr.ContainerType.list(
-                            FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
-                        )
+                        FernIr.ContainerType.list(FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }))
                     ),
                     { allowMultiple: true }
                 )
@@ -178,8 +194,11 @@ describe("GeneratedQueryParams", () => {
             const statements = generator.getBuildStatements(createMockContext());
             expect(statements).toHaveLength(1);
 
-            const text = getTextOfTsNode(statements[0]!);
-            expect(text).toMatchSnapshot();
+            const firstStatement = statements[0];
+            if (firstStatement != null) {
+                const text = getTextOfTsNode(firstStatement);
+                expect(text).toMatchSnapshot();
+            }
         });
 
         it("generates query params with date-time type needing stringify", () => {
@@ -195,8 +214,11 @@ describe("GeneratedQueryParams", () => {
             const statements = generator.getBuildStatements(createMockContext());
             expect(statements).toHaveLength(1);
 
-            const text = getTextOfTsNode(statements[0]!);
-            expect(text).toMatchSnapshot();
+            const firstStatement = statements[0];
+            if (firstStatement != null) {
+                const text = getTextOfTsNode(firstStatement);
+                expect(text).toMatchSnapshot();
+            }
         });
 
         it("handles special characters in wire values", () => {
@@ -218,8 +240,11 @@ describe("GeneratedQueryParams", () => {
             const statements = generator.getBuildStatements(createMockContext());
             expect(statements).toHaveLength(1);
 
-            const text = getTextOfTsNode(statements[0]!);
-            expect(text).toMatchSnapshot();
+            const firstStatement = statements[0];
+            if (firstStatement != null) {
+                const text = getTextOfTsNode(firstStatement);
+                expect(text).toMatchSnapshot();
+            }
         });
     });
 
@@ -237,8 +262,10 @@ describe("GeneratedQueryParams", () => {
             const result = generator.getReferenceTo();
             expect(result).toBeDefined();
 
-            const text = getTextOfTsNode(result!);
-            expect(text).toMatchSnapshot();
+            if (result != null) {
+                const text = getTextOfTsNode(result);
+                expect(text).toMatchSnapshot();
+            }
         });
 
         it("returns only requestOptions queryParams when no parameters", () => {
@@ -250,8 +277,10 @@ describe("GeneratedQueryParams", () => {
             const result = generator.getReferenceTo();
             expect(result).toBeDefined();
 
-            const text = getTextOfTsNode(result!);
-            expect(text).toMatchSnapshot();
+            if (result != null) {
+                const text = getTextOfTsNode(result);
+                expect(text).toMatchSnapshot();
+            }
         });
     });
 });

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedQueryParams.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedQueryParams.test.ts.snap
@@ -1,0 +1,43 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedQueryParams > getBuildStatements > generates query params for multiple parameters 1`] = `
+"const _queryParams: Record<string, unknown> = {
+    name,
+    age,
+    active
+};"
+`;
+
+exports[`GeneratedQueryParams > getBuildStatements > generates query params for single string parameter 1`] = `
+"const _queryParams: Record<string, unknown> = {
+    name
+};"
+`;
+
+exports[`GeneratedQueryParams > getBuildStatements > generates query params with allowMultiple and array check 1`] = `
+"const _queryParams: Record<string, unknown> = {
+    tags: Array.isArray(tags) ? tags : tags.toString()
+};"
+`;
+
+exports[`GeneratedQueryParams > getBuildStatements > generates query params with date-time type needing stringify 1`] = `
+"const _queryParams: Record<string, unknown> = {
+    createdAfter: createdAfter.toString()
+};"
+`;
+
+exports[`GeneratedQueryParams > getBuildStatements > generates query params with wire value different from name 1`] = `
+"const _queryParams: Record<string, unknown> = {
+    filter_by: filterBy
+};"
+`;
+
+exports[`GeneratedQueryParams > getBuildStatements > handles special characters in wire values 1`] = `
+"const _queryParams: Record<string, unknown> = {
+    "filter.date": request.filterDate
+};"
+`;
+
+exports[`GeneratedQueryParams > getReferenceTo > returns only requestOptions queryParams when no parameters 1`] = `"requestOptions?.queryParams"`;
+
+exports[`GeneratedQueryParams > getReferenceTo > returns spread with query params when parameters exist 1`] = `"{ ..._queryParams, ...requestOptions?.queryParams }"`;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/buildUrl.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/buildUrl.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildUrl > generates template literal for path with multiple parameters 1`] = `"\`/orgs/\${orgId}/users/\${userId}\`"`;
+
+exports[`buildUrl > generates template literal for path with one parameter 1`] = `"\`/users/\${userId}\`"`;
+
+exports[`buildUrl > generates template literal with trailing path after parameter 1`] = `"\`/users/\${userId}/profile\`"`;
+
+exports[`buildUrl > retains original casing when retainOriginalCasing is true 1`] = `"\`/users/\${user_id}\`"`;
+
+exports[`buildUrl > uses root path parameter reference for ROOT location 1`] = `"\`/tenants/\${this.tenantId}/data\`"`;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/generateHeaders.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/generateHeaders.test.ts.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generateHeaders > generates auth headers when auth provider exists and endpoint requires auth 1`] = `
+"const _authRequest: AuthRequest = getAuthRequest(this._authProvider);
+let _headers: Fetcher.Args["headers"] = mergeHeaders(_authRequest.headers, this._options?.headers, requestOptions?.headers);"
+`;
+
+exports[`generateHeaders > generates headers with additional headers parameter 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "X-Extra": "extra-value" }), requestOptions?.headers);"`;
+
+exports[`generateHeaders > generates headers with idempotency headers when endpoint is idempotent 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "Idempotency-Key": requestOptions?.idempotency-Key }), requestOptions?.headers);"`;
+
+exports[`generateHeaders > generates headers with literal header value 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "X-Fern-Language": "JavaScript" }), requestOptions?.headers);"`;
+
+exports[`generateHeaders > generates headers with no service/endpoint headers and no auth 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, requestOptions?.headers);"`;
+
+exports[`generateHeaders > generates headers with root-level overridable headers 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "X-Custom-Header": requestOptions?.x-Custom-Header ?? this._options?.x-Custom-Header }), requestOptions?.headers);"`;
+
+exports[`generateHeaders > generates headers with service and endpoint headers 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "X-API-Version": request.x-API-Version, "X-Request-Id": request.x-Request-Id }), requestOptions?.headers);"`;
+
+exports[`generateHeaders > generates headers without idempotency headers when endpoint is not idempotent 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, requestOptions?.headers);"`;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/generateHeaders.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/generateHeaders.test.ts.snap
@@ -7,14 +7,14 @@ let _headers: Fetcher.Args["headers"] = mergeHeaders(_authRequest.headers, this.
 
 exports[`generateHeaders > generates headers with additional headers parameter 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "X-Extra": "extra-value" }), requestOptions?.headers);"`;
 
-exports[`generateHeaders > generates headers with idempotency headers when endpoint is idempotent 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "Idempotency-Key": requestOptions?.idempotency-Key }), requestOptions?.headers);"`;
+exports[`generateHeaders > generates headers with idempotency headers when endpoint is idempotent 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "Idempotency-Key": requestOptions?.idempotencyKey }), requestOptions?.headers);"`;
 
 exports[`generateHeaders > generates headers with literal header value 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "X-Fern-Language": "JavaScript" }), requestOptions?.headers);"`;
 
 exports[`generateHeaders > generates headers with no service/endpoint headers and no auth 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, requestOptions?.headers);"`;
 
-exports[`generateHeaders > generates headers with root-level overridable headers 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "X-Custom-Header": requestOptions?.x-Custom-Header ?? this._options?.x-Custom-Header }), requestOptions?.headers);"`;
+exports[`generateHeaders > generates headers with root-level overridable headers 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "X-Custom-Header": requestOptions?.xCustomHeader ?? this._options?.xCustomHeader }), requestOptions?.headers);"`;
 
-exports[`generateHeaders > generates headers with service and endpoint headers 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "X-API-Version": request.x-API-Version, "X-Request-Id": request.x-Request-Id }), requestOptions?.headers);"`;
+exports[`generateHeaders > generates headers with service and endpoint headers 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, mergeOnlyDefinedHeaders({ "X-API-Version": request.xApiVersion, "X-Request-Id": request.xRequestId }), requestOptions?.headers);"`;
 
 exports[`generateHeaders > generates headers without idempotency headers when endpoint is not idempotent 1`] = `"let _headers: Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, requestOptions?.headers);"`;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/requestOptionsParameter.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/requestOptionsParameter.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`requestOptionsParameter > getAbortSignalExpression > generates abort signal reference 1`] = `"requestOptions?.abortSignal"`;
+
+exports[`requestOptionsParameter > getMaxRetriesExpression > generates max retries with nullish coalescing 1`] = `"requestOptions?.maxRetries ?? this._options?.maxRetries"`;
+
+exports[`requestOptionsParameter > getTimeoutExpression > generates timeout with custom default seconds 1`] = `"(requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 30) * 1000"`;
+
+exports[`requestOptionsParameter > getTimeoutExpression > generates timeout with default 60 seconds 1`] = `"(requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000"`;
+
+exports[`requestOptionsParameter > getTimeoutExpression > generates timeout with infinity default 1`] = `"requestOptions?.timeoutInSeconds != null ? (requestOptions.timeoutInSeconds * 1000) : this._options?.timeoutInSeconds != null ? (this._options?.timeoutInSeconds * 1000) : undefined"`;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
@@ -1,0 +1,300 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode } from "@fern-typescript/commons";
+import { ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+
+import { buildUrl } from "../endpoints/utils/buildUrl.js";
+
+function createName(name: string): FernIr.Name {
+    return {
+        originalName: name,
+        camelCase: { unsafeName: name.charAt(0).toLowerCase() + name.slice(1), safeName: name.charAt(0).toLowerCase() + name.slice(1) },
+        pascalCase: { unsafeName: name.charAt(0).toUpperCase() + name.slice(1), safeName: name.charAt(0).toUpperCase() + name.slice(1) },
+        snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
+        screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
+    };
+}
+
+function createPathParameter(
+    name: string,
+    location: FernIr.PathParameterLocation = "ENDPOINT"
+): FernIr.PathParameter {
+    return {
+        name: createName(name),
+        valueType: FernIr.TypeReference.primitive({
+            v1: "STRING",
+            v2: undefined
+        }),
+        location,
+        variable: undefined,
+        v2Examples: undefined,
+        docs: undefined,
+        explode: undefined
+    };
+}
+
+// Minimal mock that returns the expression as-is (no encoding wrapper)
+function createMockContext() {
+    return {
+        coreUtilities: {
+            urlUtils: {
+                encodePathParam: {
+                    _invoke: (expr: ts.Expression) => expr
+                }
+            }
+        },
+        requestWrapper: {
+            shouldInlinePathParameters: () => false
+        },
+        typeSchema: {
+            getSchemaOfNamedType: () => ({
+                jsonOrThrow: (expr: ts.Expression) => expr
+            })
+        }
+    } as any;
+}
+
+function createMockGeneratedClientClass() {
+    return {
+        getReferenceToVariable: (variableId: string) => ts.factory.createIdentifier(`this._${variableId}`),
+        getReferenceToRootPathParameter: (pathParam: FernIr.PathParameter) =>
+            ts.factory.createPropertyAccessExpression(
+                ts.factory.createThis(),
+                ts.factory.createIdentifier(pathParam.name.camelCase.unsafeName)
+            )
+    } as any;
+}
+
+const defaultGetReferenceToPathParameterVariableFromRequest = (pathParameter: FernIr.PathParameter) =>
+    ts.factory.createPropertyAccessExpression(
+        ts.factory.createIdentifier("request"),
+        ts.factory.createIdentifier(pathParameter.name.camelCase.unsafeName)
+    );
+
+describe("buildUrl", () => {
+    it("returns undefined for empty path with no path parameters", () => {
+        const result = buildUrl({
+            endpoint: {
+                sdkRequest: undefined,
+                fullPath: { head: "", parts: [] },
+                allPathParameters: [],
+                path: { head: "", parts: [] }
+            },
+            generatedClientClass: createMockGeneratedClientClass(),
+            context: createMockContext(),
+            includeSerdeLayer: false,
+            retainOriginalCasing: false,
+            omitUndefined: false,
+            parameterNaming: "default",
+            getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
+        });
+
+        expect(result).toBeUndefined();
+    });
+
+    it("returns string literal for static path with no parameters", () => {
+        const result = buildUrl({
+            endpoint: {
+                sdkRequest: undefined,
+                fullPath: { head: "/api/v1/users", parts: [] },
+                allPathParameters: [],
+                path: { head: "/api/v1/users", parts: [] }
+            },
+            generatedClientClass: createMockGeneratedClientClass(),
+            context: createMockContext(),
+            includeSerdeLayer: false,
+            retainOriginalCasing: false,
+            omitUndefined: false,
+            parameterNaming: "default",
+            getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
+        });
+
+        expect(result).toBeDefined();
+        expect(getTextOfTsNode(result!)).toBe('"/api/v1/users"');
+    });
+
+    it("generates template literal for path with one parameter", () => {
+        const userIdParam = createPathParameter("userId");
+
+        const result = buildUrl({
+            endpoint: {
+                sdkRequest: undefined,
+                fullPath: {
+                    head: "/users/",
+                    parts: [{ pathParameter: "userId", tail: "" }]
+                },
+                allPathParameters: [userIdParam],
+                path: {
+                    head: "/users/",
+                    parts: [{ pathParameter: "userId", tail: "" }]
+                }
+            },
+            generatedClientClass: createMockGeneratedClientClass(),
+            context: createMockContext(),
+            includeSerdeLayer: false,
+            retainOriginalCasing: false,
+            omitUndefined: false,
+            parameterNaming: "default",
+            getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
+        });
+
+        expect(result).toBeDefined();
+        const text = getTextOfTsNode(result!);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("generates template literal for path with multiple parameters", () => {
+        const orgIdParam = createPathParameter("orgId");
+        const userIdParam = createPathParameter("userId");
+
+        const result = buildUrl({
+            endpoint: {
+                sdkRequest: undefined,
+                fullPath: {
+                    head: "/orgs/",
+                    parts: [
+                        { pathParameter: "orgId", tail: "/users/" },
+                        { pathParameter: "userId", tail: "" }
+                    ]
+                },
+                allPathParameters: [orgIdParam, userIdParam],
+                path: {
+                    head: "/orgs/",
+                    parts: [
+                        { pathParameter: "orgId", tail: "/users/" },
+                        { pathParameter: "userId", tail: "" }
+                    ]
+                }
+            },
+            generatedClientClass: createMockGeneratedClientClass(),
+            context: createMockContext(),
+            includeSerdeLayer: false,
+            retainOriginalCasing: false,
+            omitUndefined: false,
+            parameterNaming: "default",
+            getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
+        });
+
+        expect(result).toBeDefined();
+        const text = getTextOfTsNode(result!);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("generates template literal with trailing path after parameter", () => {
+        const userIdParam = createPathParameter("userId");
+
+        const result = buildUrl({
+            endpoint: {
+                sdkRequest: undefined,
+                fullPath: {
+                    head: "/users/",
+                    parts: [{ pathParameter: "userId", tail: "/profile" }]
+                },
+                allPathParameters: [userIdParam],
+                path: {
+                    head: "/users/",
+                    parts: [{ pathParameter: "userId", tail: "/profile" }]
+                }
+            },
+            generatedClientClass: createMockGeneratedClientClass(),
+            context: createMockContext(),
+            includeSerdeLayer: false,
+            retainOriginalCasing: false,
+            omitUndefined: false,
+            parameterNaming: "default",
+            getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
+        });
+
+        expect(result).toBeDefined();
+        const text = getTextOfTsNode(result!);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("uses root path parameter reference for ROOT location", () => {
+        const rootParam = createPathParameter("tenantId", "ROOT");
+
+        const result = buildUrl({
+            endpoint: {
+                sdkRequest: undefined,
+                fullPath: {
+                    head: "/tenants/",
+                    parts: [{ pathParameter: "tenantId", tail: "/data" }]
+                },
+                allPathParameters: [rootParam],
+                path: {
+                    head: "/tenants/",
+                    parts: [{ pathParameter: "tenantId", tail: "/data" }]
+                }
+            },
+            generatedClientClass: createMockGeneratedClientClass(),
+            context: createMockContext(),
+            includeSerdeLayer: false,
+            retainOriginalCasing: false,
+            omitUndefined: false,
+            parameterNaming: "default",
+            getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
+        });
+
+        expect(result).toBeDefined();
+        const text = getTextOfTsNode(result!);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("retains original casing when retainOriginalCasing is true", () => {
+        const param = createPathParameter("user_id");
+
+        const result = buildUrl({
+            endpoint: {
+                sdkRequest: undefined,
+                fullPath: {
+                    head: "/users/",
+                    parts: [{ pathParameter: "user_id", tail: "" }]
+                },
+                allPathParameters: [param],
+                path: {
+                    head: "/users/",
+                    parts: [{ pathParameter: "user_id", tail: "" }]
+                }
+            },
+            generatedClientClass: createMockGeneratedClientClass(),
+            context: createMockContext(),
+            includeSerdeLayer: false,
+            retainOriginalCasing: true,
+            omitUndefined: false,
+            parameterNaming: "default",
+            getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
+        });
+
+        expect(result).toBeDefined();
+        const text = getTextOfTsNode(result!);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("throws when path parameter is not found in allPathParameters", () => {
+        // Need at least one path parameter so buildUrl doesn't take the early return path
+        const existingParam = createPathParameter("existing");
+        expect(() =>
+            buildUrl({
+                endpoint: {
+                    sdkRequest: undefined,
+                    fullPath: {
+                        head: "/users/",
+                        parts: [{ pathParameter: "nonexistent", tail: "" }]
+                    },
+                    allPathParameters: [existingParam],
+                    path: {
+                        head: "/users/",
+                        parts: [{ pathParameter: "nonexistent", tail: "" }]
+                    }
+                },
+                generatedClientClass: createMockGeneratedClientClass(),
+                context: createMockContext(),
+                includeSerdeLayer: false,
+                retainOriginalCasing: false,
+                omitUndefined: false,
+                parameterNaming: "default",
+                getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
+            })
+        ).toThrow("Could not locate path parameter: nonexistent");
+    });
+});

--- a/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
@@ -1,42 +1,19 @@
-import { constructCasingsGenerator } from "@fern-api/casings-generator";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
+import {
+    createMockCoreUtilities,
+    createMockGeneratedClientClass,
+    createPathParameter
+} from "@fern-typescript/test-utils";
 import { ts } from "ts-morph";
 import { assert, describe, expect, it } from "vitest";
 
 import { buildUrl } from "../endpoints/utils/buildUrl.js";
 
-const casingsGenerator = constructCasingsGenerator({
-    generationLanguage: undefined,
-    keywords: undefined,
-    smartCasing: false
-});
-
-function createPathParameter(name: string, location: FernIr.PathParameterLocation = "ENDPOINT"): FernIr.PathParameter {
-    return {
-        name: casingsGenerator.generateName(name),
-        valueType: FernIr.TypeReference.primitive({
-            v1: "STRING",
-            v2: undefined
-        }),
-        location,
-        variable: undefined,
-        v2Examples: undefined,
-        docs: undefined,
-        explode: undefined
-    };
-}
-
-// Minimal mock that returns the expression as-is (no encoding wrapper)
 function createMockContext() {
+    const coreUtilities = createMockCoreUtilities();
     return {
-        coreUtilities: {
-            urlUtils: {
-                encodePathParam: {
-                    _invoke: (expr: ts.Expression) => expr
-                }
-            }
-        },
+        coreUtilities,
         requestWrapper: {
             shouldInlinePathParameters: () => false
         },
@@ -45,18 +22,6 @@ function createMockContext() {
                 jsonOrThrow: (expr: ts.Expression) => expr
             })
         }
-        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
-    } as any;
-}
-
-function createMockGeneratedClientClass() {
-    return {
-        getReferenceToVariable: (variableId: string) => ts.factory.createIdentifier(`this._${variableId}`),
-        getReferenceToRootPathParameter: (pathParam: FernIr.PathParameter) =>
-            ts.factory.createPropertyAccessExpression(
-                ts.factory.createThis(),
-                ts.factory.createIdentifier(pathParam.name.camelCase.unsafeName)
-            )
         // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
     } as any;
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
@@ -1,3 +1,4 @@
+import { constructCasingsGenerator } from "@fern-api/casings-generator";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
 import { ts } from "ts-morph";
@@ -5,25 +6,15 @@ import { assert, describe, expect, it } from "vitest";
 
 import { buildUrl } from "../endpoints/utils/buildUrl.js";
 
-function createName(name: string): FernIr.Name {
-    return {
-        originalName: name,
-        camelCase: {
-            unsafeName: name.charAt(0).toLowerCase() + name.slice(1),
-            safeName: name.charAt(0).toLowerCase() + name.slice(1)
-        },
-        pascalCase: {
-            unsafeName: name.charAt(0).toUpperCase() + name.slice(1),
-            safeName: name.charAt(0).toUpperCase() + name.slice(1)
-        },
-        snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
-        screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
-    };
-}
+const casingsGenerator = constructCasingsGenerator({
+    generationLanguage: undefined,
+    keywords: undefined,
+    smartCasing: false
+});
 
 function createPathParameter(name: string, location: FernIr.PathParameterLocation = "ENDPOINT"): FernIr.PathParameter {
     return {
-        name: createName(name),
+        name: casingsGenerator.generateName(name),
         valueType: FernIr.TypeReference.primitive({
             v1: "STRING",
             v2: undefined

--- a/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
@@ -1,7 +1,7 @@
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
 import { ts } from "ts-morph";
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 
 import { buildUrl } from "../endpoints/utils/buildUrl.js";
 
@@ -114,10 +114,8 @@ describe("buildUrl", () => {
             getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
         });
 
-        expect(result).toBeDefined();
-        if (result != null) {
-            expect(getTextOfTsNode(result)).toBe('"/api/v1/users"');
-        }
+        assert(result != null, "expected buildUrl to return an expression for static path");
+        expect(getTextOfTsNode(result)).toBe('"/api/v1/users"');
     });
 
     it("generates template literal for path with one parameter", () => {
@@ -145,11 +143,9 @@ describe("buildUrl", () => {
             getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
         });
 
-        expect(result).toBeDefined();
-        if (result != null) {
-            const text = getTextOfTsNode(result);
-            expect(text).toMatchSnapshot();
-        }
+        assert(result != null, "expected buildUrl to return an expression for single parameter path");
+        const text = getTextOfTsNode(result);
+        expect(text).toMatchSnapshot();
     });
 
     it("generates template literal for path with multiple parameters", () => {
@@ -184,11 +180,9 @@ describe("buildUrl", () => {
             getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
         });
 
-        expect(result).toBeDefined();
-        if (result != null) {
-            const text = getTextOfTsNode(result);
-            expect(text).toMatchSnapshot();
-        }
+        assert(result != null, "expected buildUrl to return an expression for multiple parameter path");
+        const text = getTextOfTsNode(result);
+        expect(text).toMatchSnapshot();
     });
 
     it("generates template literal with trailing path after parameter", () => {
@@ -216,11 +210,9 @@ describe("buildUrl", () => {
             getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
         });
 
-        expect(result).toBeDefined();
-        if (result != null) {
-            const text = getTextOfTsNode(result);
-            expect(text).toMatchSnapshot();
-        }
+        assert(result != null, "expected buildUrl to return an expression for trailing path");
+        const text = getTextOfTsNode(result);
+        expect(text).toMatchSnapshot();
     });
 
     it("uses root path parameter reference for ROOT location", () => {
@@ -248,11 +240,9 @@ describe("buildUrl", () => {
             getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
         });
 
-        expect(result).toBeDefined();
-        if (result != null) {
-            const text = getTextOfTsNode(result);
-            expect(text).toMatchSnapshot();
-        }
+        assert(result != null, "expected buildUrl to return an expression for ROOT location parameter");
+        const text = getTextOfTsNode(result);
+        expect(text).toMatchSnapshot();
     });
 
     it("retains original casing when retainOriginalCasing is true", () => {
@@ -280,11 +270,9 @@ describe("buildUrl", () => {
             getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
         });
 
-        expect(result).toBeDefined();
-        if (result != null) {
-            const text = getTextOfTsNode(result);
-            expect(text).toMatchSnapshot();
-        }
+        assert(result != null, "expected buildUrl to return an expression with original casing");
+        const text = getTextOfTsNode(result);
+        expect(text).toMatchSnapshot();
     });
 
     it("throws when path parameter is not found in allPathParameters", () => {

--- a/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
@@ -8,17 +8,20 @@ import { buildUrl } from "../endpoints/utils/buildUrl.js";
 function createName(name: string): FernIr.Name {
     return {
         originalName: name,
-        camelCase: { unsafeName: name.charAt(0).toLowerCase() + name.slice(1), safeName: name.charAt(0).toLowerCase() + name.slice(1) },
-        pascalCase: { unsafeName: name.charAt(0).toUpperCase() + name.slice(1), safeName: name.charAt(0).toUpperCase() + name.slice(1) },
+        camelCase: {
+            unsafeName: name.charAt(0).toLowerCase() + name.slice(1),
+            safeName: name.charAt(0).toLowerCase() + name.slice(1)
+        },
+        pascalCase: {
+            unsafeName: name.charAt(0).toUpperCase() + name.slice(1),
+            safeName: name.charAt(0).toUpperCase() + name.slice(1)
+        },
         snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
         screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
     };
 }
 
-function createPathParameter(
-    name: string,
-    location: FernIr.PathParameterLocation = "ENDPOINT"
-): FernIr.PathParameter {
+function createPathParameter(name: string, location: FernIr.PathParameterLocation = "ENDPOINT"): FernIr.PathParameter {
     return {
         name: createName(name),
         valueType: FernIr.TypeReference.primitive({
@@ -51,6 +54,7 @@ function createMockContext() {
                 jsonOrThrow: (expr: ts.Expression) => expr
             })
         }
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
     } as any;
 }
 
@@ -62,6 +66,7 @@ function createMockGeneratedClientClass() {
                 ts.factory.createThis(),
                 ts.factory.createIdentifier(pathParam.name.camelCase.unsafeName)
             )
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
     } as any;
 }
 
@@ -110,7 +115,9 @@ describe("buildUrl", () => {
         });
 
         expect(result).toBeDefined();
-        expect(getTextOfTsNode(result!)).toBe('"/api/v1/users"');
+        if (result != null) {
+            expect(getTextOfTsNode(result)).toBe('"/api/v1/users"');
+        }
     });
 
     it("generates template literal for path with one parameter", () => {
@@ -139,8 +146,10 @@ describe("buildUrl", () => {
         });
 
         expect(result).toBeDefined();
-        const text = getTextOfTsNode(result!);
-        expect(text).toMatchSnapshot();
+        if (result != null) {
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
+        }
     });
 
     it("generates template literal for path with multiple parameters", () => {
@@ -176,8 +185,10 @@ describe("buildUrl", () => {
         });
 
         expect(result).toBeDefined();
-        const text = getTextOfTsNode(result!);
-        expect(text).toMatchSnapshot();
+        if (result != null) {
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
+        }
     });
 
     it("generates template literal with trailing path after parameter", () => {
@@ -206,8 +217,10 @@ describe("buildUrl", () => {
         });
 
         expect(result).toBeDefined();
-        const text = getTextOfTsNode(result!);
-        expect(text).toMatchSnapshot();
+        if (result != null) {
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
+        }
     });
 
     it("uses root path parameter reference for ROOT location", () => {
@@ -236,8 +249,10 @@ describe("buildUrl", () => {
         });
 
         expect(result).toBeDefined();
-        const text = getTextOfTsNode(result!);
-        expect(text).toMatchSnapshot();
+        if (result != null) {
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
+        }
     });
 
     it("retains original casing when retainOriginalCasing is true", () => {
@@ -266,8 +281,10 @@ describe("buildUrl", () => {
         });
 
         expect(result).toBeDefined();
-        const text = getTextOfTsNode(result!);
-        expect(text).toMatchSnapshot();
+        if (result != null) {
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
+        }
     });
 
     it("throws when path parameter is not found in allPathParameters", () => {

--- a/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
@@ -3,6 +3,7 @@ import { getTextOfTsNode } from "@fern-typescript/commons";
 import {
     createMockCoreUtilities,
     createMockGeneratedClientClass,
+    createMockTypeSchemaContext,
     createPathParameter
 } from "@fern-typescript/test-utils";
 import { ts } from "ts-morph";
@@ -17,11 +18,7 @@ function createMockContext() {
         requestWrapper: {
             shouldInlinePathParameters: () => false
         },
-        typeSchema: {
-            getSchemaOfNamedType: () => ({
-                jsonOrThrow: (expr: ts.Expression) => expr
-            })
-        }
+        typeSchema: createMockTypeSchemaContext()
         // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
     } as any;
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/generateHeaders.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/generateHeaders.test.ts
@@ -1,0 +1,308 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode } from "@fern-typescript/commons";
+import { ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+
+import { generateHeaders } from "../endpoints/utils/generateHeaders.js";
+
+function createName(name: string): FernIr.Name {
+    return {
+        originalName: name,
+        camelCase: { unsafeName: name.charAt(0).toLowerCase() + name.slice(1), safeName: name.charAt(0).toLowerCase() + name.slice(1) },
+        pascalCase: { unsafeName: name.charAt(0).toUpperCase() + name.slice(1), safeName: name.charAt(0).toUpperCase() + name.slice(1) },
+        snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
+        screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
+    };
+}
+
+function createNameAndWireValue(name: string, wireValue?: string): FernIr.NameAndWireValue {
+    return {
+        wireValue: wireValue ?? name,
+        name: createName(name)
+    };
+}
+
+function createHttpHeader(
+    name: string,
+    valueType: FernIr.TypeReference,
+    opts?: { wireValue?: string; env?: string }
+): FernIr.HttpHeader {
+    return {
+        name: createNameAndWireValue(name, opts?.wireValue),
+        valueType,
+        env: opts?.env ?? undefined,
+        v2Examples: undefined,
+        docs: undefined,
+        availability: undefined
+    };
+}
+
+function createMockContext() {
+    return {
+        type: {
+            resolveTypeReference: (typeRef: FernIr.TypeReference) => typeRef,
+            stringify: (expr: ts.Expression) => {
+                return ts.factory.createCallExpression(
+                    ts.factory.createPropertyAccessExpression(expr, ts.factory.createIdentifier("toString")),
+                    undefined,
+                    []
+                );
+            },
+            getTypeDeclaration: () => ({
+                shape: FernIr.Type.object({
+                    properties: [],
+                    extends: [],
+                    extraProperties: false,
+                    extendedProperties: undefined
+                })
+            }),
+            getReferenceToType: () => ({ isOptional: false })
+        },
+        importsManager: {
+            addImportFromRoot: () => {
+                // no-op for test
+            }
+        },
+        coreUtilities: {
+            fetcher: {
+                Fetcher: {
+                    Args: {
+                        _getReferenceToType: () => ts.factory.createTypeReferenceNode("Fetcher.Args")
+                    }
+                }
+            },
+            auth: {
+                AuthRequest: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("AuthRequest")
+                },
+                AuthProvider: {
+                    getAuthRequest: {
+                        invoke: (ref: ts.Expression, metadata?: ts.Expression) => {
+                            const args = metadata != null ? [ref, metadata] : [ref];
+                            return ts.factory.createCallExpression(
+                                ts.factory.createIdentifier("getAuthRequest"),
+                                undefined,
+                                args
+                            );
+                        }
+                    }
+                }
+            }
+        },
+        authProvider: {
+            isAuthEndpoint: () => false
+        },
+        versionContext: {
+            getGeneratedVersion: () => undefined
+        }
+    } as any;
+}
+
+function createMockGeneratedSdkClientClass(opts?: { hasAuthProvider?: boolean; generateEndpointMetadata?: boolean }) {
+    return {
+        hasAuthProvider: () => opts?.hasAuthProvider ?? false,
+        getGenerateEndpointMetadata: () => opts?.generateEndpointMetadata ?? false,
+        getReferenceToAuthProviderOrThrow: () => ts.factory.createIdentifier("this._authProvider"),
+        getReferenceToMetadataForEndpointSupplier: () => ts.factory.createIdentifier("_metadata")
+    } as any;
+}
+
+function createMockRequestParameter() {
+    return {
+        getReferenceToNonLiteralHeader: (header: FernIr.HttpHeader) => {
+            return ts.factory.createPropertyAccessExpression(
+                ts.factory.createIdentifier("request"),
+                ts.factory.createIdentifier(header.name.name.camelCase.unsafeName)
+            );
+        }
+    } as any;
+}
+
+function statementsToString(statements: ts.Statement[]): string {
+    return statements.map((stmt) => getTextOfTsNode(stmt)).join("\n");
+}
+
+describe("generateHeaders", () => {
+    it("generates headers with no service/endpoint headers and no auth", () => {
+        const result = generateHeaders({
+            context: createMockContext(),
+            intermediateRepresentation: { headers: [] } as any,
+            generatedSdkClientClass: createMockGeneratedSdkClientClass(),
+            requestParameter: createMockRequestParameter(),
+            service: { headers: [] } as any,
+            endpoint: { headers: [], auth: false, idempotent: false } as any,
+            idempotencyHeaders: []
+        });
+
+        expect(result.length).toBeGreaterThan(0);
+        const text = statementsToString(result);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("generates headers with service and endpoint headers", () => {
+        const serviceHeaders = [
+            createHttpHeader(
+                "X-API-Version",
+                FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                { wireValue: "X-API-Version" }
+            )
+        ];
+
+        const endpointHeaders = [
+            createHttpHeader(
+                "X-Request-Id",
+                FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                { wireValue: "X-Request-Id" }
+            )
+        ];
+
+        const result = generateHeaders({
+            context: createMockContext(),
+            intermediateRepresentation: { headers: [] } as any,
+            generatedSdkClientClass: createMockGeneratedSdkClientClass(),
+            requestParameter: createMockRequestParameter(),
+            service: { headers: serviceHeaders } as any,
+            endpoint: { headers: endpointHeaders, auth: false, idempotent: false } as any,
+            idempotencyHeaders: []
+        });
+
+        const text = statementsToString(result);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("generates headers with idempotency headers when endpoint is idempotent", () => {
+        const idempotencyHeaders = [
+            createHttpHeader(
+                "Idempotency-Key",
+                FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                { wireValue: "Idempotency-Key" }
+            )
+        ];
+
+        const result = generateHeaders({
+            context: createMockContext(),
+            intermediateRepresentation: { headers: [] } as any,
+            generatedSdkClientClass: createMockGeneratedSdkClientClass(),
+            requestParameter: createMockRequestParameter(),
+            service: { headers: [] } as any,
+            endpoint: { headers: [], auth: false, idempotent: true } as any,
+            idempotencyHeaders
+        });
+
+        const text = statementsToString(result);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("generates headers without idempotency headers when endpoint is not idempotent", () => {
+        const idempotencyHeaders = [
+            createHttpHeader(
+                "Idempotency-Key",
+                FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                { wireValue: "Idempotency-Key" }
+            )
+        ];
+
+        const result = generateHeaders({
+            context: createMockContext(),
+            intermediateRepresentation: { headers: [] } as any,
+            generatedSdkClientClass: createMockGeneratedSdkClientClass(),
+            requestParameter: createMockRequestParameter(),
+            service: { headers: [] } as any,
+            endpoint: { headers: [], auth: false, idempotent: false } as any,
+            idempotencyHeaders
+        });
+
+        const text = statementsToString(result);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("generates auth headers when auth provider exists and endpoint requires auth", () => {
+        const result = generateHeaders({
+            context: createMockContext(),
+            intermediateRepresentation: { headers: [] } as any,
+            generatedSdkClientClass: createMockGeneratedSdkClientClass({ hasAuthProvider: true }),
+            requestParameter: createMockRequestParameter(),
+            service: { headers: [] } as any,
+            endpoint: { headers: [], auth: true, idempotent: false } as any,
+            idempotencyHeaders: []
+        });
+
+        const text = statementsToString(result);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("generates headers with literal header value", () => {
+        const literalHeader = createHttpHeader(
+            "X-Fern-Language",
+            FernIr.TypeReference.container(
+                FernIr.ContainerType.literal(FernIr.Literal.string("JavaScript"))
+            ),
+            { wireValue: "X-Fern-Language" }
+        );
+
+        const mockContext = createMockContext();
+        // Override resolveTypeReference to return the literal container
+        mockContext.type.resolveTypeReference = (typeRef: FernIr.TypeReference) => typeRef;
+
+        const result = generateHeaders({
+            context: mockContext,
+            intermediateRepresentation: { headers: [] } as any,
+            generatedSdkClientClass: createMockGeneratedSdkClientClass(),
+            requestParameter: createMockRequestParameter(),
+            service: { headers: [literalHeader] } as any,
+            endpoint: { headers: [], auth: false, idempotent: false } as any,
+            idempotencyHeaders: []
+        });
+
+        const text = statementsToString(result);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("generates headers with root-level overridable headers", () => {
+        const rootHeaders = [
+            createHttpHeader(
+                "X-Custom-Header",
+                FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                { wireValue: "X-Custom-Header" }
+            )
+        ];
+
+        const mockContext = createMockContext();
+
+        const result = generateHeaders({
+            context: mockContext,
+            intermediateRepresentation: { headers: rootHeaders } as any,
+            generatedSdkClientClass: createMockGeneratedSdkClientClass(),
+            requestParameter: createMockRequestParameter(),
+            service: { headers: [] } as any,
+            endpoint: { headers: [], auth: false, idempotent: false } as any,
+            idempotencyHeaders: []
+        });
+
+        const text = statementsToString(result);
+        expect(text).toMatchSnapshot();
+    });
+
+    it("generates headers with additional headers parameter", () => {
+        const additionalHeaders = [
+            {
+                header: "X-Extra",
+                value: ts.factory.createStringLiteral("extra-value")
+            }
+        ];
+
+        const result = generateHeaders({
+            context: createMockContext(),
+            intermediateRepresentation: { headers: [] } as any,
+            generatedSdkClientClass: createMockGeneratedSdkClientClass(),
+            requestParameter: createMockRequestParameter(),
+            service: { headers: [] } as any,
+            endpoint: { headers: [], auth: false, idempotent: false } as any,
+            idempotencyHeaders: [],
+            additionalHeaders
+        });
+
+        const text = statementsToString(result);
+        expect(text).toMatchSnapshot();
+    });
+});

--- a/generators/typescript/sdk/client-class-generator/src/__test__/generateHeaders.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/generateHeaders.test.ts
@@ -8,8 +8,14 @@ import { generateHeaders } from "../endpoints/utils/generateHeaders.js";
 function createName(name: string): FernIr.Name {
     return {
         originalName: name,
-        camelCase: { unsafeName: name.charAt(0).toLowerCase() + name.slice(1), safeName: name.charAt(0).toLowerCase() + name.slice(1) },
-        pascalCase: { unsafeName: name.charAt(0).toUpperCase() + name.slice(1), safeName: name.charAt(0).toUpperCase() + name.slice(1) },
+        camelCase: {
+            unsafeName: name.charAt(0).toLowerCase() + name.slice(1),
+            safeName: name.charAt(0).toLowerCase() + name.slice(1)
+        },
+        pascalCase: {
+            unsafeName: name.charAt(0).toUpperCase() + name.slice(1),
+            safeName: name.charAt(0).toUpperCase() + name.slice(1)
+        },
         snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
         screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
     };
@@ -95,6 +101,7 @@ function createMockContext() {
         versionContext: {
             getGeneratedVersion: () => undefined
         }
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
     } as any;
 }
 
@@ -104,6 +111,7 @@ function createMockGeneratedSdkClientClass(opts?: { hasAuthProvider?: boolean; g
         getGenerateEndpointMetadata: () => opts?.generateEndpointMetadata ?? false,
         getReferenceToAuthProviderOrThrow: () => ts.factory.createIdentifier("this._authProvider"),
         getReferenceToMetadataForEndpointSupplier: () => ts.factory.createIdentifier("_metadata")
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
     } as any;
 }
 
@@ -115,6 +123,7 @@ function createMockRequestParameter() {
                 ts.factory.createIdentifier(header.name.name.camelCase.unsafeName)
             );
         }
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
     } as any;
 }
 
@@ -126,10 +135,13 @@ describe("generateHeaders", () => {
     it("generates headers with no service/endpoint headers and no auth", () => {
         const result = generateHeaders({
             context: createMockContext(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             intermediateRepresentation: { headers: [] } as any,
             generatedSdkClientClass: createMockGeneratedSdkClientClass(),
             requestParameter: createMockRequestParameter(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             service: { headers: [] } as any,
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             endpoint: { headers: [], auth: false, idempotent: false } as any,
             idempotencyHeaders: []
         });
@@ -141,27 +153,26 @@ describe("generateHeaders", () => {
 
     it("generates headers with service and endpoint headers", () => {
         const serviceHeaders = [
-            createHttpHeader(
-                "X-API-Version",
-                FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
-                { wireValue: "X-API-Version" }
-            )
+            createHttpHeader("X-API-Version", FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }), {
+                wireValue: "X-API-Version"
+            })
         ];
 
         const endpointHeaders = [
-            createHttpHeader(
-                "X-Request-Id",
-                FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
-                { wireValue: "X-Request-Id" }
-            )
+            createHttpHeader("X-Request-Id", FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }), {
+                wireValue: "X-Request-Id"
+            })
         ];
 
         const result = generateHeaders({
             context: createMockContext(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             intermediateRepresentation: { headers: [] } as any,
             generatedSdkClientClass: createMockGeneratedSdkClientClass(),
             requestParameter: createMockRequestParameter(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             service: { headers: serviceHeaders } as any,
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             endpoint: { headers: endpointHeaders, auth: false, idempotent: false } as any,
             idempotencyHeaders: []
         });
@@ -172,19 +183,20 @@ describe("generateHeaders", () => {
 
     it("generates headers with idempotency headers when endpoint is idempotent", () => {
         const idempotencyHeaders = [
-            createHttpHeader(
-                "Idempotency-Key",
-                FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
-                { wireValue: "Idempotency-Key" }
-            )
+            createHttpHeader("Idempotency-Key", FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }), {
+                wireValue: "Idempotency-Key"
+            })
         ];
 
         const result = generateHeaders({
             context: createMockContext(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             intermediateRepresentation: { headers: [] } as any,
             generatedSdkClientClass: createMockGeneratedSdkClientClass(),
             requestParameter: createMockRequestParameter(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             service: { headers: [] } as any,
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             endpoint: { headers: [], auth: false, idempotent: true } as any,
             idempotencyHeaders
         });
@@ -195,19 +207,20 @@ describe("generateHeaders", () => {
 
     it("generates headers without idempotency headers when endpoint is not idempotent", () => {
         const idempotencyHeaders = [
-            createHttpHeader(
-                "Idempotency-Key",
-                FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
-                { wireValue: "Idempotency-Key" }
-            )
+            createHttpHeader("Idempotency-Key", FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }), {
+                wireValue: "Idempotency-Key"
+            })
         ];
 
         const result = generateHeaders({
             context: createMockContext(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             intermediateRepresentation: { headers: [] } as any,
             generatedSdkClientClass: createMockGeneratedSdkClientClass(),
             requestParameter: createMockRequestParameter(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             service: { headers: [] } as any,
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             endpoint: { headers: [], auth: false, idempotent: false } as any,
             idempotencyHeaders
         });
@@ -219,10 +232,13 @@ describe("generateHeaders", () => {
     it("generates auth headers when auth provider exists and endpoint requires auth", () => {
         const result = generateHeaders({
             context: createMockContext(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             intermediateRepresentation: { headers: [] } as any,
             generatedSdkClientClass: createMockGeneratedSdkClientClass({ hasAuthProvider: true }),
             requestParameter: createMockRequestParameter(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             service: { headers: [] } as any,
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             endpoint: { headers: [], auth: true, idempotent: false } as any,
             idempotencyHeaders: []
         });
@@ -234,9 +250,7 @@ describe("generateHeaders", () => {
     it("generates headers with literal header value", () => {
         const literalHeader = createHttpHeader(
             "X-Fern-Language",
-            FernIr.TypeReference.container(
-                FernIr.ContainerType.literal(FernIr.Literal.string("JavaScript"))
-            ),
+            FernIr.TypeReference.container(FernIr.ContainerType.literal(FernIr.Literal.string("JavaScript"))),
             { wireValue: "X-Fern-Language" }
         );
 
@@ -246,10 +260,13 @@ describe("generateHeaders", () => {
 
         const result = generateHeaders({
             context: mockContext,
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             intermediateRepresentation: { headers: [] } as any,
             generatedSdkClientClass: createMockGeneratedSdkClientClass(),
             requestParameter: createMockRequestParameter(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             service: { headers: [literalHeader] } as any,
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             endpoint: { headers: [], auth: false, idempotent: false } as any,
             idempotencyHeaders: []
         });
@@ -260,21 +277,22 @@ describe("generateHeaders", () => {
 
     it("generates headers with root-level overridable headers", () => {
         const rootHeaders = [
-            createHttpHeader(
-                "X-Custom-Header",
-                FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
-                { wireValue: "X-Custom-Header" }
-            )
+            createHttpHeader("X-Custom-Header", FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }), {
+                wireValue: "X-Custom-Header"
+            })
         ];
 
         const mockContext = createMockContext();
 
         const result = generateHeaders({
             context: mockContext,
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             intermediateRepresentation: { headers: rootHeaders } as any,
             generatedSdkClientClass: createMockGeneratedSdkClientClass(),
             requestParameter: createMockRequestParameter(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             service: { headers: [] } as any,
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             endpoint: { headers: [], auth: false, idempotent: false } as any,
             idempotencyHeaders: []
         });
@@ -293,10 +311,13 @@ describe("generateHeaders", () => {
 
         const result = generateHeaders({
             context: createMockContext(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             intermediateRepresentation: { headers: [] } as any,
             generatedSdkClientClass: createMockGeneratedSdkClientClass(),
             requestParameter: createMockRequestParameter(),
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             service: { headers: [] } as any,
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
             endpoint: { headers: [], auth: false, idempotent: false } as any,
             idempotencyHeaders: [],
             additionalHeaders

--- a/generators/typescript/sdk/client-class-generator/src/__test__/generateHeaders.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/generateHeaders.test.ts
@@ -1,118 +1,32 @@
-import { constructCasingsGenerator } from "@fern-api/casings-generator";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
+import {
+    createHttpHeader,
+    createMockCoreUtilities,
+    createMockGeneratedSdkClientClass,
+    createMockRequestParameter,
+    createMockTypeContext
+} from "@fern-typescript/test-utils";
 import { ts } from "ts-morph";
 import { describe, expect, it } from "vitest";
 
 import { generateHeaders } from "../endpoints/utils/generateHeaders.js";
 
-const casingsGenerator = constructCasingsGenerator({
-    generationLanguage: undefined,
-    keywords: undefined,
-    smartCasing: false
-});
-
-function createNameAndWireValue(name: string, wireValue?: string): FernIr.NameAndWireValue {
-    return {
-        wireValue: wireValue ?? name,
-        name: casingsGenerator.generateName(name)
-    };
-}
-
-function createHttpHeader(
-    name: string,
-    valueType: FernIr.TypeReference,
-    opts?: { wireValue?: string; env?: string }
-): FernIr.HttpHeader {
-    return {
-        name: createNameAndWireValue(name, opts?.wireValue),
-        valueType,
-        env: opts?.env ?? undefined,
-        v2Examples: undefined,
-        docs: undefined,
-        availability: undefined
-    };
-}
-
 function createMockContext() {
+    const coreUtilities = createMockCoreUtilities();
     return {
-        type: {
-            resolveTypeReference: (typeRef: FernIr.TypeReference) => typeRef,
-            stringify: (expr: ts.Expression) => {
-                return ts.factory.createCallExpression(
-                    ts.factory.createPropertyAccessExpression(expr, ts.factory.createIdentifier("toString")),
-                    undefined,
-                    []
-                );
-            },
-            getTypeDeclaration: () => ({
-                shape: FernIr.Type.object({
-                    properties: [],
-                    extends: [],
-                    extraProperties: false,
-                    extendedProperties: undefined
-                })
-            }),
-            getReferenceToType: () => ({ isOptional: false })
-        },
+        type: createMockTypeContext(),
         importsManager: {
             addImportFromRoot: () => {
                 // no-op for test
             }
         },
-        coreUtilities: {
-            fetcher: {
-                Fetcher: {
-                    Args: {
-                        _getReferenceToType: () => ts.factory.createTypeReferenceNode("Fetcher.Args")
-                    }
-                }
-            },
-            auth: {
-                AuthRequest: {
-                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("AuthRequest")
-                },
-                AuthProvider: {
-                    getAuthRequest: {
-                        invoke: (ref: ts.Expression, metadata?: ts.Expression) => {
-                            const args = metadata != null ? [ref, metadata] : [ref];
-                            return ts.factory.createCallExpression(
-                                ts.factory.createIdentifier("getAuthRequest"),
-                                undefined,
-                                args
-                            );
-                        }
-                    }
-                }
-            }
-        },
+        coreUtilities,
         authProvider: {
             isAuthEndpoint: () => false
         },
         versionContext: {
             getGeneratedVersion: () => undefined
-        }
-        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
-    } as any;
-}
-
-function createMockGeneratedSdkClientClass(opts?: { hasAuthProvider?: boolean; generateEndpointMetadata?: boolean }) {
-    return {
-        hasAuthProvider: () => opts?.hasAuthProvider ?? false,
-        getGenerateEndpointMetadata: () => opts?.generateEndpointMetadata ?? false,
-        getReferenceToAuthProviderOrThrow: () => ts.factory.createIdentifier("this._authProvider"),
-        getReferenceToMetadataForEndpointSupplier: () => ts.factory.createIdentifier("_metadata")
-        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
-    } as any;
-}
-
-function createMockRequestParameter() {
-    return {
-        getReferenceToNonLiteralHeader: (header: FernIr.HttpHeader) => {
-            return ts.factory.createPropertyAccessExpression(
-                ts.factory.createIdentifier("request"),
-                ts.factory.createIdentifier(header.name.name.camelCase.unsafeName)
-            );
         }
         // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
     } as any;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/generateHeaders.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/generateHeaders.test.ts
@@ -1,3 +1,4 @@
+import { constructCasingsGenerator } from "@fern-api/casings-generator";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
 import { ts } from "ts-morph";
@@ -5,26 +6,16 @@ import { describe, expect, it } from "vitest";
 
 import { generateHeaders } from "../endpoints/utils/generateHeaders.js";
 
-function createName(name: string): FernIr.Name {
-    return {
-        originalName: name,
-        camelCase: {
-            unsafeName: name.charAt(0).toLowerCase() + name.slice(1),
-            safeName: name.charAt(0).toLowerCase() + name.slice(1)
-        },
-        pascalCase: {
-            unsafeName: name.charAt(0).toUpperCase() + name.slice(1),
-            safeName: name.charAt(0).toUpperCase() + name.slice(1)
-        },
-        snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
-        screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
-    };
-}
+const casingsGenerator = constructCasingsGenerator({
+    generationLanguage: undefined,
+    keywords: undefined,
+    smartCasing: false
+});
 
 function createNameAndWireValue(name: string, wireValue?: string): FernIr.NameAndWireValue {
     return {
         wireValue: wireValue ?? name,
-        name: createName(name)
+        name: casingsGenerator.generateName(name)
     };
 }
 

--- a/generators/typescript/sdk/client-class-generator/src/__test__/requestOptionsParameter.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/requestOptionsParameter.test.ts
@@ -1,0 +1,157 @@
+import { getTextOfTsNode } from "@fern-typescript/commons";
+import { ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+
+import {
+    getAbortSignalExpression,
+    getMaxRetriesExpression,
+    getRequestOptionsParameter,
+    getTimeoutExpression,
+    REQUEST_OPTIONS_PARAMETER_NAME
+} from "../endpoints/utils/requestOptionsParameter.js";
+
+describe("requestOptionsParameter", () => {
+    describe("getRequestOptionsParameter", () => {
+        it("generates parameter with question token", () => {
+            const requestOptionsReference = ts.factory.createTypeReferenceNode("RequestOptions");
+            const result = getRequestOptionsParameter({ requestOptionsReference });
+
+            expect(result.name).toBe(REQUEST_OPTIONS_PARAMETER_NAME);
+            expect(result.hasQuestionToken).toBe(true);
+            expect(result.type).toBe("RequestOptions");
+        });
+
+        it("generates parameter with qualified type reference", () => {
+            const requestOptionsReference = ts.factory.createTypeReferenceNode(
+                ts.factory.createQualifiedName(
+                    ts.factory.createIdentifier("MyClient"),
+                    ts.factory.createIdentifier("RequestOptions")
+                )
+            );
+            const result = getRequestOptionsParameter({ requestOptionsReference });
+
+            expect(result.name).toBe(REQUEST_OPTIONS_PARAMETER_NAME);
+            expect(result.type).toBe("MyClient.RequestOptions");
+        });
+    });
+
+    describe("getTimeoutExpression", () => {
+        const referenceToOptions = ts.factory.createPropertyAccessExpression(
+            ts.factory.createThis(),
+            ts.factory.createIdentifier("_options")
+        );
+
+        const timeoutInSecondsReference = ({
+            referenceToRequestOptions,
+            isNullable
+        }: {
+            referenceToRequestOptions: ts.Expression;
+            isNullable: boolean;
+        }) => {
+            if (isNullable) {
+                return ts.factory.createPropertyAccessChain(
+                    referenceToRequestOptions,
+                    ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                    ts.factory.createIdentifier("timeoutInSeconds")
+                );
+            }
+            return ts.factory.createPropertyAccessExpression(
+                referenceToRequestOptions,
+                ts.factory.createIdentifier("timeoutInSeconds")
+            );
+        };
+
+        it("generates timeout with default 60 seconds", () => {
+            const result = getTimeoutExpression({
+                defaultTimeoutInSeconds: undefined,
+                timeoutInSecondsReference,
+                referenceToOptions
+            });
+
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
+        });
+
+        it("generates timeout with custom default seconds", () => {
+            const result = getTimeoutExpression({
+                defaultTimeoutInSeconds: 30,
+                timeoutInSecondsReference,
+                referenceToOptions
+            });
+
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
+        });
+
+        it("generates timeout with infinity default", () => {
+            const result = getTimeoutExpression({
+                defaultTimeoutInSeconds: "infinity",
+                timeoutInSecondsReference,
+                referenceToOptions
+            });
+
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
+        });
+    });
+
+    describe("getMaxRetriesExpression", () => {
+        it("generates max retries with nullish coalescing", () => {
+            const referenceToOptions = ts.factory.createPropertyAccessExpression(
+                ts.factory.createThis(),
+                ts.factory.createIdentifier("_options")
+            );
+
+            const maxRetriesReference = ({
+                referenceToRequestOptions,
+                isNullable
+            }: {
+                referenceToRequestOptions: ts.Expression;
+                isNullable: boolean;
+            }) => {
+                if (isNullable) {
+                    return ts.factory.createPropertyAccessChain(
+                        referenceToRequestOptions,
+                        ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                        ts.factory.createIdentifier("maxRetries")
+                    );
+                }
+                return ts.factory.createPropertyAccessExpression(
+                    referenceToRequestOptions,
+                    ts.factory.createIdentifier("maxRetries")
+                );
+            };
+
+            const result = getMaxRetriesExpression({
+                maxRetriesReference,
+                referenceToOptions
+            });
+
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
+        });
+    });
+
+    describe("getAbortSignalExpression", () => {
+        it("generates abort signal reference", () => {
+            const abortSignalReference = ({
+                referenceToRequestOptions
+            }: {
+                referenceToRequestOptions: ts.Expression;
+            }) => {
+                return ts.factory.createPropertyAccessChain(
+                    referenceToRequestOptions,
+                    ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                    ts.factory.createIdentifier("abortSignal")
+                );
+            };
+
+            const result = getAbortSignalExpression({
+                abortSignalReference
+            });
+
+            const text = getTextOfTsNode(result);
+            expect(text).toMatchSnapshot();
+        });
+    });
+});

--- a/generators/typescript/sdk/client-class-generator/vitest.config.ts
+++ b/generators/typescript/sdk/client-class-generator/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -37,6 +39,7 @@
     "ts-morph": "catalog:"
   },
   "devDependencies": {
+    "@fern-api/casings-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:",

--- a/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
+++ b/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
@@ -9,10 +9,26 @@ import { GeneratedSingleUrlEnvironmentsImpl } from "../GeneratedSingleUrlEnviron
 function createName(name: string) {
     return {
         originalName: name,
-        camelCase: { unsafeName: name.charAt(0).toLowerCase() + name.slice(1), safeName: name.charAt(0).toLowerCase() + name.slice(1) },
-        pascalCase: { unsafeName: name.charAt(0).toUpperCase() + name.slice(1), safeName: name.charAt(0).toUpperCase() + name.slice(1) },
+        camelCase: {
+            unsafeName: name.charAt(0).toLowerCase() + name.slice(1),
+            safeName: name.charAt(0).toLowerCase() + name.slice(1)
+        },
+        pascalCase: {
+            unsafeName: name.charAt(0).toUpperCase() + name.slice(1),
+            safeName: name.charAt(0).toUpperCase() + name.slice(1)
+        },
         snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
         screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
+    };
+}
+
+function createMockEnvironmentsContext() {
+    return {
+        environments: {
+            getReferenceToEnvironmentsEnum: () => ({
+                getExpression: () => ts.factory.createIdentifier("MyEnvironment")
+            })
+        }
     };
 }
 
@@ -38,8 +54,7 @@ describe("EmptyGeneratedEnvironmentsImpl", () => {
         const impl = new EmptyGeneratedEnvironmentsImpl();
         const inputExpr = ts.factory.createIdentifier("myEnvironment");
         const result = impl.getReferenceToEnvironmentUrl({
-            referenceToEnvironmentValue: inputExpr,
-            baseUrlId: undefined
+            referenceToEnvironmentValue: inputExpr
         });
         expect(getTextOfTsNode(result)).toBe("myEnvironment");
     });
@@ -52,13 +67,21 @@ describe("GeneratedSingleUrlEnvironmentsImpl", () => {
                 id: "env-prod",
                 name: createName("Production"),
                 url: "https://api.example.com",
-                docs: undefined
+                docs: undefined,
+                audiences: undefined,
+                defaultUrl: undefined,
+                urlTemplate: undefined,
+                urlVariables: undefined
             },
             {
                 id: "env-staging",
                 name: createName("Staging"),
                 url: "https://staging.example.com",
-                docs: "Staging environment"
+                docs: "Staging environment",
+                audiences: undefined,
+                defaultUrl: undefined,
+                urlTemplate: undefined,
+                urlVariables: undefined
             }
         ]
     };
@@ -87,13 +110,8 @@ describe("GeneratedSingleUrlEnvironmentsImpl", () => {
             defaultEnvironmentId: undefined,
             environments: singleUrlEnvironments
         });
-        const mockContext = {
-            environments: {
-                getReferenceToEnvironmentsEnum: () => ({
-                    getExpression: () => ts.factory.createIdentifier("MyEnvironment")
-                })
-            }
-        } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+        const mockContext = createMockEnvironmentsContext() as any;
         expect(impl.getReferenceToDefaultEnvironment(mockContext)).toBeUndefined();
     });
 
@@ -103,16 +121,13 @@ describe("GeneratedSingleUrlEnvironmentsImpl", () => {
             defaultEnvironmentId: "env-prod",
             environments: singleUrlEnvironments
         });
-        const mockContext = {
-            environments: {
-                getReferenceToEnvironmentsEnum: () => ({
-                    getExpression: () => ts.factory.createIdentifier("MyEnvironment")
-                })
-            }
-        } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+        const mockContext = createMockEnvironmentsContext() as any;
         const result = impl.getReferenceToDefaultEnvironment(mockContext);
         expect(result).toBeDefined();
-        expect(getTextOfTsNode(result!)).toBe("MyEnvironment.Production");
+        if (result != null) {
+            expect(getTextOfTsNode(result)).toBe("MyEnvironment.Production");
+        }
     });
 
     it("getReferenceToEnvironmentUrl returns the input expression for single URL", () => {
@@ -154,9 +169,8 @@ describe("GeneratedSingleUrlEnvironmentsImpl", () => {
         const project = new Project({ useInMemoryFileSystem: true });
         const sourceFile = project.createSourceFile("environments.ts");
 
-        const mockContext = {
-            sourceFile
-        } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+        const mockContext = { sourceFile } as any;
 
         impl.writeToFile(mockContext);
 
@@ -185,7 +199,11 @@ describe("GeneratedMultipleUrlsEnvironmentsImpl", () => {
                     "base-url-api": "https://api.example.com",
                     "base-url-auth": "https://auth.example.com"
                 },
-                docs: undefined
+                docs: undefined,
+                audiences: undefined,
+                defaultUrls: undefined,
+                urlTemplates: undefined,
+                urlVariables: undefined
             },
             {
                 id: "env-staging",
@@ -194,7 +212,11 @@ describe("GeneratedMultipleUrlsEnvironmentsImpl", () => {
                     "base-url-api": "https://api-staging.example.com",
                     "base-url-auth": "https://auth-staging.example.com"
                 },
-                docs: "Staging environment"
+                docs: "Staging environment",
+                audiences: undefined,
+                defaultUrls: undefined,
+                urlTemplates: undefined,
+                urlVariables: undefined
             }
         ]
     };
@@ -226,16 +248,13 @@ describe("GeneratedMultipleUrlsEnvironmentsImpl", () => {
             defaultEnvironmentId: "env-prod",
             environments: multipleUrlsEnvironments
         });
-        const mockContext = {
-            environments: {
-                getReferenceToEnvironmentsEnum: () => ({
-                    getExpression: () => ts.factory.createIdentifier("MyEnvironment")
-                })
-            }
-        } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+        const mockContext = createMockEnvironmentsContext() as any;
         const result = impl.getReferenceToDefaultEnvironment(mockContext);
         expect(result).toBeDefined();
-        expect(getTextOfTsNode(result!)).toBe("MyEnvironment.Production");
+        if (result != null) {
+            expect(getTextOfTsNode(result)).toBe("MyEnvironment.Production");
+        }
     });
 
     it("getReferenceToEnvironmentUrl generates property access for baseUrl", () => {
@@ -296,9 +315,8 @@ describe("GeneratedMultipleUrlsEnvironmentsImpl", () => {
         const project = new Project({ useInMemoryFileSystem: true });
         const sourceFile = project.createSourceFile("environments.ts");
 
-        const mockContext = {
-            sourceFile
-        } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+        const mockContext = { sourceFile } as any;
 
         impl.writeToFile(mockContext);
 

--- a/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
+++ b/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
@@ -85,8 +85,7 @@ describe("GeneratedSingleUrlEnvironmentsImpl", () => {
             defaultEnvironmentId: undefined,
             environments: singleUrlEnvironments
         });
-        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
-        const mockContext = createMockEnvironmentsContext() as any;
+        const mockContext = createMockEnvironmentsContext();
         expect(impl.getReferenceToDefaultEnvironment(mockContext)).toBeUndefined();
     });
 
@@ -96,8 +95,7 @@ describe("GeneratedSingleUrlEnvironmentsImpl", () => {
             defaultEnvironmentId: "env-prod",
             environments: singleUrlEnvironments
         });
-        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
-        const mockContext = createMockEnvironmentsContext() as any;
+        const mockContext = createMockEnvironmentsContext();
         const result = impl.getReferenceToDefaultEnvironment(mockContext);
         assert(result != null, "expected getReferenceToDefaultEnvironment to return an expression");
         expect(getTextOfTsNode(result)).toBe("MyEnvironment.Production");
@@ -221,8 +219,7 @@ describe("GeneratedMultipleUrlsEnvironmentsImpl", () => {
             defaultEnvironmentId: "env-prod",
             environments: multipleUrlsEnvironments
         });
-        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
-        const mockContext = createMockEnvironmentsContext() as any;
+        const mockContext = createMockEnvironmentsContext();
         const result = impl.getReferenceToDefaultEnvironment(mockContext);
         assert(result != null, "expected getReferenceToDefaultEnvironment to return an expression for multiple URLs");
         expect(getTextOfTsNode(result)).toBe("MyEnvironment.Production");

--- a/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
+++ b/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
@@ -1,27 +1,11 @@
-import { constructCasingsGenerator } from "@fern-api/casings-generator";
 import { getTextOfTsNode } from "@fern-typescript/commons";
+import { casingsGenerator, createMockEnvironmentsContext } from "@fern-typescript/test-utils";
 import { Project, ts } from "ts-morph";
 import { assert, describe, expect, it } from "vitest";
 
 import { EmptyGeneratedEnvironmentsImpl } from "../EmptyGeneratedEnvironmentsImpl.js";
 import { GeneratedMultipleUrlsEnvironmentsImpl } from "../GeneratedMultipleUrlsEnvironmentsImpl.js";
 import { GeneratedSingleUrlEnvironmentsImpl } from "../GeneratedSingleUrlEnvironmentsImpl.js";
-
-const casingsGenerator = constructCasingsGenerator({
-    generationLanguage: undefined,
-    keywords: undefined,
-    smartCasing: false
-});
-
-function createMockEnvironmentsContext() {
-    return {
-        environments: {
-            getReferenceToEnvironmentsEnum: () => ({
-                getExpression: () => ts.factory.createIdentifier("MyEnvironment")
-            })
-        }
-    };
-}
 
 describe("EmptyGeneratedEnvironmentsImpl", () => {
     it("hasDefaultEnvironment returns false", () => {

--- a/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
+++ b/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
@@ -1,0 +1,308 @@
+import { getTextOfTsNode } from "@fern-typescript/commons";
+import { Project, ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+
+import { EmptyGeneratedEnvironmentsImpl } from "../EmptyGeneratedEnvironmentsImpl.js";
+import { GeneratedMultipleUrlsEnvironmentsImpl } from "../GeneratedMultipleUrlsEnvironmentsImpl.js";
+import { GeneratedSingleUrlEnvironmentsImpl } from "../GeneratedSingleUrlEnvironmentsImpl.js";
+
+function createName(name: string) {
+    return {
+        originalName: name,
+        camelCase: { unsafeName: name.charAt(0).toLowerCase() + name.slice(1), safeName: name.charAt(0).toLowerCase() + name.slice(1) },
+        pascalCase: { unsafeName: name.charAt(0).toUpperCase() + name.slice(1), safeName: name.charAt(0).toUpperCase() + name.slice(1) },
+        snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
+        screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
+    };
+}
+
+describe("EmptyGeneratedEnvironmentsImpl", () => {
+    it("hasDefaultEnvironment returns false", () => {
+        const impl = new EmptyGeneratedEnvironmentsImpl();
+        expect(impl.hasDefaultEnvironment()).toBe(false);
+    });
+
+    it("getReferenceToDefaultEnvironment returns undefined", () => {
+        const impl = new EmptyGeneratedEnvironmentsImpl();
+        expect(impl.getReferenceToDefaultEnvironment()).toBeUndefined();
+    });
+
+    it("getTypeForUserSuppliedEnvironment returns string type", () => {
+        const impl = new EmptyGeneratedEnvironmentsImpl();
+        const typeNode = impl.getTypeForUserSuppliedEnvironment();
+        const text = getTextOfTsNode(typeNode);
+        expect(text).toBe("string");
+    });
+
+    it("getReferenceToEnvironmentUrl returns the input expression", () => {
+        const impl = new EmptyGeneratedEnvironmentsImpl();
+        const inputExpr = ts.factory.createIdentifier("myEnvironment");
+        const result = impl.getReferenceToEnvironmentUrl({
+            referenceToEnvironmentValue: inputExpr,
+            baseUrlId: undefined
+        });
+        expect(getTextOfTsNode(result)).toBe("myEnvironment");
+    });
+});
+
+describe("GeneratedSingleUrlEnvironmentsImpl", () => {
+    const singleUrlEnvironments = {
+        environments: [
+            {
+                id: "env-prod",
+                name: createName("Production"),
+                url: "https://api.example.com",
+                docs: undefined
+            },
+            {
+                id: "env-staging",
+                name: createName("Staging"),
+                url: "https://staging.example.com",
+                docs: "Staging environment"
+            }
+        ]
+    };
+
+    it("hasDefaultEnvironment returns true when default is set", () => {
+        const impl = new GeneratedSingleUrlEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            defaultEnvironmentId: "env-prod",
+            environments: singleUrlEnvironments
+        });
+        expect(impl.hasDefaultEnvironment()).toBe(true);
+    });
+
+    it("hasDefaultEnvironment returns false when no default", () => {
+        const impl = new GeneratedSingleUrlEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            defaultEnvironmentId: undefined,
+            environments: singleUrlEnvironments
+        });
+        expect(impl.hasDefaultEnvironment()).toBe(false);
+    });
+
+    it("getReferenceToDefaultEnvironment returns undefined when no default", () => {
+        const impl = new GeneratedSingleUrlEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            defaultEnvironmentId: undefined,
+            environments: singleUrlEnvironments
+        });
+        const mockContext = {
+            environments: {
+                getReferenceToEnvironmentsEnum: () => ({
+                    getExpression: () => ts.factory.createIdentifier("MyEnvironment")
+                })
+            }
+        } as any;
+        expect(impl.getReferenceToDefaultEnvironment(mockContext)).toBeUndefined();
+    });
+
+    it("getReferenceToDefaultEnvironment generates correct property access", () => {
+        const impl = new GeneratedSingleUrlEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            defaultEnvironmentId: "env-prod",
+            environments: singleUrlEnvironments
+        });
+        const mockContext = {
+            environments: {
+                getReferenceToEnvironmentsEnum: () => ({
+                    getExpression: () => ts.factory.createIdentifier("MyEnvironment")
+                })
+            }
+        } as any;
+        const result = impl.getReferenceToDefaultEnvironment(mockContext);
+        expect(result).toBeDefined();
+        expect(getTextOfTsNode(result!)).toBe("MyEnvironment.Production");
+    });
+
+    it("getReferenceToEnvironmentUrl returns the input expression for single URL", () => {
+        const impl = new GeneratedSingleUrlEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            defaultEnvironmentId: undefined,
+            environments: singleUrlEnvironments
+        });
+        const inputExpr = ts.factory.createIdentifier("env");
+        const result = impl.getReferenceToEnvironmentUrl({
+            referenceToEnvironmentValue: inputExpr,
+            baseUrlId: undefined
+        });
+        expect(getTextOfTsNode(result)).toBe("env");
+    });
+
+    it("getReferenceToEnvironmentUrl throws when baseUrlId is provided", () => {
+        const impl = new GeneratedSingleUrlEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            defaultEnvironmentId: undefined,
+            environments: singleUrlEnvironments
+        });
+        const inputExpr = ts.factory.createIdentifier("env");
+        expect(() =>
+            impl.getReferenceToEnvironmentUrl({
+                referenceToEnvironmentValue: inputExpr,
+                baseUrlId: "some-base-url"
+            })
+        ).toThrow();
+    });
+
+    it("writeToFile generates environment const and type alias", () => {
+        const impl = new GeneratedSingleUrlEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            defaultEnvironmentId: "env-prod",
+            environments: singleUrlEnvironments
+        });
+
+        const project = new Project({ useInMemoryFileSystem: true });
+        const sourceFile = project.createSourceFile("environments.ts");
+
+        const mockContext = {
+            sourceFile
+        } as any;
+
+        impl.writeToFile(mockContext);
+
+        const text = sourceFile.getFullText();
+        expect(text).toMatchSnapshot();
+    });
+});
+
+describe("GeneratedMultipleUrlsEnvironmentsImpl", () => {
+    const multipleUrlsEnvironments = {
+        baseUrls: [
+            {
+                id: "base-url-api",
+                name: createName("api")
+            },
+            {
+                id: "base-url-auth",
+                name: createName("auth")
+            }
+        ],
+        environments: [
+            {
+                id: "env-prod",
+                name: createName("Production"),
+                urls: {
+                    "base-url-api": "https://api.example.com",
+                    "base-url-auth": "https://auth.example.com"
+                },
+                docs: undefined
+            },
+            {
+                id: "env-staging",
+                name: createName("Staging"),
+                urls: {
+                    "base-url-api": "https://api-staging.example.com",
+                    "base-url-auth": "https://auth-staging.example.com"
+                },
+                docs: "Staging environment"
+            }
+        ]
+    };
+
+    it("hasDefaultEnvironment returns true when default is set", () => {
+        const impl = new GeneratedMultipleUrlsEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            environmentUrlsTypeName: "MyEnvironmentUrls",
+            defaultEnvironmentId: "env-prod",
+            environments: multipleUrlsEnvironments
+        });
+        expect(impl.hasDefaultEnvironment()).toBe(true);
+    });
+
+    it("hasDefaultEnvironment returns false when no default", () => {
+        const impl = new GeneratedMultipleUrlsEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            environmentUrlsTypeName: "MyEnvironmentUrls",
+            defaultEnvironmentId: undefined,
+            environments: multipleUrlsEnvironments
+        });
+        expect(impl.hasDefaultEnvironment()).toBe(false);
+    });
+
+    it("getReferenceToDefaultEnvironment generates correct property access", () => {
+        const impl = new GeneratedMultipleUrlsEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            environmentUrlsTypeName: "MyEnvironmentUrls",
+            defaultEnvironmentId: "env-prod",
+            environments: multipleUrlsEnvironments
+        });
+        const mockContext = {
+            environments: {
+                getReferenceToEnvironmentsEnum: () => ({
+                    getExpression: () => ts.factory.createIdentifier("MyEnvironment")
+                })
+            }
+        } as any;
+        const result = impl.getReferenceToDefaultEnvironment(mockContext);
+        expect(result).toBeDefined();
+        expect(getTextOfTsNode(result!)).toBe("MyEnvironment.Production");
+    });
+
+    it("getReferenceToEnvironmentUrl generates property access for baseUrl", () => {
+        const impl = new GeneratedMultipleUrlsEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            environmentUrlsTypeName: "MyEnvironmentUrls",
+            defaultEnvironmentId: undefined,
+            environments: multipleUrlsEnvironments
+        });
+        const inputExpr = ts.factory.createIdentifier("env");
+        const result = impl.getReferenceToEnvironmentUrl({
+            referenceToEnvironmentValue: inputExpr,
+            baseUrlId: "base-url-api"
+        });
+        expect(getTextOfTsNode(result)).toBe("env.api");
+    });
+
+    it("getReferenceToEnvironmentUrl throws when baseUrlId is undefined", () => {
+        const impl = new GeneratedMultipleUrlsEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            environmentUrlsTypeName: "MyEnvironmentUrls",
+            defaultEnvironmentId: undefined,
+            environments: multipleUrlsEnvironments
+        });
+        const inputExpr = ts.factory.createIdentifier("env");
+        expect(() =>
+            impl.getReferenceToEnvironmentUrl({
+                referenceToEnvironmentValue: inputExpr,
+                baseUrlId: undefined
+            })
+        ).toThrow();
+    });
+
+    it("getReferenceToEnvironmentUrl throws when baseUrlId is not found", () => {
+        const impl = new GeneratedMultipleUrlsEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            environmentUrlsTypeName: "MyEnvironmentUrls",
+            defaultEnvironmentId: undefined,
+            environments: multipleUrlsEnvironments
+        });
+        const inputExpr = ts.factory.createIdentifier("env");
+        expect(() =>
+            impl.getReferenceToEnvironmentUrl({
+                referenceToEnvironmentValue: inputExpr,
+                baseUrlId: "nonexistent-base-url"
+            })
+        ).toThrow();
+    });
+
+    it("writeToFile generates interface, environment const, and type alias", () => {
+        const impl = new GeneratedMultipleUrlsEnvironmentsImpl({
+            environmentEnumName: "MyEnvironment",
+            environmentUrlsTypeName: "MyEnvironmentUrls",
+            defaultEnvironmentId: "env-prod",
+            environments: multipleUrlsEnvironments
+        });
+
+        const project = new Project({ useInMemoryFileSystem: true });
+        const sourceFile = project.createSourceFile("environments.ts");
+
+        const mockContext = {
+            sourceFile
+        } as any;
+
+        impl.writeToFile(mockContext);
+
+        const text = sourceFile.getFullText();
+        expect(text).toMatchSnapshot();
+    });
+});

--- a/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
+++ b/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
@@ -1,6 +1,6 @@
 import { getTextOfTsNode } from "@fern-typescript/commons";
 import { Project, ts } from "ts-morph";
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 
 import { EmptyGeneratedEnvironmentsImpl } from "../EmptyGeneratedEnvironmentsImpl.js";
 import { GeneratedMultipleUrlsEnvironmentsImpl } from "../GeneratedMultipleUrlsEnvironmentsImpl.js";
@@ -124,10 +124,8 @@ describe("GeneratedSingleUrlEnvironmentsImpl", () => {
         // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
         const mockContext = createMockEnvironmentsContext() as any;
         const result = impl.getReferenceToDefaultEnvironment(mockContext);
-        expect(result).toBeDefined();
-        if (result != null) {
-            expect(getTextOfTsNode(result)).toBe("MyEnvironment.Production");
-        }
+        assert(result != null, "expected getReferenceToDefaultEnvironment to return an expression");
+        expect(getTextOfTsNode(result)).toBe("MyEnvironment.Production");
     });
 
     it("getReferenceToEnvironmentUrl returns the input expression for single URL", () => {
@@ -251,10 +249,8 @@ describe("GeneratedMultipleUrlsEnvironmentsImpl", () => {
         // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
         const mockContext = createMockEnvironmentsContext() as any;
         const result = impl.getReferenceToDefaultEnvironment(mockContext);
-        expect(result).toBeDefined();
-        if (result != null) {
-            expect(getTextOfTsNode(result)).toBe("MyEnvironment.Production");
-        }
+        assert(result != null, "expected getReferenceToDefaultEnvironment to return an expression for multiple URLs");
+        expect(getTextOfTsNode(result)).toBe("MyEnvironment.Production");
     });
 
     it("getReferenceToEnvironmentUrl generates property access for baseUrl", () => {

--- a/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
+++ b/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
@@ -1,3 +1,4 @@
+import { constructCasingsGenerator } from "@fern-api/casings-generator";
 import { getTextOfTsNode } from "@fern-typescript/commons";
 import { Project, ts } from "ts-morph";
 import { assert, describe, expect, it } from "vitest";
@@ -6,21 +7,11 @@ import { EmptyGeneratedEnvironmentsImpl } from "../EmptyGeneratedEnvironmentsImp
 import { GeneratedMultipleUrlsEnvironmentsImpl } from "../GeneratedMultipleUrlsEnvironmentsImpl.js";
 import { GeneratedSingleUrlEnvironmentsImpl } from "../GeneratedSingleUrlEnvironmentsImpl.js";
 
-function createName(name: string) {
-    return {
-        originalName: name,
-        camelCase: {
-            unsafeName: name.charAt(0).toLowerCase() + name.slice(1),
-            safeName: name.charAt(0).toLowerCase() + name.slice(1)
-        },
-        pascalCase: {
-            unsafeName: name.charAt(0).toUpperCase() + name.slice(1),
-            safeName: name.charAt(0).toUpperCase() + name.slice(1)
-        },
-        snakeCase: { unsafeName: name.toLowerCase(), safeName: name.toLowerCase() },
-        screamingSnakeCase: { unsafeName: name.toUpperCase(), safeName: name.toUpperCase() }
-    };
-}
+const casingsGenerator = constructCasingsGenerator({
+    generationLanguage: undefined,
+    keywords: undefined,
+    smartCasing: false
+});
 
 function createMockEnvironmentsContext() {
     return {
@@ -65,7 +56,7 @@ describe("GeneratedSingleUrlEnvironmentsImpl", () => {
         environments: [
             {
                 id: "env-prod",
-                name: createName("Production"),
+                name: casingsGenerator.generateName("Production"),
                 url: "https://api.example.com",
                 docs: undefined,
                 audiences: undefined,
@@ -75,7 +66,7 @@ describe("GeneratedSingleUrlEnvironmentsImpl", () => {
             },
             {
                 id: "env-staging",
-                name: createName("Staging"),
+                name: casingsGenerator.generateName("Staging"),
                 url: "https://staging.example.com",
                 docs: "Staging environment",
                 audiences: undefined,
@@ -182,17 +173,17 @@ describe("GeneratedMultipleUrlsEnvironmentsImpl", () => {
         baseUrls: [
             {
                 id: "base-url-api",
-                name: createName("api")
+                name: casingsGenerator.generateName("api")
             },
             {
                 id: "base-url-auth",
-                name: createName("auth")
+                name: casingsGenerator.generateName("auth")
             }
         ],
         environments: [
             {
                 id: "env-prod",
-                name: createName("Production"),
+                name: casingsGenerator.generateName("Production"),
                 urls: {
                     "base-url-api": "https://api.example.com",
                     "base-url-auth": "https://auth.example.com"
@@ -205,7 +196,7 @@ describe("GeneratedMultipleUrlsEnvironmentsImpl", () => {
             },
             {
                 id: "env-staging",
-                name: createName("Staging"),
+                name: casingsGenerator.generateName("Staging"),
                 urls: {
                     "base-url-api": "https://api-staging.example.com",
                     "base-url-auth": "https://auth-staging.example.com"

--- a/generators/typescript/sdk/environments-generator/src/__test__/__snapshots__/EnvironmentsGenerator.test.ts.snap
+++ b/generators/typescript/sdk/environments-generator/src/__test__/__snapshots__/EnvironmentsGenerator.test.ts.snap
@@ -1,0 +1,38 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedMultipleUrlsEnvironmentsImpl > writeToFile generates interface, environment const, and type alias 1`] = `
+"export interface MyEnvironmentUrls {
+    api: string;
+    auth: string;
+}
+
+export const MyEnvironment = {
+        Production: {
+            api: "https://api.example.com",
+            auth: "https://auth.example.com"
+        },
+        /**
+         * Staging environment
+         */
+        Staging: {
+            api: "https://api-staging.example.com",
+            auth: "https://auth-staging.example.com"
+        },
+    } as const;
+
+export type MyEnvironment = typeof MyEnvironment.Production | typeof MyEnvironment.Staging;
+"
+`;
+
+exports[`GeneratedSingleUrlEnvironmentsImpl > writeToFile generates environment const and type alias 1`] = `
+"export const MyEnvironment = {
+        Production: "https://api.example.com",
+        /**
+         * Staging environment
+         */
+        Staging: "https://staging.example.com",
+    } as const;
+
+export type MyEnvironment = typeof MyEnvironment.Production | typeof MyEnvironment.Staging;
+"
+`;

--- a/generators/typescript/sdk/environments-generator/vitest.config.ts
+++ b/generators/typescript/sdk/environments-generator/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/typescript/sdk/test-utils/package.json
+++ b/generators/typescript/sdk/test-utils/package.json
@@ -30,11 +30,14 @@
   },
   "dependencies": {
     "@fern-api/casings-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.3.0",
     "ts-morph": "catalog:"
+  },
+  "peerDependencies": {
+    "@fern-fern/ir-sdk": "^65.3.0"
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/generators/typescript/sdk/test-utils/package.json
+++ b/generators/typescript/sdk/test-utils/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "@fern-typescript/environments-generator",
+  "name": "@fern-typescript/test-utils",
   "version": "0.0.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern.git",
-    "directory": "generators/typescript/sdk/environments-generator"
+    "directory": "generators/typescript/sdk/test-utils"
   },
   "sideEffects": false,
   "type": "module",
@@ -25,22 +26,16 @@
     "clean": "rm -rf ./lib",
     "compile": "tsc",
     "compile:debug": "tsc --sourceMap",
-    "depcheck": "knip --config ../../../../knip.json --no-config-hints",
-    "test": "vitest --passWithNoTests --run",
-    "test:debug": "pnpm run test --inspect --no-file-parallelism",
-    "test:update": "vitest --passWithNoTests --run -u"
+    "depcheck": "knip --config ../../../../knip.json --no-config-hints"
   },
   "dependencies": {
+    "@fern-api/casings-generator": "workspace:*",
     "@fern-fern/ir-sdk": "^65.3.0",
-    "@fern-typescript/commons": "workspace:*",
-    "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
-    "@fern-typescript/test-utils": "workspace:*",
     "@types/node": "catalog:",
-    "typescript": "catalog:",
-    "vitest": "catalog:"
+    "typescript": "catalog:"
   }
 }

--- a/generators/typescript/sdk/test-utils/src/casings.ts
+++ b/generators/typescript/sdk/test-utils/src/casings.ts
@@ -1,0 +1,23 @@
+import { constructCasingsGenerator } from "@fern-api/casings-generator";
+import type { FernIr } from "@fern-fern/ir-sdk";
+
+/**
+ * Pre-configured CasingsGenerator instance for use in tests.
+ * Uses no language-specific keywords and no smart casing.
+ */
+export const casingsGenerator = constructCasingsGenerator({
+    generationLanguage: undefined,
+    keywords: undefined,
+    smartCasing: false
+});
+
+/**
+ * Creates a NameAndWireValue using the real casings generator.
+ * If wireValue is not provided, it defaults to the name.
+ */
+export function createNameAndWireValue(name: string, wireValue?: string): FernIr.NameAndWireValue {
+    return {
+        wireValue: wireValue ?? name,
+        name: casingsGenerator.generateName(name)
+    };
+}

--- a/generators/typescript/sdk/test-utils/src/index.ts
+++ b/generators/typescript/sdk/test-utils/src/index.ts
@@ -1,0 +1,11 @@
+export { casingsGenerator, createNameAndWireValue } from "./casings.js";
+export { createHttpHeader, createPathParameter, createQueryParameter } from "./ir-factories.js";
+export {
+    createMockCoreUtilities,
+    createMockEnvironmentsContext,
+    createMockGeneratedClientClass,
+    createMockGeneratedSdkClientClass,
+    createMockRequestParameter,
+    createMockTypeContext,
+    createMockTypeSchemaContext
+} from "./mock-context.js";

--- a/generators/typescript/sdk/test-utils/src/ir-factories.ts
+++ b/generators/typescript/sdk/test-utils/src/ir-factories.ts
@@ -1,0 +1,61 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+
+import { casingsGenerator, createNameAndWireValue } from "./casings.js";
+
+/**
+ * Creates a PathParameter IR object for use in tests.
+ */
+export function createPathParameter(
+    name: string,
+    location: FernIr.PathParameterLocation = "ENDPOINT"
+): FernIr.PathParameter {
+    return {
+        name: casingsGenerator.generateName(name),
+        valueType: FernIr.TypeReference.primitive({
+            v1: "STRING",
+            v2: undefined
+        }),
+        location,
+        variable: undefined,
+        v2Examples: undefined,
+        docs: undefined,
+        explode: undefined
+    };
+}
+
+/**
+ * Creates a QueryParameter IR object for use in tests.
+ */
+export function createQueryParameter(
+    name: string,
+    valueType: FernIr.TypeReference,
+    opts?: { allowMultiple?: boolean; wireValue?: string }
+): FernIr.QueryParameter {
+    return {
+        name: createNameAndWireValue(name, opts?.wireValue),
+        valueType,
+        allowMultiple: opts?.allowMultiple ?? false,
+        v2Examples: undefined,
+        docs: undefined,
+        availability: undefined,
+        explode: undefined
+    };
+}
+
+/**
+ * Creates an HttpHeader IR object for use in tests.
+ */
+export function createHttpHeader(
+    name: string,
+    valueType: FernIr.TypeReference,
+    opts?: { wireValue?: string; env?: string }
+): FernIr.HttpHeader {
+    return {
+        name: createNameAndWireValue(name, opts?.wireValue),
+        valueType,
+        env: opts?.env ?? undefined,
+        v2Examples: undefined,
+        docs: undefined,
+        availability: undefined
+    };
+}

--- a/generators/typescript/sdk/test-utils/src/ir-factories.ts
+++ b/generators/typescript/sdk/test-utils/src/ir-factories.ts
@@ -53,7 +53,7 @@ export function createHttpHeader(
     return {
         name: createNameAndWireValue(name, opts?.wireValue),
         valueType,
-        env: opts?.env ?? undefined,
+        env: opts?.env,
         v2Examples: undefined,
         docs: undefined,
         availability: undefined

--- a/generators/typescript/sdk/test-utils/src/mock-context.ts
+++ b/generators/typescript/sdk/test-utils/src/mock-context.ts
@@ -143,5 +143,6 @@ export function createMockEnvironmentsContext() {
                 getExpression: () => ts.factory.createIdentifier("MyEnvironment")
             })
         }
-    };
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+    } as any;
 }

--- a/generators/typescript/sdk/test-utils/src/mock-context.ts
+++ b/generators/typescript/sdk/test-utils/src/mock-context.ts
@@ -1,0 +1,147 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { ts } from "ts-morph";
+
+/**
+ * Creates a mock type context with stringify, getTypeDeclaration, getReferenceToType, and resolveTypeReference.
+ * Used by query params, headers, and other components that need to interact with the type system.
+ */
+export function createMockTypeContext() {
+    return {
+        // biome-ignore lint/suspicious/noExplicitAny: test mock callback signature
+        stringify: (expr: ts.Expression, _typeRef: FernIr.TypeReference, _opts: any) => {
+            return ts.factory.createCallExpression(
+                ts.factory.createPropertyAccessExpression(expr, ts.factory.createIdentifier("toString")),
+                undefined,
+                []
+            );
+        },
+        resolveTypeReference: (typeRef: FernIr.TypeReference) => typeRef,
+        getTypeDeclaration: () => ({
+            shape: FernIr.Type.object({
+                properties: [],
+                extends: [],
+                extraProperties: false,
+                extendedProperties: undefined
+            })
+        }),
+        getReferenceToType: () => ({ isOptional: false })
+    };
+}
+
+/**
+ * Creates a mock typeSchema context with getSchemaOfNamedType.
+ * Returns a schema object with a jsonOrThrow method.
+ */
+export function createMockTypeSchemaContext(opts?: { useSerializerPrefix?: boolean }) {
+    return {
+        getSchemaOfNamedType: () => ({
+            jsonOrThrow: (expr: ts.Expression) => {
+                if (opts?.useSerializerPrefix) {
+                    return ts.factory.createCallExpression(
+                        ts.factory.createIdentifier("serializer.jsonOrThrow"),
+                        undefined,
+                        [expr]
+                    );
+                }
+                return expr;
+            }
+        })
+    };
+}
+
+/**
+ * Creates a mock core utilities context for URL encoding, fetcher, and auth.
+ */
+export function createMockCoreUtilities() {
+    return {
+        urlUtils: {
+            encodePathParam: {
+                _invoke: (expr: ts.Expression) => expr
+            }
+        },
+        fetcher: {
+            Fetcher: {
+                Args: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("Fetcher.Args")
+                }
+            }
+        },
+        auth: {
+            AuthRequest: {
+                _getReferenceToType: () => ts.factory.createTypeReferenceNode("AuthRequest")
+            },
+            AuthProvider: {
+                getAuthRequest: {
+                    invoke: (ref: ts.Expression, metadata?: ts.Expression) => {
+                        const args = metadata != null ? [ref, metadata] : [ref];
+                        return ts.factory.createCallExpression(
+                            ts.factory.createIdentifier("getAuthRequest"),
+                            undefined,
+                            args
+                        );
+                    }
+                }
+            }
+        }
+    };
+}
+
+/**
+ * Creates a mock generated client class for buildUrl tests.
+ * Provides getReferenceToVariable and getReferenceToRootPathParameter.
+ */
+export function createMockGeneratedClientClass() {
+    return {
+        getReferenceToVariable: (variableId: string) => ts.factory.createIdentifier(`this._${variableId}`),
+        getReferenceToRootPathParameter: (pathParam: FernIr.PathParameter) =>
+            ts.factory.createPropertyAccessExpression(
+                ts.factory.createThis(),
+                ts.factory.createIdentifier(pathParam.name.camelCase.unsafeName)
+            )
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+    } as any;
+}
+
+/**
+ * Creates a mock generated SDK client class for header generation tests.
+ */
+export function createMockGeneratedSdkClientClass(opts?: {
+    hasAuthProvider?: boolean;
+    generateEndpointMetadata?: boolean;
+}) {
+    return {
+        hasAuthProvider: () => opts?.hasAuthProvider ?? false,
+        getGenerateEndpointMetadata: () => opts?.generateEndpointMetadata ?? false,
+        getReferenceToAuthProviderOrThrow: () => ts.factory.createIdentifier("this._authProvider"),
+        getReferenceToMetadataForEndpointSupplier: () => ts.factory.createIdentifier("_metadata")
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+    } as any;
+}
+
+/**
+ * Creates a mock request parameter for header generation tests.
+ */
+export function createMockRequestParameter() {
+    return {
+        getReferenceToNonLiteralHeader: (header: FernIr.HttpHeader) => {
+            return ts.factory.createPropertyAccessExpression(
+                ts.factory.createIdentifier("request"),
+                ts.factory.createIdentifier(header.name.name.camelCase.unsafeName)
+            );
+        }
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+    } as any;
+}
+
+/**
+ * Creates a mock environments context for environment generator tests.
+ */
+export function createMockEnvironmentsContext() {
+    return {
+        environments: {
+            getReferenceToEnvironmentsEnum: () => ({
+                getExpression: () => ts.factory.createIdentifier("MyEnvironment")
+            })
+        }
+    };
+}

--- a/generators/typescript/sdk/test-utils/tsconfig.json
+++ b/generators/typescript/sdk/test-utils/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@fern-api/configs/tsconfig/main.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["./src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3665,9 +3665,6 @@ importers:
       '@fern-api/casings-generator':
         specifier: workspace:*
         version: link:../../../../packages/commons/casings-generator
-      '@fern-fern/ir-sdk':
-        specifier: ^65.3.0
-        version: 65.4.0
       ts-morph:
         specifier: 'catalog:'
         version: 27.0.2
@@ -3675,6 +3672,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-fern/ir-sdk':
+        specifier: ^65.3.0
+        version: 65.4.0
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3278,12 +3278,12 @@ importers:
         specifier: 'catalog:'
         version: 6.12.0
     devDependencies:
-      '@fern-api/casings-generator':
-        specifier: workspace:*
-        version: link:../../../../packages/commons/casings-generator
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-typescript/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -3346,12 +3346,12 @@ importers:
         specifier: 'catalog:'
         version: 27.0.2
     devDependencies:
-      '@fern-api/casings-generator':
-        specifier: workspace:*
-        version: link:../../../../packages/commons/casings-generator
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-typescript/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
@@ -3659,6 +3659,28 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@types/node@18.15.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.3.3)
+
+  generators/typescript/sdk/test-utils:
+    dependencies:
+      '@fern-api/casings-generator':
+        specifier: workspace:*
+        version: link:../../../../packages/commons/casings-generator
+      '@fern-fern/ir-sdk':
+        specifier: ^65.3.0
+        version: 65.4.0
+      ts-morph:
+        specifier: 'catalog:'
+        version: 27.0.2
+    devDependencies:
+      '@fern-api/configs':
+        specifier: workspace:*
+        version: link:../../../../packages/configs
+      '@types/node':
+        specifier: 'catalog:'
+        version: 18.15.3
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   generators/typescript/sdk/websocket-type-schema-generator:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3674,7 +3674,7 @@ importers:
         version: link:../../../../packages/configs
       '@fern-fern/ir-sdk':
         specifier: ^65.3.0
-        version: 65.4.0
+        version: 65.3.0
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3278,6 +3278,9 @@ importers:
         specifier: 'catalog:'
         version: 6.12.0
     devDependencies:
+      '@fern-api/casings-generator':
+        specifier: workspace:*
+        version: link:../../../../packages/commons/casings-generator
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
@@ -3343,6 +3346,9 @@ importers:
         specifier: 'catalog:'
         version: 27.0.2
     devDependencies:
+      '@fern-api/casings-generator':
+        specifier: workspace:*
+        version: link:../../../../packages/commons/casings-generator
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger

Adds focused unit tests for 5 Priority 1 TypeScript SDK generator components, establishing a snapshot testing pattern for individual code generation utilities. This is groundwork for the planned migration from ts-morph to an in-house AST — these tests lock down the current generated output so regressions can be caught at the component level rather than relying solely on massive seed tests.

Also introduces a shared **`@fern-typescript/test-utils`** package (`generators/typescript/sdk/test-utils/`) that consolidates all mock factories, IR builders, and casings utilities into a single reusable workspace dependency. This eliminates duplication across test files and provides a foundation for Priority 2+ test work.

[Link to Devin Session](https://app.devin.ai/sessions/ce25a6da44a14437a2fa92712a187cf6)

## Changes Made

### New: `@fern-typescript/test-utils` package
- **`casings.ts`**: Pre-configured `casingsGenerator` instance (using real `@fern-api/casings-generator`) and `createNameAndWireValue()` helper
- **`ir-factories.ts`**: `createPathParameter()`, `createQueryParameter()`, `createHttpHeader()` — construct FernIr objects without boilerplate
- **`mock-context.ts`**: 7 factory functions — `createMockTypeContext`, `createMockTypeSchemaContext`, `createMockCoreUtilities`, `createMockGeneratedClientClass`, `createMockGeneratedSdkClientClass`, `createMockRequestParameter`, `createMockEnvironmentsContext`
- Private workspace package (`"workspace:*"`) — not published to npm
- `@fern-fern/ir-sdk` declared as `peerDependency` to ensure test-utils uses the same IR SDK version as the consuming package (avoids type mismatch across different resolutions of `^65.3.0`)

### Test infrastructure
- Added vitest configs to `client-class-generator` and `environments-generator` packages
- Both test packages depend on `@fern-typescript/test-utils` instead of `@fern-api/casings-generator` directly

### Tests added (51 total)
- **`requestOptionsParameter`** (7 tests): `getRequestOptionsParameter`, `getTimeoutExpression` (default/custom/infinity), `getMaxRetriesExpression`, `getAbortSignalExpression`
- **`buildUrl`** (8 tests): Static paths, single/multiple path parameters, trailing paths, ROOT location parameters, original casing, error on missing parameter
- **`GeneratedQueryParams`** (10 tests): Empty params, single/multiple string params, wire value mismatches, `allowMultiple` with array checks, date-time stringify, special characters in wire values, `getReferenceTo` output
- **`generateHeaders`** (8 tests): No-header baseline, service+endpoint headers, idempotency headers, auth provider headers, literal headers, root-level overridable headers, additional headers
- **`EnvironmentsGenerator`** (18 tests): All three implementations — `EmptyGeneratedEnvironmentsImpl`, `GeneratedSingleUrlEnvironmentsImpl`, `GeneratedMultipleUrlsEnvironmentsImpl` — including `writeToFile` output via in-memory ts-morph Project

All tests use the pattern: construct mock IR → call generator → serialize AST via `getTextOfTsNode()` → assert with `toMatchSnapshot()`.

### Binary safety

Test files and snapshots will **not** be included in the generator Docker image. The generator binary is built via tsup (bundler) from `src/cli.ts` — only code reachable from imports is included, and test files are never imported by production code. Additionally, `__snapshots__` directories are excluded by the base tsconfig. The `test-utils` package is a `devDependency` in both consumer packages. This follows the same pattern as existing packages in the repo.

### Mock fidelity verification

Snapshots were compared against real seed output (`seed/ts-sdk/exhaustive/`, `seed/ts-sdk/single-url-environment-default/`, `seed/ts-sdk/multi-url-environment-no-default/`):
- **Query params**: ✅ Pattern matches exactly (`const _queryParams: Record<string, unknown> = { ... }`)
- **Timeout/retries/abort**: ✅ Exact match (e.g. `(requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000`)
- **Environments**: ✅ Structure matches (single-url const + type alias, multi-url interface + const + type alias)
- **Headers**: ✅ `mergeHeaders(...)` call structure matches; tests correctly produce `let` (matching source `ts.NodeFlags.Let` on line 171 of `generateHeaders.ts`)
- **buildUrl**: ⚠️ Known gap — mock `encodePathParam._invoke` returns the expression as-is, so snapshots show raw `${userId}` instead of `${core.url.encodePathParam(userId)}`. Sufficient for testing URL template assembly logic.

## Testing

- [x] 51 unit tests added across 5 test files, all passing locally
- [x] Snapshots generated and committed
- [x] Biome lint checks pass (all `noExplicitAny` uses have `biome-ignore` comments)
- [x] Null-check assertions use vitest `assert()` for proper type narrowing and loud failures (no silent skips)
- [x] Test-utils package properly linked via `pnpm install` (workspace dependency)
- [x] All CI checks pass (compile, lint, biome, test, test-ete, depcheck, seed tests)

## Review Checklist

- [ ] **Test-utils mock implementations**: The extracted mocks in `@fern-typescript/test-utils` should be functionally identical to the inline versions. Verify no subtle differences in mock behavior (especially `createMockContext` compositions in test files).
- [ ] **Mock fidelity**: Tests use `as any` casts with `biome-ignore` comments for `SdkContext` and other interface mocks. The mocked methods (`type.stringify`, `type.resolveTypeReference`, `encodePathParam._invoke`, etc.) are sufficient for the code paths exercised — notably `buildUrl` skips the real `encodePathParam` wrapper, so its snapshots show raw identifiers instead of encoded calls. These mocks won't catch interface signature changes at compile time.
- [ ] **Snapshot correctness**: Confirm the generated TypeScript in snapshot files matches expected output for each scenario. Snapshots have been compared against seed output and patterns match (see "Mock fidelity verification" above).
- [ ] **Casings**: Now uses real `@fern-api/casings-generator` (resolves previous `createName` helper limitation). Multi-word name handling (e.g., "userId" → "user_id") works correctly.
- [ ] **IR SDK version consistency**: The lockfile pins `@fern-fern/ir-sdk` to `65.3.0` for test-utils (matching consumer packages). Verify this doesn't regress if dependencies are updated.

## Updates since last revision

### Refactoring and cleanup
- **Created shared test-utils package**: Extracted all mock factories, IR builders, and casings utilities into `@fern-typescript/test-utils` workspace package. This eliminates ~200 lines of duplicated mock setup across test files and provides reusable utilities for Priority 2+ test work.
- **Refactored all 4 test files**: Updated `buildUrl.test.ts`, `GeneratedQueryParams.test.ts`, `generateHeaders.test.ts`, and `EnvironmentsGenerator.test.ts` to import from test-utils instead of defining helpers inline.
- **Real casings generator**: Uses actual `@fern-api/casings-generator` for name generation (resolves the simplified `createName` helper limitation from previous revision).
- **Fixed IR SDK version mismatch**: Moved `@fern-fern/ir-sdk` to `peerDependencies` in test-utils package to ensure it uses the same version as the consumer packages. Pinned lockfile resolution to `65.3.0` to prevent pnpm from resolving to `65.4.0` which caused TypeScript compilation errors in CI (mismatched type imports from different ir-sdk versions).

### Self-review cleanup
- Removed redundant `?? undefined` in `ir-factories.ts` (optional chaining already returns `undefined`)
- Deduplicated inline `typeSchema` mock in `buildUrl.test.ts` to use shared `createMockTypeSchemaContext()`
- Moved `as any` cast inside `createMockEnvironmentsContext()` for consistency with other factory functions, eliminating redundant casts at call sites
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
