### PR TITLE
chore(internal): add unit tests for GeneratedEnumTypeImpl

### DIFF
--- a/generators/typescript/model/type-generator/package.json
+++ b/generators/typescript/model/type-generator/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
+    "@fern-typescript/test-utils": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/typescript/model/type-generator/src/__test__/GeneratedEnumTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedEnumTypeImpl.test.ts
@@ -1,0 +1,330 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode } from "@fern-typescript/commons";
+import { casingsGenerator, createNameAndWireValue } from "@fern-typescript/test-utils";
+import { Project, ts } from "ts-morph";
+import { assert, describe, expect, it } from "vitest";
+
+import { GeneratedEnumTypeImpl } from "../enum/GeneratedEnumTypeImpl.js";
+
+/**
+ * Creates a minimal mock BaseContext.
+ * The enum generator only uses context for getDocs (via buildExample),
+ * which is skipped when examples array is empty.
+ */
+function createMockBaseContext() {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const sourceFile = project.createSourceFile("test.ts", "");
+    return {
+        sourceFile,
+        // biome-ignore lint/suspicious/noEmptyBlockStatements: test mock with no-op logger
+        logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+        externalDependencies: {},
+        coreUtilities: {},
+        fernConstants: {},
+        type: {},
+        typeSchema: {},
+        includeSerdeLayer: false,
+        jsonContext: {}
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+    } as any;
+}
+
+/**
+ * Creates a FernFilepath for test use.
+ */
+function createFernFilepath(): FernIr.FernFilepath {
+    return {
+        allParts: [casingsGenerator.generateName("plants")],
+        packagePath: [casingsGenerator.generateName("plants")],
+        file: casingsGenerator.generateName("types")
+    };
+}
+
+/**
+ * Creates an EnumValue IR object.
+ */
+function createEnumValue(name: string, opts?: { wireValue?: string; docs?: string }): FernIr.EnumValue {
+    return {
+        name: createNameAndWireValue(name, opts?.wireValue),
+        docs: opts?.docs ?? undefined,
+        availability: undefined,
+        v2Examples: undefined
+    };
+}
+
+/**
+ * Creates a GeneratedEnumTypeImpl with the given config.
+ */
+function createEnumGenerator(opts: {
+    typeName: string;
+    values: FernIr.EnumValue[];
+    includeEnumUtils?: boolean;
+    enableForwardCompatibleEnums?: boolean;
+    docs?: string;
+    examples?: FernIr.ExampleType[];
+    // biome-ignore lint/suspicious/noExplicitAny: test factory with generic type parameter
+}): GeneratedEnumTypeImpl<any> {
+    return new GeneratedEnumTypeImpl({
+        typeName: opts.typeName,
+        shape: { values: opts.values, default: undefined },
+        examples: opts.examples ?? [],
+        docs: opts.docs,
+        fernFilepath: createFernFilepath(),
+        getReferenceToSelf: () => ({
+            getTypeNode: () => ts.factory.createTypeReferenceNode(opts.typeName),
+            getExpression: () => ts.factory.createIdentifier(opts.typeName),
+            getEntityName: () => ts.factory.createIdentifier(opts.typeName)
+        }),
+        includeSerdeLayer: false,
+        noOptionalProperties: false,
+        retainOriginalCasing: false,
+        enableInlineTypes: false,
+        generateReadWriteOnlyTypes: false,
+        includeEnumUtils: opts.includeEnumUtils ?? false,
+        enableForwardCompatibleEnums: opts.enableForwardCompatibleEnums ?? false
+    });
+}
+
+/**
+ * Serializes generateStatements output by writing to a ts-morph SourceFile.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test utility with generic type parameter
+function serializeStatements(generator: GeneratedEnumTypeImpl<any>): string {
+    const context = createMockBaseContext();
+    const statements = generator.generateStatements(context);
+    context.sourceFile.addStatements(statements);
+    return context.sourceFile.getFullText();
+}
+
+describe("GeneratedEnumTypeImpl", () => {
+    describe("generateStatements", () => {
+        it("generates basic enum without utils", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" }),
+                    createEnumValue("Cactus", { wireValue: "cactus" })
+                ]
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates enum with utils (visitor pattern)", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" }),
+                    createEnumValue("Cactus", { wireValue: "cactus" })
+                ],
+                includeEnumUtils: true
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates forward-compatible enum (adds | string)", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ],
+                enableForwardCompatibleEnums: true
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates forward-compatible enum with utils", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ],
+                includeEnumUtils: true,
+                enableForwardCompatibleEnums: true
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates enum with single value", () => {
+            const generator = createEnumGenerator({
+                typeName: "Sunlight",
+                values: [createEnumValue("Full", { wireValue: "full" })]
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates enum with docs on values", () => {
+            const generator = createEnumGenerator({
+                typeName: "WaterFrequency",
+                values: [
+                    createEnumValue("Daily", { wireValue: "daily", docs: "Water once per day" }),
+                    createEnumValue("Weekly", { wireValue: "weekly", docs: "Water once per week" }),
+                    createEnumValue("Monthly", { wireValue: "monthly" })
+                ]
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates enum with wire values differing from names", () => {
+            const generator = createEnumGenerator({
+                typeName: "SoilType",
+                values: [
+                    createEnumValue("WellDraining", { wireValue: "well-draining" }),
+                    createEnumValue("MoistRetaining", { wireValue: "moist-retaining" }),
+                    createEnumValue("Sandy", { wireValue: "SANDY" })
+                ]
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("generateForInlineUnion", () => {
+        it("generates inline union type for basic enum", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ]
+            });
+
+            const context = createMockBaseContext();
+            const result = generator.generateForInlineUnion(context);
+            const text = getTextOfTsNode(result.typeNode);
+            expect(text).toMatchSnapshot();
+            expect(result.requestTypeNode).toBeUndefined();
+            expect(result.responseTypeNode).toBeUndefined();
+        });
+
+        it("generates inline union type with string for forward-compatible enum", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ],
+                enableForwardCompatibleEnums: true
+            });
+
+            const context = createMockBaseContext();
+            const result = generator.generateForInlineUnion(context);
+            const text = getTextOfTsNode(result.typeNode);
+            expect(text).toMatchSnapshot();
+        });
+    });
+
+    describe("generateModule", () => {
+        it("generates visitor interface module", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" }),
+                    createEnumValue("Cactus", { wireValue: "cactus" })
+                ],
+                includeEnumUtils: true
+            });
+
+            const context = createMockBaseContext();
+            const moduleDecl = generator.generateModule();
+            assert(moduleDecl != null, "expected generateModule to return a module declaration");
+            context.sourceFile.addModule(moduleDecl);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+    });
+
+    describe("buildExample", () => {
+        it("builds example for type declaration comment", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ]
+            });
+
+            const context = createMockBaseContext();
+            const example: FernIr.ExampleTypeShape = FernIr.ExampleTypeShape.enum({
+                value: createNameAndWireValue("Succulent", "succulent")
+            });
+            const result = generator.buildExample(example, context, {
+                isForComment: true,
+                isForTypeDeclarationComment: true
+            });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("builds example as string literal when not for type declaration", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ]
+            });
+
+            const context = createMockBaseContext();
+            const example: FernIr.ExampleTypeShape = FernIr.ExampleTypeShape.enum({
+                value: createNameAndWireValue("Succulent", "succulent")
+            });
+            const result = generator.buildExample(example, context, {
+                isForComment: false,
+                isForTypeDeclarationComment: false
+            });
+            expect(getTextOfTsNode(result)).toBe('"succulent"');
+        });
+
+        it("falls back to first value when wire value does not match", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ]
+            });
+
+            const context = createMockBaseContext();
+            const example: FernIr.ExampleTypeShape = FernIr.ExampleTypeShape.enum({
+                value: createNameAndWireValue("Nonexistent", "nonexistent")
+            });
+            const result = generator.buildExample(example, context, {
+                isForComment: true,
+                isForTypeDeclarationComment: true
+            });
+            // Falls back to first value "Succulent"
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("throws for non-enum example shape", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [createEnumValue("Succulent", { wireValue: "succulent" })]
+            });
+
+            const context = createMockBaseContext();
+            const example: FernIr.ExampleTypeShape = FernIr.ExampleTypeShape.object({
+                properties: []
+            });
+            expect(() => generator.buildExample(example, context, { isForComment: true })).toThrow(
+                "Example is not for an enum"
+            );
+        });
+    });
+});

--- a/generators/typescript/model/type-generator/src/__test__/GeneratedEnumTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedEnumTypeImpl.test.ts
@@ -194,6 +194,9 @@ describe("GeneratedEnumTypeImpl", () => {
             expect(output).toMatchSnapshot();
         });
 
+        // retainOriginalCasing only affects object/union types, not enums.
+        // Enum keys always use pascalCase.unsafeName via getEnumValueName().
+        // This test documents that the flag has no effect on enum output.
         it("generates enum with retainOriginalCasing", () => {
             const generator = createEnumGenerator({
                 typeName: "PlantType",

--- a/generators/typescript/model/type-generator/src/__test__/GeneratedEnumTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedEnumTypeImpl.test.ts
@@ -59,6 +59,7 @@ function createEnumGenerator(opts: {
     values: FernIr.EnumValue[];
     includeEnumUtils?: boolean;
     enableForwardCompatibleEnums?: boolean;
+    retainOriginalCasing?: boolean;
     docs?: string;
     examples?: FernIr.ExampleType[];
     // biome-ignore lint/suspicious/noExplicitAny: test factory with generic type parameter
@@ -76,7 +77,7 @@ function createEnumGenerator(opts: {
         }),
         includeSerdeLayer: false,
         noOptionalProperties: false,
-        retainOriginalCasing: false,
+        retainOriginalCasing: opts.retainOriginalCasing ?? false,
         enableInlineTypes: false,
         generateReadWriteOnlyTypes: false,
         includeEnumUtils: opts.includeEnumUtils ?? false,
@@ -186,6 +187,83 @@ describe("GeneratedEnumTypeImpl", () => {
                     createEnumValue("WellDraining", { wireValue: "well-draining" }),
                     createEnumValue("MoistRetaining", { wireValue: "moist-retaining" }),
                     createEnumValue("Sandy", { wireValue: "SANDY" })
+                ]
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates enum with retainOriginalCasing", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ],
+                retainOriginalCasing: true
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates enum with top-level type docs", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ],
+                docs: "Represents different types of plants."
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates enum with top-level docs and examples", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ],
+                docs: "Represents different types of plants.",
+                examples: [
+                    {
+                        name: undefined,
+                        docs: undefined,
+                        jsonExample: "succulent",
+                        shape: FernIr.ExampleTypeShape.enum({
+                            value: createNameAndWireValue("Succulent", "succulent")
+                        })
+                    }
+                ]
+            });
+
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates enum with top-level docs and utils", () => {
+            const generator = createEnumGenerator({
+                typeName: "PlantType",
+                values: [
+                    createEnumValue("Succulent", { wireValue: "succulent" }),
+                    createEnumValue("Fern", { wireValue: "fern" })
+                ],
+                docs: "Represents different types of plants.",
+                includeEnumUtils: true,
+                examples: [
+                    {
+                        name: undefined,
+                        docs: undefined,
+                        jsonExample: "succulent",
+                        shape: FernIr.ExampleTypeShape.enum({
+                            value: createNameAndWireValue("Succulent", "succulent")
+                        })
+                    }
                 ]
             });
 

--- a/generators/typescript/model/type-generator/src/__test__/GeneratedEnumTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedEnumTypeImpl.test.ts
@@ -46,9 +46,8 @@ function createFernFilepath(): FernIr.FernFilepath {
 function createEnumValue(name: string, opts?: { wireValue?: string; docs?: string }): FernIr.EnumValue {
     return {
         name: createNameAndWireValue(name, opts?.wireValue),
-        docs: opts?.docs ?? undefined,
-        availability: undefined,
-        v2Examples: undefined
+        docs: opts?.docs,
+        availability: undefined
     };
 }
 
@@ -320,7 +319,8 @@ describe("GeneratedEnumTypeImpl", () => {
 
             const context = createMockBaseContext();
             const example: FernIr.ExampleTypeShape = FernIr.ExampleTypeShape.object({
-                properties: []
+                properties: [],
+                extraProperties: undefined
             });
             expect(() => generator.buildExample(example, context, { isForComment: true })).toThrow(
                 "Example is not for an enum"

--- a/generators/typescript/model/type-generator/src/__test__/__snapshots__/GeneratedEnumTypeImpl.test.ts.snap
+++ b/generators/typescript/model/type-generator/src/__test__/__snapshots__/GeneratedEnumTypeImpl.test.ts.snap
@@ -44,11 +44,80 @@ export type WaterFrequency = typeof WaterFrequency[keyof typeof WaterFrequency];
 "
 `;
 
+exports[`GeneratedEnumTypeImpl > generateStatements > generates enum with retainOriginalCasing 1`] = `
+"export const PlantType = {
+        Succulent: "succulent",
+        Fern: "fern"
+    } as const;
+export type PlantType = typeof PlantType[keyof typeof PlantType];
+"
+`;
+
 exports[`GeneratedEnumTypeImpl > generateStatements > generates enum with single value 1`] = `
 "export const Sunlight = {
         Full: "full"
     } as const;
 export type Sunlight = typeof Sunlight[keyof typeof Sunlight];
+"
+`;
+
+exports[`GeneratedEnumTypeImpl > generateStatements > generates enum with top-level docs and examples 1`] = `
+"/**
+ * Represents different types of plants.
+ *
+ * @example
+ *     PlantType.Succulent
+ */
+export const PlantType = {
+        Succulent: "succulent",
+        Fern: "fern"
+    } as const;
+export type PlantType = typeof PlantType[keyof typeof PlantType];
+"
+`;
+
+exports[`GeneratedEnumTypeImpl > generateStatements > generates enum with top-level docs and utils 1`] = `
+"/**
+ * Represents different types of plants.
+ *
+ * @example
+ *     PlantType.Succulent
+ */
+const PlantTypeValues = {
+        Succulent: "succulent",
+        Fern: "fern"
+    } as const;
+export type PlantType = typeof PlantTypeValues[keyof typeof PlantTypeValues];
+export const PlantType: typeof PlantTypeValues & {
+        _visit: <R>(value: PlantType, visitor: PlantType.Visitor<R>) => R;
+    } = {
+        ...PlantTypeValues,
+        _visit: <R>(value: PlantType, visitor: PlantType.Visitor<R>): R => {
+            switch (value) {
+                case PlantType.Succulent: return visitor.succulent();
+                case PlantType.Fern: return visitor.fern();
+                default: return visitor._other();
+            }
+        }
+    };
+
+export namespace PlantType {
+    export interface Visitor<R> {
+        succulent: () => R;
+        fern: () => R;
+        _other: () => R;
+    }
+}
+"
+`;
+
+exports[`GeneratedEnumTypeImpl > generateStatements > generates enum with top-level type docs 1`] = `
+"/** Represents different types of plants. */
+export const PlantType = {
+        Succulent: "succulent",
+        Fern: "fern"
+    } as const;
+export type PlantType = typeof PlantType[keyof typeof PlantType];
 "
 `;
 

--- a/generators/typescript/model/type-generator/src/__test__/__snapshots__/GeneratedEnumTypeImpl.test.ts.snap
+++ b/generators/typescript/model/type-generator/src/__test__/__snapshots__/GeneratedEnumTypeImpl.test.ts.snap
@@ -1,0 +1,133 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedEnumTypeImpl > buildExample > builds example for type declaration comment 1`] = `"PlantType.Succulent"`;
+
+exports[`GeneratedEnumTypeImpl > buildExample > falls back to first value when wire value does not match 1`] = `"PlantType.Succulent"`;
+
+exports[`GeneratedEnumTypeImpl > generateForInlineUnion > generates inline union type for basic enum 1`] = `"("succulent" | "fern")"`;
+
+exports[`GeneratedEnumTypeImpl > generateForInlineUnion > generates inline union type with string for forward-compatible enum 1`] = `"("succulent" | "fern" | string)"`;
+
+exports[`GeneratedEnumTypeImpl > generateModule > generates visitor interface module 1`] = `
+"export namespace PlantType {
+    export interface Visitor<R> {
+        succulent: () => R;
+        fern: () => R;
+        cactus: () => R;
+        _other: () => R;
+    }
+}
+"
+`;
+
+exports[`GeneratedEnumTypeImpl > generateStatements > generates basic enum without utils 1`] = `
+"export const PlantType = {
+        Succulent: "succulent",
+        Fern: "fern",
+        Cactus: "cactus"
+    } as const;
+export type PlantType = typeof PlantType[keyof typeof PlantType];
+"
+`;
+
+exports[`GeneratedEnumTypeImpl > generateStatements > generates enum with docs on values 1`] = `
+"export const WaterFrequency = {
+        /**
+     * Water once per day */
+    Daily: "daily",
+        /**
+     * Water once per week */
+    Weekly: "weekly",
+        Monthly: "monthly"
+    } as const;
+export type WaterFrequency = typeof WaterFrequency[keyof typeof WaterFrequency];
+"
+`;
+
+exports[`GeneratedEnumTypeImpl > generateStatements > generates enum with single value 1`] = `
+"export const Sunlight = {
+        Full: "full"
+    } as const;
+export type Sunlight = typeof Sunlight[keyof typeof Sunlight];
+"
+`;
+
+exports[`GeneratedEnumTypeImpl > generateStatements > generates enum with utils (visitor pattern) 1`] = `
+"const PlantTypeValues = {
+        Succulent: "succulent",
+        Fern: "fern",
+        Cactus: "cactus"
+    } as const;
+export type PlantType = typeof PlantTypeValues[keyof typeof PlantTypeValues];
+export const PlantType: typeof PlantTypeValues & {
+        _visit: <R>(value: PlantType, visitor: PlantType.Visitor<R>) => R;
+    } = {
+        ...PlantTypeValues,
+        _visit: <R>(value: PlantType, visitor: PlantType.Visitor<R>): R => {
+            switch (value) {
+                case PlantType.Succulent: return visitor.succulent();
+                case PlantType.Fern: return visitor.fern();
+                case PlantType.Cactus: return visitor.cactus();
+                default: return visitor._other();
+            }
+        }
+    };
+
+export namespace PlantType {
+    export interface Visitor<R> {
+        succulent: () => R;
+        fern: () => R;
+        cactus: () => R;
+        _other: () => R;
+    }
+}
+"
+`;
+
+exports[`GeneratedEnumTypeImpl > generateStatements > generates enum with wire values differing from names 1`] = `
+"export const SoilType = {
+        WellDraining: "well-draining",
+        MoistRetaining: "moist-retaining",
+        Sandy: "SANDY"
+    } as const;
+export type SoilType = typeof SoilType[keyof typeof SoilType];
+"
+`;
+
+exports[`GeneratedEnumTypeImpl > generateStatements > generates forward-compatible enum (adds | string) 1`] = `
+"export const PlantType = {
+        Succulent: "succulent",
+        Fern: "fern"
+    } as const;
+export type PlantType = typeof PlantType[keyof typeof PlantType] | string;
+"
+`;
+
+exports[`GeneratedEnumTypeImpl > generateStatements > generates forward-compatible enum with utils 1`] = `
+"const PlantTypeValues = {
+        Succulent: "succulent",
+        Fern: "fern"
+    } as const;
+export type PlantType = typeof PlantTypeValues[keyof typeof PlantTypeValues] | string;
+export const PlantType: typeof PlantTypeValues & {
+        _visit: <R>(value: PlantType, visitor: PlantType.Visitor<R>) => R;
+    } = {
+        ...PlantTypeValues,
+        _visit: <R>(value: PlantType, visitor: PlantType.Visitor<R>): R => {
+            switch (value) {
+                case PlantType.Succulent: return visitor.succulent();
+                case PlantType.Fern: return visitor.fern();
+                default: return visitor._other();
+            }
+        }
+    };
+
+export namespace PlantType {
+    export interface Visitor<R> {
+        succulent: () => R;
+        fern: () => R;
+        _other: () => R;
+    }
+}
+"
+`;

