### PR TITLE
feat(cli): Add fern org create command

### DIFF
--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -8,6 +8,7 @@ import { addCheckCommand } from "./commands/check/index.js";
 import { addConfigCommand } from "./commands/config/index.js";
 import { addDocsCommand } from "./commands/docs/index.js";
 import { addInitCommand } from "./commands/init/index.js";
+import { addOrgCommand } from "./commands/org/index.js";
 import { addSdkCommand } from "./commands/sdk/index.js";
 import { addTelemetryCommand } from "./commands/telemetry/index.js";
 import { GlobalArgs } from "./context/GlobalArgs.js";
@@ -53,6 +54,7 @@ function createCliV2(argv?: string[]): Argv<GlobalArgs> {
     addConfigCommand(cli);
     addDocsCommand(cli);
     addInitCommand(cli);
+    addOrgCommand(cli);
     addSdkCommand(cli);
     addTelemetryCommand(cli);
 

--- a/packages/cli/cli-v2/src/commands/docs/publish/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/publish/command.ts
@@ -64,6 +64,7 @@ export class PublishCommand {
 
         const ossWorkspaces = await filterOssWorkspaces(project);
         const token = await this.getToken(context);
+        await context.verifyOrgAccess({ organization: workspace.org, token });
 
         const taskGroup = await this.setupTaskGroup({ context, instanceUrl, org: workspace.org });
         const docsTask = taskGroup.getTask("publish");

--- a/packages/cli/cli-v2/src/commands/org/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/command.ts
@@ -1,0 +1,9 @@
+import type { Argv } from "yargs";
+
+import type { GlobalArgs } from "../../context/GlobalArgs.js";
+import { commandGroup } from "../_internal/commandGroup.js";
+import { addCreateCommand } from "./create/index.js";
+
+export function addOrgCommand(cli: Argv<GlobalArgs>): void {
+    commandGroup(cli, "org", "Manage your organizations", [addCreateCommand]);
+}

--- a/packages/cli/cli-v2/src/commands/org/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/create/command.ts
@@ -1,0 +1,71 @@
+import { createOrganizationIfDoesNotExist, getOrganizationNameValidationError } from "@fern-api/auth";
+import type { Argv } from "yargs";
+
+import { TaskContextAdapter } from "../../../context/adapter/TaskContextAdapter.js";
+import type { Context } from "../../../context/Context.js";
+import type { GlobalArgs } from "../../../context/GlobalArgs.js";
+import { CliError } from "../../../errors/CliError.js";
+import { Icons } from "../../../ui/format.js";
+import { withSpinner } from "../../../ui/withSpinner.js";
+import { command } from "../../_internal/command.js";
+
+export declare namespace CreateCommand {
+    export interface Args extends GlobalArgs {
+        name: string;
+    }
+}
+
+export class CreateCommand {
+    public async handle(context: Context, args: CreateCommand.Args): Promise<void> {
+        const token = await context.getTokenOrPrompt();
+
+        if (token.type === "organization") {
+            context.stderr.error(
+                `${Icons.error} Organization tokens cannot create organizations. Unset the FERN_TOKEN environment variable and run 'fern auth login' to create an organization.`
+            );
+            throw CliError.exit();
+        }
+
+        const validationError = getOrganizationNameValidationError(args.name);
+        if (validationError != null) {
+            throw CliError.validationError(validationError);
+        }
+
+        const created = await withSpinner({
+            message: `Creating organization "${args.name}"`,
+            operation: () =>
+                createOrganizationIfDoesNotExist({
+                    organization: args.name,
+                    token,
+                    context: new TaskContextAdapter({ context })
+                })
+        });
+
+        if (created) {
+            context.stderr.info(`${Icons.success} Created organization "${args.name}"`);
+            return;
+        }
+
+        context.stderr.info(`${Icons.info} Organization "${args.name}" already exists`);
+    }
+}
+
+export function addCreateCommand(cli: Argv<GlobalArgs>, parentPath?: string): void {
+    const cmd = new CreateCommand();
+    command(
+        cli,
+        "create <name>",
+        "Create a new organization",
+        (context, args) => cmd.handle(context, args as CreateCommand.Args),
+        (yargs) =>
+            yargs
+                .usage("\nUsage:\n  $0 org create <name>")
+                .positional("name", {
+                    type: "string",
+                    demandOption: true,
+                    description: "Organization name"
+                })
+                .example("$0 org create acme", "# Create the 'acme' organization"),
+        parentPath
+    );
+}

--- a/packages/cli/cli-v2/src/commands/org/create/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/create/index.ts
@@ -1,0 +1,1 @@
+export { addCreateCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/org/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/index.ts
@@ -1,0 +1,1 @@
+export { addOrgCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -239,6 +239,10 @@ export class GenerateCommand {
             ? await context.getTokenOrPrompt()
             : undefined;
 
+        if (token != null) {
+            await context.verifyOrgAccess({ organization: workspace.sdks.org, token });
+        }
+
         const runtime = isLocal ? "local" : "remote";
 
         const taskGroup = new SdkTaskGroup({ context });

--- a/packages/cli/cli-v2/src/context/Context.ts
+++ b/packages/cli/cli-v2/src/context/Context.ts
@@ -1,4 +1,10 @@
-import { FernToken, FernUserToken, getAccessToken, verifyAndDecodeJwt } from "@fern-api/auth";
+import {
+    checkOrganizationMembership,
+    FernToken,
+    FernUserToken,
+    getAccessToken,
+    verifyAndDecodeJwt
+} from "@fern-api/auth";
 import { Log, TtyAwareLogger } from "@fern-api/cli-logger";
 import { schemas } from "@fern-api/config";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
@@ -181,6 +187,37 @@ export class Context {
         this.stderr.info(`${Icons.success} Logged in as ${chalk.bold(email)}`);
 
         return { type: "user", value: accessToken };
+    }
+
+    /**
+     * Verify that the current user has access to the given organization.
+     *
+     * Organization tokens are already scoped to an organization, so this is a no-op.
+     * User tokens are checked for membership via the Venus API.
+     *
+     * @throws CliError if the organization doesn't exist or the user doesn't have access
+     */
+    public async verifyOrgAccess({ organization, token }: { organization: string; token: FernToken }): Promise<void> {
+        if (token.type === "organization") {
+            return;
+        }
+
+        const result = await checkOrganizationMembership({ organization, token });
+
+        switch (result.type) {
+            case "member":
+                return;
+            case "not-found":
+                throw CliError.notFound(
+                    `Organization "${organization}" does not exist.\n\n  To create it, run: fern org create ${organization}`
+                );
+            case "no-access":
+                throw CliError.unauthorized(
+                    `You do not have access to organization "${organization}".\n\n  Contact an organization admin to request access.`
+                );
+            case "unknown-error":
+                throw CliError.internalError(`Failed to verify access to organization "${organization}".`);
+        }
     }
 
     public resolveTargetOutputs(target: Target): string[] | undefined {

--- a/packages/cli/cli-v2/src/errors/CliError.ts
+++ b/packages/cli/cli-v2/src/errors/CliError.ts
@@ -8,6 +8,7 @@ export declare namespace CliError {
         | "EXIT"
         | "GENERATION_FAILED"
         | "BAD_REQUEST_ERROR"
+        | "NOT_FOUND_ERROR"
         | "UNAUTHORIZED_ERROR"
         | "VALIDATION_ERROR"
         | "INTERNAL_ERROR";
@@ -56,6 +57,10 @@ export class CliError extends Error {
 
     public static badRequest(message: string): CliError {
         return new CliError({ message, code: "BAD_REQUEST_ERROR" });
+    }
+
+    public static notFound(message: string): CliError {
+        return new CliError({ message, code: "NOT_FOUND_ERROR" });
     }
 
     public static unauthorized(message?: string): CliError {

--- a/packages/cli/cli-v2/src/init/Wizard.ts
+++ b/packages/cli/cli-v2/src/init/Wizard.ts
@@ -244,13 +244,12 @@ export class Wizard {
 
                 case "not-found": {
                     const taskContext = new TaskContextAdapter({ context: this.context });
-                    const created = await withSpinner("Creating organization...", () =>
-                        createOrganizationIfDoesNotExist({
-                            organization,
-                            token,
-                            context: taskContext
-                        })
-                    );
+                    const created = await withSpinner({
+                        message: `Creating organization "${organization}"`,
+                        operation: () =>
+                            createOrganizationIfDoesNotExist({ organization, token, context: taskContext }),
+                        indent: 2
+                    });
                     if (created) {
                         this.context.stderr.info(`  ${Icons.success} Created organization "${organization}"\n`);
                     }

--- a/packages/cli/cli-v2/src/ui/withSpinner.ts
+++ b/packages/cli/cli-v2/src/ui/withSpinner.ts
@@ -1,9 +1,17 @@
 import ora from "ora";
 
-export async function withSpinner<T>(message: string, operation: () => Promise<T>): Promise<T> {
+export async function withSpinner<T>({
+    message,
+    operation,
+    indent
+}: {
+    message: string;
+    operation: () => Promise<T>;
+    indent?: number;
+}): Promise<T> {
     const spinner = ora({
         text: message,
-        indent: 2,
+        indent: indent ?? 0,
         color: "cyan"
     }).start();
     try {


### PR DESCRIPTION
## Description

This adds a new `fern org create` command, which makes it easier for users to explicitly create a new organization. With this, we can more clearly recommend what a user should do when they try to perform some operation without the organization existing. That way they don't accidentally create a resource they didn't mean to use.

```sh
$ fern org create amckinney
◆ Organization "amckinney" already exists

$ fern org create amckinney-test
✓ Created organization "amckinney-test"

$ fern org create x-
Organization name must contain only lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen
```

Then, if I have a `fern.yml` with the following organization that doesn't exist:

```yaml
org: xxxx
api:
  specs:
    - openapi: openapi/openapi.yml
docs:
  $ref: ./docs.yml
sdks:
  targets:
    go:
      output: ./sdks/go
      config:
        packageName: true
```

```sh
$ fern sdk generate
Organization "xxxx" does not exist.

  To create it, run: fern org create xxxx
```
