### PR TITLE
fix(python): use WireMock mapping query params as source of truth in wire tests

### DIFF
--- a/generators/python-v2/sdk/src/SdkCustomConfig.ts
+++ b/generators/python-v2/sdk/src/SdkCustomConfig.ts
@@ -63,7 +63,14 @@ export const SdkCustomConfigSchema = z.object({
     client_class_name: z.string().optional(),
     inline_request_params: z.boolean().optional(),
     wire_tests: WireTestsConfigSchema.optional(),
-    custom_readme_sections: z.array(CustomReadmeSectionSchema).optional()
+    custom_readme_sections: z.array(CustomReadmeSectionSchema).optional(),
+    /**
+     * When true, datetime values are serialized with millisecond precision
+     * (e.g., "2008-01-02T00:00:00.000Z" instead of "2008-01-02T00:00:00Z").
+     * This also affects WireMock stubs and wire test verification code to ensure
+     * all three components (SDK, stubs, tests) use the same datetime format.
+     */
+    datetime_milliseconds: z.boolean().optional()
 });
 
 export type SdkCustomConfigSchema = z.infer<typeof SdkCustomConfigSchema>;

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -620,8 +620,8 @@ export class WireTestGenerator {
 
     private buildQueryParamsCode(endpoint: FernIr.HttpEndpoint): string {
         // Use the WireMock mapping as the source of truth for expected query parameter values.
-        // This ensures the test verification matches exactly what WireMock expects (e.g., datetime
-        // values serialized via Date.toISOString() always include milliseconds like "2018-11-10T20:00:00.000Z").
+        // The mapping values are already normalized by getWireMockConfigContent() based on
+        // the datetime_milliseconds config, so they match what the SDK actually sends.
         const basePath = this.buildPathTemplate(endpoint);
         const mappingKey = this.wiremockMappingKey({
             requestMethod: endpoint.method,
@@ -700,6 +700,14 @@ export class WireTestGenerator {
     private getWireMockConfigContent(): Record<string, WireMockMapping> {
         const out: Record<string, WireMockMapping> = {};
         const wiremockStubMapping = WireTestSetupGenerator.getWiremockConfigContent(this.context.ir);
+
+        // Normalize datetime values to match the SDK's serialization format.
+        // When datetime_milliseconds is false (default), strip ".000" milliseconds
+        // so test verification matches what the SDK actually sends.
+        if (!this.context.customConfig.datetime_milliseconds) {
+            WireTestSetupGenerator.stripDatetimeMilliseconds(wiremockStubMapping);
+        }
+
         for (const mapping of wiremockStubMapping.mappings) {
             const key = this.wiremockMappingKey({
                 requestMethod: mapping.request.method,

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -628,10 +628,7 @@ export class WireTestGenerator {
         if (this.context.customConfig.datetime_milliseconds) {
             // Use replace with a capture group to insert ".000" before the timezone suffix.
             // The regex matches the seconds portion followed by the timezone (Z or +/-offset).
-            return value.replace(
-                /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(Z|[+-]\d{2}:\d{2})$/,
-                "$1.000$2"
-            );
+            return value.replace(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(Z|[+-]\d{2}:\d{2})$/, "$1.000$2");
         }
         return value;
     }

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -618,39 +618,37 @@ export class WireTestGenerator {
     // PATH AND QUERY PARAMETER HELPERS
     // =============================================================================
 
-    private buildQueryParamsCode(endpoint: FernIr.HttpEndpoint): string {
-        // Use the WireMock mapping as the source of truth for expected query parameter values.
-        // The mapping values are already normalized by getWireMockConfigContent() based on
-        // the datetime_milliseconds config, so they match what the SDK actually sends.
-        let basePath = this.buildPathTemplate(endpoint);
-
-        // Strip URL fragment — fragments are never sent to the server in HTTP requests
-        // and mock-utils strips them when generating WireMock mapping keys.
-        // e.g., "/oauth2/token#refresh" -> "/oauth2/token"
-        const fragmentIndex = basePath.indexOf("#");
-        if (fragmentIndex !== -1) {
-            basePath = basePath.substring(0, fragmentIndex);
+    /**
+     * Normalizes a query parameter value for datetime_milliseconds config.
+     * When datetime_milliseconds is true, adds ".000" to datetime values that lack fractional seconds
+     * so the test verification matches the SDK's millisecond-precision output.
+     * When false (default), values are left as-is (dynamic IR already has no milliseconds).
+     */
+    private normalizeDatetimeQueryParamValue(value: string): string {
+        if (this.context.customConfig.datetime_milliseconds) {
+            // Use replace with a capture group to insert ".000" before the timezone suffix.
+            // The regex matches the seconds portion followed by the timezone (Z or +/-offset).
+            return value.replace(
+                /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(Z|[+-]\d{2}:\d{2})$/,
+                "$1.000$2"
+            );
         }
+        return value;
+    }
 
-        const mappingKey = this.wiremockMappingKey({
-            requestMethod: endpoint.method,
-            requestUrlPathTemplate: basePath
-        });
-        const wiremockMapping = this.wireMockConfigContent[mappingKey];
-
-        if (!wiremockMapping?.request.queryParameters) {
+    private buildQueryParamsCode(endpoint: FernIr.HttpEndpoint): string {
+        const dynamicEndpoint = this.dynamicIr.endpoints[endpoint.id];
+        if (!dynamicEndpoint?.examples?.[0]?.queryParameters) {
             return "None";
         }
 
-        const queryParams = wiremockMapping.request.queryParameters;
+        const queryParams = dynamicEndpoint.examples[0].queryParameters;
         const entries: string[] = [];
 
         for (const [key, value] of Object.entries(queryParams)) {
-            const paramValue = value as { equalTo: string };
-            if (paramValue.equalTo != null) {
-                entries.push(
-                    `"${this.escapeStringForPython(key)}": "${this.escapeStringForPython(paramValue.equalTo)}"`
-                );
+            if (value != null) {
+                const normalized = this.normalizeDatetimeQueryParamValue(String(value));
+                entries.push(`"${this.escapeStringForPython(key)}": "${this.escapeStringForPython(normalized)}"`);
             }
         }
 
@@ -709,14 +707,6 @@ export class WireTestGenerator {
     private getWireMockConfigContent(): Record<string, WireMockMapping> {
         const out: Record<string, WireMockMapping> = {};
         const wiremockStubMapping = WireTestSetupGenerator.getWiremockConfigContent(this.context.ir);
-
-        // Normalize datetime values to match the SDK's serialization format.
-        // When datetime_milliseconds is false (default), strip ".000" milliseconds
-        // so test verification matches what the SDK actually sends.
-        if (!this.context.customConfig.datetime_milliseconds) {
-            WireTestSetupGenerator.stripDatetimeMilliseconds(wiremockStubMapping);
-        }
-
         for (const mapping of wiremockStubMapping.mappings) {
             const key = this.wiremockMappingKey({
                 requestMethod: mapping.request.method,

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -619,17 +619,29 @@ export class WireTestGenerator {
     // =============================================================================
 
     private buildQueryParamsCode(endpoint: FernIr.HttpEndpoint): string {
-        const dynamicEndpoint = this.dynamicIr.endpoints[endpoint.id];
-        if (!dynamicEndpoint?.examples?.[0]?.queryParameters) {
+        // Use the WireMock mapping as the source of truth for expected query parameter values.
+        // This ensures the test verification matches exactly what WireMock expects (e.g., datetime
+        // values serialized via Date.toISOString() always include milliseconds like "2018-11-10T20:00:00.000Z").
+        const basePath = this.buildPathTemplate(endpoint);
+        const mappingKey = this.wiremockMappingKey({
+            requestMethod: endpoint.method,
+            requestUrlPathTemplate: basePath
+        });
+        const wiremockMapping = this.wireMockConfigContent[mappingKey];
+
+        if (!wiremockMapping?.request.queryParameters) {
             return "None";
         }
 
-        const queryParams = dynamicEndpoint.examples[0].queryParameters;
+        const queryParams = wiremockMapping.request.queryParameters;
         const entries: string[] = [];
 
         for (const [key, value] of Object.entries(queryParams)) {
-            if (value != null) {
-                entries.push(`"${this.escapeStringForPython(key)}": "${this.escapeStringForPython(String(value))}"`);
+            const paramValue = value as { equalTo: string };
+            if (paramValue.equalTo != null) {
+                entries.push(
+                    `"${this.escapeStringForPython(key)}": "${this.escapeStringForPython(paramValue.equalTo)}"`
+                );
             }
         }
 

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -622,7 +622,16 @@ export class WireTestGenerator {
         // Use the WireMock mapping as the source of truth for expected query parameter values.
         // The mapping values are already normalized by getWireMockConfigContent() based on
         // the datetime_milliseconds config, so they match what the SDK actually sends.
-        const basePath = this.buildPathTemplate(endpoint);
+        let basePath = this.buildPathTemplate(endpoint);
+
+        // Strip URL fragment — fragments are never sent to the server in HTTP requests
+        // and mock-utils strips them when generating WireMock mapping keys.
+        // e.g., "/oauth2/token#refresh" -> "/oauth2/token"
+        const fragmentIndex = basePath.indexOf("#");
+        if (fragmentIndex !== -1) {
+            basePath = basePath.substring(0, fragmentIndex);
+        }
+
         const mappingKey = this.wiremockMappingKey({
             requestMethod: endpoint.method,
             requestUrlPathTemplate: basePath

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,7 +1,7 @@
 import { File } from "@fern-api/base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { WireMock } from "@fern-api/mock-utils";
+import { WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
@@ -34,8 +34,49 @@ export class WireTestSetupGenerator {
         return new WireMock().convertToWireMock(ir);
     }
 
+    /**
+     * ISO 8601 datetime pattern that matches values with `.000` milliseconds.
+     * Example: "2008-01-02T00:00:00.000Z" or "2008-01-02T00:00:00.000+05:00"
+     */
+    private static readonly DATETIME_WITH_ZERO_MILLIS_REGEX =
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000(Z|[+-]\d{2}:\d{2})$/;
+
+    /**
+     * Strips ".000" milliseconds from all datetime values in WireMock stub mappings.
+     * This is used when datetime_milliseconds is false (default) so that WireMock stubs
+     * match the SDK's default serialize_datetime output (which omits zero fractional seconds).
+     *
+     * Mutates the input in-place for efficiency.
+     */
+    public static stripDatetimeMilliseconds(stubMapping: WireMockStubMapping): void {
+        for (const mapping of stubMapping.mappings) {
+            // Strip from query parameters
+            if (mapping.request.queryParameters) {
+                for (const [, value] of Object.entries(mapping.request.queryParameters)) {
+                    const paramValue = value as { equalTo: string };
+                    if (
+                        paramValue.equalTo != null &&
+                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(paramValue.equalTo)
+                    ) {
+                        paramValue.equalTo = paramValue.equalTo.replace(".000", "");
+                    }
+                }
+            }
+        }
+    }
+
     private generateWireMockConfigFile(): void {
         const wireMockConfigContent = WireTestSetupGenerator.getWiremockConfigContent(this.ir);
+
+        // When datetime_milliseconds is not enabled (default), strip milliseconds from datetime
+        // values in WireMock stubs. mock-utils always generates datetime values using
+        // Date.toISOString() which includes ".000Z", but the Python SDK's default
+        // serialize_datetime (isoformat()) omits zero fractional seconds. Stripping here
+        // ensures the stubs match what the SDK actually sends.
+        if (!this.context.customConfig.datetime_milliseconds) {
+            WireTestSetupGenerator.stripDatetimeMilliseconds(wireMockConfigContent);
+        }
+
         const wireMockConfigFile = new File(
             "wiremock-mappings.json",
             RelativeFilePath.of("wiremock"),

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.63.2
+  changelogEntry:
+    - summary: |
+        Fix wire test datetime format mismatch. When `datetime_milliseconds` is false (default),
+        WireMock stubs are now stripped of `.000` milliseconds to match the SDK's default
+        `serialize_datetime` output. When true, test verification values include `.000` to match
+        millisecond-precision output. Fixes wire test failures for APIs with datetime query parameters.
+      type: fix
+  createdAt: "2026-03-10"
+  irVersion: 65
+
 - version: 4.63.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: https://github.com/fern-demo/twilio-core-python-sdk/pull/94

Fixes wire test datetime format mismatches by normalizing datetime values in both WireMock stubs and test verification code based on the `datetime_milliseconds` custom config. `buildQueryParamsCode` continues to read from the dynamic IR (cleaner endpoint ID lookup), with a new normalization layer applied on top.

**Link to Devin Session:** https://app.devin.ai/sessions/c53b1e7fd9e44fe3b1172f658443c7d9
**Requested by:** @iamnamananand996

## Problem

`mock-utils` generates WireMock stubs using JavaScript's `Date.toISOString()`, which always includes `.000Z` milliseconds. Meanwhile, Python's default `datetime.isoformat()` omits zero fractional seconds (producing `Z` instead of `.000Z`). This creates a mismatch between what the SDK sends and what WireMock expects:

| Component | Format (default) | Example |
|---|---|---|
| WireMock stub (before fix) | `.000Z` | `2008-01-02T00:00:00.000Z` |
| SDK serialization (default) | `Z` | `2008-01-02T00:00:00Z` |
| Test verification (dynamic IR) | `Z` | `2008-01-02T00:00:00Z` |

This caused WireMock to reject SDK requests (format mismatch), failing 22+ wire tests in downstream SDKs like `fern-demo/twilio-core-python-sdk`.

## Changes Made

- **`SdkCustomConfig`**: Added `datetime_milliseconds: z.boolean().optional()` to the v2 generator schema so wire test generation can read this config.
- **`WireTestSetupGenerator.stripDatetimeMilliseconds`**: New static method that strips `.000` from ISO 8601 datetime values in WireMock stub query parameters. Called during `generateWireMockConfigFile` when `datetime_milliseconds` is `false` (default), so the WireMock stubs match the SDK's default output.
- **`WireTestGenerator.normalizeDatetimeQueryParamValue`**: New method that adds `.000` to datetime values read from the dynamic IR when `datetime_milliseconds` is `true`, so test verification matches the SDK's millisecond-precision output.
- **`WireTestGenerator.buildQueryParamsCode`**: Passes each query param value through `normalizeDatetimeQueryParamValue` before emitting it into test code. Still uses the dynamic IR as the data source (endpoint ID lookup).

With these changes, all three components stay in sync:
- `datetime_milliseconds: false` (default) → stubs stripped to `Z`, SDK sends `Z`, tests verify `Z`
- `datetime_milliseconds: true` → stubs keep `.000Z`, SDK sends `.000Z`, tests verify `.000Z`

## Human Review Checklist

- [ ] The `DATETIME_WITH_ZERO_MILLIS_REGEX` in `WireTestSetupGenerator` correctly matches only datetime values with `.000` milliseconds — note it won't catch non-zero milliseconds (e.g. `.123Z`) if `mock-utils` ever produces those
- [ ] `stripDatetimeMilliseconds` only processes query parameters — confirm datetime values don't appear in headers or request bodies that also need normalization
- [ ] The `value as { equalTo: string }` cast in `stripDatetimeMilliseconds` matches the actual WireMock mapping type structure from `@fern-api/mock-utils`
- [ ] `normalizeDatetimeQueryParamValue` regex could match non-datetime string values that happen to look like ISO 8601 datetimes — verify this is acceptable given the data in dynamic IR
- [ ] **Critical**: Confirm the v2 generator runtime also respects `datetime_milliseconds` config (not just wire tests). The v1 generator does this via `string_replacements`, but v2 may need equivalent logic to actually serialize datetimes with milliseconds.

## Testing

- [x] TypeScript compilation passes
- [x] CI passed (287 checks, including all seed tests)
- [x] Companion fix applied to [twilio-core-python-sdk PR #94](https://github.com/fern-demo/twilio-core-python-sdk/pull/94) — CI green with equivalent datetime changes