### PR TITLE
chore(internal): add unit tests for GeneratedUndiscriminatedUnionTypeImpl

### DIFF
--- a/generators/typescript/model/type-generator/src/__test__/GeneratedUndiscriminatedUnionTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedUndiscriminatedUnionTypeImpl.test.ts
@@ -679,12 +679,7 @@ describe("GeneratedUndiscriminatedUnionTypeImpl", () => {
                 ],
                 generateReadWriteOnlyTypes: true
             });
-            const context2 = createMockBaseContext({
-                typeRefOverrides: new Map([
-                    [userType.typeId, namedTypeRefNodeWithVariants("User", "User.Request", "User.Response")]
-                ])
-            });
-            const result = generator.generateModule(context2);
+            const result = generator.generateModule(context);
             assert(result != null, "module should be defined");
             expect(result.name).toBe("UserOrAdmin");
             expect(result.isExported).toBe(true);

--- a/generators/typescript/model/type-generator/src/__test__/GeneratedUndiscriminatedUnionTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedUndiscriminatedUnionTypeImpl.test.ts
@@ -1,0 +1,801 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode, TypeReferenceNode } from "@fern-typescript/commons";
+import { casingsGenerator, createDeclaredTypeName } from "@fern-typescript/test-utils";
+import { Project, ts } from "ts-morph";
+import { assert, describe, expect, it } from "vitest";
+
+import { GeneratedUndiscriminatedUnionTypeImpl } from "../undiscriminated-union/GeneratedUndiscriminatedUnionTypeImpl.js";
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function createFernFilepath(packageName = "types"): FernIr.FernFilepath {
+    return {
+        allParts: [casingsGenerator.generateName(packageName)],
+        packagePath: [casingsGenerator.generateName(packageName)],
+        file: casingsGenerator.generateName(packageName)
+    };
+}
+
+/**
+ * Builds a TypeReferenceNode for a primitive type (non-optional).
+ */
+function primitiveTypeRefNode(typeName: string): TypeReferenceNode {
+    const typeNode = ts.factory.createKeywordTypeNode(
+        typeName === "string"
+            ? ts.SyntaxKind.StringKeyword
+            : typeName === "number"
+              ? ts.SyntaxKind.NumberKeyword
+              : typeName === "boolean"
+                ? ts.SyntaxKind.BooleanKeyword
+                : ts.SyntaxKind.AnyKeyword
+    );
+    return {
+        isOptional: false,
+        typeNode,
+        typeNodeWithoutUndefined: typeNode,
+        requestTypeNode: undefined,
+        requestTypeNodeWithoutUndefined: undefined,
+        responseTypeNode: undefined,
+        responseTypeNodeWithoutUndefined: undefined
+    };
+}
+
+/**
+ * Builds a TypeReferenceNode pointing to a named type reference.
+ */
+function namedTypeRefNode(name: string): TypeReferenceNode {
+    const typeNode = ts.factory.createTypeReferenceNode(name);
+    return {
+        isOptional: false,
+        typeNode,
+        typeNodeWithoutUndefined: typeNode,
+        requestTypeNode: undefined,
+        requestTypeNodeWithoutUndefined: undefined,
+        responseTypeNode: undefined,
+        responseTypeNodeWithoutUndefined: undefined
+    };
+}
+
+/**
+ * Builds a TypeReferenceNode with separate request/response type nodes.
+ */
+function namedTypeRefNodeWithVariants(name: string, requestName: string, responseName: string): TypeReferenceNode {
+    const typeNode = ts.factory.createTypeReferenceNode(name);
+    return {
+        isOptional: false,
+        typeNode,
+        typeNodeWithoutUndefined: typeNode,
+        requestTypeNode: ts.factory.createTypeReferenceNode(requestName),
+        requestTypeNodeWithoutUndefined: ts.factory.createTypeReferenceNode(requestName),
+        responseTypeNode: ts.factory.createTypeReferenceNode(responseName),
+        responseTypeNodeWithoutUndefined: ts.factory.createTypeReferenceNode(responseName)
+    };
+}
+
+/**
+ * Creates a mock BaseContext for undiscriminated union type tests.
+ * Provides: getReferenceToTypeForInlineUnion, getGeneratedExample, getTypeDeclaration.
+ */
+function createMockBaseContext(opts?: {
+    typeRefOverrides?: Map<string, TypeReferenceNode>;
+    getTypeDeclarationFn?: (typeName: FernIr.DeclaredTypeName) => FernIr.TypeDeclaration;
+}) {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const sourceFile = project.createSourceFile("test.ts", "");
+
+    const typeRefMap = opts?.typeRefOverrides ?? new Map<string, TypeReferenceNode>();
+
+    return {
+        sourceFile,
+        // biome-ignore lint/suspicious/noEmptyBlockStatements: test mock with no-op logger
+        logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+        type: {
+            getReferenceToTypeForInlineUnion: (typeRef: FernIr.TypeReference): TypeReferenceNode => {
+                if (typeRef.type === "named") {
+                    const override = typeRefMap.get(typeRef.typeId);
+                    if (override) {
+                        return override;
+                    }
+                }
+                return primitiveTypeRefNode("string");
+            },
+            getGeneratedExample: (_example: FernIr.ExampleTypeReference) => ({
+                build: () => ts.factory.createStringLiteral("example-value")
+            }),
+            getTypeDeclaration:
+                opts?.getTypeDeclarationFn ??
+                ((typeName: FernIr.DeclaredTypeName): FernIr.TypeDeclaration => {
+                    return {
+                        name: typeName,
+                        shape: FernIr.Type.object({
+                            properties: [],
+                            extends: [],
+                            extraProperties: false,
+                            extendedProperties: undefined
+                        }),
+                        referencedTypes: new Set<string>(),
+                        encoding: undefined,
+                        autogeneratedExamples: [],
+                        userProvidedExamples: [],
+                        v2Examples: undefined,
+                        docs: undefined,
+                        availability: undefined,
+                        source: undefined,
+                        inline: undefined
+                    };
+                })
+        }
+        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal interface
+    } as any;
+}
+
+/**
+ * Creates an UndiscriminatedUnionMember IR object.
+ */
+function createUnionMember(opts: { type: FernIr.TypeReference; docs?: string }): FernIr.UndiscriminatedUnionMember {
+    return {
+        type: opts.type,
+        docs: opts.docs
+    };
+}
+
+/**
+ * Creates a GeneratedUndiscriminatedUnionTypeImpl with the given config.
+ */
+function createGenerator(opts: {
+    typeName: string;
+    members: FernIr.UndiscriminatedUnionMember[];
+    docs?: string;
+    examples?: FernIr.ExampleType[];
+    includeSerdeLayer?: boolean;
+    retainOriginalCasing?: boolean;
+    noOptionalProperties?: boolean;
+    enableInlineTypes?: boolean;
+    generateReadWriteOnlyTypes?: boolean;
+    // biome-ignore lint/suspicious/noExplicitAny: test factory with generic type parameter
+}): GeneratedUndiscriminatedUnionTypeImpl<any> {
+    return new GeneratedUndiscriminatedUnionTypeImpl({
+        typeName: opts.typeName,
+        shape: { members: opts.members },
+        examples: opts.examples ?? [],
+        docs: opts.docs,
+        fernFilepath: createFernFilepath(),
+        getReferenceToSelf: () => ({
+            getTypeNode: () => ts.factory.createTypeReferenceNode(opts.typeName),
+            getExpression: () => ts.factory.createIdentifier(opts.typeName),
+            getEntityName: () => ts.factory.createIdentifier(opts.typeName)
+        }),
+        includeSerdeLayer: opts.includeSerdeLayer ?? true,
+        noOptionalProperties: opts.noOptionalProperties ?? false,
+        retainOriginalCasing: opts.retainOriginalCasing ?? false,
+        enableInlineTypes: opts.enableInlineTypes ?? false,
+        generateReadWriteOnlyTypes: opts.generateReadWriteOnlyTypes ?? false
+    });
+}
+
+/**
+ * Serializes generateStatements output by writing to a ts-morph SourceFile.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test utility accepting mock context or generator
+function serializeStatements(generator: any, context?: any): string {
+    const ctx = context ?? createMockBaseContext();
+    const statements = generator.generateStatements(ctx);
+    ctx.sourceFile.addStatements(statements);
+    return ctx.sourceFile.getFullText();
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests — GeneratedUndiscriminatedUnionTypeImpl
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("GeneratedUndiscriminatedUnionTypeImpl", () => {
+    describe("generateStatements / writeToFile", () => {
+        it("generates basic union with primitive members", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "INTEGER", v2: undefined })
+                    })
+                ]
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with named type members", () => {
+            const userType = createDeclaredTypeName("User");
+            const adminType = createDeclaredTypeName("Admin");
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([
+                    [userType.typeId, namedTypeRefNode("User")],
+                    [adminType.typeId, namedTypeRefNode("Admin")]
+                ])
+            });
+
+            const generator = createGenerator({
+                typeName: "UserOrAdmin",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.named({
+                            typeId: userType.typeId,
+                            fernFilepath: userType.fernFilepath,
+                            name: userType.name,
+                            displayName: undefined,
+                            default: undefined,
+                            inline: undefined
+                        })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.named({
+                            typeId: adminType.typeId,
+                            fernFilepath: adminType.fernFilepath,
+                            name: adminType.name,
+                            displayName: undefined,
+                            default: undefined,
+                            inline: undefined
+                        })
+                    })
+                ]
+            });
+            const output = serializeStatements(generator, context);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with member docs", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        docs: "A string variant."
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "INTEGER", v2: undefined }),
+                        docs: "An integer variant."
+                    })
+                ]
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with top-level docs", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "BOOLEAN", v2: undefined })
+                    })
+                ],
+                docs: "A simple undiscriminated union."
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with single member", () => {
+            const generator = createGenerator({
+                typeName: "SingleMember",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    })
+                ]
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with self-recursive map member (index signature)", () => {
+            const selfType = createDeclaredTypeName("NestedValue");
+
+            // getTypeDeclaration should return a type whose pascalCase.unsafeName matches the typeName
+            const getTypeDeclarationFn = (typeName: FernIr.DeclaredTypeName): FernIr.TypeDeclaration => ({
+                name: typeName,
+                shape: FernIr.Type.object({
+                    properties: [],
+                    extends: [],
+                    extraProperties: false,
+                    extendedProperties: undefined
+                }),
+                referencedTypes: new Set<string>(),
+                encoding: undefined,
+                autogeneratedExamples: [],
+                userProvidedExamples: [],
+                v2Examples: undefined,
+                docs: undefined,
+                availability: undefined,
+                source: undefined,
+                inline: undefined
+            });
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([[selfType.typeId, namedTypeRefNode("NestedValue")]]),
+                getTypeDeclarationFn
+            });
+
+            // Create a map member where valueType is a named type whose declaration name matches the typeName
+            const generator = createGenerator({
+                typeName: "NestedValue",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.container(
+                            FernIr.ContainerType.map({
+                                keyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                                valueType: FernIr.TypeReference.named({
+                                    typeId: selfType.typeId,
+                                    fernFilepath: selfType.fernFilepath,
+                                    name: selfType.name,
+                                    displayName: undefined,
+                                    default: undefined,
+                                    inline: undefined
+                                })
+                            })
+                        )
+                    })
+                ]
+            });
+            const output = serializeStatements(generator, context);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with self-recursive map wrapped in optional", () => {
+            const selfType = createDeclaredTypeName("NestedValue");
+
+            const getTypeDeclarationFn = (typeName: FernIr.DeclaredTypeName): FernIr.TypeDeclaration => ({
+                name: typeName,
+                shape: FernIr.Type.object({
+                    properties: [],
+                    extends: [],
+                    extraProperties: false,
+                    extendedProperties: undefined
+                }),
+                referencedTypes: new Set<string>(),
+                encoding: undefined,
+                autogeneratedExamples: [],
+                userProvidedExamples: [],
+                v2Examples: undefined,
+                docs: undefined,
+                availability: undefined,
+                source: undefined,
+                inline: undefined
+            });
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([[selfType.typeId, namedTypeRefNode("NestedValue")]]),
+                getTypeDeclarationFn
+            });
+
+            // The map valueType is wrapped in optional, but unwrapOptionalAndNullable should detect self-recursion
+            const generator = createGenerator({
+                typeName: "NestedValue",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.container(
+                            FernIr.ContainerType.map({
+                                keyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                                valueType: FernIr.TypeReference.container(
+                                    FernIr.ContainerType.optional(
+                                        FernIr.TypeReference.named({
+                                            typeId: selfType.typeId,
+                                            fernFilepath: selfType.fernFilepath,
+                                            name: selfType.name,
+                                            displayName: undefined,
+                                            default: undefined,
+                                            inline: undefined
+                                        })
+                                    )
+                                )
+                            })
+                        )
+                    })
+                ]
+            });
+            const output = serializeStatements(generator, context);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with non-recursive map member (no index signature)", () => {
+            const otherType = createDeclaredTypeName("OtherType");
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([[otherType.typeId, namedTypeRefNode("OtherType")]])
+            });
+
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.container(
+                            FernIr.ContainerType.map({
+                                keyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                                valueType: FernIr.TypeReference.named({
+                                    typeId: otherType.typeId,
+                                    fernFilepath: otherType.fernFilepath,
+                                    name: otherType.name,
+                                    displayName: undefined,
+                                    default: undefined,
+                                    inline: undefined
+                                })
+                            })
+                        )
+                    })
+                ]
+            });
+            const output = serializeStatements(generator, context);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with generateReadWriteOnlyTypes and request/response variants", () => {
+            const userType = createDeclaredTypeName("User");
+            const adminType = createDeclaredTypeName("Admin");
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([
+                    [userType.typeId, namedTypeRefNodeWithVariants("User", "User.Request", "User.Response")],
+                    [adminType.typeId, namedTypeRefNodeWithVariants("Admin", "Admin.Request", "Admin.Response")]
+                ])
+            });
+
+            const generator = createGenerator({
+                typeName: "UserOrAdmin",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.named({
+                            typeId: userType.typeId,
+                            fernFilepath: userType.fernFilepath,
+                            name: userType.name,
+                            displayName: undefined,
+                            default: undefined,
+                            inline: undefined
+                        })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.named({
+                            typeId: adminType.typeId,
+                            fernFilepath: adminType.fernFilepath,
+                            name: adminType.name,
+                            displayName: undefined,
+                            default: undefined,
+                            inline: undefined
+                        })
+                    })
+                ],
+                generateReadWriteOnlyTypes: true,
+                docs: "Example of an undiscriminated union"
+            });
+            const output = serializeStatements(generator, context);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("does not generate module when generateReadWriteOnlyTypes but no variants needed", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "INTEGER", v2: undefined })
+                    })
+                ],
+                generateReadWriteOnlyTypes: true
+            });
+            // Primitive types don't have request/response variants, so no module should be generated
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates union with examples in docs", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "INTEGER", v2: undefined })
+                    })
+                ],
+                docs: "A union type.",
+                examples: [
+                    {
+                        shape: FernIr.ExampleTypeShape.undiscriminatedUnion({
+                            index: 0,
+                            singleUnionType: {
+                                shape: FernIr.ExampleTypeReferenceShape.primitive(
+                                    FernIr.ExamplePrimitive.string({ original: "hello" })
+                                ),
+                                jsonExample: "hello"
+                            }
+                        }),
+                        docs: undefined,
+                        name: undefined,
+                        jsonExample: "hello"
+                    }
+                ]
+            });
+            const output = serializeStatements(generator);
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("generateForInlineUnion", () => {
+        it("returns union type node", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "INTEGER", v2: undefined })
+                    })
+                ]
+            });
+            const context = createMockBaseContext();
+            const result = generator.generateForInlineUnion(context);
+            expect(getTextOfTsNode(result.typeNode)).toMatchSnapshot();
+        });
+
+        it("returns request/response type nodes with named variants", () => {
+            const userType = createDeclaredTypeName("User");
+            const adminType = createDeclaredTypeName("Admin");
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([
+                    [userType.typeId, namedTypeRefNodeWithVariants("User", "User.Request", "User.Response")],
+                    [adminType.typeId, namedTypeRefNodeWithVariants("Admin", "Admin.Request", "Admin.Response")]
+                ])
+            });
+
+            const generator = createGenerator({
+                typeName: "UserOrAdmin",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.named({
+                            typeId: userType.typeId,
+                            fernFilepath: userType.fernFilepath,
+                            name: userType.name,
+                            displayName: undefined,
+                            default: undefined,
+                            inline: undefined
+                        })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.named({
+                            typeId: adminType.typeId,
+                            fernFilepath: adminType.fernFilepath,
+                            name: adminType.name,
+                            displayName: undefined,
+                            default: undefined,
+                            inline: undefined
+                        })
+                    })
+                ]
+            });
+            const result = generator.generateForInlineUnion(context);
+            expect(getTextOfTsNode(result.typeNode)).toMatchSnapshot();
+            assert(result.requestTypeNode != null, "requestTypeNode should be defined");
+            expect(getTextOfTsNode(result.requestTypeNode)).toMatchSnapshot();
+            assert(result.responseTypeNode != null, "responseTypeNode should be defined");
+            expect(getTextOfTsNode(result.responseTypeNode)).toMatchSnapshot();
+        });
+
+        it("falls back to base typeNode when no request/response variants", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "BOOLEAN", v2: undefined })
+                    })
+                ]
+            });
+            const context = createMockBaseContext();
+            const result = generator.generateForInlineUnion(context);
+            // When no request/response variants, they still have values (fallback to typeNode)
+            assert(result.requestTypeNode != null, "requestTypeNode should be defined");
+            expect(getTextOfTsNode(result.requestTypeNode)).toEqual(getTextOfTsNode(result.typeNode));
+            assert(result.responseTypeNode != null, "responseTypeNode should be defined");
+            expect(getTextOfTsNode(result.responseTypeNode)).toEqual(getTextOfTsNode(result.typeNode));
+        });
+    });
+
+    describe("generateModule", () => {
+        it("returns undefined when generateReadWriteOnlyTypes is false", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    })
+                ]
+            });
+            const context = createMockBaseContext();
+            const result = generator.generateModule(context);
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined when generateReadWriteOnlyTypes is true but no variants needed", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    })
+                ],
+                generateReadWriteOnlyTypes: true
+            });
+            const context = createMockBaseContext();
+            const result = generator.generateModule(context);
+            expect(result).toBeUndefined();
+        });
+
+        it("returns namespace module with Request/Response when variants are needed", () => {
+            const userType = createDeclaredTypeName("User");
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([
+                    [userType.typeId, namedTypeRefNodeWithVariants("User", "User.Request", "User.Response")]
+                ])
+            });
+
+            const generator = createGenerator({
+                typeName: "UserOrAdmin",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.named({
+                            typeId: userType.typeId,
+                            fernFilepath: userType.fernFilepath,
+                            name: userType.name,
+                            displayName: undefined,
+                            default: undefined,
+                            inline: undefined
+                        })
+                    }),
+                    createUnionMember({ type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }) })
+                ],
+                generateReadWriteOnlyTypes: true
+            });
+            const context2 = createMockBaseContext({
+                typeRefOverrides: new Map([
+                    [userType.typeId, namedTypeRefNodeWithVariants("User", "User.Request", "User.Response")]
+                ])
+            });
+            const result = generator.generateModule(context2);
+            assert(result != null, "module should be defined");
+            expect(result.name).toBe("UserOrAdmin");
+            expect(result.isExported).toBe(true);
+        });
+
+        it("generates only Request variant when only request types differ", () => {
+            const userType = createDeclaredTypeName("User");
+
+            const requestOnlyNode: TypeReferenceNode = {
+                isOptional: false,
+                typeNode: ts.factory.createTypeReferenceNode("User"),
+                typeNodeWithoutUndefined: ts.factory.createTypeReferenceNode("User"),
+                requestTypeNode: ts.factory.createTypeReferenceNode("User.Request"),
+                requestTypeNodeWithoutUndefined: ts.factory.createTypeReferenceNode("User.Request"),
+                responseTypeNode: undefined,
+                responseTypeNodeWithoutUndefined: undefined
+            };
+
+            const context = createMockBaseContext({
+                typeRefOverrides: new Map([[userType.typeId, requestOnlyNode]])
+            });
+
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.named({
+                            typeId: userType.typeId,
+                            fernFilepath: userType.fernFilepath,
+                            name: userType.name,
+                            displayName: undefined,
+                            default: undefined,
+                            inline: undefined
+                        })
+                    }),
+                    createUnionMember({ type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }) })
+                ],
+                generateReadWriteOnlyTypes: true
+            });
+            const result = generator.generateModule(context);
+            expect(result).toBeDefined();
+            // Should only have Request, not Response
+            assert(result != null, "module should be defined");
+            const statementNames = (result.statements as Array<{ name: string }>).map((s) => s.name);
+            expect(statementNames).toContain("Request");
+            expect(statementNames).not.toContain("Response");
+        });
+    });
+
+    describe("buildExample", () => {
+        it("builds example for undiscriminated union", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    }),
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "INTEGER", v2: undefined })
+                    })
+                ]
+            });
+            const context = createMockBaseContext();
+
+            const example = FernIr.ExampleTypeShape.undiscriminatedUnion({
+                index: 0,
+                singleUnionType: {
+                    shape: FernIr.ExampleTypeReferenceShape.primitive(
+                        FernIr.ExamplePrimitive.string({ original: "hello" })
+                    ),
+                    jsonExample: "hello"
+                }
+            });
+
+            const result = generator.buildExample(example, context, { isForComment: true });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("throws for non-undiscriminated union example shape", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    })
+                ]
+            });
+            const context = createMockBaseContext();
+
+            const example = FernIr.ExampleTypeShape.object({
+                properties: [],
+                extraProperties: undefined
+            });
+
+            expect(() => generator.buildExample(example, context, { isForComment: true })).toThrow(
+                "Example is not for an undiscriminated union"
+            );
+        });
+    });
+
+    describe("type property", () => {
+        it("has type='undiscriminatedUnion'", () => {
+            const generator = createGenerator({
+                typeName: "MyUnion",
+                members: [
+                    createUnionMember({
+                        type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+                    })
+                ]
+            });
+            expect(generator.type).toBe("undiscriminatedUnion");
+        });
+    });
+});

--- a/generators/typescript/model/type-generator/src/__test__/__snapshots__/GeneratedUndiscriminatedUnionTypeImpl.test.ts.snap
+++ b/generators/typescript/model/type-generator/src/__test__/__snapshots__/GeneratedUndiscriminatedUnionTypeImpl.test.ts.snap
@@ -1,0 +1,122 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > buildExample > builds example for undiscriminated union 1`] = `""example-value""`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateForInlineUnion > returns request/response type nodes with named variants 1`] = `"User | Admin"`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateForInlineUnion > returns request/response type nodes with named variants 2`] = `"User.Request | Admin.Request"`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateForInlineUnion > returns request/response type nodes with named variants 3`] = `"User.Response | Admin.Response"`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateForInlineUnion > returns union type node 1`] = `"string | string"`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > does not generate module when generateReadWriteOnlyTypes but no variants needed 1`] = `
+"export type MyUnion = 
+    | string
+    | string;
+"
+`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > generates basic union with primitive members 1`] = `
+"export type MyUnion = 
+    | string
+    | string;
+"
+`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > generates union with examples in docs 1`] = `
+"/**
+ * A union type.
+ *
+ * @example
+ *     "example-value"
+ */
+export type MyUnion = 
+    | string
+    | string;
+"
+`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > generates union with generateReadWriteOnlyTypes and request/response variants 1`] = `
+"/**
+ * Example of an undiscriminated union
+ */
+export type UserOrAdmin = 
+    | User
+    | Admin;
+
+export namespace UserOrAdmin {
+    /**
+     * Example of an undiscriminated union
+     */
+    export type Request = 
+        | User.Request
+        | Admin.Request;
+    /**
+     * Example of an undiscriminated union
+     */
+    export type Response = 
+        | User.Response
+        | Admin.Response;
+}
+"
+`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > generates union with member docs 1`] = `
+"export type MyUnion = 
+    /**
+     * A string variant. */
+    | string
+    /**
+     * An integer variant. */
+    | string;
+"
+`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > generates union with named type members 1`] = `
+"export type UserOrAdmin = 
+    | User
+    | Admin;
+"
+`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > generates union with non-recursive map member (no index signature) 1`] = `
+"export type MyUnion = 
+    | string
+    | string;
+"
+`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > generates union with self-recursive map member (index signature) 1`] = `
+"export type NestedValue = 
+    | string
+    | {
+        [key: string]: NestedValue;
+    };
+"
+`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > generates union with self-recursive map wrapped in optional 1`] = `
+"export type NestedValue = 
+    | string
+    | {
+        [key: string]: NestedValue;
+    };
+"
+`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > generates union with single member 1`] = `
+"export type SingleMember = 
+    | string;
+"
+`;
+
+exports[`GeneratedUndiscriminatedUnionTypeImpl > generateStatements / writeToFile > generates union with top-level docs 1`] = `
+"/**
+ * A simple undiscriminated union.
+ */
+export type MyUnion = 
+    | string
+    | string;
+"
+`;


