### PR TITLE
fix(python): make datetime normalization type-aware for wire tests

### DIFF
--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -619,13 +619,46 @@ export class WireTestGenerator {
     // =============================================================================
 
     /**
-     * Normalizes a query parameter value for datetime_milliseconds config.
-     * When datetime_milliseconds is true, adds ".000" to datetime values that lack fractional seconds
-     * so the test verification matches the SDK's millisecond-precision output.
-     * When false (default), values are left as-is (dynamic IR already has no milliseconds).
+     * Checks if a query parameter is typed as datetime (DATE_TIME) in the IR.
+     * Handles optional/nullable wrappers by unwrapping to the inner type.
+     * String-typed parameters that happen to contain datetime-looking values return false.
      */
-    private normalizeDatetimeQueryParamValue(value: string): string {
-        if (this.context.customConfig.datetime_milliseconds) {
+    private isDatetimeTypedQueryParam(endpoint: FernIr.HttpEndpoint, wireKey: string): boolean {
+        const queryParam = endpoint.queryParameters.find((qp) => qp.name.wireValue === wireKey);
+        if (!queryParam) {
+            return false;
+        }
+        return this.isDatetimeTypeReference(queryParam.valueType);
+    }
+
+    /**
+     * Recursively checks if a TypeReference resolves to a datetime primitive.
+     * Unwraps optional/nullable containers to check the inner type.
+     */
+    private isDatetimeTypeReference(typeRef: FernIr.TypeReference): boolean {
+        if (typeRef.type === "primitive") {
+            return typeRef.primitive.v1 === "DATE_TIME";
+        }
+        if (typeRef.type === "container") {
+            if (typeRef.container.type === "optional") {
+                return this.isDatetimeTypeReference(typeRef.container.optional);
+            }
+            if (typeRef.container.type === "nullable") {
+                return this.isDatetimeTypeReference(typeRef.container.nullable);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Normalizes a query parameter value for datetime_milliseconds config.
+     * When datetime_milliseconds is true AND the parameter is datetime-typed, adds ".000" to
+     * datetime values that lack fractional seconds so the test verification matches the SDK's
+     * millisecond-precision output from serialize_datetime.
+     * String-typed parameters are never normalized because the SDK passes them through as-is.
+     */
+    private normalizeDatetimeQueryParamValue(value: string, isDatetimeTyped: boolean): string {
+        if (this.context.customConfig.datetime_milliseconds && isDatetimeTyped) {
             // Use replace with a capture group to insert ".000" before the timezone suffix.
             // The regex matches the seconds portion followed by the timezone (Z or +/-offset).
             return value.replace(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(Z|[+-]\d{2}:\d{2})$/, "$1.000$2");
@@ -644,7 +677,8 @@ export class WireTestGenerator {
 
         for (const [key, value] of Object.entries(queryParams)) {
             if (value != null) {
-                const normalized = this.normalizeDatetimeQueryParamValue(String(value));
+                const isDatetimeTyped = this.isDatetimeTypedQueryParam(endpoint, key);
+                const normalized = this.normalizeDatetimeQueryParamValue(String(value), isDatetimeTyped);
                 entries.push(`"${this.escapeStringForPython(key)}": "${this.escapeStringForPython(normalized)}"`);
             }
         }

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -65,16 +65,105 @@ export class WireTestSetupGenerator {
         }
     }
 
+    /**
+     * Strips ".000" milliseconds only from string-typed query parameters in WireMock stub mappings.
+     * When datetime_milliseconds is true, datetime-typed params should keep ".000" (because
+     * serialize_datetime will output milliseconds), but string-typed params should have ".000"
+     * stripped (because the SDK passes strings through as-is without millisecond normalization).
+     *
+     * Mutates the input in-place for efficiency.
+     */
+    private stripDatetimeMillisecondsForStringParams(
+        stubMapping: WireMockStubMapping,
+        ir: FernIr.IntermediateRepresentation
+    ): void {
+        // Build a lookup: mapping key -> set of datetime-typed query param wire names
+        const datetimeParamsByEndpoint = new Map<string, Set<string>>();
+        for (const service of Object.values(ir.services)) {
+            for (const endpoint of service.endpoints) {
+                let path = endpoint.fullPath.head;
+                for (const part of endpoint.fullPath.parts) {
+                    path += `{${part.pathParameter}}${part.tail}`;
+                }
+                if (!path.startsWith("/")) {
+                    path = "/" + path;
+                }
+                // Strip URL fragments (mock-utils strips them too)
+                const fragmentIndex = path.indexOf("#");
+                if (fragmentIndex !== -1) {
+                    path = path.substring(0, fragmentIndex);
+                }
+                const key = `${endpoint.method} - ${path}`;
+                const datetimeParams = new Set<string>();
+                for (const qp of endpoint.queryParameters) {
+                    if (WireTestSetupGenerator.isDatetimeTypeReference(qp.valueType)) {
+                        datetimeParams.add(qp.name.wireValue);
+                    }
+                }
+                datetimeParamsByEndpoint.set(key, datetimeParams);
+            }
+        }
+
+        for (const mapping of stubMapping.mappings) {
+            if (!mapping.request.queryParameters) {
+                continue;
+            }
+            const mappingKey = `${mapping.request.method} - ${mapping.request.urlPathTemplate}`;
+            const datetimeParams = datetimeParamsByEndpoint.get(mappingKey) ?? new Set<string>();
+
+            for (const [paramName, value] of Object.entries(mapping.request.queryParameters)) {
+                // Skip datetime-typed params — they should keep .000 when datetime_milliseconds is true
+                if (datetimeParams.has(paramName)) {
+                    continue;
+                }
+                const paramValue = value as { equalTo: string };
+                if (
+                    paramValue.equalTo != null &&
+                    WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(paramValue.equalTo)
+                ) {
+                    paramValue.equalTo = paramValue.equalTo.replace(".000", "");
+                }
+            }
+        }
+    }
+
+    /**
+     * Recursively checks if a TypeReference resolves to a datetime primitive.
+     * Unwraps optional/nullable containers to check the inner type.
+     */
+    private static isDatetimeTypeReference(typeRef: FernIr.TypeReference): boolean {
+        if (typeRef.type === "primitive") {
+            return typeRef.primitive.v1 === "DATE_TIME";
+        }
+        if (typeRef.type === "container") {
+            if (typeRef.container.type === "optional") {
+                return WireTestSetupGenerator.isDatetimeTypeReference(typeRef.container.optional);
+            }
+            if (typeRef.container.type === "nullable") {
+                return WireTestSetupGenerator.isDatetimeTypeReference(typeRef.container.nullable);
+            }
+        }
+        return false;
+    }
+
     private generateWireMockConfigFile(): void {
         const wireMockConfigContent = WireTestSetupGenerator.getWiremockConfigContent(this.ir);
 
-        // When datetime_milliseconds is not enabled (default), strip milliseconds from datetime
-        // values in WireMock stubs. mock-utils always generates datetime values using
-        // Date.toISOString() which includes ".000Z", but the Python SDK's default
-        // serialize_datetime (isoformat()) omits zero fractional seconds. Stripping here
-        // ensures the stubs match what the SDK actually sends.
+        // mock-utils always generates datetime values using Date.toISOString() which includes
+        // ".000Z". We need to normalize these based on the datetime_milliseconds config and
+        // the actual parameter types:
+        //
+        // When datetime_milliseconds is false (default): strip ".000" from ALL datetime query
+        // param values, since the SDK's default serialize_datetime (isoformat()) omits zero
+        // fractional seconds.
+        //
+        // When datetime_milliseconds is true: keep ".000" for datetime-typed params (because
+        // serialize_datetime will output milliseconds), but strip ".000" for string-typed params
+        // (because the SDK passes strings through as-is without calling serialize_datetime).
         if (!this.context.customConfig.datetime_milliseconds) {
             WireTestSetupGenerator.stripDatetimeMilliseconds(wireMockConfigContent);
+        } else {
+            this.stripDatetimeMillisecondsForStringParams(wireMockConfigContent, this.ir);
         }
 
         const wireMockConfigFile = new File(

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.63.3
+  changelogEntry:
+    - summary: |
+        Make wire test datetime normalization type-aware. String-typed query parameters
+        that look like datetimes (e.g., `created_after: str`) are no longer incorrectly
+        normalized with `.000` milliseconds. Only `DATE_TIME`-typed parameters are affected
+        by the `datetime_milliseconds` config.
+      type: fix
+  createdAt: "2026-03-11"
+  irVersion: 65
+
 - version: 4.63.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs [PR #96 CI failures](https://github.com/fern-demo/twilio-core-python-sdk/actions/runs/22946022750/job/66598502522?pr=96)

When `datetime_milliseconds: true`, the wire test generator was unconditionally adding `.000` to all datetime-looking query parameter values. This broke endpoints where datetime query params are typed as `str` (not `datetime`) in the API spec — the SDK passes string values through as-is without calling `serialize_datetime`, so WireMock stubs and test verification expected `.000Z` but the SDK sent the raw string without it.

Affected endpoints: `Insights.ListConference` (`created_after: str`), `Intelligence.ListTranscript` (`after_date_created: str`).

Link to Devin session: https://app.devin.ai/sessions/c53b1e7fd9e44fe3b1172f658443c7d9
Requested by: @iamnamananand996

## Changes Made

- **`WireTestGenerator.ts`**: Added `isDatetimeTypedQueryParam()` / `isDatetimeTypeReference()` to check query param types from the IR. `normalizeDatetimeQueryParamValue()` now only adds `.000` for `DATE_TIME`-typed params (not `STRING`-typed).
- **`WireTestSetupGenerator.ts`**: Added `stripDatetimeMillisecondsForStringParams()` which builds a per-endpoint lookup of datetime-typed param names, then strips `.000` only from string-typed params in WireMock stubs when `datetime_milliseconds: true`.
- When `datetime_milliseconds: false` (default), behavior is unchanged — all `.000` values are stripped.
- [ ] Updated README.md generator (not applicable)

## Human Review Checklist

- [ ] **Duplicated `isDatetimeTypeReference`**: The same type-checking logic exists in both `WireTestGenerator` (instance method) and `WireTestSetupGenerator` (static method). Verify both implementations are equivalent and consider extracting to a shared utility.
- [ ] **Path matching correctness**: `stripDatetimeMillisecondsForStringParams` reconstructs endpoint paths from `fullPath.head`/`parts` to match against WireMock mapping keys. Confirm this matches how `mock-utils` generates `urlPathTemplate` (especially edge cases like fragments, leading slashes, path parameters).
- [ ] **Container type unwrapping**: `isDatetimeTypeReference` only unwraps `optional` and `nullable` containers. Verify no query params use `list<datetime>` or other container types that should also be treated as datetime-typed.
- [ ] **No seed test coverage**: This diff does not add a seed fixture for string-typed datetime query params. The existing `exhaustive:datetime-milliseconds` fixture may not cover this case.

## Testing

- [ ] Unit tests added/updated (no new seed fixture added — relies on Twilio SDK regeneration CI for validation)
- [x] Manual testing completed (verified the 2 failing endpoints have `str`-typed datetime params in the generated SDK)