### PR TITLE
fix(php): fix serialization/deserialization of `boolean`

### DIFF
--- a/generators/php/base/src/asIs/Json/JsonDeserializer.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonDeserializer.Template.php
@@ -144,6 +144,11 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
+        if ($type === 'bool' && is_bool($data)) {
+            return $data;
+        }
+
         if (gettype($data) === $type) {
             return $data;
         }

--- a/generators/php/base/src/asIs/Json/JsonSerializer.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonSerializer.Template.php
@@ -133,6 +133,11 @@ class JsonSerializer
             return $data;
         }
 
+        // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
+        if ($type === 'bool' && is_bool($data)) {
+            return $data;
+        }
+
         if (gettype($data) === $type) {
             return $data;
         }

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.10
+  changelogEntry:
+    - summary: |
+        Fix serialization and deserialization of boolean values in union types.
+        (Matches existing fix for floats.)
+      type: fix
+  createdAt: "2026-03-10"
+  irVersion: 62
+
 - version: 2.1.9
   changelogEntry:
     - summary: |

--- a/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,11 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
+        if ($type === 'bool' && is_bool($data)) {
+            return $data;
+        }
+
         if (gettype($data) === $type) {
             return $data;
         }

--- a/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializer.php
+++ b/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializer.php
@@ -133,6 +133,11 @@ class JsonSerializer
             return $data;
         }
 
+        // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
+        if ($type === 'bool' && is_bool($data)) {
+            return $data;
+        }
+
         if (gettype($data) === $type) {
             return $data;
         }


### PR DESCRIPTION
## Description
In the serialization layer, PHP's `gettype()` would return `boolean`, but the union type annotation we used had `bool`, which would cause booleans to slip through; now we explicitly check, matching the existing check for `float`s.

## Changes Made
Two one-liners for PHP serialization and deserialization.

## Testing
`undiscriminated-union` reflects the changes.
- [X] Unit tests added/updated
- [X] Manual testing completed
