### PR TITLE
feat(cli): Implement fern docs publish

### DIFF
--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -52,6 +52,8 @@
     "@fern-api/core": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-preview": "workspace:*",
+    "@fern-api/docs-resolver": "workspace:*",
+    "@fern-api/docs-validator": "workspace:*",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fern-definition-validator": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",

--- a/packages/cli/cli-v2/src/__test__/loadFernYml.test.ts
+++ b/packages/cli/cli-v2/src/__test__/loadFernYml.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadFernYml } from "../config/fern-yml/loadFernYml.js";
-import { ValidationError } from "../errors/ValidationError.js";
+import { SourcedValidationError } from "../errors/SourcedValidationError.js";
 
 const SAMPLE_FERN_YML = `edition: 2026-01-01
 org: acme
@@ -123,7 +123,7 @@ describe("loadFernYml", () => {
     });
 
     describe("validation errors", () => {
-        it("throws ValidationError with descriptive messages for missing required fields", async () => {
+        it("throws SourcedValidationError with descriptive messages for missing required fields", async () => {
             await writeFile(
                 join(testDir, "fern.yml"),
                 `
@@ -135,11 +135,11 @@ cli:
 
             try {
                 await loadFernYml({ cwd: testDir });
-                expect.fail("Expected ValidationError to be thrown");
+                expect.fail("Expected SourcedValidationError to be thrown");
             } catch (error) {
-                expect(error).toBeInstanceOf(ValidationError);
+                expect(error).toBeInstanceOf(SourcedValidationError);
 
-                const validationError = error as ValidationError;
+                const validationError = error as SourcedValidationError;
                 expect(validationError.issues.length).toEqual(1);
                 expect(validationError.issues[0]?.message).toContain("org is required");
             }