### PR DESCRIPTION
## Description

Refs: Priority 2h of the TS SDK unit test initiative

Adds comprehensive snapshot-based unit tests for `GeneratedUndiscriminatedUnionTypeImpl`, the undiscriminated union type generator (~263 lines of source). This completes all Priority 2 Type Generator tests.

Link to Devin Session: https://app.devin.ai/sessions/ce25a6da44a14437a2fa92712a187cf6
Requested by: @Swimburger

## Changes Made

- Added `GeneratedUndiscriminatedUnionTypeImpl.test.ts` with **21 tests** covering:
  - `generateStatements/writeToFile` (10 tests): basic primitives, named types, member docs, top-level docs, single member, self-recursive map index signature, optional-wrapped self-recursive map, non-recursive map, read/write-only namespace variants, examples in docs
  - `generateForInlineUnion` (3 tests): union type node, request/response variant type nodes, fallback to base type node
  - `generateModule` (4 tests): undefined without flag, undefined without variants, namespace with Request/Response, Request-only variant
  - `buildExample` (2 tests): valid delegation, error for wrong shape
  - `type` property (1 test)
- 16 snapshots generated, verified against seed output patterns

## Updates Since Last Revision

- **Fixed unused `context` variable**: In the "returns namespace module" test, removed the duplicate `context2` and now correctly uses `context` directly.
- **Verified all review items** (see checklist below).

