### PR TITLE
fix(typescript): websockets failing for `bun` and `deno` runtimes

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.53.13
+  changelogEntry:
+    - summary: |
+        Fix WebSocket connections failing silently in Bun and Deno. The `getGlobalWebSocket()`
+        function now prefers the `ws` library for Bun and Deno runtimes, whose native WebSocket
+        constructors ignore the options argument containing authentication headers.
+      type: fix
+  createdAt: "2026-03-11"
+  irVersion: 65
+
 - version: 3.53.12
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/websocket/ws.ts
+++ b/generators/typescript/utils/core-utilities/src/core/websocket/ws.ts
@@ -5,11 +5,11 @@ import { toQueryString } from "../url/qs";
 import * as Events from "./events";
 
 const getGlobalWebSocket = (): WebSocket | undefined => {
-    if (typeof WebSocket !== "undefined") {
+    if (RUNTIME.type === "node" || RUNTIME.type === "bun" || RUNTIME.type === "deno") {
+        return NodeWebSocket as unknown as WebSocket;
+    } else if (typeof WebSocket !== "undefined") {
         // @ts-ignore
         return WebSocket;
-    } else if (RUNTIME.type === "node") {
-        return NodeWebSocket as unknown as WebSocket;
     }
     return undefined;
 };

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/websocket/ws.ts
@@ -5,11 +5,11 @@ import { toQueryString } from "../url/qs.js";
 import * as Events from "./events.js";
 
 const getGlobalWebSocket = (): WebSocket | undefined => {
-    if (typeof WebSocket !== "undefined") {
+    if (RUNTIME.type === "node" || RUNTIME.type === "bun" || RUNTIME.type === "deno") {
+        return NodeWebSocket as unknown as WebSocket;
+    } else if (typeof WebSocket !== "undefined") {
         // @ts-ignore
         return WebSocket;
-    } else if (RUNTIME.type === "node") {
-        return NodeWebSocket as unknown as WebSocket;
     }
     return undefined;
 };

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/websocket/ws.ts
@@ -5,11 +5,11 @@ import { toQueryString } from "../url/qs.js";
 import * as Events from "./events.js";
 
 const getGlobalWebSocket = (): WebSocket | undefined => {
-    if (typeof WebSocket !== "undefined") {
+    if (RUNTIME.type === "node" || RUNTIME.type === "bun" || RUNTIME.type === "deno") {
+        return NodeWebSocket as unknown as WebSocket;
+    } else if (typeof WebSocket !== "undefined") {
         // @ts-ignore
         return WebSocket;
-    } else if (RUNTIME.type === "node") {
-        return NodeWebSocket as unknown as WebSocket;
     }
     return undefined;
 };

--- a/seed/ts-sdk/websocket/no-serde/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/websocket/ws.ts
@@ -5,11 +5,11 @@ import { toQueryString } from "../url/qs.js";
 import * as Events from "./events.js";
 
 const getGlobalWebSocket = (): WebSocket | undefined => {
-    if (typeof WebSocket !== "undefined") {
+    if (RUNTIME.type === "node" || RUNTIME.type === "bun" || RUNTIME.type === "deno") {
+        return NodeWebSocket as unknown as WebSocket;
+    } else if (typeof WebSocket !== "undefined") {
         // @ts-ignore
         return WebSocket;
-    } else if (RUNTIME.type === "node") {
-        return NodeWebSocket as unknown as WebSocket;
     }
     return undefined;
 };

--- a/seed/ts-sdk/websocket/serde/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/websocket/ws.ts
@@ -5,11 +5,11 @@ import { toQueryString } from "../url/qs.js";
 import * as Events from "./events.js";
 
 const getGlobalWebSocket = (): WebSocket | undefined => {
-    if (typeof WebSocket !== "undefined") {
+    if (RUNTIME.type === "node" || RUNTIME.type === "bun" || RUNTIME.type === "deno") {
+        return NodeWebSocket as unknown as WebSocket;
+    } else if (typeof WebSocket !== "undefined") {
         // @ts-ignore
         return WebSocket;
-    } else if (RUNTIME.type === "node") {
-        return NodeWebSocket as unknown as WebSocket;
     }
     return undefined;
 };


### PR DESCRIPTION
## Description
```ts
  const getGlobalWebSocket = (): WebSocket | undefined => {
      if (typeof WebSocket !== "undefined") {
          // @ts-ignore
          return WebSocket;
      } else if (RUNTIME.type === "node") {
          return NodeWebSocket as unknown as WebSocket;
      }
      return undefined;
  };

  After:
  const getGlobalWebSocket = (): WebSocket | undefined => {
      if (RUNTIME.type === "node" || RUNTIME.type === "bun" || RUNTIME.type === "deno") {
          return NodeWebSocket as unknown as WebSocket;
      } else if (typeof WebSocket !== "undefined") {
          // @ts-ignore
          return WebSocket;
      }
      return undefined;
  };
```
We now check runtime type first, which is important since the native `WebSocket` option would automatically drop headers for `bun` and `deno`, causing them to fail silently.

## Testing
To the `websocket` fixtures, which have changed accordingly.
- [X] Unit tests added/updated
- [X] Manual testing completed