--- a/generators/typescript/model/type-generator/vitest.config.ts
+++ b/generators/typescript/model/type-generator/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3041,6 +3041,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-typescript/test-utils':
+        specifier: workspace:*
+        version: link:../../sdk/test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3


### PR DESCRIPTION
## Description

Refs: Priority 2 of the TS SDK generator unit testing plan (follow-up to #13293)

Adds unit tests for `GeneratedEnumTypeImpl`, the first Priority 2 component. This covers the enum type code generation in the TypeScript SDK generator, locking down its output ahead of an eventual migration from ts-morph to an in-house AST.

[Link to Devin Session](https://app.devin.ai/sessions/ce25a6da44a14437a2fa92712a187cf6)
Requested by: @Swimburger

## Changes Made

- Added `vitest.config.ts` to the `type-generator` package (previously had no test infrastructure)
- Added `@fern-typescript/test-utils` as a devDependency to reuse shared mock factories from Phase 1
- Created `GeneratedEnumTypeImpl.test.ts` with **18 test cases** across 4 groups:
  - **`generateStatements`** (11 tests): basic enum, enum with visitor/utils, forward-compatible enum (`| string`), forward-compatible with utils, single value, docs on values, wire values differing from names, `retainOriginalCasing: true`, top-level type docs, top-level docs with `@example` annotations, top-level docs with utils + examples
  - **`generateForInlineUnion`** (2 tests): basic inline type, forward-compatible inline type
  - **`generateModule`** (1 test): visitor interface namespace generation
  - **`buildExample`** (4 tests): type declaration comment format, string literal format, fallback for unknown wire value, error on non-enum shape

### Notes for reviewers

- **`retainOriginalCasing` test**: Intentionally produces identical output to the basic enum test. The flag only affects object/union types — enum keys always use `pascalCase.unsafeName` via `getEnumValueName()`. The test documents this behavior (see code comment).
- **`createMockBaseContext()`**: Uses `as any` with a minimal mock. The enum generator only accesses context for `getDocs()` (via `buildExample`), which is only exercised when the `examples` array is non-empty. All 18 tests pass with this minimal surface.
- **Snapshot indentation**: Value-level docs show slightly unusual indentation (e.g., JSDoc comment indented differently from property key). This is the actual generator output from `printDocs()` + `getPropertyKey()` — not a test artifact.

## Testing

- [x] Unit tests added (18 tests, all passing)
- [x] Biome lint checks passing (`pnpm run check`)
- [x] Snapshots verified against seed output (`seed/ts-sdk/enum/`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