@@ -160,10 +160,10 @@ sdks:
 
             try {
                 await loadFernYml({ cwd: testDir });
-                expect.fail("Expected ValidationError to be thrown");
+                expect.fail("Expected SourcedValidationError to be thrown");
             } catch (error) {
-                expect(error).toBeInstanceOf(ValidationError);
-                const validationError = error as ValidationError;
+                expect(error).toBeInstanceOf(SourcedValidationError);
+                const validationError = error as SourcedValidationError;
 
                 const [issue] = validationError.issues;
                 if (issue == null) {
@@ -192,11 +192,11 @@ sdks:
 
             try {
                 await loadFernYml({ cwd: testDir });
-                expect.fail("Expected ValidationError to be thrown");
+                expect.fail("Expected SourcedValidationError to be thrown");
             } catch (error) {
-                expect(error).toBeInstanceOf(ValidationError);
+                expect(error).toBeInstanceOf(SourcedValidationError);
 
-                const validationError = error as ValidationError;
+                const validationError = error as SourcedValidationError;
                 expect(validationError.issues.length).toBeGreaterThan(0);
 
                 const [issue] = validationError.issues;
@@ -223,10 +223,10 @@ sdks:
 
             try {
                 await loadFernYml({ cwd: testDir });
-                expect.fail("Expected ValidationError to be thrown");
+                expect.fail("Expected SourcedValidationError to be thrown");
             } catch (error) {
-                expect(error).toBeInstanceOf(ValidationError);
-                const validationError = error as ValidationError;
+                expect(error).toBeInstanceOf(SourcedValidationError);
+                const validationError = error as SourcedValidationError;
                 const issueWithLocation = validationError.issues.find((i) => i.location.line > 0);
                 expect(issueWithLocation).toBeDefined();
                 expect(issueWithLocation?.location.line).toBeGreaterThan(0);
@@ -249,10 +249,10 @@ sdks:
 
             try {
                 await loadFernYml({ cwd: testDir });
-                expect.fail("Expected ValidationError to be thrown");
+                expect.fail("Expected SourcedValidationError to be thrown");
             } catch (error) {
-                expect(error).toBeInstanceOf(ValidationError);
-                const validationError = error as ValidationError;
+                expect(error).toBeInstanceOf(SourcedValidationError);
+                const validationError = error as SourcedValidationError;
 
                 const expectedMessage = validationError.issues.map((i) => i.toString()).join("\n");
                 expect(validationError.message).toBe(expectedMessage);
@@ -276,10 +276,10 @@ sdks:
 
             try {
                 await loadFernYml({ cwd: testDir });
-                expect.fail("Expected ValidationError to be thrown");
+                expect.fail("Expected SourcedValidationError to be thrown");
             } catch (error) {
-                expect(error).toBeInstanceOf(ValidationError);
-                const validationError = error as ValidationError;
+                expect(error).toBeInstanceOf(SourcedValidationError);
+                const validationError = error as SourcedValidationError;
 
                 const output: string[] = [];
                 for (const issue of validationError.issues) {
@@ -462,7 +462,7 @@ sdks:
             }
         });
 
-        it("throws ValidationError when $ref file does not exist", async () => {
+        it("throws SourcedValidationError when $ref file does not exist", async () => {
             await writeFile(
                 join(testDir, "fern.yml"),
                 `
@@ -475,16 +475,16 @@ cli:
 
             try {
                 await loadFernYml({ cwd: testDir });
-                expect.fail("Expected ValidationError to be thrown");
+                expect.fail("Expected SourcedValidationError to be thrown");
             } catch (error) {
-                expect(error).toBeInstanceOf(ValidationError);
-                const validationError = error as ValidationError;
+                expect(error).toBeInstanceOf(SourcedValidationError);
+                const validationError = error as SourcedValidationError;
                 expect(validationError.issues.length).toBeGreaterThan(0);
                 expect(validationError.issues[0]?.message).toContain("Referenced file does not exist");
             }
         });
 
-        it("throws ValidationError when $ref has sibling keys", async () => {
+        it("throws SourcedValidationError when $ref has sibling keys", async () => {
             await writeFile(
                 join(testDir, "cli.yaml"),
                 `
@@ -505,16 +505,16 @@ cli:
 
             try {
                 await loadFernYml({ cwd: testDir });
-                expect.fail("Expected ValidationError to be thrown");
+                expect.fail("Expected SourcedValidationError to be thrown");
             } catch (error) {
-                expect(error).toBeInstanceOf(ValidationError);
-                const validationError = error as ValidationError;
+                expect(error).toBeInstanceOf(SourcedValidationError);
+                const validationError = error as SourcedValidationError;
                 expect(validationError.issues.length).toBeGreaterThan(0);
                 expect(validationError.issues[0]?.message).toContain("$ref cannot have sibling keys");
             }
         });
 
-        it("throws ValidationError on circular $ref", async () => {
+        it("throws SourcedValidationError on circular $ref", async () => {
             await writeFile(
                 join(testDir, "a.yaml"),
                 `
@@ -547,10 +547,10 @@ sdks:
 
             try {
                 await loadFernYml({ cwd: testDir });
-                expect.fail("Expected ValidationError to be thrown");
+                expect.fail("Expected SourcedValidationError to be thrown");
             } catch (error) {
-                expect(error).toBeInstanceOf(ValidationError);
-                const validationError = error as ValidationError;
+                expect(error).toBeInstanceOf(SourcedValidationError);
+                const validationError = error as SourcedValidationError;
                 expect(validationError.issues.length).toBeGreaterThan(0);
                 expect(validationError.issues[0]?.message).toContain("Circular $ref detected");
             }

--- a/packages/cli/cli-v2/src/commands/docs/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/command.ts
@@ -2,7 +2,11 @@ import type { Argv } from "yargs";
 import type { GlobalArgs } from "../../context/GlobalArgs.js";
 import { commandGroup } from "../_internal/commandGroup.js";
 import { addDevCommand } from "./dev/index.js";
+import { addPublishCommand } from "./publish/index.js";
 
 export function addDocsCommand(cli: Argv<GlobalArgs>): void {
-    commandGroup(cli, "docs", "Manage documentation", [addDevCommand]);
+    commandGroup(cli, "docs", "Configure, edit, preview, and publish your documentation.", [
+        addDevCommand,
+        addPublishCommand
+    ]);
 }

--- a/packages/cli/cli-v2/src/commands/docs/publish/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/publish/command.ts
@@ -1,0 +1,210 @@
+import chalk from "chalk";
+import inquirer from "inquirer";
+import type { Argv } from "yargs";
+import { GENERATE_COMMAND_TIMEOUT_MS } from "../../../constants.js";
+import type { Context } from "../../../context/Context.js";
+import type { GlobalArgs } from "../../../context/GlobalArgs.js";
+import { LegacyDocsPublisher } from "../../../docs/publisher/LegacyDocsPublisher.js";
+import { DocsTaskGroup } from "../../../docs/task/DocsTaskGroup.js";
+import { CliError } from "../../../errors/CliError.js";
+import { command } from "../../_internal/command.js";
+
+export declare namespace PublishCommand {
+    export interface Args extends GlobalArgs {
+        force: boolean;
+        instance?: string;
+        strict: boolean;
+        preview: boolean;
+    }
+}
+
+export class PublishCommand {
+    public async handle(context: Context, args: PublishCommand.Args): Promise<void> {
+        const workspace = await context.loadWorkspaceOrThrow();
+
+        if (workspace.docs == null) {
+            throw new CliError({
+                message:
+                    "No docs configuration found in fern.yml.\n\n" +
+                    "  Add a 'docs:' section to your fern.yml to get started."
+            });
+        }
+
+        const instanceUrl = this.resolveInstanceUrl({
+            instances: workspace.docs.raw.instances,
+            instance: args.instance
+        });
+
+        // Confirm production publish before starting the task group.
+        // The task group takes over the terminal, so the prompt must complete first.
+        if (!args.preview && context.isTTY && !args.force) {
+            const shouldProceed = await this.confirmPublish(instanceUrl);
+            if (!shouldProceed) {
+                context.stderr.info("Docs publish cancelled.");
+                return;
+            }
+        }
+
+        const taskGroup = await this.setupTaskGroup({ context, instanceUrl, org: workspace.org });
+        const docsTask = taskGroup.getTask("publish");
+        if (docsTask == null) {
+            throw new CliError({ message: "Internal error; task 'publish' not found" });
+        }
+
+        docsTask.start();
+
+        const publisher = new LegacyDocsPublisher({ context, task: docsTask.getTask() });
+
+        docsTask.stage.validation.start();
+        try {
+            await publisher.validate({ strict: args.strict });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            docsTask.stage.validation.fail(message);
+        }
+        if (docsTask.getTask().status !== "error") {
+            docsTask.stage.validation.complete();
+
+            docsTask.stage.publish.start();
+            const result = await publisher.publish({
+                instanceUrl,
+                preview: args.preview
+            });
+            if (!result.success) {
+                docsTask.stage.publish.fail(result.error);
+            } else {
+                docsTask.stage.publish.complete();
+                docsTask.complete();
+            }
+        }
+
+        const summary = taskGroup.finish({
+            successMessage: "Published docs",
+            errorMessage: "Failed to publish docs"
+        });
+
+        if (summary.failedCount > 0) {
+            throw CliError.exit();
+        }
+    }
+
+    private resolveInstanceUrl({
+        instances,
+        instance
+    }: {
+        instances: Array<{ url: string }>;
+        instance: string | undefined;
+    }): string {
+        if (instances.length === 0) {
+            throw new CliError({
+                message: "No docs instances configured.\n\n  Add an instance to the 'docs:' section of your fern.yml."
+            });
+        }
+
+        if (instance != null) {
+            const match = instances.find((i) => i.url === instance);
+            if (match == null) {
+                const available = instances.map((i) => `  - ${i.url}`).join("\n");
+                throw new CliError({
+                    message:
+                        `No docs instance found with URL '${instance}'.\n\n` +
+                        `Available instances:\n${available}\n\n` +
+                        `  Use --instance <url> with one of the URLs above.`
+                });
+            }
+            return match.url;
+        }
+
+        if (instances.length > 1) {
+            const available = instances.map((i) => `  - ${i.url}`).join("\n");
+            throw new CliError({
+                message:
+                    `Multiple docs instances configured. Please specify which instance to publish.\n\n` +
+                    `Available instances:\n${available}\n\n` +
+                    `  Use --instance <url> to select one.`
+            });
+        }
+
+        const first = instances[0];
+        if (first == null) {
+            throw new CliError({
+                message: "No docs instances configured.\n\n  Add an instance to the 'docs:' section of your fern.yml."
+            });
+        }
+        return first.url;
+    }
+
+    private async confirmPublish(instanceUrl: string): Promise<boolean> {
+        const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+            {
+                type: "confirm",
+                name: "confirm",
+                message: `This will affect a production site ${chalk.cyan(instanceUrl)}. Are you sure you want to continue?`,
+                default: false
+            }
+        ]);
+        return confirm;
+    }
+
+    private async setupTaskGroup({
+        context,
+        instanceUrl,
+        org
+    }: {
+        context: Context;
+        instanceUrl: string;
+        org: string;
+    }): Promise<DocsTaskGroup> {
+        const taskGroup = new DocsTaskGroup({ context });
+        taskGroup.addTask({ id: "publish", name: instanceUrl });
+        await taskGroup.start({ title: "Publishing docs", subtitle: `org: ${org}` });
+        context.onShutdown(() => {
+            taskGroup.finish({
+                successMessage: "Published docs",
+                errorMessage: "Docs publish interrupted"
+            });
+        });
+        return taskGroup;
+    }
+}
+
+export function addPublishCommand(cli: Argv<GlobalArgs>, parentPath?: string): void {
+    const cmd = new PublishCommand();
+    command(
+        cli,
+        "publish",
+        "Publish your documentation site",
+        async (context, args) => {
+            const timeout = new Promise<never>((_, reject) => {
+                setTimeout(
+                    () => reject(new CliError({ message: "Docs publish timed out after 10 minutes." })),
+                    GENERATE_COMMAND_TIMEOUT_MS
+                ).unref();
+            });
+            await Promise.race([cmd.handle(context, args as PublishCommand.Args), timeout]);
+        },
+        (yargs) =>
+            yargs
+                .option("force", {
+                    type: "boolean",
+                    default: false,
+                    description: "Skip confirmation prompts"
+                })
+                .option("instance", {
+                    type: "string",
+                    description: "Select which docs instance to publish"
+                })
+                .option("strict", {
+                    type: "boolean",
+                    default: false,
+                    description: "Treat all validation warnings (including broken links) as errors"
+                })
+                .option("preview", {
+                    type: "boolean",
+                    default: false,
+                    description: "Generate a preview link instead of publishing to production",
+                    hidden: true
+                }),
+        parentPath
+    );
+}

--- a/packages/cli/cli-v2/src/commands/docs/publish/index.ts
+++ b/packages/cli/cli-v2/src/commands/docs/publish/index.ts
@@ -1,0 +1,1 @@
+export { addPublishCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -16,7 +16,7 @@ import { GENERATE_COMMAND_TIMEOUT_MS } from "../../../constants.js";
 import type { Context } from "../../../context/Context.js";
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { CliError } from "../../../errors/CliError.js";
-import { ValidationError } from "../../../errors/ValidationError.js";
+import { SourcedValidationError } from "../../../errors/SourcedValidationError.js";
 import { SdkChecker } from "../../../sdk/checker/SdkChecker.js";
 import { LANGUAGES, type Language } from "../../../sdk/config/Language.js";
 import type { Target } from "../../../sdk/config/Target.js";
@@ -81,7 +81,7 @@ export class GenerateCommand {
             return this.handleWithFlags(context, args);
         }
         if (!result.success) {
-            throw new ValidationError(result.issues);
+            throw new SourcedValidationError(result.issues);
         }
         return this.handleWithWorkspace(context, result.workspace, args);
     }
@@ -373,7 +373,7 @@ export class GenerateCommand {
             }
         }
         if (issues.length > 0) {
-            throw new ValidationError(issues);
+            throw new SourcedValidationError(issues);
         }
     }
 

--- a/packages/cli/cli-v2/src/config/fern-yml/FernYmlSchemaLoader.ts
+++ b/packages/cli/cli-v2/src/config/fern-yml/FernYmlSchemaLoader.ts
@@ -1,7 +1,7 @@
 import { FernYmlSchema } from "@fern-api/config";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { ValidationIssue, YamlConfigLoader } from "@fern-api/yaml-loader";
-import { ValidationError } from "../../errors/ValidationError.js";
+import { SourcedValidationError } from "../../errors/SourcedValidationError.js";
 import { FileFinder } from "../FileFinder.js";
 
 const FILENAME = "fern.yml";
@@ -50,7 +50,7 @@ export class FernYmlSchemaLoader {
             throw new Error(`${FILENAME} file not found in any parent directory; did you forget to run \`fern init\`?`);
         }
         if (loadResult.type === "failure") {
-            throw new ValidationError(loadResult.issues);
+            throw new SourcedValidationError(loadResult.issues);
         }
         return loadResult;
     }
@@ -70,7 +70,8 @@ export class FernYmlSchemaLoader {
         }
         const result = await this.loader.load({
             absoluteFilePath,
-            schema: FernYmlSchema
+            schema: FernYmlSchema,
+            strict: true
         });
         if (!result.success) {
             return { type: "failure", issues: result.issues };

--- a/packages/cli/cli-v2/src/config/fern-yml/loadFernYml.ts
+++ b/packages/cli/cli-v2/src/config/fern-yml/loadFernYml.ts
@@ -8,7 +8,7 @@ import { FernYmlSchemaLoader } from "./FernYmlSchemaLoader.js";
  * error reporting. Domain-specific converters (e.g., SDKConfigConverter)
  * handle conversion to their respective config types.
  *
- * @throws ValidationError if the configuration is invalid.
+ * @throws SourcedValidationError if the configuration is invalid.
  * @throws Error if fern.yml is not found.
  */
 export async function loadFernYml({ cwd }: { cwd?: AbsoluteFilePath }): Promise<FernYmlSchemaLoader.Success> {

--- a/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
@@ -55,8 +55,15 @@ export class TaskContextAdapter implements TaskContext {
 
     public failWithoutThrowing(message?: string, error?: unknown): void {
         const errorDetails = this.formatError(error);
-        const fullMessage =
-            message != null && errorDetails != null ? `${message}: ${errorDetails}` : (message ?? errorDetails);
+        let fullMessage: string | undefined;
+        if (message != null && errorDetails != null) {
+            // Avoid stuttering when the message already contains the error details.
+            // Legacy callers often pass the same message and error as the second
+            // argument.
+            fullMessage = message.includes(errorDetails) ? message : `${message}: ${errorDetails}`;
+        } else {
+            fullMessage = message ?? errorDetails;
+        }
         if (fullMessage != null) {
             this.logger.error(fullMessage);
         }

--- a/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
@@ -54,7 +54,7 @@ export class TaskContextAdapter implements TaskContext {
     }
 
     public failWithoutThrowing(message?: string, error?: unknown): void {
-        const errorDetails = error instanceof Error ? error.message : error != null ? String(error) : undefined;
+        const errorDetails = this.formatError(error);
         const fullMessage =
             message != null && errorDetails != null ? `${message}: ${errorDetails}` : (message ?? errorDetails);
         if (fullMessage != null) {
@@ -108,5 +108,60 @@ export class TaskContextAdapter implements TaskContext {
 
     public async instrumentPostHogEvent(_event: PosthogEvent): Promise<void> {
         // no-op for now
+    }
+
+    private formatError(error: unknown): string | undefined {
+        if (error == null) {
+            return undefined;
+        }
+        if (error instanceof Error) {
+            return error.message;
+        }
+        if (typeof error === "string") {
+            return error;
+        }
+        if (typeof error === "object") {
+            const message = this.extractErrorMessage(error);
+            if (message != null) {
+                return message;
+            }
+        }
+        try {
+            return JSON.stringify(error);
+        } catch {
+            return String(error);
+        }
+    }
+
+    /**
+     * Attempts to extract a human-readable message from a structured error object.
+     *
+     * Handles common shapes from the FDR SDK and other API clients, e.g.:
+     *   { content: { body: { message: "..." } } }
+     *   { body: { message: "..." } }
+     *   { message: "..." }
+     */
+    private extractErrorMessage(error: object): string | undefined {
+        const record = error as Record<string, unknown>;
+
+        // { message: "..." }
+        if (typeof record.message === "string") {
+            return record.message;
+        }
+
+        // { body: { message: "..." } }
+        if (record.body != null && typeof record.body === "object") {
+            const body = record.body as Record<string, unknown>;
+            if (typeof body.message === "string") {
+                return body.message;
+            }
+        }
+
+        // { content: { body: { message: "..." } } }
+        if (record.content != null && typeof record.content === "object") {
+            return this.extractErrorMessage(record.content);
+        }
+
+        return undefined;
     }
 }

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -3,6 +3,7 @@ import { FernCliError } from "@fern-api/task-context";
 import chalk from "chalk";
 import { KeyringUnavailableError } from "../auth/errors/KeyringUnavailableError.js";
 import { CliError } from "../errors/CliError.js";
+import { SourcedValidationError } from "../errors/SourcedValidationError.js";
 import { ValidationError } from "../errors/ValidationError.js";
 import { Icons } from "../ui/format.js";
 import { Context } from "./Context.js";
@@ -66,9 +67,17 @@ function createContext(options: GlobalArgs): Context {
  * Handles errors by writing appropriate output to stderr.
  */
 function handleError(context: Context, error: unknown): void {
-    if (error instanceof ValidationError) {
+    if (error instanceof SourcedValidationError) {
         for (const issue of error.issues) {
             process.stderr.write(`${chalk.red(issue.toString())}\n`);
+        }
+        return;
+    }
+
+    if (error instanceof ValidationError) {
+        for (const violation of error.violations) {
+            const color = violation.severity === "warning" ? chalk.yellow : chalk.red;
+            process.stderr.write(`${color(`${violation.relativeFilepath}: ${violation.message}`)}\n`);
         }
         return;
     }
@@ -106,7 +115,7 @@ function extractErrorCode(error: unknown): CliError.Code {
     if (error instanceof CliError && error.code != null) {
         return error.code;
     }
-    if (error instanceof ValidationError) {
+    if (error instanceof ValidationError || error instanceof SourcedValidationError) {
         return "VALIDATION_ERROR";
     }
     if (error instanceof KeyringUnavailableError) {

--- a/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
+++ b/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
@@ -1,0 +1,185 @@
+import type { FernToken } from "@fern-api/auth";
+import { filterOssWorkspaces } from "@fern-api/docs-resolver";
+import { Rules } from "@fern-api/docs-validator";
+import type { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
+import type { Project } from "@fern-api/project-loader";
+import { runRemoteGenerationForDocsWorkspace } from "@fern-api/remote-workspace-runner";
+import { TaskResult } from "@fern-api/task-context";
+import type { DocsWorkspace } from "@fern-api/workspace-loader";
+import { TaskContextAdapter } from "../../context/adapter/TaskContextAdapter.js";
+import type { Context } from "../../context/Context.js";
+import { CliError } from "../../errors/CliError.js";
+import { ValidationError } from "../../errors/ValidationError.js";
+import type { Task } from "../../ui/Task.js";
+import { LegacyProjectAdapter } from "../adapter/LegacyProjectAdapter.js";
+import { DocsWorkspaceValidator } from "../validator/DocsWorkspaceValidator.js";
+
+export declare namespace LegacyDocsPublisher {
+    export interface PublishResult {
+        success: boolean;
+        error?: string;
+    }
+}
+
+/**
+ * Encapsulates all interaction with the legacy docs publishing infrastructure.
+ *
+ * Usage:
+ *   const publisher = new LegacyDocsPublisher({ context, task });
+ *   await publisher.validate({ strict });
+ *   const result = await publisher.publish({ instanceUrl, preview });
+ */
+export class LegacyDocsPublisher {
+    private readonly context: Context;
+    private readonly adapter: LegacyProjectAdapter;
+    private readonly task: Task | undefined;
+
+    private prepared:
+        | {
+              project: Project;
+              docsWorkspace: DocsWorkspace;
+              ossWorkspaces: OSSWorkspace[];
+              token: FernToken;
+          }
+        | undefined;
+
+    constructor({ context, task }: { context: Context; task?: Task }) {
+        this.context = context;
+        this.adapter = new LegacyProjectAdapter({ context });
+        this.task = task;
+    }
+
+    /**
+     * Validate the docs workspace configuration.
+     *
+     * @throws ValidationError if validation fails.
+     *
+     * TODO: Extract this out into a separate class. We shouldn't need to cache the "prepared" content
+     * here -- it should just be passed in as part of the constructor and handled by an upstream component.
+     * The implementation is not ideal as-is -- it should be implemented similar to the `fern sdk generate` command instead.
+     */
+    public async validate({ strict }: { strict: boolean }): Promise<void> {
+        const { docsWorkspace, project, ossWorkspaces } = await this.prepare();
+
+        const isRunningOnSelfHosted = process.env["FERN_FDR_ORIGIN"] != null;
+        const excludeRules: string[] = [];
+        if (isRunningOnSelfHosted) {
+            excludeRules.push(Rules.ValidFileTypes.name);
+        }
+
+        const validator = new DocsWorkspaceValidator({ context: this.context });
+        const result = await validator.validate({
+            workspace: docsWorkspace,
+            apiWorkspaces: project.apiWorkspaces,
+            ossWorkspaces,
+            excludeRules
+        });
+
+        if (result.hasErrors || (strict && result.hasWarnings)) {
+            const violationsToThrow = strict
+                ? result.violations
+                : result.violations.filter((v) => v.severity === "fatal" || v.severity === "error");
+            throw new ValidationError(violationsToThrow);
+        }
+    }
+
+    /**
+     * Publish the docs workspace to the given instance.
+     *
+     * Call validate() first to ensure the workspace is valid.
+     */
+    public async publish({
+        instanceUrl,
+        preview
+    }: {
+        instanceUrl: string;
+        preview: boolean;
+    }): Promise<LegacyDocsPublisher.PublishResult> {
+        const { project, docsWorkspace, ossWorkspaces, token } = await this.prepare();
+
+        const taskContext = new TaskContextAdapter({ context: this.context, task: this.task });
+        try {
+            await runRemoteGenerationForDocsWorkspace({
+                organization: project.config.organization,
+                apiWorkspaces: project.apiWorkspaces,
+                ossWorkspaces,
+                docsWorkspace,
+                context: taskContext,
+                token,
+                instanceUrl,
+                preview,
+                disableTemplates: undefined,
+                skipUpload: undefined
+            });
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : String(error)
+            };
+        }
+
+        // The legacy infrastructure swallows errors via runInteractiveTask.
+        // Check the task context result to detect silent failures.
+        if (taskContext.getResult() === TaskResult.Failure) {
+            const errorLog = this.task?.logs?.findLast((log) => log.level === "error");
+            return {
+                success: false,
+                error: errorLog?.message
+            };
+        }
+
+        return { success: true };
+    }
+
+    /**
+     * Lazily loads and caches the project, docs workspace, OSS workspaces, and auth token.
+     */
+    private async prepare(): Promise<{
+        project: Project;
+        docsWorkspace: DocsWorkspace;
+        ossWorkspaces: OSSWorkspace[];
+        token: FernToken;
+    }> {
+        if (this.prepared != null) {
+            return this.prepared;
+        }
+
+        const workspace = await this.context.loadWorkspaceOrThrow();
+        const project = this.adapter.adapt(workspace);
+
+        const docsWorkspace = project.docsWorkspaces;
+        if (docsWorkspace == null) {
+            throw new CliError({
+                message:
+                    "No docs configuration found in fern.yml.\n\n" +
+                    "  Add a 'docs:' section to your fern.yml to get started."
+            });
+        }
+
+        const isRunningOnSelfHosted = process.env["FERN_FDR_ORIGIN"] != null;
+        const ossWorkspaces = await filterOssWorkspaces(project);
+        const token = await this.getToken({ isRunningOnSelfHosted });
+
+        if (token.type === "user") {
+            // TODO: Check if the organization exists. If not, tell the user to run `fern org create <name>`.
+            // That way, it remains an explicit operation instead of the user accidentally creating an organization.
+            // We should use the same thing in other commands, such as `fern sdk generate`.
+        }
+
+        this.prepared = { project, docsWorkspace, ossWorkspaces, token };
+        return this.prepared;
+    }
+
+    private getToken({ isRunningOnSelfHosted }: { isRunningOnSelfHosted: boolean }): Promise<FernToken> {
+        if (isRunningOnSelfHosted) {
+            const fernToken = process.env["FERN_TOKEN"];
+            if (fernToken == null) {
+                throw new CliError({
+                    message: "No organization token found. Please set the FERN_TOKEN environment variable."
+                });
+            }
+            return Promise.resolve({ type: "organization", value: fernToken });
+        }
+        return this.context.getTokenOrPrompt();
+    }
+}

--- a/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
+++ b/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
@@ -67,7 +67,7 @@ export class LegacyDocsPublisher {
             excludeRules.push(Rules.ValidFileTypes.name);
         }
 
-        const validator = new DocsWorkspaceValidator({ context: this.context });
+        const validator = new DocsWorkspaceValidator({ context: this.context, task: this.task });
         const result = await validator.validate({
             workspace: docsWorkspace,
             apiWorkspaces: project.apiWorkspaces,
@@ -118,14 +118,9 @@ export class LegacyDocsPublisher {
             };
         }
 
-        // The legacy infrastructure swallows errors via runInteractiveTask.
-        // Check the task context result to detect silent failures.
         if (taskContext.getResult() === TaskResult.Failure) {
-            const errorLog = this.task?.logs?.findLast((log) => log.level === "error");
-            return {
-                success: false,
-                error: errorLog?.message
-            };
+            // Don't extract the error message here — it's already in task.logs.
+            return { success: false };
         }
 
         return { success: true };

--- a/packages/cli/cli-v2/src/docs/task/DocsTask.ts
+++ b/packages/cli/cli-v2/src/docs/task/DocsTask.ts
@@ -1,0 +1,61 @@
+import type { Task } from "../../ui/Task.js";
+import type { TaskGroup } from "../../ui/TaskGroup.js";
+import { TaskStageController } from "../../ui/TaskStageController.js";
+
+/**
+ * Represents a single docs publishing task with type-safe stage controls.
+ */
+export class DocsTask {
+    private readonly id: string;
+    private readonly taskGroup: TaskGroup;
+
+    public readonly stage: {
+        readonly validation: TaskStageController;
+        readonly publish: TaskStageController;
+    };
+
+    constructor({ id, taskGroup }: { id: string; taskGroup: TaskGroup }) {
+        this.id = id;
+        this.taskGroup = taskGroup;
+
+        this.stage = {
+            validation: new TaskStageController({ taskId: id, taskGroup, stageId: "validation" }),
+            publish: new TaskStageController({ taskId: id, taskGroup, stageId: "publish" })
+        };
+    }
+
+    /**
+     * Get the underlying Task object for this DocsTask.
+     */
+    public getTask(): Task {
+        const task = this.taskGroup.getTask(this.id);
+        if (task == null) {
+            throw new Error(`Internal error; task '${this.id}' does not exist`);
+        }
+        return task;
+    }
+
+    /** Mark the task as running */
+    public start(currentStep?: string): void {
+        this.taskGroup.updateTask({
+            id: this.id,
+            update: { status: "running", currentStep }
+        });
+    }
+
+    /** Mark the task as successfully completed */
+    public complete(output?: string[]): void {
+        this.taskGroup.updateTask({
+            id: this.id,
+            update: { status: "success", output }
+        });
+    }
+
+    /** Mark the task as failed */
+    public fail(error?: string): void {
+        this.taskGroup.updateTask({
+            id: this.id,
+            update: { status: "error", error }
+        });
+    }
+}

--- a/packages/cli/cli-v2/src/docs/task/DocsTaskGroup.ts
+++ b/packages/cli/cli-v2/src/docs/task/DocsTaskGroup.ts
@@ -1,0 +1,66 @@
+import type { Context } from "../../context/Context.js";
+import { TaskGroup } from "../../ui/TaskGroup.js";
+import type { TaskStageDefinition } from "../../ui/TaskStage.js";
+import { DocsTask } from "./DocsTask.js";
+
+/**
+ * Manages docs publishing tasks with visual progress tracking.
+ */
+export class DocsTaskGroup {
+    private readonly taskGroup: TaskGroup;
+    private readonly tasks: Record<string, DocsTask> = {};
+    private readonly defaultStages: TaskStageDefinition[] = [
+        {
+            id: "validation",
+            labels: {
+                pending: "Validate docs",
+                running: "Validating docs...",
+                success: "Validated docs"
+            }
+        },
+        {
+            id: "publish",
+            labels: {
+                pending: "Publish",
+                running: "Publishing...",
+                success: "Published"
+            }
+        }
+    ];
+
+    constructor({ context }: { context: Context }) {
+        this.tasks = {};
+        this.taskGroup = new TaskGroup({ context });
+    }
+
+    public addTask({ id, name }: { id: string; name?: string }): DocsTask {
+        const displayName = name ?? id;
+        this.taskGroup.addTask({ id, name: displayName });
+        this.taskGroup.setStages(id, this.defaultStages);
+
+        const task = new DocsTask({ taskGroup: this.taskGroup, id });
+        this.tasks[id] = task;
+        return task;
+    }
+
+    public getTask(id: string): DocsTask | undefined {
+        return this.tasks[id];
+    }
+
+    public async start(header: { title: string; subtitle?: string }): Promise<void> {
+        await this.taskGroup.start(header);
+    }
+
+    public finish({
+        successMessage,
+        errorMessage
+    }: {
+        successMessage: string;
+        errorMessage: string;
+    }): TaskGroup.CompleteResult {
+        return this.taskGroup.complete({
+            successMessage,
+            errorMessage
+        });
+    }
+}

--- a/packages/cli/cli-v2/src/docs/task/DocsTaskStageId.ts
+++ b/packages/cli/cli-v2/src/docs/task/DocsTaskStageId.ts
@@ -1,0 +1,2 @@
+/** The stage IDs used in docs publishing tasks */
+export type DocsTaskStageId = "validation" | "publish";

--- a/packages/cli/cli-v2/src/docs/validator/DocsWorkspaceValidator.ts
+++ b/packages/cli/cli-v2/src/docs/validator/DocsWorkspaceValidator.ts
@@ -1,0 +1,90 @@
+import { replaceEnvVariables } from "@fern-api/core-utils";
+import type { ValidationViolation } from "@fern-api/docs-validator";
+import { validateDocsWorkspace } from "@fern-api/docs-validator";
+import type { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
+import type { AbstractAPIWorkspace, DocsWorkspace } from "@fern-api/workspace-loader";
+import { TaskContextAdapter } from "../../context/adapter/TaskContextAdapter.js";
+import type { Context } from "../../context/Context.js";
+import type { Task } from "../../ui/Task.js";
+
+/**
+ * Validates DocsWorkspaces before publishing.
+ *
+ * This runs the same validation rules as `fern docs check`:
+ *  - validateDocsWorkspace: Validates docs configuration, markdown links, file types, etc.
+ */
+export namespace DocsWorkspaceValidator {
+    export interface Config {
+        /** The CLI context */
+        context: Context;
+
+        /** The current task, if any */
+        task?: Task;
+    }
+
+    export interface Result {
+        /** All validation violations found */
+        violations: ValidationViolation[];
+
+        /** Whether any errors (fatal or error severity) were found */
+        hasErrors: boolean;
+
+        /** Whether any warnings (warning severity) were found */
+        hasWarnings: boolean;
+
+        /** Time taken to validate in milliseconds */
+        elapsedMillis: number;
+    }
+}
+
+export class DocsWorkspaceValidator {
+    private readonly context: Context;
+    private readonly taskContext: TaskContextAdapter;
+
+    constructor(config: DocsWorkspaceValidator.Config) {
+        this.context = config.context;
+        this.taskContext = new TaskContextAdapter({ context: this.context, task: config.task });
+    }
+
+    /**
+     * Validate a DocsWorkspace.
+     *
+     * Substitutes environment variables if configured, then runs all docs
+     * validation rules against the workspace.
+     */
+    public async validate({
+        workspace,
+        apiWorkspaces,
+        ossWorkspaces,
+        excludeRules
+    }: {
+        workspace: DocsWorkspace;
+        apiWorkspaces: AbstractAPIWorkspace<unknown>[];
+        ossWorkspaces: OSSWorkspace[];
+        excludeRules?: string[];
+    }): Promise<DocsWorkspaceValidator.Result> {
+        const startTime = performance.now();
+
+        if (workspace.config.settings?.substituteEnvVars) {
+            workspace.config = replaceEnvVariables(workspace.config, {
+                onError: (error) => this.taskContext.failAndThrow(error)
+            });
+        }
+
+        const violations = await validateDocsWorkspace(
+            workspace,
+            this.taskContext,
+            apiWorkspaces,
+            ossWorkspaces,
+            false,
+            excludeRules
+        );
+
+        return {
+            violations,
+            hasErrors: violations.some((v) => v.severity === "fatal" || v.severity === "error"),
+            hasWarnings: violations.some((v) => v.severity === "warning"),
+            elapsedMillis: performance.now() - startTime
+        };
+    }
+}

--- a/packages/cli/cli-v2/src/errors/SourcedValidationError.ts
+++ b/packages/cli/cli-v2/src/errors/SourcedValidationError.ts
@@ -1,0 +1,16 @@
+import { ValidationIssue } from "@fern-api/yaml-loader";
+
+/**
+ * A validation error that contains source-located issues (with file:line:col).
+ *
+ * Used for fern.yml schema validation where each issue has a precise SourceLocation.
+ * When displayed, each issue is shown on its own line with file:line:col prefix.
+ */
+export class SourcedValidationError extends Error {
+    public readonly issues: ValidationIssue[];
+
+    constructor(issues: ValidationIssue[]) {
+        super(issues.map((issue) => issue.toString()).join("\n"));
+        this.issues = issues;
+    }
+}

--- a/packages/cli/cli-v2/src/errors/ValidationError.ts
+++ b/packages/cli/cli-v2/src/errors/ValidationError.ts
@@ -1,15 +1,16 @@
-import { ValidationIssue } from "@fern-api/yaml-loader";
+import type { ValidationViolation } from "./ValidationViolation.js";
 
 /**
- * A validation error that contains source code for each validation issue.
+ * A general-purpose validation error containing violations.
  *
- * When displayed, each issue is shown on its own line with file:line:col prefix.
+ * When displayed, each violation is shown on its own line with filepath prefix
+ * and severity-appropriate coloring.
  */
 export class ValidationError extends Error {
-    public readonly issues: ValidationIssue[];
+    public readonly violations: ValidationViolation[];
 
-    constructor(issues: ValidationIssue[]) {
-        super(issues.map((issue) => issue.toString()).join("\n"));
-        this.issues = issues;
+    constructor(violations: ValidationViolation[]) {
+        super(violations.map((v) => `${v.relativeFilepath}: ${v.message}`).join("\n"));
+        this.violations = violations;
     }
 }

--- a/packages/cli/cli-v2/src/errors/ValidationViolation.ts
+++ b/packages/cli/cli-v2/src/errors/ValidationViolation.ts
@@ -1,0 +1,19 @@
+/**
+ * A validation violation found during API or docs validation.
+ *
+ * This is a local type that mirrors the structure of validation violations
+ * from legacy packages (docs-validator, fern-definition-validator) without
+ * importing their types directly.
+ */
+export interface ValidationViolation {
+    /** The rule name that produced this violation */
+    name?: string;
+    /** The severity of the violation */
+    severity: "fatal" | "error" | "warning";
+    /** File path relative to the workspace root */
+    relativeFilepath: string;
+    /** Path to the node in the document tree */
+    nodePath: ReadonlyArray<string | { key: string; arrayIndex?: number }>;
+    /** Human-readable description of the violation */
+    message: string;
+}

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyLocalGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyLocalGenerationRunner.ts
@@ -135,6 +135,10 @@ export class LegacyLocalGenerationRunner {
                 generatorInvocation
             });
         } catch (error) {
+            if (taskContext.getResult() === TaskResult.Failure) {
+                // If the task already recorded a failure, the error is in task.logs.
+                return { success: false };
+            }
             return {
                 success: false,
                 error: error instanceof Error ? error.message : String(error)

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -165,6 +165,10 @@ export class LegacyRemoteGenerationRunner {
                 })
             };
         } catch (error) {
+            if (taskContext.getResult() === TaskResult.Failure) {
+                // If the task already recorded a failure, the error is in task.logs.
+                return { success: false };
+            }
             return {
                 success: false,
                 error: error instanceof Error ? error.message : String(error)

--- a/packages/cli/cli-v2/src/ui/TaskGroup.ts
+++ b/packages/cli/cli-v2/src/ui/TaskGroup.ts
@@ -328,7 +328,12 @@ export class TaskGroup {
                     line += logLines;
                 }
                 if (stage.error != null) {
-                    line += `\n        ${chalk.red(stage.error)}`;
+                    line += formatMultilineText({
+                        text: stage.error,
+                        colorFn: chalk.red.bind(chalk),
+                        baseIndent: 8,
+                        continuationIndent: 10
+                    });
                 }
             }
 

--- a/packages/cli/cli-v2/src/ui/TaskStageController.ts
+++ b/packages/cli/cli-v2/src/ui/TaskStageController.ts
@@ -44,7 +44,8 @@ export class TaskStageController {
         this.taskGroup.updateStage({
             taskId: this.taskId,
             stageId: this.stageId,
-            status: "error"
+            status: "error",
+            options: { error }
         });
         // If at least one stage fails, the task should fail.
         const task = this.taskGroup.getTask(this.taskId);

--- a/packages/cli/cli-v2/src/workspace/WorkspaceLoader.ts
+++ b/packages/cli/cli-v2/src/workspace/WorkspaceLoader.ts
@@ -7,7 +7,7 @@ import { ApiDefinitionConverter } from "../api/config/converter/ApiDefinitionCon
 import { FernYmlSchemaLoader } from "../config/fern-yml/FernYmlSchemaLoader.js";
 import { DocsConfigConverter } from "../docs/config/converter/DocsConfigConverter.js";
 import type { DocsConfig } from "../docs/config/DocsConfig.js";
-import { ValidationError } from "../errors/ValidationError.js";
+import { SourcedValidationError } from "../errors/SourcedValidationError.js";
 import { SdkConfigConverter } from "../sdk/config/converter/SdkConfigConverter.js";
 import { SdkConfig } from "../sdk/config/SdkConfig.js";
 import { Version } from "../version.js";
@@ -50,7 +50,7 @@ export class WorkspaceLoader {
     public async loadOrThrow({ fernYml }: { fernYml: FernYmlSchemaLoader.Success }): Promise<Workspace> {
         const result = await this.load({ fernYml });
         if (!result.success) {
-            throw new ValidationError(result.issues);
+            throw new SourcedValidationError(result.issues);
         }
         return result.workspace;
     }

--- a/packages/cli/yaml/docs-validator/src/index.ts
+++ b/packages/cli/yaml/docs-validator/src/index.ts
@@ -9,4 +9,5 @@ export { visitDocsConfigFileYamlAst } from "./docsAst/visitDocsConfigFileYamlAst
 export * as Rules from "./rules/index.js";
 export { FrontmatterSchema } from "./rules/valid-markdown/valid-markdown.js";
 export { collectLinksAndSources } from "./rules/valid-markdown-link/collect-links.js";
+export { type ValidationViolation } from "./ValidationViolation.js";
 export { validateDocsWorkspace } from "./validateDocsWorkspace.js";

--- a/packages/cli/yaml/loader/src/YamlConfigLoader.ts
+++ b/packages/cli/yaml/loader/src/YamlConfigLoader.ts
@@ -1,6 +1,7 @@
 import { AbsoluteFilePath, RelativeFilePath, relative } from "@fern-api/fs-utils";
 import { type Sourced, SourceLocation } from "@fern-api/source";
 import { z } from "zod";
+import { deepStrict } from "./deepStrict.js";
 import { ReferenceResolver } from "./ReferenceResolver.js";
 import { ValidationIssue } from "./ValidationIssue.js";
 import type { YamlDocument } from "./YamlDocument.js";
@@ -61,11 +62,15 @@ export class YamlConfigLoader {
     public async load<S extends z.ZodSchema>({
         absoluteFilePath,
         schema,
-        resolveReferences = true
+        resolveReferences = true,
+        strict = false
     }: {
         absoluteFilePath: AbsoluteFilePath;
         schema: S;
         resolveReferences?: boolean;
+        /** When true, recursively applies `.strict()` to all objects in the schema,
+         *  causing validation errors for unrecognized keys at any depth. */
+        strict?: boolean;
     }): Promise<YamlConfigLoader.Result<z.infer<S>>> {
         const document = await this.parseDocument(absoluteFilePath);
 
@@ -81,7 +86,8 @@ export class YamlConfigLoader {
                 issues: resolved.issues
             };
         }
-        const parseResult = schema.safeParse(resolved.data);
+        const effectiveSchema = strict ? deepStrict(schema) : schema;
+        const parseResult = effectiveSchema.safeParse(resolved.data);
         if (!parseResult.success) {
             const issues = parseResult.error.issues.map((issue) => {
                 // Zod paths are PropertyKey[] but YAML paths are string | number

--- a/packages/cli/yaml/loader/src/deepStrict.ts
+++ b/packages/cli/yaml/loader/src/deepStrict.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+
+/**
+ * Recursively applies `.strict()` to all `z.object()` schemas in a schema tree.
+ *
+ * By default, Zod silently strips unrecognized keys during parsing. This utility
+ * walks the schema graph and applies `.strict()` to every object schema, causing
+ * validation errors for unknown keys at any depth.
+ */
+export function deepStrict<S extends z.ZodSchema>(schema: S): S {
+    return deepStrictImpl(schema, new WeakMap()) as S;
+}
+
+/**
+ * Internal type for Zod schema definition internals.
+ * This is not part of Zod's public API but is stable across Zod 4.x.
+ */
+interface ZodDef {
+    type?: string;
+    shape?: Record<string, z.ZodSchema>;
+    element?: z.ZodSchema;
+    innerType?: z.ZodSchema;
+    options?: z.ZodSchema[];
+    keyType?: z.ZodString;
+    valueType?: z.ZodSchema;
+    getter?: () => z.ZodSchema;
+    items?: z.ZodSchema[];
+    defaultValue?: unknown;
+}
+
+function getDef(schema: z.ZodSchema): ZodDef | undefined {
+    return (schema as unknown as { _zod?: { def?: ZodDef } })._zod?.def;
+}
+
+function deepStrictImpl(schema: z.ZodSchema, cache: WeakMap<object, z.ZodSchema>): z.ZodSchema {
+    if (cache.has(schema)) {
+        return cache.get(schema) as z.ZodSchema;
+    }
+
+    const def = getDef(schema);
+    if (def == null) {
+        return schema;
+    }
+
+    switch (def.type) {
+        case "object": {
+            const shape = def.shape ?? {};
+            const newShape: Record<string, z.ZodSchema> = {};
+            for (const [key, value] of Object.entries(shape)) {
+                newShape[key] = deepStrictImpl(value, cache);
+            }
+            const result = z.object(newShape).strict();
+            cache.set(schema, result);
+            return result;
+        }
+        case "array": {
+            const element = def.element;
+            return element != null ? z.array(deepStrictImpl(element, cache)) : schema;
+        }
+        case "optional": {
+            const inner = def.innerType;
+            return inner != null ? deepStrictImpl(inner, cache).optional() : schema;
+        }
+        case "nullable": {
+            const inner = def.innerType;
+            return inner != null ? deepStrictImpl(inner, cache).nullable() : schema;
+        }
+        case "union": {
+            const options = def.options;
+            return options != null ? z.union(options.map((option) => deepStrictImpl(option, cache))) : schema;
+        }
+        case "record": {
+            const keyType = def.keyType;
+            const valueType = def.valueType;
+            return keyType != null && valueType != null ? z.record(keyType, deepStrictImpl(valueType, cache)) : schema;
+        }
+        case "lazy": {
+            const getter = def.getter;
+            if (getter == null) {
+                return schema;
+            }
+            const result = z.lazy(() => deepStrictImpl(getter(), cache));
+            cache.set(schema, result);
+            return result;
+        }
+        case "tuple": {
+            const items = def.items;
+            if (items == null) {
+                return schema;
+            }
+            return (z.tuple as (...args: unknown[]) => z.ZodSchema)(items.map((item) => deepStrictImpl(item, cache)));
+        }
+        case "default": {
+            const inner = def.innerType;
+            return inner != null ? deepStrictImpl(inner, cache).default(def.defaultValue) : schema;
+        }
+        default:
+            return schema;
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4984,6 +4984,12 @@ importers:
       '@fern-api/docs-preview':
         specifier: workspace:*
         version: link:../docs-preview
+      '@fern-api/docs-resolver':
+        specifier: workspace:*
+        version: link:../docs-resolver
+      '@fern-api/docs-validator':
+        specifier: workspace:*
+        version: link:../yaml/docs-validator
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../fern-definition/schema


### PR DESCRIPTION
## Description

This implements the new `fern docs publish` command with a new and improved flag set, UI, progress report, and error reporting experience.

```sh
$ fern docs publish --help
Publish your documentation site

Options:
  --help       Show help                                                                                       [boolean]
  --log-level  Set log level                      [string] [choices: "debug", "info", "warn", "error"] [default: "info"]
  --force      Skip confirmation prompts                                                      [boolean] [default: false]
  --instance   Select which docs instance to publish                                                            [string]
  --strict     Treat all validation warnings (including broken links) as errors               [boolean] [default: false]
```

A few examples are shown below:

```sh
$ fern docs publish
? This will affect a production site https://amckinney-fern.docs.buildwithfern.com. Are you sure you want to continue? Yes

◆ Publishing docs
  org: amckinney-fern

┌─
│ ✓ https://amckinney-fern.docs.buildwithfern.com 5.0s
│     ✓ Validated docs
│     ✓ Published
└─

✓ Published docs in 5.0s

Logs written to: /Users/alex/.cache/fern/v1/logs/2026-03-10T21-19-41-142Z.log
```

```sh
# Basic configuration errors are more clearly shown on a specific line/column.
$ fern docs publish
docs.yml:9:18: docs.colors.accentPrimary must be a string or object
```

```sh
# Error messages are nested within the respective step.
$ fern docs publish --log-level debug
? This will affect a production site https://amckinney-fern.docs.buildwithfern.com. Are you sure you want to continue? Yes

◆ Publishing docs
  org: amckinney

┌─
│ ✗ https://amckinney-fern.docs.buildwithfern.com 938ms
│     ✓ Validated docs
│     ✗ Publish
│         ✗ You do not have permission to publish docs to organization 'amckinney'. Please run 'fern login' to ensure you are logged in with the correct account.
│           Please ensure you have membership at https://dashboard.buildwithfern.com, and ask a team member for an invite if not.
└─

✕ Failed to publish docs in 939ms

Logs written to: /Users/alex/.cache/fern/v1/logs/2026-03-10T20-59-16-286Z.log
```

## Implementation

A few improvements will be made to the implementation in a follow-up with the creation of the `fern docs check` command. This will split out the `prepare`, `validate`, and `publish` steps into clear abstractions. A `TODO` is left in the code for now.

## Changes made

- This also introduces a `strict` application on all `zod` schemas so that any CLI usage of the `fern.yml` schemas is strictly validated (i.e. no extra, unrecognized key, value pairs are allowed).
