### PR TITLE
chore(internal): add unit tests for GeneratedUnionTypeImpl

### DIFF
--- a/generators/typescript/model/type-generator/src/__test__/GeneratedUnionTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedUnionTypeImpl.test.ts
@@ -1,0 +1,1113 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode, TypeReferenceNode } from "@fern-typescript/commons";
+import { casingsGenerator, createDeclaredTypeName, createNameAndWireValue } from "@fern-typescript/test-utils";
+import { Project, ts } from "ts-morph";
+import { assert, describe, expect, it } from "vitest";
+
+import { GeneratedUnionTypeImpl } from "../union/GeneratedUnionTypeImpl.js";
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function createFernFilepath(packageName = "types"): FernIr.FernFilepath {
+    return {
+        allParts: [casingsGenerator.generateName(packageName)],
+        packagePath: [casingsGenerator.generateName(packageName)],
+        file: casingsGenerator.generateName(packageName)
+    };
+}
+
+/**
+ * Builds a TypeReferenceNode for a primitive type (non-optional).
+ */
+function primitiveTypeRefNode(typeName: string): TypeReferenceNode {
+    const typeNode = ts.factory.createKeywordTypeNode(
+        typeName === "string"
+            ? ts.SyntaxKind.StringKeyword
+            : typeName === "number"
+              ? ts.SyntaxKind.NumberKeyword
+              : typeName === "boolean"
+                ? ts.SyntaxKind.BooleanKeyword
+                : ts.SyntaxKind.AnyKeyword
+    );
+    return {
+        isOptional: false,
+        typeNode,
+        typeNodeWithoutUndefined: typeNode,
+        requestTypeNode: undefined,
+        requestTypeNodeWithoutUndefined: undefined,
+        responseTypeNode: undefined,
+        responseTypeNodeWithoutUndefined: undefined
+    };
+}
+
+/**
+ * Builds a TypeReferenceNode pointing to a named type reference.
+ */
+function namedTypeRefNode(name: string): TypeReferenceNode {
+    const typeNode = ts.factory.createTypeReferenceNode(name);
+    return {
+        isOptional: false,
+        typeNode,
+        typeNodeWithoutUndefined: typeNode,
+        requestTypeNode: undefined,
+        requestTypeNodeWithoutUndefined: undefined,
+        responseTypeNode: undefined,
+        responseTypeNodeWithoutUndefined: undefined
+    };
+}
+
+/**
+ * Creates a NameAndWireValue using the casings generator.
+ */
+function createNameAndWireValueFromName(name: string, wireValue?: string): FernIr.NameAndWireValue {
+    return createNameAndWireValue(name, wireValue);
+}
+
+/**
+ * Creates a SingleUnionType with singleProperty shape.
+ */
+function createSinglePropertyUnionType(opts: {
+    discriminantValue: string;
+    propertyName: string;
+    propertyWireValue?: string;
+    propertyType?: FernIr.TypeReference;
+    docs?: string;
+}): FernIr.SingleUnionType {
+    return {
+        discriminantValue: createNameAndWireValueFromName(opts.discriminantValue),
+        shape: FernIr.SingleUnionTypeProperties.singleProperty({
+            name: createNameAndWireValueFromName(opts.propertyName, opts.propertyWireValue),
+            type: opts.propertyType ?? FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+        }),
+        displayName: undefined,
+        availability: undefined,
+        docs: opts.docs
+    };
+}
+
+/**
+ * Creates a SingleUnionType with samePropertiesAsObject shape.
+ */
+function createSamePropertiesAsObjectUnionType(opts: {
+    discriminantValue: string;
+    typeName: FernIr.DeclaredTypeName;
+    docs?: string;
+}): FernIr.SingleUnionType {
+    return {
+        discriminantValue: createNameAndWireValueFromName(opts.discriminantValue),
+        shape: FernIr.SingleUnionTypeProperties.samePropertiesAsObject(opts.typeName),
+        displayName: undefined,
+        availability: undefined,
+        docs: opts.docs
+    };
+}
+
+/**
+ * Creates a SingleUnionType with noProperties shape.
+ */
+function createNoPropertiesUnionType(opts: { discriminantValue: string; docs?: string }): FernIr.SingleUnionType {
+    return {
+        discriminantValue: createNameAndWireValueFromName(opts.discriminantValue),
+        shape: FernIr.SingleUnionTypeProperties.noProperties(),
+        displayName: undefined,
+        availability: undefined,
+        docs: opts.docs
+    };
+}
+
+/**
+ * Creates a UnionTypeDeclaration IR object.
+ */
+function createUnionDeclaration(opts: {
+    discriminantName: string;
+    discriminantWireValue?: string;
+    types: FernIr.SingleUnionType[];
+    baseProperties?: FernIr.ObjectProperty[];
+    extends?: FernIr.DeclaredTypeName[];
+}): FernIr.UnionTypeDeclaration {
+    return {
+        discriminant: createNameAndWireValueFromName(opts.discriminantName, opts.discriminantWireValue),
+        types: opts.types,
+        baseProperties: opts.baseProperties ?? [],
+        extends: opts.extends ?? []
+    };
+}
+
+/**
+ * Creates a mock BaseContext for union type tests.
+ * Provides: getReferenceToType, getReferenceToTypeForInlineUnion, getReferenceToNamedType,
+ * getTypeDeclaration, getGeneratedType, getGeneratedTypeById, getGeneratedExample,
+ * needsRequestResponseTypeVariantByType, needsRequestResponseTypeVariantById, typeNameToTypeReference.
+ */
+function createMockBaseContext(opts?: {
+    typeRefOverrides?: Map<string, TypeReferenceNode>;
+    generatedTypeOverrides?: Map<string, unknown>;
+    generatedTypeByIdOverrides?: Map<string, unknown>;
+}) {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const sourceFile = project.createSourceFile("test.ts", "");
+
+    const typeRefMap = opts?.typeRefOverrides ?? new Map<string, TypeReferenceNode>();
+    const generatedTypeMap = opts?.generatedTypeOverrides ?? new Map<string, unknown>();
+    const generatedTypeByIdMap = opts?.generatedTypeByIdOverrides ?? new Map<string, unknown>();
+
+    return {
+        sourceFile,
+        // biome-ignore lint/suspicious/noEmptyBlockStatements: test mock with no-op logger
+        logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+        type: {
+            getReferenceToType: (typeRef: FernIr.TypeReference): TypeReferenceNode => {
+                if (typeRef.type === "named") {
+                    const override = typeRefMap.get(typeRef.typeId);
+                    if (override) {
+                        return override;
+                    }
+                }
+                return primitiveTypeRefNode("string");
+            },
+            getReferenceToTypeForInlineUnion: (typeRef: FernIr.TypeReference): TypeReferenceNode => {
+                if (typeRef.type === "named") {
+                    const override = typeRefMap.get(typeRef.typeId);
+                    if (override) {
+                        return override;
+                    }
+                }
+                return primitiveTypeRefNode("string");
+            },
+            getReferenceToNamedType: (typeName: FernIr.DeclaredTypeName) => ({
+                getTypeNode: () => ts.factory.createTypeReferenceNode(typeName.name.pascalCase.unsafeName),
+                getExpression: () => ts.factory.createIdentifier(typeName.name.pascalCase.unsafeName),
+                getEntityName: () => ts.factory.createIdentifier(typeName.name.pascalCase.unsafeName)
+            }),
+            getTypeDeclaration: (typeName: FernIr.DeclaredTypeName): FernIr.TypeDeclaration => {
+                return {
+                    name: typeName,
+                    shape: FernIr.Type.object({
+                        properties: [],
+                        extends: [],
+                        extraProperties: false,
+                        extendedProperties: undefined
+                    }),
+                    referencedTypes: new Set<string>(),
+                    encoding: undefined,
+                    autogeneratedExamples: [],
+                    userProvidedExamples: [],
+                    v2Examples: undefined,
+                    docs: undefined,
+                    availability: undefined,
+                    source: undefined,
+                    inline: undefined
+                };
+            },
+            getGeneratedType: (typeName: FernIr.DeclaredTypeName) => {
+                const override = generatedTypeMap.get(typeName.typeId);
+                if (override) {
+                    return override;
+                }
+                return {
+                    type: "object",
+                    generateStatements: () => [],
+                    generateForInlineUnion: () => ({
+                        typeNode: ts.factory.createTypeReferenceNode(typeName.name.pascalCase.unsafeName),
+                        requestTypeNode: undefined,
+                        responseTypeNode: undefined
+                    }),
+                    getAllPropertiesIncludingExtensions: () => [],
+                    getPropertyKey: ({ propertyWireKey }: { propertyWireKey: string }) => propertyWireKey,
+                    generateProperties: () => [],
+                    generateModule: () => undefined,
+                    buildExample: () => ts.factory.createStringLiteral("example-value"),
+                    buildExampleProperties: () => []
+                };
+            },
+            getGeneratedTypeById: (typeId: string) => {
+                const override = generatedTypeByIdMap.get(typeId);
+                if (override) {
+                    return override;
+                }
+                return {
+                    type: "object",
+                    buildExample: () => ts.factory.createStringLiteral("example-value"),
+                    buildExampleProperties: () => []
+                };
+            },
+            getGeneratedExample: (_example: FernIr.ExampleTypeReference) => ({
+                build: () => ts.factory.createStringLiteral("example-value")
+            }),
+            needsRequestResponseTypeVariantByType: () => ({ request: false, response: false }),
+            needsRequestResponseTypeVariantById: () => ({ request: false, response: false }),
+            typeNameToTypeReference: (typeName: FernIr.DeclaredTypeName): FernIr.TypeReference => {
+                return FernIr.TypeReference.named({
+                    typeId: typeName.typeId,
+                    fernFilepath: typeName.fernFilepath,
+                    name: typeName.name,
+                    displayName: typeName.displayName,
+                    default: undefined,
+                    inline: undefined
+                });
+            }
+        }
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+    } as any;
+}
+
+/**
+ * Creates a GeneratedUnionTypeImpl with the given config.
+ */
+function createUnionGenerator(opts: {
+    typeName: string;
+    shape: FernIr.UnionTypeDeclaration;
+    docs?: string;
+    examples?: FernIr.ExampleType[];
+    includeUtilsOnUnionMembers?: boolean;
+    includeOtherInUnionTypes?: boolean;
+    includeSerdeLayer?: boolean;
+    retainOriginalCasing?: boolean;
+    noOptionalProperties?: boolean;
+    enableInlineTypes?: boolean;
+    generateReadWriteOnlyTypes?: boolean;
+    inline?: boolean;
+    // biome-ignore lint/suspicious/noExplicitAny: test factory with generic type parameter
+}): GeneratedUnionTypeImpl<any> {
+    return new GeneratedUnionTypeImpl({
+        typeName: opts.typeName,
+        shape: opts.shape,
+        examples: opts.examples ?? [],
+        docs: opts.docs,
+        fernFilepath: createFernFilepath(),
+        getReferenceToSelf: () => ({
+            getTypeNode: () => ts.factory.createTypeReferenceNode(opts.typeName),
+            getExpression: () => ts.factory.createIdentifier(opts.typeName),
+            getEntityName: () => ts.factory.createIdentifier(opts.typeName)
+        }),
+        includeSerdeLayer: opts.includeSerdeLayer ?? true,
+        noOptionalProperties: opts.noOptionalProperties ?? false,
+        retainOriginalCasing: opts.retainOriginalCasing ?? false,
+        enableInlineTypes: opts.enableInlineTypes ?? false,
+        generateReadWriteOnlyTypes: opts.generateReadWriteOnlyTypes ?? false,
+        includeUtilsOnUnionMembers: opts.includeUtilsOnUnionMembers ?? false,
+        includeOtherInUnionTypes: opts.includeOtherInUnionTypes ?? false,
+        inline: opts.inline ?? false
+    });
+}
+
+/**
+ * Serializes generateStatements output by writing to a ts-morph SourceFile.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test utility accepting mock context or generator
+function serializeStatements(generator: any, context?: any): string {
+    const ctx = context ?? createMockBaseContext();
+    const statements = generator.generateStatements(ctx);
+    ctx.sourceFile.addStatements(statements);
+    return ctx.sourceFile.getFullText();
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests — GeneratedUnionTypeImpl
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("GeneratedUnionTypeImpl", () => {
+    describe("generateStatements / writeToFile", () => {
+        it("generates basic union with singleProperty members", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "foo",
+                        propertyName: "value",
+                        propertyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createSinglePropertyUnionType({
+                        discriminantValue: "bar",
+                        propertyName: "value",
+                        propertyType: FernIr.TypeReference.primitive({ v1: "INTEGER", v2: undefined })
+                    })
+                ]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with samePropertiesAsObject members", () => {
+            const circleType = createDeclaredTypeName("Circle");
+            const squareType = createDeclaredTypeName("Square");
+
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSamePropertiesAsObjectUnionType({
+                        discriminantValue: "circle",
+                        typeName: circleType
+                    }),
+                    createSamePropertiesAsObjectUnionType({
+                        discriminantValue: "square",
+                        typeName: squareType
+                    })
+                ]
+            });
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([
+                    [circleType.typeId, namedTypeRefNode("Circle")],
+                    [squareType.typeId, namedTypeRefNode("Square")]
+                ])
+            });
+
+            const generator = createUnionGenerator({ typeName: "Shape", shape });
+            const output = serializeStatements(generator, context);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with noProperties members", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createNoPropertiesUnionType({ discriminantValue: "foo" }),
+                    createNoPropertiesUnionType({ discriminantValue: "empty" })
+                ]
+            });
+
+            const generator = createUnionGenerator({ typeName: "UnionWithNoProperties", shape });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with mixed member shapes", () => {
+            const circleType = createDeclaredTypeName("Circle");
+
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "value",
+                        propertyName: "data",
+                        propertyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createSamePropertiesAsObjectUnionType({
+                        discriminantValue: "circle",
+                        typeName: circleType
+                    }),
+                    createNoPropertiesUnionType({ discriminantValue: "empty" })
+                ]
+            });
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([[circleType.typeId, namedTypeRefNode("Circle")]])
+            });
+
+            const generator = createUnionGenerator({ typeName: "MixedUnion", shape });
+            const output = serializeStatements(generator, context);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with baseProperties", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createNoPropertiesUnionType({ discriminantValue: "foo" }),
+                    createNoPropertiesUnionType({ discriminantValue: "bar" })
+                ],
+                baseProperties: [
+                    {
+                        name: createNameAndWireValueFromName("id"),
+                        valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        docs: undefined,
+                        availability: undefined,
+                        v2Examples: undefined,
+                        propertyAccess: undefined
+                    }
+                ]
+            });
+
+            const generator = createUnionGenerator({ typeName: "UnionWithBase", shape });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with extends", () => {
+            const withNameType = createDeclaredTypeName("WithName");
+
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createNoPropertiesUnionType({ discriminantValue: "foo" }),
+                    createNoPropertiesUnionType({ discriminantValue: "bar" })
+                ],
+                baseProperties: [
+                    {
+                        name: createNameAndWireValueFromName("id"),
+                        valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        docs: undefined,
+                        availability: undefined,
+                        v2Examples: undefined,
+                        propertyAccess: undefined
+                    }
+                ],
+                extends: [withNameType]
+            });
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([[withNameType.typeId, namedTypeRefNode("WithName")]])
+            });
+
+            const generator = createUnionGenerator({ typeName: "Shape", shape });
+            const output = serializeStatements(generator, context);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with includeUtilsOnUnionMembers (builders + visitor)", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "foo",
+                        propertyName: "value",
+                        propertyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createNoPropertiesUnionType({ discriminantValue: "bar" })
+                ]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                includeUtilsOnUnionMembers: true
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with includeOtherInUnionTypes", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "foo",
+                        propertyName: "value",
+                        propertyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    })
+                ]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                includeUtilsOnUnionMembers: true,
+                includeOtherInUnionTypes: true
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with docs on type", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createNoPropertiesUnionType({ discriminantValue: "foo" }),
+                    createNoPropertiesUnionType({ discriminantValue: "bar" })
+                ]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                docs: "This is a simple union type."
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with docs on members", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createNoPropertiesUnionType({ discriminantValue: "foo", docs: "The foo variant." }),
+                    createNoPropertiesUnionType({ discriminantValue: "bar", docs: "The bar variant." })
+                ]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with single member", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "foo",
+                        propertyName: "name",
+                        propertyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    })
+                ]
+            });
+
+            const generator = createUnionGenerator({ typeName: "UnionWithSingleElement", shape });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with retainOriginalCasing", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                discriminantWireValue: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "foo",
+                        propertyName: "value",
+                        propertyWireValue: "value",
+                        propertyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    })
+                ]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                retainOriginalCasing: true
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union without serde layer", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                discriminantWireValue: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "foo",
+                        propertyName: "value",
+                        propertyWireValue: "value",
+                        propertyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    })
+                ]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                includeSerdeLayer: false
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with examples in docs", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createNoPropertiesUnionType({ discriminantValue: "foo" }),
+                    createNoPropertiesUnionType({ discriminantValue: "bar" })
+                ]
+            });
+
+            const exampleShape = FernIr.ExampleTypeShape.union({
+                singleUnionType: {
+                    wireDiscriminantValue: createNameAndWireValueFromName("foo"),
+                    shape: FernIr.ExampleSingleUnionTypeProperties.noProperties()
+                },
+                baseProperties: undefined,
+                extendProperties: undefined
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                docs: "A union type.",
+                examples: [{ shape: exampleShape, docs: undefined, name: undefined, jsonExample: {} }]
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("generateForInlineUnion", () => {
+        it("returns parenthesized union type node", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createNoPropertiesUnionType({ discriminantValue: "foo" }),
+                    createNoPropertiesUnionType({ discriminantValue: "bar" })
+                ]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            const context = createMockBaseContext();
+            const result = generator.generateForInlineUnion(context);
+            expect(getTextOfTsNode(result.typeNode)).toMatchSnapshot();
+            expect(result.requestTypeNode).toBeUndefined();
+            expect(result.responseTypeNode).toBeUndefined();
+        });
+
+        it("returns request/response type nodes when generateReadWriteOnlyTypes is true", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createNoPropertiesUnionType({ discriminantValue: "foo" }),
+                    createNoPropertiesUnionType({ discriminantValue: "bar" })
+                ]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                generateReadWriteOnlyTypes: true
+            });
+            const context = createMockBaseContext();
+            const result = generator.generateForInlineUnion(context);
+            expect(getTextOfTsNode(result.typeNode)).toMatchSnapshot();
+            assert(result.requestTypeNode != null, "requestTypeNode should be defined");
+            expect(getTextOfTsNode(result.requestTypeNode)).toMatchSnapshot();
+            assert(result.responseTypeNode != null, "responseTypeNode should be defined");
+            expect(getTextOfTsNode(result.responseTypeNode)).toMatchSnapshot();
+        });
+    });
+
+    describe("generateModule", () => {
+        it("always returns undefined", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "foo" })]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            const result = generator.generateModule();
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe("getGeneratedUnion", () => {
+        it("returns the wrapped GeneratedUnionImpl", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "foo" })]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            const union = generator.getGeneratedUnion();
+            expect(union).toBeDefined();
+            expect(union.discriminant).toBe("type");
+        });
+    });
+
+    describe("getSinglePropertyKey", () => {
+        it("returns camelCase name with serde layer", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "foo",
+                        propertyName: "myValue",
+                        propertyWireValue: "my_value"
+                    })
+                ]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                includeSerdeLayer: true,
+                retainOriginalCasing: false
+            });
+
+            const singleProperty: FernIr.SingleUnionTypeProperty = {
+                name: createNameAndWireValueFromName("myValue", "my_value"),
+                type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+            };
+
+            expect(generator.getSinglePropertyKey(singleProperty)).toBe("myValue");
+        });
+
+        it("returns wire value without serde layer", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "foo",
+                        propertyName: "myValue",
+                        propertyWireValue: "my_value"
+                    })
+                ]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                includeSerdeLayer: false
+            });
+
+            const singleProperty: FernIr.SingleUnionTypeProperty = {
+                name: createNameAndWireValueFromName("myValue", "my_value"),
+                type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+            };
+
+            expect(generator.getSinglePropertyKey(singleProperty)).toBe("my_value");
+        });
+
+        it("returns wire value with serde layer and retainOriginalCasing", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "foo",
+                        propertyName: "myValue",
+                        propertyWireValue: "my_value"
+                    })
+                ]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                includeSerdeLayer: true,
+                retainOriginalCasing: true
+            });
+
+            const singleProperty: FernIr.SingleUnionTypeProperty = {
+                name: createNameAndWireValueFromName("myValue", "my_value"),
+                type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+            };
+
+            expect(generator.getSinglePropertyKey(singleProperty)).toBe("my_value");
+        });
+    });
+
+    describe("buildExample", () => {
+        it("builds example with noProperties shape", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createNoPropertiesUnionType({ discriminantValue: "foo" }),
+                    createNoPropertiesUnionType({ discriminantValue: "bar" })
+                ]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            const context = createMockBaseContext();
+
+            const example = FernIr.ExampleTypeShape.union({
+                singleUnionType: {
+                    wireDiscriminantValue: createNameAndWireValueFromName("foo"),
+                    shape: FernIr.ExampleSingleUnionTypeProperties.noProperties()
+                },
+                baseProperties: undefined,
+                extendProperties: undefined
+            });
+
+            const result = generator.buildExample(example, context, { isForComment: true });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("builds example with singleProperty shape", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSinglePropertyUnionType({
+                        discriminantValue: "foo",
+                        propertyName: "value",
+                        propertyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    })
+                ]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            const context = createMockBaseContext();
+
+            const example = FernIr.ExampleTypeShape.union({
+                singleUnionType: {
+                    wireDiscriminantValue: createNameAndWireValueFromName("foo"),
+                    shape: FernIr.ExampleSingleUnionTypeProperties.singleProperty({
+                        shape: FernIr.ExampleTypeReferenceShape.primitive(
+                            FernIr.ExamplePrimitive.string({ original: "hello" })
+                        ),
+                        jsonExample: "hello"
+                    })
+                },
+                baseProperties: undefined,
+                extendProperties: undefined
+            });
+
+            const result = generator.buildExample(example, context, { isForComment: true });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("builds example with samePropertiesAsObject shape", () => {
+            const circleType = createDeclaredTypeName("Circle");
+
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [
+                    createSamePropertiesAsObjectUnionType({
+                        discriminantValue: "circle",
+                        typeName: circleType
+                    })
+                ]
+            });
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([[circleType.typeId, namedTypeRefNode("Circle")]]),
+                generatedTypeByIdOverrides: new Map([
+                    [
+                        circleType.typeId,
+                        {
+                            type: "object",
+                            buildExample: () => ts.factory.createStringLiteral("circle-example"),
+                            buildExampleProperties: () => [
+                                ts.factory.createPropertyAssignment("radius", ts.factory.createNumericLiteral(5))
+                            ]
+                        }
+                    ]
+                ])
+            });
+
+            const example = FernIr.ExampleTypeShape.union({
+                singleUnionType: {
+                    wireDiscriminantValue: createNameAndWireValueFromName("circle"),
+                    shape: FernIr.ExampleSingleUnionTypeProperties.samePropertiesAsObject({
+                        typeId: circleType.typeId,
+                        object: { properties: [], extraProperties: undefined }
+                    })
+                },
+                baseProperties: undefined,
+                extendProperties: undefined
+            });
+
+            const generator = createUnionGenerator({ typeName: "Shape", shape });
+            const result = generator.buildExample(example, context, { isForComment: true });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("builds example with baseProperties", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "foo" })],
+                baseProperties: [
+                    {
+                        name: createNameAndWireValueFromName("id"),
+                        valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        docs: undefined,
+                        availability: undefined,
+                        v2Examples: undefined,
+                        propertyAccess: undefined
+                    }
+                ]
+            });
+
+            const generator = createUnionGenerator({ typeName: "UnionWithBase", shape });
+            const context = createMockBaseContext();
+
+            const example = FernIr.ExampleTypeShape.union({
+                singleUnionType: {
+                    wireDiscriminantValue: createNameAndWireValueFromName("foo"),
+                    shape: FernIr.ExampleSingleUnionTypeProperties.noProperties()
+                },
+                baseProperties: [
+                    {
+                        name: createNameAndWireValueFromName("id"),
+                        value: {
+                            shape: FernIr.ExampleTypeReferenceShape.primitive(
+                                FernIr.ExamplePrimitive.string({ original: "abc123" })
+                            ),
+                            jsonExample: "abc123"
+                        }
+                    }
+                ],
+                extendProperties: undefined
+            });
+
+            const result = generator.buildExample(example, context, { isForComment: true });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("builds example with extendProperties", () => {
+            const withNameType = createDeclaredTypeName("WithName");
+
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "foo" })],
+                extends: [withNameType]
+            });
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([[withNameType.typeId, namedTypeRefNode("WithName")]])
+            });
+
+            const generator = createUnionGenerator({ typeName: "Shape", shape });
+
+            const example = FernIr.ExampleTypeShape.union({
+                singleUnionType: {
+                    wireDiscriminantValue: createNameAndWireValueFromName("foo"),
+                    shape: FernIr.ExampleSingleUnionTypeProperties.noProperties()
+                },
+                baseProperties: undefined,
+                extendProperties: [
+                    {
+                        name: createNameAndWireValueFromName("name"),
+                        value: {
+                            shape: FernIr.ExampleTypeReferenceShape.primitive(
+                                FernIr.ExamplePrimitive.string({ original: "my-name" })
+                            ),
+                            jsonExample: "my-name"
+                        }
+                    }
+                ]
+            });
+
+            const result = generator.buildExample(example, context, { isForComment: true });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("builds example with includeUtilsOnUnionMembers (calls builder)", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "foo" })]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                includeUtilsOnUnionMembers: true
+            });
+            const context = createMockBaseContext();
+
+            const example = FernIr.ExampleTypeShape.union({
+                singleUnionType: {
+                    wireDiscriminantValue: createNameAndWireValueFromName("foo"),
+                    shape: FernIr.ExampleSingleUnionTypeProperties.noProperties()
+                },
+                baseProperties: undefined,
+                extendProperties: undefined
+            });
+
+            const result = generator.buildExample(example, context, { isForComment: true });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("throws for non-union example shape", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "foo" })]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            const context = createMockBaseContext();
+
+            const example = FernIr.ExampleTypeShape.object({
+                properties: [],
+                extraProperties: undefined
+            });
+
+            expect(() => generator.buildExample(example, context, { isForComment: true })).toThrow(
+                "Example is not for an union"
+            );
+        });
+
+        it("throws when singleProperty member not found in shape", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "bar" })]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            const context = createMockBaseContext();
+
+            const example = FernIr.ExampleTypeShape.union({
+                singleUnionType: {
+                    wireDiscriminantValue: createNameAndWireValueFromName("nonexistent"),
+                    shape: FernIr.ExampleSingleUnionTypeProperties.singleProperty({
+                        shape: FernIr.ExampleTypeReferenceShape.primitive(
+                            FernIr.ExamplePrimitive.string({ original: "test" })
+                        ),
+                        jsonExample: "test"
+                    })
+                },
+                baseProperties: undefined,
+                extendProperties: undefined
+            });
+
+            expect(() => generator.buildExample(example, context, { isForComment: true })).toThrow(
+                "Cannot generate union example because union member is not singleProperty"
+            );
+        });
+
+        it("throws when singleProperty example references a non-singleProperty member", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "foo" })]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            const context = createMockBaseContext();
+
+            const example = FernIr.ExampleTypeShape.union({
+                singleUnionType: {
+                    wireDiscriminantValue: createNameAndWireValueFromName("foo"),
+                    shape: FernIr.ExampleSingleUnionTypeProperties.singleProperty({
+                        shape: FernIr.ExampleTypeReferenceShape.primitive(
+                            FernIr.ExamplePrimitive.string({ original: "test" })
+                        ),
+                        jsonExample: "test"
+                    })
+                },
+                baseProperties: undefined,
+                extendProperties: undefined
+            });
+
+            expect(() => generator.buildExample(example, context, { isForComment: true })).toThrow(
+                "Cannot generate union example because union member is not singleProperty"
+            );
+        });
+    });
+
+    describe("type property", () => {
+        it("has type='union'", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "foo" })]
+            });
+
+            const generator = createUnionGenerator({ typeName: "MyUnion", shape });
+            expect(generator.type).toBe("union");
+        });
+    });
+
+    describe("discriminant handling", () => {
+        it("uses camelCase discriminant name with serde layer", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "unionType",
+                discriminantWireValue: "union_type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "foo" })]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                includeSerdeLayer: true
+            });
+            const union = generator.getGeneratedUnion();
+            expect(union.discriminant).toBe("unionType");
+        });
+
+        it("uses wire value discriminant without serde layer", () => {
+            const shape = createUnionDeclaration({
+                discriminantName: "unionType",
+                discriminantWireValue: "union_type",
+                types: [createNoPropertiesUnionType({ discriminantValue: "foo" })]
+            });
+
+            const generator = createUnionGenerator({
+                typeName: "MyUnion",
+                shape,
+                includeSerdeLayer: false
+            });
+            const union = generator.getGeneratedUnion();
+            expect(union.discriminant).toBe("union_type");
+        });
+    });
+});

--- a/generators/typescript/model/type-generator/src/__test__/GeneratedUnionTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedUnionTypeImpl.test.ts
@@ -131,7 +131,8 @@ function createUnionDeclaration(opts: {
         discriminant: createNameAndWireValueFromName(opts.discriminantName, opts.discriminantWireValue),
         types: opts.types,
         baseProperties: opts.baseProperties ?? [],
-        extends: opts.extends ?? []
+        extends: opts.extends ?? [],
+        discriminatorContext: undefined
     };
 }
 
@@ -608,6 +609,7 @@ describe("GeneratedUnionTypeImpl", () => {
             });
 
             const exampleShape = FernIr.ExampleTypeShape.union({
+                discriminant: createNameAndWireValueFromName("type"),
                 singleUnionType: {
                     wireDiscriminantValue: createNameAndWireValueFromName("foo"),
                     shape: FernIr.ExampleSingleUnionTypeProperties.noProperties()
@@ -792,6 +794,7 @@ describe("GeneratedUnionTypeImpl", () => {
             const context = createMockBaseContext();
 
             const example = FernIr.ExampleTypeShape.union({
+                discriminant: createNameAndWireValueFromName("type"),
                 singleUnionType: {
                     wireDiscriminantValue: createNameAndWireValueFromName("foo"),
                     shape: FernIr.ExampleSingleUnionTypeProperties.noProperties()
@@ -820,6 +823,7 @@ describe("GeneratedUnionTypeImpl", () => {
             const context = createMockBaseContext();
 
             const example = FernIr.ExampleTypeShape.union({
+                discriminant: createNameAndWireValueFromName("type"),
                 singleUnionType: {
                     wireDiscriminantValue: createNameAndWireValueFromName("foo"),
                     shape: FernIr.ExampleSingleUnionTypeProperties.singleProperty({
@@ -867,6 +871,7 @@ describe("GeneratedUnionTypeImpl", () => {
             });
 
             const example = FernIr.ExampleTypeShape.union({
+                discriminant: createNameAndWireValueFromName("type"),
                 singleUnionType: {
                     wireDiscriminantValue: createNameAndWireValueFromName("circle"),
                     shape: FernIr.ExampleSingleUnionTypeProperties.samePropertiesAsObject({
@@ -903,6 +908,7 @@ describe("GeneratedUnionTypeImpl", () => {
             const context = createMockBaseContext();
 
             const example = FernIr.ExampleTypeShape.union({
+                discriminant: createNameAndWireValueFromName("type"),
                 singleUnionType: {
                     wireDiscriminantValue: createNameAndWireValueFromName("foo"),
                     shape: FernIr.ExampleSingleUnionTypeProperties.noProperties()
@@ -941,6 +947,7 @@ describe("GeneratedUnionTypeImpl", () => {
             const generator = createUnionGenerator({ typeName: "Shape", shape });
 
             const example = FernIr.ExampleTypeShape.union({
+                discriminant: createNameAndWireValueFromName("type"),
                 singleUnionType: {
                     wireDiscriminantValue: createNameAndWireValueFromName("foo"),
                     shape: FernIr.ExampleSingleUnionTypeProperties.noProperties()
@@ -954,7 +961,9 @@ describe("GeneratedUnionTypeImpl", () => {
                                 FernIr.ExamplePrimitive.string({ original: "my-name" })
                             ),
                             jsonExample: "my-name"
-                        }
+                        },
+                        propertyAccess: undefined,
+                        originalTypeDeclaration: createDeclaredTypeName("WithName")
                     }
                 ]
             });
@@ -977,6 +986,7 @@ describe("GeneratedUnionTypeImpl", () => {
             const context = createMockBaseContext();
 
             const example = FernIr.ExampleTypeShape.union({
+                discriminant: createNameAndWireValueFromName("type"),
                 singleUnionType: {
                     wireDiscriminantValue: createNameAndWireValueFromName("foo"),
                     shape: FernIr.ExampleSingleUnionTypeProperties.noProperties()
@@ -1018,6 +1028,7 @@ describe("GeneratedUnionTypeImpl", () => {
             const context = createMockBaseContext();
 
             const example = FernIr.ExampleTypeShape.union({
+                discriminant: createNameAndWireValueFromName("type"),
                 singleUnionType: {
                     wireDiscriminantValue: createNameAndWireValueFromName("nonexistent"),
                     shape: FernIr.ExampleSingleUnionTypeProperties.singleProperty({
@@ -1046,6 +1057,7 @@ describe("GeneratedUnionTypeImpl", () => {
             const context = createMockBaseContext();
 
             const example = FernIr.ExampleTypeShape.union({
+                discriminant: createNameAndWireValueFromName("type"),
                 singleUnionType: {
                     wireDiscriminantValue: createNameAndWireValueFromName("foo"),
                     shape: FernIr.ExampleSingleUnionTypeProperties.singleProperty({

--- a/generators/typescript/model/type-generator/src/__test__/__snapshots__/GeneratedUnionTypeImpl.test.ts.snap
+++ b/generators/typescript/model/type-generator/src/__test__/__snapshots__/GeneratedUnionTypeImpl.test.ts.snap
@@ -1,0 +1,386 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedUnionTypeImpl > buildExample > builds example with baseProperties 1`] = `
+"{
+    type: "foo",
+    id: "example-value"
+}"
+`;
+
+exports[`GeneratedUnionTypeImpl > buildExample > builds example with extendProperties 1`] = `
+"{
+    type: "foo",
+    name: "example-value"
+}"
+`;
+
+exports[`GeneratedUnionTypeImpl > buildExample > builds example with includeUtilsOnUnionMembers (calls builder) 1`] = `"MyUnion.foo()"`;
+
+exports[`GeneratedUnionTypeImpl > buildExample > builds example with noProperties shape 1`] = `
+"{
+    type: "foo"
+}"
+`;
+
+exports[`GeneratedUnionTypeImpl > buildExample > builds example with samePropertiesAsObject shape 1`] = `
+"{
+    type: "circle",
+    radius: 5
+}"
+`;
+
+exports[`GeneratedUnionTypeImpl > buildExample > builds example with singleProperty shape 1`] = `
+"{
+    type: "foo",
+    value: "example-value"
+}"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateForInlineUnion > returns parenthesized union type node 1`] = `"({} | {})"`;
+
+exports[`GeneratedUnionTypeImpl > generateForInlineUnion > returns request/response type nodes when generateReadWriteOnlyTypes is true 1`] = `"({} | {})"`;
+
+exports[`GeneratedUnionTypeImpl > generateForInlineUnion > returns request/response type nodes when generateReadWriteOnlyTypes is true 2`] = `"({} | {})"`;
+
+exports[`GeneratedUnionTypeImpl > generateForInlineUnion > returns request/response type nodes when generateReadWriteOnlyTypes is true 3`] = `"({} | {})"`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates basic union with singleProperty members 1`] = `
+"export type MyUnion = 
+    | MyUnion.Foo
+    | MyUnion.Bar;
+
+export namespace MyUnion {
+    export interface Foo {
+        type: "foo";
+        value: string;
+    }
+
+    export interface Bar {
+        type: "bar";
+        value: string;
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with baseProperties 1`] = `
+"export type UnionWithBase = 
+    | UnionWithBase.Foo
+    | UnionWithBase.Bar;
+
+export namespace UnionWithBase {
+    export interface Foo extends _Base {
+        type: "foo";
+    }
+
+    export interface Bar extends _Base {
+        type: "bar";
+    }
+
+    export interface _Base {
+        id: string;
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with docs on members 1`] = `
+"export type MyUnion = 
+    /**
+     * The foo variant. */
+    | MyUnion.Foo
+    /**
+     * The bar variant. */
+    | MyUnion.Bar;
+
+export namespace MyUnion {
+    export interface Foo {
+        type: "foo";
+    }
+
+    export interface Bar {
+        type: "bar";
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with docs on type 1`] = `
+"/**
+ * This is a simple union type.
+ */
+export type MyUnion = 
+    | MyUnion.Foo
+    | MyUnion.Bar;
+
+export namespace MyUnion {
+    export interface Foo {
+        type: "foo";
+    }
+
+    export interface Bar {
+        type: "bar";
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with examples in docs 1`] = `
+"/**
+ * A union type.
+ *
+ * @example
+ *     {
+ *         type: "foo"
+ *     }
+ */
+export type MyUnion = 
+    | MyUnion.Foo
+    | MyUnion.Bar;
+
+export namespace MyUnion {
+    export interface Foo {
+        type: "foo";
+    }
+
+    export interface Bar {
+        type: "bar";
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with extends 1`] = `
+"export type Shape = 
+    | Shape.Foo
+    | Shape.Bar;
+
+export namespace Shape {
+    export interface Foo extends _Base {
+        type: "foo";
+    }
+
+    export interface Bar extends _Base {
+        type: "bar";
+    }
+
+    export interface _Base extends WithName {
+        id: string;
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with includeOtherInUnionTypes 1`] = `
+"export type MyUnion = 
+    | MyUnion.Foo
+    | MyUnion._Unknown;
+
+export namespace MyUnion {
+    export interface Foo extends _Utils {
+        type: "foo";
+        value: string;
+    }
+
+    export interface _Unknown extends _Utils {
+        type: string;
+    }
+
+    export interface _Utils {
+        _visit: <_Result>(visitor: MyUnion._Visitor<_Result>) => _Result;
+    }
+
+    export interface _Visitor<_Result> {
+        foo: (value: string) => _Result;
+        _other: (value: {
+                type: string;
+            }) => _Result;
+    }
+}
+
+export const MyUnion = {
+        foo: (value: string): MyUnion.Foo => {
+            return {
+                value: value,
+                type: "foo",
+                "_visit": function <_Result>(this: MyUnion.Foo, visitor: MyUnion._Visitor<_Result>) {
+                    return MyUnion._visit(this, visitor);
+                }
+            };
+        },
+
+        _unknown: (value: {
+            type: string;
+        }): MyUnion._Unknown => {
+            return {
+                ...value,
+                "_visit": function <_Result>(this: MyUnion._Unknown, visitor: MyUnion._Visitor<_Result>) {
+                    return MyUnion._visit(this, visitor);
+                }
+            };
+        },
+
+        _visit: <_Result>(value: MyUnion, visitor: MyUnion._Visitor<_Result>): _Result => {
+            switch (value.type) {
+                case "foo": return visitor.foo((value as MyUnion.Foo).value);
+                default: return visitor._other(value);
+            }
+        },
+    } as const;
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with includeUtilsOnUnionMembers (builders + visitor) 1`] = `
+"export type MyUnion = 
+    | MyUnion.Foo
+    | MyUnion.Bar;
+
+export namespace MyUnion {
+    export interface Foo extends _Utils {
+        type: "foo";
+        value: string;
+    }
+
+    export interface Bar extends _Utils {
+        type: "bar";
+    }
+
+    export interface _Utils {
+        _visit: <_Result>(visitor: MyUnion._Visitor<_Result>) => _Result;
+    }
+
+    export interface _Visitor<_Result> {
+        foo: (value: string) => _Result;
+        bar: () => _Result;
+        _other: (value: {
+                type: string;
+            }) => _Result;
+    }
+}
+
+export const MyUnion = {
+        foo: (value: string): MyUnion.Foo => {
+            return {
+                value: value,
+                type: "foo",
+                "_visit": function <_Result>(this: MyUnion.Foo, visitor: MyUnion._Visitor<_Result>) {
+                    return MyUnion._visit(this, visitor);
+                }
+            };
+        },
+
+        bar: (): MyUnion.Bar => {
+            return {
+                type: "bar",
+                "_visit": function <_Result>(this: MyUnion.Bar, visitor: MyUnion._Visitor<_Result>) {
+                    return MyUnion._visit(this, visitor);
+                }
+            };
+        },
+
+        _visit: <_Result>(value: MyUnion, visitor: MyUnion._Visitor<_Result>): _Result => {
+            switch (value.type) {
+                case "foo": return visitor.foo(value.value);
+                case "bar": return visitor.bar();
+                default: return visitor._other(value);
+            }
+        },
+    } as const;
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with mixed member shapes 1`] = `
+"export type MixedUnion = 
+    | MixedUnion.Value
+    | MixedUnion.Circle
+    | MixedUnion.Empty;
+
+export namespace MixedUnion {
+    export interface Value {
+        type: "value";
+        data: string;
+    }
+
+    export interface Circle extends Circle {
+        type: "circle";
+    }
+
+    export interface Empty {
+        type: "empty";
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with noProperties members 1`] = `
+"export type UnionWithNoProperties = 
+    | UnionWithNoProperties.Foo
+    | UnionWithNoProperties.Empty;
+
+export namespace UnionWithNoProperties {
+    export interface Foo {
+        type: "foo";
+    }
+
+    export interface Empty {
+        type: "empty";
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with retainOriginalCasing 1`] = `
+"export type MyUnion = 
+    | MyUnion.Foo;
+
+export namespace MyUnion {
+    export interface Foo {
+        type: "foo";
+        value: string;
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with samePropertiesAsObject members 1`] = `
+"export type Shape = 
+    | Shape.Circle
+    | Shape.Square;
+
+export namespace Shape {
+    export interface Circle extends Circle {
+        type: "circle";
+    }
+
+    export interface Square extends Square {
+        type: "square";
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union with single member 1`] = `
+"export type UnionWithSingleElement = 
+    | UnionWithSingleElement.Foo;
+
+export namespace UnionWithSingleElement {
+    export interface Foo {
+        type: "foo";
+        name: string;
+    }
+}
+"
+`;
+
+exports[`GeneratedUnionTypeImpl > generateStatements / writeToFile > generates union without serde layer 1`] = `
+"export type MyUnion = 
+    | MyUnion.Foo;
+
+export namespace MyUnion {
+    export interface Foo {
+        type: "foo";
+        value: string;
+    }
+}
+"
+`;


### PR DESCRIPTION
## Description

Adds comprehensive Vitest snapshot tests for `GeneratedUnionTypeImpl`, the discriminated union type generator in the TypeScript SDK generator. This is part of the ongoing effort to add targeted unit tests for individual generator components (Priority 2: Type Generators).

Requested by: @Swimburger
[Link to Devin Session](https://app.devin.ai/sessions/ce25a6da44a14437a2fa92712a187cf6)

## Changes Made

- Added `GeneratedUnionTypeImpl.test.ts` with 33 tests across 7 describe blocks:
  - **`generateStatements`** (14 tests): basic singleProperty, samePropertiesAsObject, noProperties, mixed shapes, baseProperties, extends, includeUtilsOnUnionMembers (builders + visitor pattern), includeOtherInUnionTypes (_Unknown variant), docs on type/members, single member, retainOriginalCasing, no serde layer, examples in docs
  - **`generateForInlineUnion`** (2 tests): parenthesized union type node, request/response variants with generateReadWriteOnlyTypes
  - **`generateModule`** (1 test): always returns undefined
  - **`getGeneratedUnion`** (1 test): returns wrapped GeneratedUnionImpl
  - **`getSinglePropertyKey`** (3 tests): serde on/off, retainOriginalCasing combinations
  - **`buildExample`** (8 tests): noProperties, singleProperty, samePropertiesAsObject, baseProperties, extendProperties, builder mode (includeUtilsOnUnionMembers), error cases (non-union shape, member not found, shape mismatch)
  - **`discriminant handling`** (2 tests): camelCase vs wire value based on serde layer
  - **`type property`** (1 test): verifies `type === "union"`
- 24 Vitest snapshots covering generated TypeScript output

## Updates since last revision

Fixed compile errors caught by CI (tests passed locally via vitest but tsc strict compilation found missing required IR fields):
- Added `discriminatorContext: undefined` to `UnionTypeDeclaration` factory (`createUnionDeclaration`)
- Added `discriminant` field to all `ExampleTypeShape.union()` calls in `buildExample` tests
- Added `propertyAccess` and `originalTypeDeclaration` to `ExampleObjectProperty` in the extendProperties test

## Testing

- [x] Unit tests added (33 tests, all passing)
- [x] Snapshots verified against seed output patterns (`seed/ts-sdk/unions/`)
- [x] Biome lint passes clean
- [x] `compile` CI check passes

## Reviewer Checklist

- **Mock context coverage**: `createMockBaseContext` mocks 10 `context.type.*` methods with `as any`. Verify the mocked surface covers all code paths exercised in the 207-line source. Key methods: `getReferenceToType`, `getReferenceToTypeForInlineUnion`, `getReferenceToNamedType`, `getTypeDeclaration`, `getGeneratedType`, `getGeneratedTypeById`, `getGeneratedExample`, `needsRequestResponseTypeVariantByType/ById`, `typeNameToTypeReference`.
- **Self-referential extends in snapshot**: The `samePropertiesAsObject` snapshot shows `interface Circle extends Circle` — this is a mock artifact (mock `getReferenceToNamedType` returns the same identifier). In real output it would be `extends SeedUnions.Circle`. Not a bug.
- **IR field completeness**: The initial version was missing required IR fields (`discriminatorContext`, `discriminant` on `ExampleUnionType`, `propertyAccess`/`originalTypeDeclaration` on `ExampleObjectProperty`). These were added in a follow-up commit. Worth verifying the values used (e.g., `discriminatorContext: undefined`, `propertyAccess: undefined`) match what real IR produces.
- **Known mock simplifications** (acceptable for unit test scope):
  - `getGeneratedExample` returns hardcoded `"example-value"` (tests verify wiring, not example data flow)
  - `needsRequestResponseTypeVariant*` always returns `{ request: false, response: false }` (no tests for actual request/response variant generation)
  - No tests for `enableInlineTypes=true` + `inline=true` combination
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