## Human Review Checklist

- **Mock returns `string` for all primitive types**: `getReferenceToTypeForInlineUnion` defaults to `primitiveTypeRefNode("string")` regardless of actual primitive kind — several snapshots show `string | string` for `STRING | INTEGER` unions. This is acceptable: it tests structural generation (union formatting, docs, module generation) rather than type-specific resolution, which is the responsibility of the context layer.
- **`getGeneratedExample` hardcoded**: Always returns `"example-value"` string literal — tests verify wiring/delegation (that `buildExample` correctly dispatches to `context.type.getGeneratedExample`), not end-to-end example data flow.
- **Self-recursive map snapshots**: Verified against seed output. Snapshot produces `{ [key: string]: NestedValue; }` which matches the real seed pattern in `seed/ts-sdk/circular-references/.../JsonLike.ts` (`[key: string]: JsonLike;`). Both direct and optional-wrapped self-references correctly trigger index signature substitution.
- **Mock context coverage**: Only 3 `context.type.*` methods are needed (`getReferenceToTypeForInlineUnion`, `getGeneratedExample`, `getTypeDeclaration`) — all are covered. No gaps.

## Testing

- [x] Unit tests added (21 tests, all passing)
- [x] Snapshots generated and verified against seed output
- [x] `pnpm run check` (biome lint/format) passes clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
