### PR TITLE
chore(internal): add unit tests for Auth Provider instances and generators

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/__test__/AuthProviders.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/AuthProviders.test.ts
@@ -1,0 +1,738 @@
+import { getTextOfTsNode } from "@fern-typescript/commons";
+import {
+    createAuthScheme,
+    createBasicAuthScheme,
+    createBearerAuthScheme,
+    createHeaderAuthScheme,
+    createMinimalIR
+} from "@fern-typescript/test-utils";
+import { Project, ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import { AnyAuthProviderInstance } from "../auth-provider/AnyAuthProviderInstance.js";
+import { BasicAuthProviderGenerator } from "../auth-provider/BasicAuthProviderGenerator.js";
+import { BasicAuthProviderInstance } from "../auth-provider/BasicAuthProviderInstance.js";
+import { BearerAuthProviderGenerator } from "../auth-provider/BearerAuthProviderGenerator.js";
+import { BearerAuthProviderInstance } from "../auth-provider/BearerAuthProviderInstance.js";
+import { HeaderAuthProviderGenerator } from "../auth-provider/HeaderAuthProviderGenerator.js";
+import { HeaderAuthProviderInstance } from "../auth-provider/HeaderAuthProviderInstance.js";
+import { InferredAuthProviderInstance } from "../auth-provider/InferredAuthProviderInstance.js";
+import { OAuthAuthProviderInstance } from "../auth-provider/OAuthAuthProviderInstance.js";
+import { RoutingAuthProviderInstance } from "../auth-provider/RoutingAuthProviderInstance.js";
+
+// ─── Mock Context Helpers ────────────────────────────────────────────────────
+
+/**
+ * Creates a minimal mock SdkContext for AuthProviderInstance tests.
+ * Instance classes only need importsManager.addImportFromRoot and generateOAuthClients.
+ */
+function createMockInstanceContext(opts?: { generateOAuthClients?: boolean }) {
+    return {
+        importsManager: {
+            addImportFromRoot: () => {
+                /* noop */
+            }
+        },
+        generateOAuthClients: opts?.generateOAuthClients ?? false
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+    } as any;
+}
+
+/**
+ * Creates a mock SdkContext for AuthProviderGenerator writeToFile() tests.
+ * Uses a real ts-morph SourceFile and mocks the core utilities used by the generators.
+ */
+function createMockGeneratorContext(project: Project, fileName: string) {
+    const sourceFile = project.createSourceFile(fileName, "", { overwrite: true });
+    return {
+        sourceFile,
+        coreUtilities: {
+            auth: {
+                AuthProvider: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.AuthProvider")
+                },
+                AuthRequest: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.AuthRequest")
+                },
+                BearerToken: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.BearerToken")
+                },
+                BasicAuth: {
+                    toAuthorizationHeader: (username: ts.Expression, password: ts.Expression) =>
+                        ts.factory.createCallExpression(
+                            ts.factory.createIdentifier("core.BasicAuth.toAuthorizationHeader"),
+                            undefined,
+                            [username, password]
+                        )
+                }
+            },
+            fetcher: {
+                SupplierOrEndpointSupplier: {
+                    _getReferenceToType: (innerType: ts.TypeNode) =>
+                        ts.factory.createTypeReferenceNode("core.Supplier", [innerType]),
+                    get: (expr: ts.Expression, metadata: ts.Expression) =>
+                        ts.factory.createAwaitExpression(
+                            ts.factory.createCallExpression(
+                                ts.factory.createIdentifier("core.Supplier.get"),
+                                undefined,
+                                [expr, metadata]
+                            )
+                        )
+                },
+                EndpointMetadata: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.EndpointMetadata")
+                }
+            }
+        },
+        genericAPISdkError: {
+            getReferenceToGenericAPISdkError: () => ({
+                getExpression: () => ts.factory.createIdentifier("errors.SeedApiError")
+            })
+        }
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+    } as any;
+}
+
+/** Serializes an AST expression to a string for snapshot comparison. */
+function printExpression(expr: ts.Expression): string {
+    return getTextOfTsNode(expr);
+}
+
+/** Serializes an array of ObjectLiteralElementLike to string for snapshot comparison. */
+function printProperties(props: ts.ObjectLiteralElementLike[]): string {
+    const obj = ts.factory.createObjectLiteralExpression(props, true);
+    return getTextOfTsNode(obj);
+}
+
+// ─── AuthProviderInstance Tests ──────────────────────────────────────────────
+
+describe("AuthProviderInstance", () => {
+    describe("BasicAuthProviderInstance", () => {
+        const scheme = createBasicAuthScheme();
+
+        it("instantiate() produces BasicAuthProvider.createInstance call", () => {
+            const instance = new BasicAuthProviderInstance(scheme);
+            const context = createMockInstanceContext();
+            const params = [ts.factory.createIdentifier("options")];
+            const result = instance.instantiate({ context, params });
+            expect(printExpression(result)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() returns username and password properties", () => {
+            const instance = new BasicAuthProviderInstance(scheme);
+            const context = createMockInstanceContext();
+            const props = instance.getSnippetProperties(context);
+            expect(props).toHaveLength(2);
+            expect(printProperties(props)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() uses custom field names from auth scheme", () => {
+            const customScheme = createBasicAuthScheme({ username: "user", password: "pass" });
+            const instance = new BasicAuthProviderInstance(customScheme);
+            const context = createMockInstanceContext();
+            const props = instance.getSnippetProperties(context);
+            expect(printProperties(props)).toMatchSnapshot();
+        });
+    });
+
+    describe("BearerAuthProviderInstance", () => {
+        const scheme = createBearerAuthScheme();
+
+        it("instantiate() produces new BearerAuthProvider call", () => {
+            const instance = new BearerAuthProviderInstance(scheme);
+            const context = createMockInstanceContext();
+            const params = [ts.factory.createIdentifier("options")];
+            const result = instance.instantiate({ context, params });
+            expect(printExpression(result)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() returns token property", () => {
+            const instance = new BearerAuthProviderInstance(scheme);
+            const context = createMockInstanceContext();
+            const props = instance.getSnippetProperties(context);
+            expect(props).toHaveLength(1);
+            expect(printProperties(props)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() uses custom token name", () => {
+            const customScheme = createBearerAuthScheme({ tokenName: "accessToken" });
+            const instance = new BearerAuthProviderInstance(customScheme);
+            const context = createMockInstanceContext();
+            const props = instance.getSnippetProperties(context);
+            expect(printProperties(props)).toMatchSnapshot();
+        });
+    });
+
+    describe("HeaderAuthProviderInstance", () => {
+        const scheme = createHeaderAuthScheme();
+
+        it("instantiate() produces new HeaderAuthProvider call", () => {
+            const instance = new HeaderAuthProviderInstance(scheme);
+            const context = createMockInstanceContext();
+            const params = [ts.factory.createIdentifier("options")];
+            const result = instance.instantiate({ context, params });
+            expect(printExpression(result)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() returns header name property", () => {
+            const instance = new HeaderAuthProviderInstance(scheme);
+            const context = createMockInstanceContext();
+            const props = instance.getSnippetProperties(context);
+            expect(props).toHaveLength(1);
+            expect(printProperties(props)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() uses custom header name", () => {
+            const customScheme = createHeaderAuthScheme({ name: "authToken", wireValue: "X-Auth-Token" });
+            const instance = new HeaderAuthProviderInstance(customScheme);
+            const context = createMockInstanceContext();
+            const props = instance.getSnippetProperties(context);
+            expect(printProperties(props)).toMatchSnapshot();
+        });
+    });
+
+    describe("OAuthAuthProviderInstance", () => {
+        it("instantiate() produces new OAuthAuthProvider call", () => {
+            const instance = new OAuthAuthProviderInstance();
+            const context = createMockInstanceContext();
+            const params = [ts.factory.createIdentifier("options")];
+            const result = instance.instantiate({ context, params });
+            expect(printExpression(result)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() returns clientId and clientSecret when generateOAuthClients is true", () => {
+            const instance = new OAuthAuthProviderInstance();
+            const context = createMockInstanceContext({ generateOAuthClients: true });
+            const props = instance.getSnippetProperties(context);
+            expect(props).toHaveLength(2);
+            expect(printProperties(props)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() returns empty array when generateOAuthClients is false", () => {
+            const instance = new OAuthAuthProviderInstance();
+            const context = createMockInstanceContext({ generateOAuthClients: false });
+            const props = instance.getSnippetProperties(context);
+            expect(props).toHaveLength(0);
+        });
+    });
+
+    describe("InferredAuthProviderInstance", () => {
+        it("instantiate() produces InferredAuthProvider.createInstance call", () => {
+            const instance = new InferredAuthProviderInstance();
+            const context = createMockInstanceContext();
+            const params = [ts.factory.createIdentifier("options")];
+            const result = instance.instantiate({ context, params });
+            expect(printExpression(result)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() returns empty array", () => {
+            const instance = new InferredAuthProviderInstance();
+            const context = createMockInstanceContext();
+            const props = instance.getSnippetProperties(context);
+            expect(props).toHaveLength(0);
+        });
+    });
+
+    describe("AnyAuthProviderInstance", () => {
+        it("instantiate() produces new AnyAuthProvider call", () => {
+            const bearerInstance = new BearerAuthProviderInstance(createBearerAuthScheme());
+            const instance = new AnyAuthProviderInstance([bearerInstance]);
+            const context = createMockInstanceContext();
+            const params = [ts.factory.createIdentifier("providers")];
+            const result = instance.instantiate({ context, params });
+            expect(printExpression(result)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() combines properties from all constituent providers", () => {
+            const bearerInstance = new BearerAuthProviderInstance(createBearerAuthScheme());
+            const basicInstance = new BasicAuthProviderInstance(createBasicAuthScheme());
+            const instance = new AnyAuthProviderInstance([bearerInstance, basicInstance]);
+            const context = createMockInstanceContext();
+            const props = instance.getSnippetProperties(context);
+            // bearer: token, basic: username + password = 3 total
+            expect(props).toHaveLength(3);
+            expect(printProperties(props)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() returns empty for empty providers list", () => {
+            const instance = new AnyAuthProviderInstance([]);
+            const context = createMockInstanceContext();
+            const props = instance.getSnippetProperties(context);
+            expect(props).toHaveLength(0);
+        });
+    });
+
+    describe("RoutingAuthProviderInstance", () => {
+        it("instantiate() produces new RoutingAuthProvider call", () => {
+            const providers = new Map<string, BasicAuthProviderInstance>();
+            providers.set("basic", new BasicAuthProviderInstance(createBasicAuthScheme()));
+            const instance = new RoutingAuthProviderInstance(providers);
+            const context = createMockInstanceContext();
+            const params = [ts.factory.createIdentifier("providers")];
+            const result = instance.instantiate({ context, params });
+            expect(printExpression(result)).toMatchSnapshot();
+        });
+
+        it("getSnippetProperties() combines properties from all routed providers", () => {
+            const providers = new Map<string, BearerAuthProviderInstance | HeaderAuthProviderInstance>();
+            providers.set("bearer", new BearerAuthProviderInstance(createBearerAuthScheme()));
+            providers.set("header", new HeaderAuthProviderInstance(createHeaderAuthScheme()));
+            const instance = new RoutingAuthProviderInstance(providers);
+            const context = createMockInstanceContext();
+            const props = instance.getSnippetProperties(context);
+            // bearer: token, header: apiKey = 2 total
+            expect(props).toHaveLength(2);
+            expect(printProperties(props)).toMatchSnapshot();
+        });
+    });
+});
+
+// ─── AuthProviderGenerator Tests ─────────────────────────────────────────────
+//
+// In the real code (AuthProvidersGenerator.ts), the same AuthScheme union variant from
+// ir.auth.schemes is passed directly as the constructor's `authScheme` parameter.
+// Generators use identity comparison (scheme === this.authScheme) internally to find
+// their scheme in the IR's auth.schemes array.
+//
+// We replicate this by passing the AuthScheme union variant (from createAuthScheme())
+// as both the IR scheme entry and the constructor `authScheme`, cast to the inner type.
+
+// biome-ignore lint/suspicious/noExplicitAny: AuthScheme union variant is structurally compatible with inner scheme types; cast matches real code pattern in AuthProvidersGenerator.ts
+type AnyScheme = any;
+
+describe("BearerAuthProviderGenerator", () => {
+    describe("getFilePath()", () => {
+        it("returns auth/BearerAuthProvider.ts path", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            expect(generator.getFilePath()).toMatchSnapshot();
+        });
+    });
+
+    describe("getAuthProviderClassType()", () => {
+        it("returns BearerAuthProvider type reference", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            expect(getTextOfTsNode(generator.getAuthProviderClassType())).toBe("BearerAuthProvider");
+        });
+    });
+
+    describe("getAuthOptionsProperties()", () => {
+        it("returns required token property when auth is mandatory and no env var", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "test.ts");
+            const props = generator.getAuthOptionsProperties(context);
+            expect(props).toMatchSnapshot();
+        });
+
+        it("returns optional token property with union type when env var is present", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme({ tokenEnvVar: "MY_TOKEN_ENV" }));
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "test.ts");
+            const props = generator.getAuthOptionsProperties(context);
+            expect(props).toMatchSnapshot();
+        });
+
+        it("returns optional token when auth is not mandatory", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: false,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "test.ts");
+            const props = generator.getAuthOptionsProperties(context);
+            expect(props).toMatchSnapshot();
+        });
+
+        it("includes docs when present on auth scheme", () => {
+            const authScheme = createAuthScheme(
+                "bearer",
+                createBearerAuthScheme({ docs: "The bearer token for authentication" })
+            );
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "test.ts");
+            const props = generator.getAuthOptionsProperties(context);
+            expect(props).toMatchSnapshot();
+        });
+    });
+
+    describe("instantiate()", () => {
+        it("produces BearerAuthProvider.createInstance call", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const result = generator.instantiate([ts.factory.createIdentifier("options")]);
+            expect(printExpression(result)).toMatchSnapshot();
+        });
+    });
+
+    describe("writeToFile()", () => {
+        it("generates bearer auth provider without env var", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "BearerAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates bearer auth provider with env var", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme({ tokenEnvVar: "PLANT_API_TOKEN" }));
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "BearerAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates bearer auth provider with neverThrowErrors", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: true,
+                isAuthMandatory: false,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "BearerAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates bearer auth provider with wrapper (multiple auth schemes)", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: true
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "BearerAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates bearer auth provider with env var + neverThrowErrors", () => {
+            const authScheme = createAuthScheme("bearer", createBearerAuthScheme({ tokenEnvVar: "PLANT_API_TOKEN" }));
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BearerAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: true,
+                isAuthMandatory: false,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "BearerAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+    });
+});
+
+describe("BasicAuthProviderGenerator", () => {
+    describe("getAuthOptionsProperties()", () => {
+        it("returns required username and password when auth is mandatory and no env vars", () => {
+            const authScheme = createAuthScheme("basic", createBasicAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BasicAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "test.ts");
+            const props = generator.getAuthOptionsProperties(context);
+            expect(props).toMatchSnapshot();
+        });
+
+        it("returns optional properties with union type when env vars are present", () => {
+            const authScheme = createAuthScheme(
+                "basic",
+                createBasicAuthScheme({
+                    usernameEnvVar: "PLANT_API_USERNAME",
+                    passwordEnvVar: "PLANT_API_PASSWORD"
+                })
+            );
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BasicAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "test.ts");
+            const props = generator.getAuthOptionsProperties(context);
+            expect(props).toMatchSnapshot();
+        });
+    });
+
+    describe("writeToFile()", () => {
+        it("generates basic auth provider without env vars", () => {
+            const authScheme = createAuthScheme("basic", createBasicAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BasicAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "BasicAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates basic auth provider with env vars", () => {
+            const authScheme = createAuthScheme(
+                "basic",
+                createBasicAuthScheme({
+                    usernameEnvVar: "PLANT_API_USERNAME",
+                    passwordEnvVar: "PLANT_API_PASSWORD"
+                })
+            );
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BasicAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "BasicAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates basic auth provider with neverThrowErrors", () => {
+            const authScheme = createAuthScheme("basic", createBasicAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BasicAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: true,
+                isAuthMandatory: false,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "BasicAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates basic auth provider with wrapper", () => {
+            const authScheme = createAuthScheme("basic", createBasicAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new BasicAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: true
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "BasicAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+    });
+});
+
+describe("HeaderAuthProviderGenerator", () => {
+    describe("getAuthOptionsProperties()", () => {
+        it("returns required header property when auth is mandatory and no env var", () => {
+            const authScheme = createAuthScheme("header", createHeaderAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new HeaderAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "test.ts");
+            const props = generator.getAuthOptionsProperties(context);
+            expect(props).toMatchSnapshot();
+        });
+
+        it("returns optional header property with env var fallback", () => {
+            const authScheme = createAuthScheme("header", createHeaderAuthScheme({ headerEnvVar: "PLANT_API_KEY" }));
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new HeaderAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "test.ts");
+            const props = generator.getAuthOptionsProperties(context);
+            expect(props).toMatchSnapshot();
+        });
+    });
+
+    describe("writeToFile()", () => {
+        it("generates header auth provider without env var", () => {
+            const authScheme = createAuthScheme("header", createHeaderAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new HeaderAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "HeaderAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates header auth provider with env var", () => {
+            const authScheme = createAuthScheme("header", createHeaderAuthScheme({ headerEnvVar: "PLANT_API_KEY" }));
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new HeaderAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "HeaderAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates header auth provider with neverThrowErrors", () => {
+            const authScheme = createAuthScheme("header", createHeaderAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new HeaderAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: true,
+                isAuthMandatory: false,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "HeaderAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates header auth provider with wrapper", () => {
+            const authScheme = createAuthScheme("header", createHeaderAuthScheme());
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new HeaderAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: true
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "HeaderAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("generates header auth provider with custom header name and prefix", () => {
+            const authScheme = createAuthScheme(
+                "header",
+                createHeaderAuthScheme({
+                    name: "authorization",
+                    wireValue: "Authorization",
+                    prefix: "Bearer "
+                })
+            );
+            const ir = createMinimalIR({ authSchemes: [authScheme] });
+            const generator = new HeaderAuthProviderGenerator({
+                ir,
+                authScheme: authScheme as AnyScheme,
+                neverThrowErrors: false,
+                isAuthMandatory: true,
+                shouldUseWrapper: false
+            });
+            const project = new Project({ useInMemoryFileSystem: true });
+            const context = createMockGeneratorContext(project, "HeaderAuthProvider.ts");
+            generator.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+    });
+});

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/AuthProviders.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/AuthProviders.test.ts.snap
@@ -1,0 +1,904 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthProviderInstance > AnyAuthProviderInstance > getSnippetProperties() combines properties from all constituent providers 1`] = `
+"{
+    token: "YOUR_TOKEN",
+    username: "YOUR_USERNAME",
+    password: "YOUR_PASSWORD"
+}"
+`;
+
+exports[`AuthProviderInstance > AnyAuthProviderInstance > instantiate() produces new AnyAuthProvider call 1`] = `"new AnyAuthProvider(providers)"`;
+
+exports[`AuthProviderInstance > BasicAuthProviderInstance > getSnippetProperties() returns username and password properties 1`] = `
+"{
+    username: "YOUR_USERNAME",
+    password: "YOUR_PASSWORD"
+}"
+`;
+
+exports[`AuthProviderInstance > BasicAuthProviderInstance > getSnippetProperties() uses custom field names from auth scheme 1`] = `
+"{
+    user: "YOUR_USER",
+    pass: "YOUR_PASS"
+}"
+`;
+
+exports[`AuthProviderInstance > BasicAuthProviderInstance > instantiate() produces BasicAuthProvider.createInstance call 1`] = `"BasicAuthProvider.createInstance(options)"`;
+
+exports[`AuthProviderInstance > BearerAuthProviderInstance > getSnippetProperties() returns token property 1`] = `
+"{
+    token: "YOUR_TOKEN"
+}"
+`;
+
+exports[`AuthProviderInstance > BearerAuthProviderInstance > getSnippetProperties() uses custom token name 1`] = `
+"{
+    accessToken: "YOUR_ACCESS_TOKEN"
+}"
+`;
+
+exports[`AuthProviderInstance > BearerAuthProviderInstance > instantiate() produces new BearerAuthProvider call 1`] = `"new BearerAuthProvider(options)"`;
+
+exports[`AuthProviderInstance > HeaderAuthProviderInstance > getSnippetProperties() returns header name property 1`] = `
+"{
+    apiKey: "YOUR_API_KEY"
+}"
+`;
+
+exports[`AuthProviderInstance > HeaderAuthProviderInstance > getSnippetProperties() uses custom header name 1`] = `
+"{
+    authToken: "YOUR_AUTH_TOKEN"
+}"
+`;
+
+exports[`AuthProviderInstance > HeaderAuthProviderInstance > instantiate() produces new HeaderAuthProvider call 1`] = `"new HeaderAuthProvider(options)"`;
+
+exports[`AuthProviderInstance > InferredAuthProviderInstance > instantiate() produces InferredAuthProvider.createInstance call 1`] = `"InferredAuthProvider.createInstance(options)"`;
+
+exports[`AuthProviderInstance > OAuthAuthProviderInstance > getSnippetProperties() returns clientId and clientSecret when generateOAuthClients is true 1`] = `
+"{
+    clientId: "YOUR_CLIENT_ID",
+    clientSecret: "YOUR_CLIENT_SECRET"
+}"
+`;
+
+exports[`AuthProviderInstance > OAuthAuthProviderInstance > instantiate() produces new OAuthAuthProvider call 1`] = `"new OAuthAuthProvider(options)"`;
+
+exports[`AuthProviderInstance > RoutingAuthProviderInstance > getSnippetProperties() combines properties from all routed providers 1`] = `
+"{
+    token: "YOUR_TOKEN",
+    apiKey: "YOUR_API_KEY"
+}"
+`;
+
+exports[`AuthProviderInstance > RoutingAuthProviderInstance > instantiate() produces new RoutingAuthProvider call 1`] = `"new RoutingAuthProvider(providers)"`;
+
+exports[`BasicAuthProviderGenerator > getAuthOptionsProperties() > returns optional properties with union type when env vars are present 1`] = `
+[
+  {
+    "docs": undefined,
+    "hasQuestionToken": true,
+    "kind": 33,
+    "name": "username",
+    "type": "core.Supplier<string> | undefined",
+  },
+  {
+    "docs": undefined,
+    "hasQuestionToken": true,
+    "kind": 33,
+    "name": "password",
+    "type": "core.Supplier<string> | undefined",
+  },
+]
+`;
+
+exports[`BasicAuthProviderGenerator > getAuthOptionsProperties() > returns required username and password when auth is mandatory and no env vars 1`] = `
+[
+  {
+    "docs": undefined,
+    "hasQuestionToken": false,
+    "kind": 33,
+    "name": "username",
+    "type": "core.Supplier<string>",
+  },
+  {
+    "docs": undefined,
+    "hasQuestionToken": false,
+    "kind": 33,
+    "name": "password",
+    "type": "core.Supplier<string>",
+  },
+]
+`;
+
+exports[`BasicAuthProviderGenerator > writeToFile() > generates basic auth provider with env vars 1`] = `
+"const USERNAME_PARAM = "username" as const;
+const PASSWORD_PARAM = "password" as const;
+const ENV_USERNAME = "PLANT_API_USERNAME" as const;
+const ENV_PASSWORD = "PLANT_API_PASSWORD" as const;
+
+export class BasicAuthProvider implements core.AuthProvider {
+    private readonly options: BasicAuthProvider.Options;
+
+    constructor(options: BasicAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<BasicAuthProvider.Options>): boolean {
+        return (options?.[USERNAME_PARAM] != null || process.env?.[ENV_USERNAME] != null) && (options?.[PASSWORD_PARAM] != null || process.env?.[ENV_PASSWORD] != null);
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const username = 
+                    (await core.Supplier.get(this.options[USERNAME_PARAM], { endpointMetadata })) ??
+                    process.env?.[ENV_USERNAME];
+                if (username == null) {
+                    throw new errors.SeedApiError({
+                        message: BasicAuthProvider.AUTH_CONFIG_ERROR_MESSAGE_USERNAME,
+                    });
+                }
+
+                const password = 
+                    (await core.Supplier.get(this.options[PASSWORD_PARAM], { endpointMetadata })) ??
+                    process.env?.[ENV_PASSWORD];
+                if (password == null) {
+                    throw new errors.SeedApiError({
+                        message: BasicAuthProvider.AUTH_CONFIG_ERROR_MESSAGE_PASSWORD,
+                    });
+                }
+
+                const authHeader = core.BasicAuth.toAuthorizationHeader(username, password);
+
+                return {
+                    headers: authHeader != null ? { Authorization: authHeader } : {},
+                };
+                
+    }
+}
+
+export namespace BasicAuthProvider {
+    export const AUTH_SCHEME = "BasicAuth" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = "Please provide username and password when initializing the client" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE_USERNAME: string = \`Please provide '\${USERNAME_PARAM}' when initializing the client, or set the '\${ENV_USERNAME}' environment variable\` as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE_PASSWORD: string = \`Please provide '\${PASSWORD_PARAM}' when initializing the client, or set the '\${ENV_PASSWORD}' environment variable\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [USERNAME_PARAM]?: core.Supplier<string> | undefined; [PASSWORD_PARAM]?: core.Supplier<string> | undefined };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new BasicAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`BasicAuthProviderGenerator > writeToFile() > generates basic auth provider with neverThrowErrors 1`] = `
+"const USERNAME_PARAM = "username" as const;
+const PASSWORD_PARAM = "password" as const;
+
+export class BasicAuthProvider implements core.AuthProvider {
+    private readonly options: BasicAuthProvider.Options;
+
+    constructor(options: BasicAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<BasicAuthProvider.Options>): boolean {
+        return (options?.[USERNAME_PARAM] != null) && (options?.[PASSWORD_PARAM] != null);
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const username = await core.Supplier.get(this.options[USERNAME_PARAM], { endpointMetadata });
+                if (username == null) {
+                    return { headers: {} };
+                }
+
+                const password = await core.Supplier.get(this.options[PASSWORD_PARAM], { endpointMetadata });
+                if (password == null) {
+                    return { headers: {} };
+                }
+
+                const authHeader = core.BasicAuth.toAuthorizationHeader(username, password);
+
+                return {
+                    headers: authHeader != null ? { Authorization: authHeader } : {},
+                };
+                
+    }
+}
+
+export namespace BasicAuthProvider {
+    export const AUTH_SCHEME = "BasicAuth" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = "Please provide username and password when initializing the client" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE_USERNAME: string = \`Please provide '\${USERNAME_PARAM}' when initializing the client\` as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE_PASSWORD: string = \`Please provide '\${PASSWORD_PARAM}' when initializing the client\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [USERNAME_PARAM]?: core.Supplier<string>; [PASSWORD_PARAM]?: core.Supplier<string> };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new BasicAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`BasicAuthProviderGenerator > writeToFile() > generates basic auth provider with wrapper 1`] = `
+"const WRAPPER_PROPERTY = "basicAuth" as const;
+const USERNAME_PARAM = "username" as const;
+const PASSWORD_PARAM = "password" as const;
+
+export class BasicAuthProvider implements core.AuthProvider {
+    private readonly options: BasicAuthProvider.Options;
+
+    constructor(options: BasicAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<BasicAuthProvider.Options>): boolean {
+        return (options?.[WRAPPER_PROPERTY]?.[USERNAME_PARAM] != null) && (options?.[WRAPPER_PROPERTY]?.[PASSWORD_PARAM] != null);
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const username = await core.Supplier.get(this.options[WRAPPER_PROPERTY]?.[USERNAME_PARAM], { endpointMetadata });
+                if (username == null) {
+                    throw new errors.SeedApiError({
+                        message: BasicAuthProvider.AUTH_CONFIG_ERROR_MESSAGE_USERNAME,
+                    });
+                }
+
+                const password = await core.Supplier.get(this.options[WRAPPER_PROPERTY]?.[PASSWORD_PARAM], { endpointMetadata });
+                if (password == null) {
+                    throw new errors.SeedApiError({
+                        message: BasicAuthProvider.AUTH_CONFIG_ERROR_MESSAGE_PASSWORD,
+                    });
+                }
+
+                const authHeader = core.BasicAuth.toAuthorizationHeader(username, password);
+
+                return {
+                    headers: authHeader != null ? { Authorization: authHeader } : {},
+                };
+                
+    }
+}
+
+export namespace BasicAuthProvider {
+    export const AUTH_SCHEME = "BasicAuth" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = "Please provide username and password when initializing the client" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE_USERNAME: string = \`Please provide '\${USERNAME_PARAM}' when initializing the client\` as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE_PASSWORD: string = \`Please provide '\${PASSWORD_PARAM}' when initializing the client\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = {
+                [WRAPPER_PROPERTY]?: { [USERNAME_PARAM]: core.Supplier<string>; [PASSWORD_PARAM]: core.Supplier<string> };
+            };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new BasicAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`BasicAuthProviderGenerator > writeToFile() > generates basic auth provider without env vars 1`] = `
+"const USERNAME_PARAM = "username" as const;
+const PASSWORD_PARAM = "password" as const;
+
+export class BasicAuthProvider implements core.AuthProvider {
+    private readonly options: BasicAuthProvider.Options;
+
+    constructor(options: BasicAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<BasicAuthProvider.Options>): boolean {
+        return (options?.[USERNAME_PARAM] != null) && (options?.[PASSWORD_PARAM] != null);
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const username = await core.Supplier.get(this.options[USERNAME_PARAM], { endpointMetadata });
+                if (username == null) {
+                    throw new errors.SeedApiError({
+                        message: BasicAuthProvider.AUTH_CONFIG_ERROR_MESSAGE_USERNAME,
+                    });
+                }
+
+                const password = await core.Supplier.get(this.options[PASSWORD_PARAM], { endpointMetadata });
+                if (password == null) {
+                    throw new errors.SeedApiError({
+                        message: BasicAuthProvider.AUTH_CONFIG_ERROR_MESSAGE_PASSWORD,
+                    });
+                }
+
+                const authHeader = core.BasicAuth.toAuthorizationHeader(username, password);
+
+                return {
+                    headers: authHeader != null ? { Authorization: authHeader } : {},
+                };
+                
+    }
+}
+
+export namespace BasicAuthProvider {
+    export const AUTH_SCHEME = "BasicAuth" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = "Please provide username and password when initializing the client" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE_USERNAME: string = \`Please provide '\${USERNAME_PARAM}' when initializing the client\` as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE_PASSWORD: string = \`Please provide '\${PASSWORD_PARAM}' when initializing the client\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [USERNAME_PARAM]: core.Supplier<string>; [PASSWORD_PARAM]: core.Supplier<string> };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new BasicAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`BearerAuthProviderGenerator > getAuthOptionsProperties() > includes docs when present on auth scheme 1`] = `
+[
+  {
+    "docs": [
+      "The bearer token for authentication",
+    ],
+    "hasQuestionToken": false,
+    "kind": 33,
+    "name": "token",
+    "type": "core.Supplier<core.BearerToken>",
+  },
+]
+`;
+
+exports[`BearerAuthProviderGenerator > getAuthOptionsProperties() > returns optional token property with union type when env var is present 1`] = `
+[
+  {
+    "docs": undefined,
+    "hasQuestionToken": true,
+    "kind": 33,
+    "name": "token",
+    "type": "core.Supplier<core.BearerToken> | undefined",
+  },
+]
+`;
+
+exports[`BearerAuthProviderGenerator > getAuthOptionsProperties() > returns optional token when auth is not mandatory 1`] = `
+[
+  {
+    "docs": undefined,
+    "hasQuestionToken": true,
+    "kind": 33,
+    "name": "token",
+    "type": "core.Supplier<core.BearerToken>",
+  },
+]
+`;
+
+exports[`BearerAuthProviderGenerator > getAuthOptionsProperties() > returns required token property when auth is mandatory and no env var 1`] = `
+[
+  {
+    "docs": undefined,
+    "hasQuestionToken": false,
+    "kind": 33,
+    "name": "token",
+    "type": "core.Supplier<core.BearerToken>",
+  },
+]
+`;
+
+exports[`BearerAuthProviderGenerator > getFilePath() > returns auth/BearerAuthProvider.ts path 1`] = `
+{
+  "directories": [
+    {
+      "nameOnDisk": "auth",
+    },
+  ],
+  "file": {
+    "exportDeclaration": {
+      "namedExports": [
+        "BearerAuthProvider",
+      ],
+    },
+    "nameOnDisk": "BearerAuthProvider.ts",
+  },
+}
+`;
+
+exports[`BearerAuthProviderGenerator > instantiate() > produces BearerAuthProvider.createInstance call 1`] = `"BearerAuthProvider.createInstance(options)"`;
+
+exports[`BearerAuthProviderGenerator > writeToFile() > generates bearer auth provider with env var + neverThrowErrors 1`] = `
+"const TOKEN_PARAM = "token" as const;
+const ENV_TOKEN = "PLANT_API_TOKEN" as const;
+
+export class BearerAuthProvider implements core.AuthProvider {
+    private readonly options: BearerAuthProvider.Options;
+
+    constructor(options: BearerAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<BearerAuthProvider.Options>): boolean {
+        return options?.[TOKEN_PARAM] != null || process.env?.[ENV_TOKEN] != null;
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const token = 
+                    (await core.Supplier.get(this.options[TOKEN_PARAM], { endpointMetadata })) ??
+                    process.env?.[ENV_TOKEN];
+                if (token == null) {
+                    return { headers: {} };
+                }
+
+                return {
+                    headers: { Authorization: \`Bearer \${token}\` },
+                };
+                
+    }
+}
+
+export namespace BearerAuthProvider {
+    export const AUTH_SCHEME = "Bearer" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = \`Please provide '\${TOKEN_PARAM}' when initializing the client, or set the '\${ENV_TOKEN}' environment variable\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [TOKEN_PARAM]?: core.Supplier<core.BearerToken> | undefined };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new BearerAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`BearerAuthProviderGenerator > writeToFile() > generates bearer auth provider with env var 1`] = `
+"const TOKEN_PARAM = "token" as const;
+const ENV_TOKEN = "PLANT_API_TOKEN" as const;
+
+export class BearerAuthProvider implements core.AuthProvider {
+    private readonly options: BearerAuthProvider.Options;
+
+    constructor(options: BearerAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<BearerAuthProvider.Options>): boolean {
+        return options?.[TOKEN_PARAM] != null || process.env?.[ENV_TOKEN] != null;
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const token = 
+                    (await core.Supplier.get(this.options[TOKEN_PARAM], { endpointMetadata })) ??
+                    process.env?.[ENV_TOKEN];
+                if (token == null) {
+                    throw new errors.SeedApiError({
+                        message: BearerAuthProvider.AUTH_CONFIG_ERROR_MESSAGE,
+                    });
+                }
+
+                return {
+                    headers: { Authorization: \`Bearer \${token}\` },
+                };
+                
+    }
+}
+
+export namespace BearerAuthProvider {
+    export const AUTH_SCHEME = "Bearer" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = \`Please provide '\${TOKEN_PARAM}' when initializing the client, or set the '\${ENV_TOKEN}' environment variable\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [TOKEN_PARAM]?: core.Supplier<core.BearerToken> | undefined };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new BearerAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`BearerAuthProviderGenerator > writeToFile() > generates bearer auth provider with neverThrowErrors 1`] = `
+"const TOKEN_PARAM = "token" as const;
+
+export class BearerAuthProvider implements core.AuthProvider {
+    private readonly options: BearerAuthProvider.Options;
+
+    constructor(options: BearerAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<BearerAuthProvider.Options>): boolean {
+        return options?.[TOKEN_PARAM] != null;
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const token = await core.Supplier.get(this.options[TOKEN_PARAM], { endpointMetadata });
+                if (token == null) {
+                    return { headers: {} };
+                }
+
+                return {
+                    headers: { Authorization: \`Bearer \${token}\` },
+                };
+                
+    }
+}
+
+export namespace BearerAuthProvider {
+    export const AUTH_SCHEME = "Bearer" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = \`Please provide '\${TOKEN_PARAM}' when initializing the client\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [TOKEN_PARAM]?: core.Supplier<core.BearerToken> };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new BearerAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`BearerAuthProviderGenerator > writeToFile() > generates bearer auth provider with wrapper (multiple auth schemes) 1`] = `
+"const WRAPPER_PROPERTY = "bearer" as const;
+const TOKEN_PARAM = "token" as const;
+
+export class BearerAuthProvider implements core.AuthProvider {
+    private readonly options: BearerAuthProvider.Options;
+
+    constructor(options: BearerAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<BearerAuthProvider.Options>): boolean {
+        return options?.[WRAPPER_PROPERTY]?.[TOKEN_PARAM] != null;
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const token = await core.Supplier.get(this.options[WRAPPER_PROPERTY]?.[TOKEN_PARAM], { endpointMetadata });
+                if (token == null) {
+                    throw new errors.SeedApiError({
+                        message: BearerAuthProvider.AUTH_CONFIG_ERROR_MESSAGE,
+                    });
+                }
+
+                return {
+                    headers: { Authorization: \`Bearer \${token}\` },
+                };
+                
+    }
+}
+
+export namespace BearerAuthProvider {
+    export const AUTH_SCHEME = "Bearer" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = \`Please provide '\${TOKEN_PARAM}' when initializing the client\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = {
+                [WRAPPER_PROPERTY]?: { [TOKEN_PARAM]: core.Supplier<core.BearerToken> };
+            };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new BearerAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`BearerAuthProviderGenerator > writeToFile() > generates bearer auth provider without env var 1`] = `
+"const TOKEN_PARAM = "token" as const;
+
+export class BearerAuthProvider implements core.AuthProvider {
+    private readonly options: BearerAuthProvider.Options;
+
+    constructor(options: BearerAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<BearerAuthProvider.Options>): boolean {
+        return options?.[TOKEN_PARAM] != null;
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const token = await core.Supplier.get(this.options[TOKEN_PARAM], { endpointMetadata });
+                if (token == null) {
+                    throw new errors.SeedApiError({
+                        message: BearerAuthProvider.AUTH_CONFIG_ERROR_MESSAGE,
+                    });
+                }
+
+                return {
+                    headers: { Authorization: \`Bearer \${token}\` },
+                };
+                
+    }
+}
+
+export namespace BearerAuthProvider {
+    export const AUTH_SCHEME = "Bearer" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = \`Please provide '\${TOKEN_PARAM}' when initializing the client\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [TOKEN_PARAM]: core.Supplier<core.BearerToken> };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new BearerAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`HeaderAuthProviderGenerator > getAuthOptionsProperties() > returns optional header property with env var fallback 1`] = `
+[
+  {
+    "docs": undefined,
+    "hasQuestionToken": true,
+    "kind": 33,
+    "name": "apiKey",
+    "type": "core.Supplier<string> | undefined",
+  },
+]
+`;
+
+exports[`HeaderAuthProviderGenerator > getAuthOptionsProperties() > returns required header property when auth is mandatory and no env var 1`] = `
+[
+  {
+    "docs": undefined,
+    "hasQuestionToken": false,
+    "kind": 33,
+    "name": "apiKey",
+    "type": "core.Supplier<string>",
+  },
+]
+`;
+
+exports[`HeaderAuthProviderGenerator > writeToFile() > generates header auth provider with custom header name and prefix 1`] = `
+"const PARAM_KEY = "authorization" as const;
+const HEADER_NAME = "Authorization" as const;
+
+export class HeaderAuthProvider implements core.AuthProvider {
+    private readonly options: HeaderAuthProvider.Options;
+
+    constructor(options: HeaderAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<HeaderAuthProvider.Options>): boolean {
+        return options?.[PARAM_KEY] != null;
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const headerValue = await core.Supplier.get(this.options[PARAM_KEY], { endpointMetadata });
+                if (headerValue == null) {
+                    throw new errors.SeedApiError({
+                        message: HeaderAuthProvider.AUTH_CONFIG_ERROR_MESSAGE,
+                    });
+                }
+
+                return {
+                    headers: { [HEADER_NAME]: headerValue },
+                };
+                
+    }
+}
+
+export namespace HeaderAuthProvider {
+    export const AUTH_SCHEME = "ApiKey" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = \`Please provide '\${PARAM_KEY}' when initializing the client\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [PARAM_KEY]: core.Supplier<string> };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new HeaderAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`HeaderAuthProviderGenerator > writeToFile() > generates header auth provider with env var 1`] = `
+"const PARAM_KEY = "apiKey" as const;
+const ENV_HEADER_KEY = "PLANT_API_KEY" as const;
+const HEADER_NAME = "X-API-Key" as const;
+
+export class HeaderAuthProvider implements core.AuthProvider {
+    private readonly options: HeaderAuthProvider.Options;
+
+    constructor(options: HeaderAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<HeaderAuthProvider.Options>): boolean {
+        return options?.[PARAM_KEY] != null || process.env?.[ENV_HEADER_KEY] != null;
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const headerValue = 
+                    (await core.Supplier.get(this.options[PARAM_KEY], { endpointMetadata })) ??
+                    process.env?.[ENV_HEADER_KEY];
+                if (headerValue == null) {
+                    throw new errors.SeedApiError({
+                        message: HeaderAuthProvider.AUTH_CONFIG_ERROR_MESSAGE,
+                    });
+                }
+
+                return {
+                    headers: { [HEADER_NAME]: headerValue },
+                };
+                
+    }
+}
+
+export namespace HeaderAuthProvider {
+    export const AUTH_SCHEME = "ApiKey" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = \`Please provide '\${PARAM_KEY}' when initializing the client, or set the '\${ENV_HEADER_KEY}' environment variable\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [PARAM_KEY]?: core.Supplier<string> | undefined };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new HeaderAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`HeaderAuthProviderGenerator > writeToFile() > generates header auth provider with neverThrowErrors 1`] = `
+"const PARAM_KEY = "apiKey" as const;
+const HEADER_NAME = "X-API-Key" as const;
+
+export class HeaderAuthProvider implements core.AuthProvider {
+    private readonly options: HeaderAuthProvider.Options;
+
+    constructor(options: HeaderAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<HeaderAuthProvider.Options>): boolean {
+        return options?.[PARAM_KEY] != null;
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const headerValue = await core.Supplier.get(this.options[PARAM_KEY], { endpointMetadata });
+                if (headerValue == null) {
+                    return { headers: {} };
+                }
+
+                return {
+                    headers: { [HEADER_NAME]: headerValue },
+                };
+                
+    }
+}
+
+export namespace HeaderAuthProvider {
+    export const AUTH_SCHEME = "ApiKey" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = \`Please provide '\${PARAM_KEY}' when initializing the client\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [PARAM_KEY]?: core.Supplier<string> };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new HeaderAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`HeaderAuthProviderGenerator > writeToFile() > generates header auth provider with wrapper 1`] = `
+"const WRAPPER_PROPERTY = "apiKey" as const;
+const PARAM_KEY = "apiKey" as const;
+const HEADER_NAME = "X-API-Key" as const;
+
+export class HeaderAuthProvider implements core.AuthProvider {
+    private readonly options: HeaderAuthProvider.Options;
+
+    constructor(options: HeaderAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<HeaderAuthProvider.Options>): boolean {
+        return options?.[WRAPPER_PROPERTY]?.[PARAM_KEY] != null;
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const headerValue = await core.Supplier.get(this.options[WRAPPER_PROPERTY]?.[PARAM_KEY], { endpointMetadata });
+                if (headerValue == null) {
+                    throw new errors.SeedApiError({
+                        message: HeaderAuthProvider.AUTH_CONFIG_ERROR_MESSAGE,
+                    });
+                }
+
+                return {
+                    headers: { [HEADER_NAME]: headerValue },
+                };
+                
+    }
+}
+
+export namespace HeaderAuthProvider {
+    export const AUTH_SCHEME = "ApiKey" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = \`Please provide '\${PARAM_KEY}' when initializing the client\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = {
+                [WRAPPER_PROPERTY]?: { [PARAM_KEY]: core.Supplier<string> };
+            };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new HeaderAuthProvider(options);
+    }
+}
+"
+`;
+
+exports[`HeaderAuthProviderGenerator > writeToFile() > generates header auth provider without env var 1`] = `
+"const PARAM_KEY = "apiKey" as const;
+const HEADER_NAME = "X-API-Key" as const;
+
+export class HeaderAuthProvider implements core.AuthProvider {
+    private readonly options: HeaderAuthProvider.Options;
+
+    constructor(options: HeaderAuthProvider.Options) {
+        this.options = options;
+    }
+
+    public static canCreate(options: Partial<HeaderAuthProvider.Options>): boolean {
+        return options?.[PARAM_KEY] != null;
+    }
+
+    public async getAuthRequest({ endpointMetadata }: {
+            endpointMetadata?: core.EndpointMetadata;
+        } = {}): Promise<core.AuthRequest> {
+
+                const headerValue = await core.Supplier.get(this.options[PARAM_KEY], { endpointMetadata });
+                if (headerValue == null) {
+                    throw new errors.SeedApiError({
+                        message: HeaderAuthProvider.AUTH_CONFIG_ERROR_MESSAGE,
+                    });
+                }
+
+                return {
+                    headers: { [HEADER_NAME]: headerValue },
+                };
+                
+    }
+}
+
+export namespace HeaderAuthProvider {
+    export const AUTH_SCHEME = "ApiKey" as const;
+    export const AUTH_CONFIG_ERROR_MESSAGE: string = \`Please provide '\${PARAM_KEY}' when initializing the client\` as const;
+    export type Options = AuthOptions;
+    export type AuthOptions = { [PARAM_KEY]: core.Supplier<string> };
+
+    export function createInstance(options: Options): core.AuthProvider {
+        return new HeaderAuthProvider(options);
+    }
+}
+"
+`;

--- a/generators/typescript/sdk/test-utils/src/index.ts
+++ b/generators/typescript/sdk/test-utils/src/index.ts
@@ -1,5 +1,14 @@
 export { casingsGenerator, createNameAndWireValue } from "./casings.js";
-export { createHttpHeader, createPathParameter, createQueryParameter } from "./ir-factories.js";
+export {
+    createAuthScheme,
+    createBasicAuthScheme,
+    createBearerAuthScheme,
+    createHeaderAuthScheme,
+    createHttpHeader,
+    createMinimalIR,
+    createPathParameter,
+    createQueryParameter
+} from "./ir-factories.js";
 export {
     createMockCoreUtilities,
     createMockEnvironmentsContext,

--- a/generators/typescript/sdk/test-utils/src/ir-factories.ts
+++ b/generators/typescript/sdk/test-utils/src/ir-factories.ts
@@ -3,6 +3,91 @@ import { FernIr } from "@fern-fern/ir-sdk";
 import { casingsGenerator, createNameAndWireValue } from "./casings.js";
 
 /**
+ * Creates a BearerAuthScheme IR object for use in tests.
+ */
+export function createBearerAuthScheme(opts?: {
+    tokenName?: string;
+    tokenEnvVar?: string;
+    docs?: string;
+}): FernIr.BearerAuthScheme {
+    return {
+        docs: opts?.docs,
+        token: casingsGenerator.generateName(opts?.tokenName ?? "token"),
+        tokenEnvVar: opts?.tokenEnvVar
+    };
+}
+
+/**
+ * Creates a BasicAuthScheme IR object for use in tests.
+ */
+export function createBasicAuthScheme(opts?: {
+    username?: string;
+    password?: string;
+    usernameEnvVar?: string;
+    passwordEnvVar?: string;
+    docs?: string;
+}): FernIr.BasicAuthScheme {
+    return {
+        docs: opts?.docs,
+        username: casingsGenerator.generateName(opts?.username ?? "username"),
+        usernameEnvVar: opts?.usernameEnvVar,
+        password: casingsGenerator.generateName(opts?.password ?? "password"),
+        passwordEnvVar: opts?.passwordEnvVar
+    };
+}
+
+/**
+ * Creates a HeaderAuthScheme IR object for use in tests.
+ */
+export function createHeaderAuthScheme(opts?: {
+    name?: string;
+    wireValue?: string;
+    headerEnvVar?: string;
+    docs?: string;
+    prefix?: string;
+}): FernIr.HeaderAuthScheme {
+    return {
+        docs: opts?.docs,
+        name: createNameAndWireValue(opts?.name ?? "apiKey", opts?.wireValue ?? "X-API-Key"),
+        valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+        prefix: opts?.prefix,
+        headerEnvVar: opts?.headerEnvVar
+    };
+}
+
+/**
+ * Creates a minimal IR object with auth configuration for use in auth provider tests.
+ * Only populates the fields that auth provider generators actually access.
+ */
+export function createMinimalIR(opts?: {
+    authSchemes?: FernIr.AuthScheme[];
+    isAuthMandatory?: boolean;
+    services?: Record<string, FernIr.HttpService>;
+}): FernIr.IntermediateRepresentation {
+    return {
+        auth: {
+            schemes: opts?.authSchemes ?? [],
+            docs: undefined,
+            requirement: "ALL"
+        },
+        sdkConfig: {
+            isAuthMandatory: opts?.isAuthMandatory ?? false,
+            hasStreamingEndpoints: false,
+            hasPaginatedEndpoints: false,
+            hasFileDownloadEndpoints: false,
+            platformHeaders: {
+                language: "",
+                sdkName: "",
+                sdkVersion: "",
+                userAgent: undefined
+            }
+        },
+        services: opts?.services ?? {}
+        // biome-ignore lint/suspicious/noExplicitAny: minimal IR mock for auth provider tests
+    } as any;
+}
+
+/**
  * Creates a PathParameter IR object for use in tests.
  */
 export function createPathParameter(
@@ -45,6 +130,36 @@ export function createQueryParameter(
 /**
  * Creates an HttpHeader IR object for use in tests.
  */
+/**
+ * Creates an AuthScheme union variant for use in IR auth configuration.
+ * The returned object preserves reference identity with the input scheme object,
+ * which is required because generators use identity comparison (=== this.authScheme)
+ * to find their scheme in the IR's auth.schemes array.
+ */
+export function createAuthScheme(
+    type: "bearer" | "basic" | "header",
+    scheme: FernIr.BearerAuthScheme | FernIr.BasicAuthScheme | FernIr.HeaderAuthScheme,
+    key?: string
+): FernIr.AuthScheme {
+    // We must create the union variant and then mutate the key onto the same object
+    // so that identity comparison (scheme === this.authScheme) works in the generators.
+    let authScheme: FernIr.AuthScheme;
+    switch (type) {
+        case "bearer":
+            authScheme = FernIr.AuthScheme.bearer(scheme as FernIr.BearerAuthScheme);
+            break;
+        case "basic":
+            authScheme = FernIr.AuthScheme.basic(scheme as FernIr.BasicAuthScheme);
+            break;
+        case "header":
+            authScheme = FernIr.AuthScheme.header(scheme as FernIr.HeaderAuthScheme);
+            break;
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: AuthScheme union type doesn't include key in its type definition but IR objects have it at runtime
+    (authScheme as any).key = key ?? (type === "bearer" ? "Bearer" : type === "basic" ? "BasicAuth" : "ApiKey");
+    return authScheme;
+}
+
 export function createHttpHeader(
     name: string,
     valueType: FernIr.TypeReference,

--- a/generators/typescript/sdk/test-utils/src/ir-factories.ts
+++ b/generators/typescript/sdk/test-utils/src/ir-factories.ts
@@ -13,7 +13,8 @@ export function createBearerAuthScheme(opts?: {
     return {
         docs: opts?.docs,
         token: casingsGenerator.generateName(opts?.tokenName ?? "token"),
-        tokenEnvVar: opts?.tokenEnvVar
+        tokenEnvVar: opts?.tokenEnvVar,
+        key: opts?.tokenName ?? "Bearer"
     };
 }
 
@@ -31,8 +32,11 @@ export function createBasicAuthScheme(opts?: {
         docs: opts?.docs,
         username: casingsGenerator.generateName(opts?.username ?? "username"),
         usernameEnvVar: opts?.usernameEnvVar,
+        usernameOmit: undefined,
         password: casingsGenerator.generateName(opts?.password ?? "password"),
-        passwordEnvVar: opts?.passwordEnvVar
+        passwordEnvVar: opts?.passwordEnvVar,
+        passwordOmit: undefined,
+        key: "BasicAuth"
     };
 }
 
@@ -51,7 +55,8 @@ export function createHeaderAuthScheme(opts?: {
         name: createNameAndWireValue(opts?.name ?? "apiKey", opts?.wireValue ?? "X-API-Key"),
         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
         prefix: opts?.prefix,
-        headerEnvVar: opts?.headerEnvVar
+        headerEnvVar: opts?.headerEnvVar,
+        key: opts?.name ?? "ApiKey"
     };
 }
 
@@ -128,9 +133,6 @@ export function createQueryParameter(
 }
 
 /**
- * Creates an HttpHeader IR object for use in tests.
- */
-/**
  * Creates an AuthScheme union variant for use in IR auth configuration.
  * The returned object preserves reference identity with the input scheme object,
  * which is required because generators use identity comparison (=== this.authScheme)
@@ -160,6 +162,9 @@ export function createAuthScheme(
     return authScheme;
 }
 
+/**
+ * Creates an HttpHeader IR object for use in tests.
+ */
 export function createHttpHeader(
     name: string,
     valueType: FernIr.TypeReference,

--- a/generators/typescript/sdk/test-utils/src/ir-factories.ts
+++ b/generators/typescript/sdk/test-utils/src/ir-factories.ts
@@ -14,7 +14,7 @@ export function createBearerAuthScheme(opts?: {
         docs: opts?.docs,
         token: casingsGenerator.generateName(opts?.tokenName ?? "token"),
         tokenEnvVar: opts?.tokenEnvVar,
-        key: opts?.tokenName ?? "Bearer"
+        key: "Bearer"
     };
 }
 
@@ -49,6 +49,7 @@ export function createHeaderAuthScheme(opts?: {
     headerEnvVar?: string;
     docs?: string;
     prefix?: string;
+    key?: string;
 }): FernIr.HeaderAuthScheme {
     return {
         docs: opts?.docs,
@@ -56,7 +57,7 @@ export function createHeaderAuthScheme(opts?: {
         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
         prefix: opts?.prefix,
         headerEnvVar: opts?.headerEnvVar,
-        key: opts?.name ?? "ApiKey"
+        key: opts?.key ?? "ApiKey"
     };
 }
 


### PR DESCRIPTION
## Description

Refs: Priority 2 of TS SDK generator unit testing plan (follow-up to #13293, #13298)

Adds comprehensive unit tests for all Auth Provider Instance classes and the three Auth Provider Generator classes (Bearer, Basic, Header). This is the third PR in a series adding targeted unit tests to the TypeScript SDK generator ahead of the AST migration.

Link to Devin session: https://app.devin.ai/sessions/ce25a6da44a14437a2fa92712a187cf6
Requested by: @Swimburger

## Changes Made

- **New test file** `AuthProviders.test.ts` — 44 tests covering:
  - **Instance classes** (31 tests): `BasicAuthProviderInstance`, `BearerAuthProviderInstance`, `HeaderAuthProviderInstance`, `OAuthAuthProviderInstance`, `InferredAuthProviderInstance`, `AnyAuthProviderInstance`, `RoutingAuthProviderInstance` — tests `instantiate()` and `getSnippetProperties()` for each
  - **Generator classes** (13 tests): `BearerAuthProviderGenerator`, `BasicAuthProviderGenerator`, `HeaderAuthProviderGenerator` — tests `getFilePath()`, `getAuthProviderClassType()`, `getAuthOptionsProperties()`, `instantiate()`, and `writeToFile()` across permutations (with/without env vars, neverThrowErrors, wrapper mode, docs)
- **New IR factories** in `test-utils/src/ir-factories.ts`: `createBearerAuthScheme()`, `createBasicAuthScheme()`, `createHeaderAuthScheme()`, `createMinimalIR()`, `createAuthScheme()`
- **Updated exports** in `test-utils/src/index.ts` for the new factories

## Important review notes

1. **Identity comparison pattern**: Auth provider generators use `scheme === this.authScheme` (reference equality) to locate their scheme in the IR. `createAuthScheme()` works around this by creating the union variant via `FernIr.AuthScheme.bearer(scheme)` and then mutating a `key` property onto the result via `(authScheme as any).key = ...`. Please verify this matches the real runtime behavior in `AuthProvidersGenerator.ts`.

2. **Mock context coverage**: Tests use minimal mock contexts (`createMockInstanceContext`, `createMockGeneratorContext`) with `as any` casts. The mocks only provide the subset of properties actually accessed by the tested code paths. If generators are refactored to access additional context properties, these tests may pass incorrectly.

3. **Snapshot verification**: All 40 snapshots verified against seed fixture patterns (`seed/ts-sdk/*/src/auth/*AuthProvider.ts`). Class structure, error handling, env var fallback, and wrapper mode all match. Minor expected differences from seed: `Supplier.get` now passes `{ endpointMetadata }` (newer generator feature), and formatting differences (ts-morph serialization vs prettier).

## Updates since last revision

- **Fixed compilation errors**: Added missing `key` property to all three auth scheme factories and `usernameOmit`/`passwordOmit` to `createBasicAuthScheme()` (required by updated `BaseAuthScheme` IR type)
- **Fixed auth scheme `key` values** (Devin Review feedback): Decoupled `key` from parameter names — `createBearerAuthScheme` now always uses `key: "Bearer"` regardless of `tokenName`; `createHeaderAuthScheme` uses a separate `key` option instead of deriving from `name`
- **Fixed orphaned JSDoc comment**: Restored `/** Creates an HttpHeader IR object ... */` above `createHttpHeader()`

## Suggested human review checklist

- [ ] Verify `createAuthScheme()` identity-preserving mutation (`(authScheme as any).key = ...`) is safe given how `FernIr.AuthScheme.bearer/basic/header` constructs union variants
- [ ] Confirm `as any` mock contexts cover all code paths exercised in tests (search for property accesses in the real Instance/Generator classes that aren't in the mocks)
- [ ] Spot-check a few `writeToFile()` snapshots against seed output for structural correctness

## Testing

- [x] Unit tests added (77 total tests pass across 5 test files)
- [x] Manual testing: ran `pnpm run check` (lint passes) and `pnpm --filter @fern-typescript/sdk-client-class-generator run test` (all pass)
- [x] Snapshots verified against seed output patterns
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
