### PR TITLE
fix(seed): use customer organization from fern.config.json in seed run command

### DIFF
--- a/packages/cli/configuration-loader/src/generators-yml/loadGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/loadGeneratorsConfiguration.ts
@@ -13,10 +13,13 @@ import { convertGeneratorsConfiguration } from "./convertGeneratorsConfiguration
 
 export async function loadRawGeneratorsConfiguration({
     absolutePathToWorkspace,
-    context
+    context,
+    lenient
 }: {
     absolutePathToWorkspace: AbsoluteFilePath;
     context: TaskContext;
+    /** If true, use lenient parsing that tolerates unrecognized keys/union members (useful for seed run against customer configs that may use a different CLI version) */
+    lenient?: boolean;
 }): Promise<generatorsYml.GeneratorsConfigurationSchema | undefined> {
     const filepath = await getPathToGeneratorsConfiguration({ absolutePathToWorkspace });
     if (filepath == null) {
@@ -27,9 +30,9 @@ export async function loadRawGeneratorsConfiguration({
     try {
         const contentsParsed = yaml.load(contentsStr.toString());
         const parsed = generatorsYml.serialization.GeneratorsConfigurationSchema.parse(contentsParsed, {
-            allowUnrecognizedEnumValues: false,
-            unrecognizedObjectKeys: "fail",
-            allowUnrecognizedUnionMembers: false,
+            allowUnrecognizedEnumValues: lenient === true,
+            unrecognizedObjectKeys: lenient === true ? "passthrough" : "fail",
+            allowUnrecognizedUnionMembers: lenient === true,
             skipValidation: false,
             breadcrumbsPrefix: undefined,
             omitUndefined: false
@@ -82,12 +85,19 @@ export async function loadRawGeneratorsConfiguration({
 
 export async function loadGeneratorsConfiguration({
     absolutePathToWorkspace,
-    context
+    context,
+    lenient
 }: {
     absolutePathToWorkspace: AbsoluteFilePath;
     context: TaskContext;
+    /** If true, use lenient parsing that tolerates unrecognized keys/union members */
+    lenient?: boolean;
 }): Promise<generatorsYml.GeneratorsConfiguration | undefined> {
-    const rawGeneratorsConfiguration = await loadRawGeneratorsConfiguration({ absolutePathToWorkspace, context });
+    const rawGeneratorsConfiguration = await loadRawGeneratorsConfiguration({
+        absolutePathToWorkspace,
+        context,
+        lenient
+    });
     if (rawGeneratorsConfiguration == null) {
         return undefined;
     }

--- a/packages/cli/workspace/loader/src/loadAPIWorkspace.ts
+++ b/packages/cli/workspace/loader/src/loadAPIWorkspace.ts
@@ -203,17 +203,21 @@ export async function loadAPIWorkspace({
     absolutePathToWorkspace,
     context,
     cliVersion,
-    workspaceName
+    workspaceName,
+    lenient
 }: {
     absolutePathToWorkspace: AbsoluteFilePath;
     context: TaskContext;
     cliVersion: string;
     workspaceName: string | undefined;
+    /** If true, use lenient parsing that tolerates unrecognized keys/union members */
+    lenient?: boolean;
 }): Promise<WorkspaceLoader.Result> {
     const [generatorsConfiguration, changelog] = await Promise.all([
         loadGeneratorsConfiguration({
             absolutePathToWorkspace,
-            context
+            context,
+            lenient
         }),
         loadAPIChangelog({ absolutePathToWorkspace }).catch(() => undefined)
     ]);

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -85,17 +85,23 @@ export async function runWithCustomFixture({
     }
 
     try {
+        // Read project config (organization, version, config path) from fern.config.json
+        const projectConfig = await readFernProjectConfig(pathToFixture);
+
+        // Derive workspace name from the directory path (e.g. "payments" from fern/apis/payments/)
+        const workspaceName = path.basename(pathToFixture);
+
         const apiWorkspace = await convertGeneratorWorkspaceToFernWorkspace({
             absolutePathToAPIDefinition: pathToFixture,
             taskContext,
-            fixture: "custom"
+            fixture: "custom",
+            workspaceName,
+            cliVersion: projectConfig?.version
         });
         if (apiWorkspace == null) {
             taskContext.logger.error("Failed to load API definition.");
             return;
         }
-
-        const organization = await readOrganizationFromFernConfig(pathToFixture);
 
         const generatorGroup = getGeneratorGroup({
             apiWorkspace,
@@ -131,7 +137,8 @@ export async function runWithCustomFixture({
             absolutePathToApiDefinition: pathToFixture,
             outputDir: absolutePathToOutput,
             generatorInvocation: generatorGroup.invocation,
-            organization
+            organization: projectConfig?.organization,
+            absolutePathToFernConfig: projectConfig?.absolutePathToFernConfig
         });
 
         taskContext.logger.info(`Wrote files to ${absolutePathToOutput}`);
@@ -151,11 +158,17 @@ export async function runWithCustomFixture({
     }
 }
 
+interface FernProjectConfig {
+    organization?: string;
+    version?: string;
+    absolutePathToFernConfig: AbsoluteFilePath;
+}
+
 /**
  * Walks up the directory tree from the given path to find fern.config.json
- * and reads the organization name from it.
+ * and reads the project configuration (organization, version) from it.
  */
-async function readOrganizationFromFernConfig(startPath: AbsoluteFilePath): Promise<string | undefined> {
+async function readFernProjectConfig(startPath: AbsoluteFilePath): Promise<FernProjectConfig | undefined> {
     let currentDir = startPath;
     // Walk up the directory tree looking for fern.config.json
     while (true) {
@@ -163,11 +176,15 @@ async function readOrganizationFromFernConfig(startPath: AbsoluteFilePath): Prom
         if (await doesPathExist(configPath)) {
             try {
                 const configContents = await readFile(configPath, "utf-8");
-                const config = JSON.parse(configContents) as { organization?: string };
-                return config.organization;
+                const config = JSON.parse(configContents) as { organization?: string; version?: string };
+                return {
+                    organization: config.organization,
+                    version: config.version,
+                    absolutePathToFernConfig: configPath
+                };
             } catch (error) {
                 // eslint-disable-next-line no-console
-                console.warn(`Failed to read organization from ${configPath}: ${error}`);
+                console.warn(`Failed to read project config from ${configPath}: ${error}`);
                 return undefined;
             }
         }

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -165,7 +165,9 @@ async function readOrganizationFromFernConfig(startPath: AbsoluteFilePath): Prom
                 const configContents = await readFile(configPath, "utf-8");
                 const config = JSON.parse(configContents) as { organization?: string };
                 return config.organization;
-            } catch {
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.warn(`Failed to read organization from ${configPath}: ${error}`);
                 return undefined;
             }
         }

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -96,7 +96,8 @@ export async function runWithCustomFixture({
             taskContext,
             fixture: "custom",
             workspaceName,
-            cliVersion: projectConfig?.version
+            cliVersion: projectConfig?.version,
+            lenient: true
         });
         if (apiWorkspace == null) {
             taskContext.logger.error("Failed to load API definition.");
@@ -138,7 +139,8 @@ export async function runWithCustomFixture({
             outputDir: absolutePathToOutput,
             generatorInvocation: generatorGroup.invocation,
             organization: projectConfig?.organization,
-            absolutePathToFernConfig: projectConfig?.absolutePathToFernConfig
+            absolutePathToFernConfig: projectConfig?.absolutePathToFernConfig,
+            lenient: true
         });
 
         taskContext.logger.info(`Wrote files to ${absolutePathToOutput}`);

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -178,10 +178,12 @@ async function readFernProjectConfig(startPath: AbsoluteFilePath): Promise<FernP
         if (await doesPathExist(configPath)) {
             try {
                 const configContents = await readFile(configPath, "utf-8");
-                const config = JSON.parse(configContents) as { organization?: string; version?: string };
+                const config = JSON.parse(configContents) as Record<string, unknown>;
+                const organization = typeof config.organization === "string" ? config.organization : undefined;
+                const version = typeof config.version === "string" ? config.version : undefined;
                 return {
-                    organization: config.organization,
-                    version: config.version,
+                    organization,
+                    version,
                     absolutePathToFernConfig: configPath
                 };
             } catch (error) {

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -1,7 +1,9 @@
-import { GeneratorGroup, GeneratorInvocation } from "@fern-api/configuration";
-import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { GeneratorGroup, GeneratorInvocation, PROJECT_CONFIG_FILENAME } from "@fern-api/configuration";
+import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { LogLevel } from "@fern-api/logger";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
+import { readFile } from "fs/promises";
+import path from "path";
 import tmp from "tmp-promise";
 import { FixtureConfigurations } from "../../config/api/index.js";
 import { GeneratorWorkspace } from "../../loadGeneratorWorkspaces.js";
@@ -93,6 +95,8 @@ export async function runWithCustomFixture({
             return;
         }
 
+        const organization = await readOrganizationFromFernConfig(pathToFixture);
+
         const generatorGroup = getGeneratorGroup({
             apiWorkspace,
             image: workspace.workspaceConfig.image,
@@ -126,7 +130,8 @@ export async function runWithCustomFixture({
             inspect,
             absolutePathToApiDefinition: pathToFixture,
             outputDir: absolutePathToOutput,
-            generatorInvocation: generatorGroup.invocation
+            generatorInvocation: generatorGroup.invocation,
+            organization
         });
 
         taskContext.logger.info(`Wrote files to ${absolutePathToOutput}`);
@@ -143,6 +148,33 @@ export async function runWithCustomFixture({
             await scriptRunner?.stop();
         }
         await testRunner.cleanup();
+    }
+}
+
+/**
+ * Walks up the directory tree from the given path to find fern.config.json
+ * and reads the organization name from it.
+ */
+async function readOrganizationFromFernConfig(startPath: AbsoluteFilePath): Promise<string | undefined> {
+    let currentDir = startPath;
+    // Walk up the directory tree looking for fern.config.json
+    while (true) {
+        const configPath = join(currentDir, RelativeFilePath.of(PROJECT_CONFIG_FILENAME));
+        if (await doesPathExist(configPath)) {
+            try {
+                const configContents = await readFile(configPath, "utf-8");
+                const config = JSON.parse(configContents) as { organization?: string };
+                return config.organization;
+            } catch {
+                return undefined;
+            }
+        }
+        const parentDir = AbsoluteFilePath.of(path.dirname(currentDir));
+        if (parentDir === currentDir) {
+            // Reached filesystem root
+            return undefined;
+        }
+        currentDir = parentDir;
     }
 }
 

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -98,7 +98,8 @@ export class ContainerTestRunner extends TestRunner {
         shouldGenerateDynamicSnippetTests,
         inspect = false,
         license,
-        smartCasing
+        smartCasing,
+        organization
     }: TestRunner.DoRunArgs): Promise<void> {
         const generatorGroup: generatorsYml.GeneratorGroup = {
             groupName: "test",
@@ -122,7 +123,7 @@ export class ContainerTestRunner extends TestRunner {
             ]
         };
         await runContainerizedGenerationForSeed({
-            organization: DUMMY_ORGANIZATION,
+            organization: organization ?? DUMMY_ORGANIZATION,
             absolutePathToFernConfig: absolutePathToFernDefinition,
             workspace: fernWorkspace,
             generatorGroup,

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -99,7 +99,8 @@ export class ContainerTestRunner extends TestRunner {
         inspect = false,
         license,
         smartCasing,
-        organization
+        organization,
+        absolutePathToFernConfig
     }: TestRunner.DoRunArgs): Promise<void> {
         const generatorGroup: generatorsYml.GeneratorGroup = {
             groupName: "test",
@@ -124,7 +125,7 @@ export class ContainerTestRunner extends TestRunner {
         };
         await runContainerizedGenerationForSeed({
             organization: organization ?? DUMMY_ORGANIZATION,
-            absolutePathToFernConfig: absolutePathToFernDefinition,
+            absolutePathToFernConfig: absolutePathToFernConfig ?? absolutePathToFernDefinition,
             workspace: fernWorkspace,
             generatorGroup,
             context: taskContext,

--- a/packages/seed/src/commands/test/test-runner/LocalTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/LocalTestRunner.ts
@@ -55,7 +55,8 @@ export class LocalTestRunner extends TestRunner {
             shouldGenerateDynamicSnippetTests,
             inspect = false,
             license,
-            smartCasing
+            smartCasing,
+            organization
         } = args;
 
         const generatorGroup: generatorsYml.GeneratorGroup = {
@@ -83,7 +84,7 @@ export class LocalTestRunner extends TestRunner {
 
         await runNativeGenerationForSeed(
             {
-                organization: DUMMY_ORGANIZATION,
+                organization: organization ?? DUMMY_ORGANIZATION,
                 absolutePathToFernConfig: absolutePathToFernDefinition,
                 workspace: fernWorkspace,
                 generatorGroup,

--- a/packages/seed/src/commands/test/test-runner/LocalTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/LocalTestRunner.ts
@@ -56,7 +56,8 @@ export class LocalTestRunner extends TestRunner {
             inspect = false,
             license,
             smartCasing,
-            organization
+            organization,
+            absolutePathToFernConfig
         } = args;
 
         const generatorGroup: generatorsYml.GeneratorGroup = {
@@ -85,7 +86,7 @@ export class LocalTestRunner extends TestRunner {
         await runNativeGenerationForSeed(
             {
                 organization: organization ?? DUMMY_ORGANIZATION,
-                absolutePathToFernConfig: absolutePathToFernDefinition,
+                absolutePathToFernConfig: absolutePathToFernConfig ?? absolutePathToFernDefinition,
                 workspace: fernWorkspace,
                 generatorGroup,
                 context: taskContext,

--- a/packages/seed/src/commands/test/test-runner/TestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/TestRunner.ts
@@ -37,6 +37,8 @@ export declare namespace TestRunner {
         outputDir?: AbsoluteFilePath;
         /** Generator invocation with per-generator API overrides **/
         generatorInvocation?: GeneratorInvocation;
+        /** Organization name override (e.g. from customer's fern.config.json) **/
+        organization?: string;
     }
 
     interface DoRunArgs {
@@ -62,6 +64,8 @@ export declare namespace TestRunner {
         inspect: boolean | undefined;
         license?: unknown;
         smartCasing?: boolean;
+        /** Organization name override (e.g. from customer's fern.config.json) **/
+        organization?: string;
     }
 
     type TestResult = TestSuccess | TestFailure;
@@ -151,7 +155,8 @@ export abstract class TestRunner {
         inspect,
         absolutePathToApiDefinition,
         outputDir,
-        generatorInvocation
+        generatorInvocation,
+        organization
     }: TestRunner.RunArgs): Promise<TestRunner.TestResult> {
         let lockAcquired = false;
         try {
@@ -268,7 +273,8 @@ export abstract class TestRunner {
                         !disableDynamicSnippetTests && workspaceShouldGenerateDynamicSnippetTests(this.generator),
                     inspect,
                     license,
-                    smartCasing
+                    smartCasing,
+                    organization
                 });
 
                 generationStopwatch.stop();

--- a/packages/seed/src/commands/test/test-runner/TestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/TestRunner.ts
@@ -41,6 +41,8 @@ export declare namespace TestRunner {
         organization?: string;
         /** Absolute path to fern.config.json (used for license path resolution) **/
         absolutePathToFernConfig?: AbsoluteFilePath;
+        /** If true, use lenient parsing for generators config (tolerates unrecognized keys) */
+        lenient?: boolean;
     }
 
     interface DoRunArgs {
@@ -161,7 +163,8 @@ export abstract class TestRunner {
         outputDir,
         generatorInvocation,
         organization,
-        absolutePathToFernConfig
+        absolutePathToFernConfig,
+        lenient
     }: TestRunner.RunArgs): Promise<TestRunner.TestResult> {
         let lockAcquired = false;
         try {
@@ -224,7 +227,8 @@ export abstract class TestRunner {
                 const apiWorkspace = await convertGeneratorWorkspaceToFernWorkspace({
                     absolutePathToAPIDefinition: absolutePathToApiDefinition,
                     taskContext,
-                    fixture
+                    fixture,
+                    lenient
                 });
                 const workspaceSettings =
                     generatorInvocation != null

--- a/packages/seed/src/commands/test/test-runner/TestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/TestRunner.ts
@@ -39,6 +39,8 @@ export declare namespace TestRunner {
         generatorInvocation?: GeneratorInvocation;
         /** Organization name override (e.g. from customer's fern.config.json) **/
         organization?: string;
+        /** Absolute path to fern.config.json (used for license path resolution) **/
+        absolutePathToFernConfig?: AbsoluteFilePath;
     }
 
     interface DoRunArgs {
@@ -66,6 +68,8 @@ export declare namespace TestRunner {
         smartCasing?: boolean;
         /** Organization name override (e.g. from customer's fern.config.json) **/
         organization?: string;
+        /** Absolute path to fern.config.json (used for license path resolution) **/
+        absolutePathToFernConfig?: AbsoluteFilePath;
     }
 
     type TestResult = TestSuccess | TestFailure;
@@ -156,7 +160,8 @@ export abstract class TestRunner {
         absolutePathToApiDefinition,
         outputDir,
         generatorInvocation,
-        organization
+        organization,
+        absolutePathToFernConfig
     }: TestRunner.RunArgs): Promise<TestRunner.TestResult> {
         let lockAcquired = false;
         try {
@@ -274,7 +279,8 @@ export abstract class TestRunner {
                     inspect,
                     license,
                     smartCasing,
-                    organization
+                    organization,
+                    absolutePathToFernConfig
                 });
 
                 generationStopwatch.stop();

--- a/packages/seed/src/utils/convertSeedWorkspaceToFernWorkspace.ts
+++ b/packages/seed/src/utils/convertSeedWorkspaceToFernWorkspace.ts
@@ -7,7 +7,8 @@ export async function convertGeneratorWorkspaceToFernWorkspace({
     absolutePathToAPIDefinition,
     taskContext,
     workspaceName,
-    cliVersion
+    cliVersion,
+    lenient
 }: {
     fixture: string;
     absolutePathToAPIDefinition: AbsoluteFilePath;
@@ -16,12 +17,15 @@ export async function convertGeneratorWorkspaceToFernWorkspace({
     workspaceName?: string;
     /** Override CLI version (defaults to "DUMMY") */
     cliVersion?: string;
+    /** If true, use lenient parsing for generators config (tolerates unrecognized keys) */
+    lenient?: boolean;
 }): Promise<AbstractAPIWorkspace<unknown> | undefined> {
     const workspace = await loadAPIWorkspace({
         absolutePathToWorkspace: absolutePathToAPIDefinition,
         context: taskContext,
         cliVersion: cliVersion ?? "DUMMY",
-        workspaceName: workspaceName ?? fixture
+        workspaceName: workspaceName ?? fixture,
+        lenient
     });
     if (!workspace.didSucceed) {
         taskContext.logger.info(

--- a/packages/seed/src/utils/convertSeedWorkspaceToFernWorkspace.ts
+++ b/packages/seed/src/utils/convertSeedWorkspaceToFernWorkspace.ts
@@ -5,17 +5,23 @@ import { AbstractAPIWorkspace, loadAPIWorkspace } from "@fern-api/workspace-load
 export async function convertGeneratorWorkspaceToFernWorkspace({
     fixture,
     absolutePathToAPIDefinition,
-    taskContext
+    taskContext,
+    workspaceName,
+    cliVersion
 }: {
     fixture: string;
     absolutePathToAPIDefinition: AbsoluteFilePath;
     taskContext: TaskContext;
+    /** Override workspace name (defaults to fixture name) */
+    workspaceName?: string;
+    /** Override CLI version (defaults to "DUMMY") */
+    cliVersion?: string;
 }): Promise<AbstractAPIWorkspace<unknown> | undefined> {
     const workspace = await loadAPIWorkspace({
         absolutePathToWorkspace: absolutePathToAPIDefinition,
         context: taskContext,
-        cliVersion: "DUMMY",
-        workspaceName: fixture
+        cliVersion: cliVersion ?? "DUMMY",
+        workspaceName: workspaceName ?? fixture
     });
     if (!workspace.didSucceed) {
         taskContext.logger.info(


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger

When using `pnpm seed run --path <customer-config>`, the generated SDK incorrectly uses `Seed`/`SeedApi` as names, namespaces, and project names. More broadly, the `seed run` command was using hardcoded dummy values instead of reading real workspace configuration from the customer's `fern.config.json`, making it diverge from how `fern generate` behaves.

This PR makes `seed run` behave as close to `fern generate` as possible by reading real values from the customer's workspace, with dummy values as fallbacks for `seed test` compatibility.

[Link to Devin Session](https://app.devin.ai/sessions/40c54633dfb940e9b2e3ba17874e21d7)

## Changes Made

- Added `readFernProjectConfig()` helper in `runWithCustomFixture.ts` that walks up the directory tree from the provided `--path` to locate `fern.config.json` and reads `organization`, `version`, and the config file path
- Derives workspace name from the directory path basename (e.g. `"payments"` from `fern/apis/payments/`) instead of hardcoded `"custom"`
- Passes the real `absolutePathToFernConfig` (path to `fern.config.json`) through to the generation pipeline for correct license path resolution, instead of incorrectly using the API definition directory
- Passes the `version` from `fern.config.json` as `cliVersion` to the workspace loader instead of hardcoded `"DUMMY"`
- Added optional `organization`, `absolutePathToFernConfig`, and `lenient` fields to `TestRunner.RunArgs` and `TestRunner.DoRunArgs` interfaces
- Updated `LocalTestRunner` and `ContainerTestRunner` to use passed values with fallbacks: `organization ?? DUMMY_ORGANIZATION` and `absolutePathToFernConfig ?? absolutePathToFernDefinition`
- Updated `convertGeneratorWorkspaceToFernWorkspace` to accept optional `workspaceName`, `cliVersion`, and `lenient` overrides
- **Added lenient config parsing for `seed run`**: Customer configs may use settings from a different CLI version (e.g. `coerce-const-to-literal`) that don't exist in the current schema. The `loadRawGeneratorsConfiguration` and `loadGeneratorsConfiguration` functions now accept an optional `lenient` flag (threaded through `loadAPIWorkspace`) that uses `passthrough` for unrecognized object keys and tolerates unrecognized union members. Only `seed run` uses `lenient: true`; the CLI and `seed test` retain strict parsing.
- Added runtime `typeof` checks for `organization` and `version` fields parsed from `fern.config.json` (uses `Record<string, unknown>` instead of unsafe type assertion)

`seed test` is unaffected — it does not pass any of the new optional fields, so all fallbacks to existing dummy defaults are preserved.

### Values now aligned with `fern generate`

| Value | `fern generate` | `seed run` (before) | `seed run` (after) |
|---|---|---|---|
| `organization` | `projectConfig.organization` | `"seed"` | from `fern.config.json` ✓ |
| `absolutePathToFernConfig` | `projectConfig._absolutePath` | API definition dir | from `fern.config.json` ✓ |
| `workspaceName` | directory name | `"custom"` | `path.basename(pathToFixture)` ✓ |
| `cliVersion` | CLI package version | `"DUMMY"` | `fern.config.json` version ✓ |
| Config parsing | strict | strict (fails on unknown keys) | lenient (tolerates unknown keys) ✓ |

## Human Review Checklist

- [x] **Directory traversal logic**: `readFernProjectConfig` walks up from `startPath` until it finds `fern.config.json` or hits the filesystem root. Verified with both single API (`fern/`) and multi-API (`fern/apis/<name>/`) structures locally.
- [x] **Fallback behavior**: If `fern.config.json` is not found, returns `undefined` and all values fall back to existing dummy defaults. If found but malformed, logs a warning via `console.warn` before falling back.
- [x] **`absolutePathToFernConfig` usage**: Previously the API definition directory was passed as `absolutePathToFernConfig`. Now the actual `fern.config.json` path is used. This affects `extractLicenseFilePath()` in `runGenerator.ts` which calls `path.dirname(absolutePathToFernConfig)` to resolve relative license paths. Verified this is correct: `path.dirname()` of the config path yields the correct base directory for license resolution (same for single-API, correct for multi-API).
- [x] **Workspace name derivation**: `path.basename(pathToFixture)` is used to derive workspace name. Verified it handles trailing slashes correctly (Node.js `path.basename()` strips them automatically).
- [x] **CLI version**: The `version` field from `fern.config.json` (e.g. `"3.64.5"`) is used as `cliVersion`. This is the Fern platform version (what the customer is targeting), not the CLI package version. The workspace loader uses `cliVersion` for version-gated feature flags during OpenAPI import, so using the customer's target version is actually more correct than using `"DUMMY"` or the current CLI version.
- [x] **Lenient parsing implications**: `seed run` now uses `unrecognizedObjectKeys: "passthrough"` which means typos or invalid settings in customer configs won't be caught. This is intentional (customer configs may use different CLI versions), but worth being aware of. The lenient flag is only used by `seed run`; the CLI and `seed test` retain strict parsing.
- [x] **Lenient parsing doesn't affect shared callers**: The `lenient` parameter defaults to `undefined`/`false` in `loadRawGeneratorsConfiguration`, `loadGeneratorsConfiguration`, and `loadAPIWorkspace`, preserving strict behavior for all existing callers (CLI, `seed test`, etc.).
- [x] **Runtime type safety**: Added `typeof` checks for `organization` and `version` fields to protect against malformed config files where these fields might be `null`, numbers, or other non-string values.

## Testing

- [x] Lint/type check passes (`pnpm run check`)
- [x] Manual testing: single API structure (org: `"corti"`) → generates `CortiApiClient`, `CortiApiError`
- [x] Manual testing: multi-API structure at `fern/apis/payments/` (org: `"acme-corp"`) → generates `AcmeCorpApiClient`, `AcmeCorpApiError`
- [x] Verified workspace name derived from directory path
- [x] **End-to-end test with real customer config**: Cloned [corti-config](https://github.com/fern-demo/corti-config) and ran `pnpm seed run --generator ts-sdk --path /tmp/corti-config/fern --local --output-path /tmp/corti-output --skip-scripts`. Config contains `coerce-const-to-literal` setting (doesn't exist in current schema) and asyncapi specs. With lenient parsing, generation succeeded and produced correctly named `CortiClient`, `Corti` namespace, `CortiEnvironment`, `CortiError`.
- [x] Verified no "seed" references in generated output
- [x] All CI checks pass

## Updates Since Last Revision

- **Added runtime type validation** (commit 4ad6708): Replaced unsafe `as { organization?: string; version?: string }` type assertion with `Record<string, unknown>` and added explicit `typeof` checks for `organization` and `version` fields before returning them. This prevents type errors if `fern.config.json` contains these fields as `null`, numbers, or other non-string values.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
