### PR TITLE
chore(internal): add unit tests for Priority 3 endpoint implementation classes

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
@@ -560,34 +560,36 @@ function createCursorPagination(): FernIr.Pagination {
                 valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                 docs: undefined,
                 availability: undefined,
+                propertyAccess: undefined,
                 v2Examples: undefined
             })
         },
         next: {
             propertyPath: undefined,
-            property: FernIr.RequestPropertyValue.body({
+            property: {
                 name: createNameAndWireValue("nextCursor"),
                 valueType: FernIr.TypeReference.container(
                     FernIr.ContainerType.optional(FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }))
                 ),
                 docs: undefined,
                 availability: undefined,
+                propertyAccess: undefined,
                 v2Examples: undefined
-            })
+            }
         },
         results: {
             propertyPath: undefined,
-            property: FernIr.RequestPropertyValue.body({
+            property: {
                 name: createNameAndWireValue("items"),
                 valueType: FernIr.TypeReference.container(
                     FernIr.ContainerType.list(FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }))
                 ),
                 docs: undefined,
                 availability: undefined,
+                propertyAccess: undefined,
                 v2Examples: undefined
-            })
-        },
-        extendedResults: undefined
+            }
+        }
     });
 }
 

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
@@ -2,7 +2,7 @@ import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
 import { createHttpEndpoint, createNameAndWireValue } from "@fern-typescript/test-utils";
 import { ts } from "ts-morph";
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 import type { GeneratedEndpointRequest } from "../endpoint-request/GeneratedEndpointRequest.js";
 import type { GeneratedEndpointResponse } from "../endpoints/default/endpoint-response/GeneratedEndpointResponse.js";
 import { GeneratedDefaultEndpointImplementation } from "../endpoints/default/GeneratedDefaultEndpointImplementation.js";
@@ -389,7 +389,8 @@ describe("GeneratedDefaultEndpointImplementation", () => {
                 clientReference: ts.factory.createIdentifier("client")
             });
             expect(example).toBeDefined();
-            expect(getTextOfTsNode(example?.endpointInvocation)).toMatchSnapshot();
+            assert(example?.endpointInvocation != null, "Expected endpointInvocation to be defined");
+            expect(getTextOfTsNode(example.endpointInvocation)).toMatchSnapshot();
         });
 
         it("returns undefined when example parameters are null", () => {
@@ -554,40 +555,37 @@ function createCursorPagination(): FernIr.Pagination {
     return FernIr.Pagination.cursor({
         page: {
             propertyPath: undefined,
-            property: {
+            property: FernIr.RequestPropertyValue.body({
                 name: createNameAndWireValue("cursor"),
                 valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                 docs: undefined,
                 availability: undefined,
-                v2Examples: undefined,
-                propertyAccess: undefined
-            }
+                v2Examples: undefined
+            })
         },
         next: {
             propertyPath: undefined,
-            property: {
+            property: FernIr.RequestPropertyValue.body({
                 name: createNameAndWireValue("nextCursor"),
                 valueType: FernIr.TypeReference.container(
                     FernIr.ContainerType.optional(FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }))
                 ),
                 docs: undefined,
                 availability: undefined,
-                v2Examples: undefined,
-                propertyAccess: undefined
-            }
+                v2Examples: undefined
+            })
         },
         results: {
             propertyPath: undefined,
-            property: {
+            property: FernIr.RequestPropertyValue.body({
                 name: createNameAndWireValue("items"),
                 valueType: FernIr.TypeReference.container(
                     FernIr.ContainerType.list(FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }))
                 ),
                 docs: undefined,
                 availability: undefined,
-                v2Examples: undefined,
-                propertyAccess: undefined
-            }
+                v2Examples: undefined
+            })
         },
         extendedResults: undefined
     });
@@ -605,7 +603,7 @@ function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
         serviceHeaders: [],
         queryParameters: [],
         request: undefined,
-        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body({ jsonExample: undefined, docs: undefined })),
+        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body(undefined)),
         docs: undefined
     };
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
@@ -376,6 +376,23 @@ describe("GeneratedDefaultEndpointImplementation", () => {
             const docs = impl.getDocs(context);
             expect(docs).toContain("IdempotentRequestOptions");
         });
+
+        it("generates multiline parameter docs with proper indentation", () => {
+            const impl = createImpl({
+                request: createMockRequest({
+                    endpointParameters: [
+                        {
+                            name: "options",
+                            type: "Options",
+                            docs: "Configuration options.\nIncludes timeout and retry settings.\nSee docs for details."
+                        }
+                    ]
+                })
+            });
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toMatchSnapshot();
+        });
     });
 
     describe("getExample", () => {
@@ -443,6 +460,151 @@ describe("GeneratedDefaultEndpointImplementation", () => {
             const impl = createImpl({
                 generateEndpointMetadata: true,
                 request: createMockRequest()
+            });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates cursor pagination body with requestParameter", () => {
+            const impl = createImpl({
+                request: createMockRequest({
+                    requestParameter: ts.factory.createTypeReferenceNode("ListUsersRequest")
+                }),
+                response: createMockResponse({
+                    paginationInfo: {
+                        type: "cursor",
+                        responseType: ts.factory.createTypeReferenceNode("ListResponse"),
+                        itemType: ts.factory.createTypeReferenceNode("User"),
+                        getItems: ts.factory.createPropertyAccessExpression(
+                            ts.factory.createIdentifier("response"),
+                            ts.factory.createIdentifier("items")
+                        ),
+                        hasNextPage: ts.factory.createBinaryExpression(
+                            ts.factory.createPropertyAccessExpression(
+                                ts.factory.createIdentifier("response"),
+                                ts.factory.createIdentifier("nextCursor")
+                            ),
+                            ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsEqualsToken),
+                            ts.factory.createNull()
+                        ),
+                        loadPage: [
+                            ts.factory.createExpressionStatement(ts.factory.createIdentifier("// load next page"))
+                        ]
+                    }
+                })
+            });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates offset pagination body with initializeOffset", () => {
+            const impl = createImpl({
+                request: createMockRequest({
+                    requestParameter: ts.factory.createTypeReferenceNode("ListUsersRequest")
+                }),
+                response: createMockResponse({
+                    paginationInfo: {
+                        type: "offset",
+                        initializeOffset: ts.factory.createVariableStatement(
+                            undefined,
+                            ts.factory.createVariableDeclarationList(
+                                [
+                                    ts.factory.createVariableDeclaration(
+                                        "_offset",
+                                        undefined,
+                                        undefined,
+                                        ts.factory.createNumericLiteral(0)
+                                    )
+                                ],
+                                ts.NodeFlags.Let
+                            )
+                        ),
+                        responseType: ts.factory.createTypeReferenceNode("ListResponse"),
+                        itemType: ts.factory.createTypeReferenceNode("User"),
+                        getItems: ts.factory.createPropertyAccessExpression(
+                            ts.factory.createIdentifier("response"),
+                            ts.factory.createIdentifier("items")
+                        ),
+                        hasNextPage: ts.factory.createBinaryExpression(
+                            ts.factory.createPropertyAccessExpression(
+                                ts.factory.createIdentifier("response"),
+                                ts.factory.createIdentifier("items")
+                            ),
+                            ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsEqualsToken),
+                            ts.factory.createNull()
+                        ),
+                        loadPage: [
+                            ts.factory.createExpressionStatement(ts.factory.createIdentifier("// load next page"))
+                        ]
+                    }
+                })
+            });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates custom pagination body with sendRequest and CustomPager", () => {
+            const impl = createImpl({
+                response: createMockResponse({
+                    paginationInfo: {
+                        type: "custom",
+                        responseType: ts.factory.createTypeReferenceNode("ListResponse"),
+                        itemType: ts.factory.createTypeReferenceNode("User"),
+                        getItems: ts.factory.createPropertyAccessExpression(
+                            ts.factory.createIdentifier("response"),
+                            ts.factory.createIdentifier("items")
+                        ),
+                        hasNextPage: ts.factory.createIdentifier("false"),
+                        loadPage: []
+                    }
+                })
+            });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates offset-step pagination body", () => {
+            const impl = createImpl({
+                request: createMockRequest({
+                    requestParameter: ts.factory.createTypeReferenceNode("ListUsersRequest")
+                }),
+                response: createMockResponse({
+                    paginationInfo: {
+                        type: "offset-step",
+                        initializeOffset: ts.factory.createVariableStatement(
+                            undefined,
+                            ts.factory.createVariableDeclarationList(
+                                [
+                                    ts.factory.createVariableDeclaration(
+                                        "_page",
+                                        undefined,
+                                        undefined,
+                                        ts.factory.createNumericLiteral(1)
+                                    )
+                                ],
+                                ts.NodeFlags.Let
+                            )
+                        ),
+                        responseType: ts.factory.createTypeReferenceNode("ListResponse"),
+                        itemType: ts.factory.createTypeReferenceNode("User"),
+                        getItems: ts.factory.createPropertyAccessExpression(
+                            ts.factory.createIdentifier("response"),
+                            ts.factory.createIdentifier("items")
+                        ),
+                        hasNextPage: ts.factory.createIdentifier("true"),
+                        loadPage: [
+                            ts.factory.createExpressionStatement(ts.factory.createIdentifier("// load next page"))
+                        ]
+                    }
+                })
             });
             const context = createMockSdkContext();
             const stmts = impl.getStatements(context);

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
@@ -48,7 +48,8 @@ function createMockRequest(opts?: {
         getReferenceToQueryParameter: (key: string) => ts.factory.createIdentifier(key),
         getExampleEndpointParameters: () => opts?.exampleParameters ?? [ts.factory.createStringLiteral("example-arg")],
         getExampleEndpointImports: () => opts?.exampleImports ?? []
-    };
+        // biome-ignore lint/suspicious/noExplicitAny: test mock for GeneratedEndpointRequest
+    } as any;
 }
 
 /**
@@ -531,11 +532,10 @@ describe("GeneratedDefaultEndpointImplementation", () => {
         it("sets responseType to text for text response endpoints", () => {
             const endpoint = createHttpEndpoint();
             endpoint.response = {
-                body: FernIr.HttpResponseBody.text({}),
-                headers: undefined,
+                body: FernIr.HttpResponseBody.text({ docs: undefined, v2Examples: undefined }),
                 statusCode: undefined,
-                docs: undefined,
-                v2StatusCodes: undefined
+                isWildcardStatusCode: undefined,
+                docs: undefined
             };
             const impl = createImpl({ endpoint });
             const context = createMockSdkContext();
@@ -595,6 +595,7 @@ function createCursorPagination(): FernIr.Pagination {
 
 function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
     return {
+        id: undefined,
         name: undefined,
         url: "/test",
         rootPathParameters: [],
@@ -604,10 +605,7 @@ function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
         serviceHeaders: [],
         queryParameters: [],
         request: undefined,
-        response: {
-            type: "ok",
-            body: undefined
-        },
+        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body({ jsonExample: undefined, docs: undefined })),
         docs: undefined
     };
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
@@ -1,0 +1,613 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode } from "@fern-typescript/commons";
+import { createHttpEndpoint, createNameAndWireValue } from "@fern-typescript/test-utils";
+import { ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import type { GeneratedEndpointRequest } from "../endpoint-request/GeneratedEndpointRequest.js";
+import type { GeneratedEndpointResponse } from "../endpoints/default/endpoint-response/GeneratedEndpointResponse.js";
+import { GeneratedDefaultEndpointImplementation } from "../endpoints/default/GeneratedDefaultEndpointImplementation.js";
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function serializeStatements(statements: ts.Statement[]): string {
+    return statements.map((s) => getTextOfTsNode(s)).join("\n");
+}
+
+/**
+ * Creates a mock GeneratedEndpointRequest with configurable return values.
+ */
+function createMockRequest(opts?: {
+    endpointParameters?: { name: string; type: string; docs?: string }[];
+    buildStatements?: ts.Statement[];
+    fetcherArgs?: Record<string, ts.Expression>;
+    requestParameter?: ts.TypeNode;
+    exampleParameters?: ts.Expression[];
+    exampleImports?: ts.Statement[];
+}): GeneratedEndpointRequest {
+    return {
+        getEndpointParameters: () =>
+            (opts?.endpointParameters ?? []).map((p) => ({
+                name: p.name,
+                type: p.type,
+                hasQuestionToken: false,
+                docs: p.docs
+            })),
+        getBuildRequestStatements: () => opts?.buildStatements ?? [],
+        getFetcherRequestArgs: () => ({
+            headers: opts?.fetcherArgs?.headers,
+            queryParameters: opts?.fetcherArgs?.queryParameters,
+            body: opts?.fetcherArgs?.body,
+            contentType: undefined,
+            requestType: undefined
+        }),
+        getRequestParameter: () => opts?.requestParameter,
+        getReferenceToRequestBody: () => undefined,
+        getReferenceToPathParameter: (key: string) => ts.factory.createIdentifier(key),
+        getReferenceToQueryParameter: (key: string) => ts.factory.createIdentifier(key),
+        getExampleEndpointParameters: () => opts?.exampleParameters ?? [ts.factory.createStringLiteral("example-arg")],
+        getExampleEndpointImports: () => opts?.exampleImports ?? []
+    };
+}
+
+/**
+ * Creates a mock GeneratedEndpointResponse with configurable return values.
+ */
+function createMockResponse(opts?: {
+    returnType?: ts.TypeNode;
+    responseVariableName?: string;
+    returnStatements?: ts.Statement[];
+    thrownExceptions?: string[];
+    paginationInfo?: GeneratedEndpointResponse["getPaginationInfo"] extends (ctx: infer _C) => infer R ? R : never;
+}): GeneratedEndpointResponse {
+    return {
+        getReturnType: () => opts?.returnType ?? ts.factory.createTypeReferenceNode("void"),
+        getResponseVariableName: () => opts?.responseVariableName ?? "_response",
+        getReturnResponseStatements: () =>
+            opts?.returnStatements ?? [
+                ts.factory.createReturnStatement(
+                    ts.factory.createPropertyAccessExpression(
+                        ts.factory.createIdentifier("_response"),
+                        ts.factory.createIdentifier("body")
+                    )
+                )
+            ],
+        getNamesOfThrownExceptions: () => opts?.thrownExceptions ?? [],
+        getPaginationInfo: () => opts?.paginationInfo ?? undefined
+    };
+}
+
+/**
+ * Creates a mock GeneratedSdkClientClassImpl that satisfies what endpoint implementations access.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test mock needs to satisfy complex interface
+function createMockClientClass(opts?: { hasRequestOptions?: boolean }): any {
+    return {
+        getBaseUrl: () => ts.factory.createIdentifier("this._options.baseUrl"),
+        getReferenceToOptions: () =>
+            ts.factory.createPropertyAccessExpression(ts.factory.createThis(), ts.factory.createIdentifier("_options")),
+        getReferenceToTimeoutInSeconds: () => ts.factory.createIdentifier("this._options.timeoutInSeconds"),
+        getReferenceToMaxRetries: () => ts.factory.createIdentifier("this._options.maxRetries"),
+        getReferenceToAbortSignal: () => ts.factory.createIdentifier("requestOptions?.abortSignal"),
+        getReferenceToFetch: () => undefined,
+        getReferenceToLogger: () => undefined,
+        getReferenceToFetcher: () => ts.factory.createIdentifier("this._options.fetcher"),
+        getReferenceToRequestOptions: () => ts.factory.createTypeReferenceNode("RequestOptions"),
+        getReferenceToMetadataForEndpointSupplier: () => undefined,
+        getRequestOptionsType: (idempotent: boolean) => (idempotent ? "IdempotentRequestOptions" : "RequestOptions"),
+        accessFromRootClient: ({ referenceToRootClient }: { referenceToRootClient: ts.Identifier }) =>
+            ts.factory.createPropertyAccessExpression(referenceToRootClient, ts.factory.createIdentifier("service")),
+        hasAuthProvider: () => false,
+        getGenerateEndpointMetadata: () => false,
+        getReferenceToAuthProviderOrThrow: () => ts.factory.createIdentifier("this._authProvider"),
+        getEnvironment: () => undefined
+    };
+}
+
+/**
+ * Creates a mock SdkContext for endpoint implementation tests.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test mock needs to satisfy complex SdkContext interface
+function createMockSdkContext(): any {
+    return {
+        config: {
+            generatePaginatedClients: false
+        },
+        sdkInstanceReferenceForSnippet: ts.factory.createIdentifier("client"),
+        coreUtilities: {
+            fetcher: {
+                EndpointMetadata: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.EndpointMetadata")
+                },
+                fetcher: {
+                    _invoke: (
+                        // biome-ignore lint/suspicious/noExplicitAny: test mock
+                        args: any,
+                        // biome-ignore lint/suspicious/noExplicitAny: test mock
+                        invokeOpts: any
+                    ) =>
+                        ts.factory.createAwaitExpression(
+                            ts.factory.createCallExpression(
+                                ts.factory.createPropertyAccessExpression(
+                                    invokeOpts.referenceToFetcher,
+                                    ts.factory.createIdentifier("fetch")
+                                ),
+                                undefined,
+                                [ts.factory.createObjectLiteralExpression([], true)]
+                            )
+                        ),
+                    _getReferenceTo: () => ts.factory.createIdentifier("core.fetcher")
+                },
+                Fetcher: {
+                    Args: {
+                        _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.Fetcher.Args")
+                    }
+                },
+                HttpResponsePromise: {
+                    interceptFunction: (fn: ts.Expression) =>
+                        ts.factory.createCallExpression(
+                            ts.factory.createIdentifier("core.HttpResponsePromise.interceptFunction"),
+                            undefined,
+                            [fn]
+                        )
+                },
+                RawResponse: {
+                    WithRawResponse: {
+                        _getReferenceToType: (typeArg: ts.TypeNode) =>
+                            ts.factory.createTypeReferenceNode("core.RawResponse.WithRawResponse", [typeArg])
+                    }
+                },
+                BinaryResponse: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.BinaryResponse")
+                }
+            },
+            urlUtils: {
+                join: {
+                    _invoke: (args: ts.Expression[]) =>
+                        ts.factory.createCallExpression(ts.factory.createIdentifier("core.urlJoin"), undefined, args)
+                }
+            },
+            pagination: {
+                Page: {
+                    _getReferenceToType: (itemType: ts.TypeNode, responseType: ts.TypeNode) =>
+                        ts.factory.createTypeReferenceNode("core.Page", [itemType, responseType]),
+                    _construct: (args: Record<string, ts.Expression | ts.TypeNode>) =>
+                        ts.factory.createNewExpression(ts.factory.createIdentifier("core.Page"), undefined, [
+                            ts.factory.createObjectLiteralExpression([], true)
+                        ])
+                }
+            },
+            customPagination: {
+                CustomPager: {
+                    _getReferenceToType: (itemType: ts.TypeNode, responseType: ts.TypeNode) =>
+                        ts.factory.createTypeReferenceNode("core.CustomPager", [itemType, responseType]),
+                    _create: (args: Record<string, ts.Expression | ts.TypeNode>) =>
+                        ts.factory.createCallExpression(
+                            ts.factory.createIdentifier("core.CustomPager.create"),
+                            undefined,
+                            [ts.factory.createObjectLiteralExpression([], true)]
+                        )
+                }
+            }
+        }
+    };
+}
+
+/**
+ * Creates a GeneratedDefaultEndpointImplementation with configurable options.
+ */
+function createImpl(opts?: {
+    endpoint?: FernIr.HttpEndpoint;
+    request?: GeneratedEndpointRequest;
+    response?: GeneratedEndpointResponse;
+    includeCredentialsOnCrossOriginRequests?: boolean;
+    defaultTimeoutInSeconds?: number | "infinity" | undefined;
+    includeSerdeLayer?: boolean;
+    retainOriginalCasing?: boolean;
+    omitUndefined?: boolean;
+    generateEndpointMetadata?: boolean;
+    parameterNaming?: "originalName" | "wireValue" | "camelCase" | "snakeCase" | "default";
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    generatedSdkClientClass?: any;
+}): GeneratedDefaultEndpointImplementation {
+    return new GeneratedDefaultEndpointImplementation({
+        endpoint: opts?.endpoint ?? createHttpEndpoint(),
+        request: opts?.request ?? createMockRequest(),
+        response: opts?.response ?? createMockResponse(),
+        generatedSdkClientClass: opts?.generatedSdkClientClass ?? createMockClientClass(),
+        includeCredentialsOnCrossOriginRequests: opts?.includeCredentialsOnCrossOriginRequests ?? false,
+        defaultTimeoutInSeconds: opts?.defaultTimeoutInSeconds,
+        includeSerdeLayer: opts?.includeSerdeLayer ?? true,
+        retainOriginalCasing: opts?.retainOriginalCasing ?? false,
+        omitUndefined: opts?.omitUndefined ?? false,
+        generateEndpointMetadata: opts?.generateEndpointMetadata ?? false,
+        parameterNaming: opts?.parameterNaming ?? "default"
+    });
+}
+
+// ========================== Tests ==========================
+
+describe("GeneratedDefaultEndpointImplementation", () => {
+    describe("isPaginated", () => {
+        it("returns false when no pagination info", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            expect(impl.isPaginated(context)).toBe(false);
+        });
+
+        it("returns true when pagination info is present", () => {
+            const impl = createImpl({
+                response: createMockResponse({
+                    paginationInfo: {
+                        type: "cursor",
+                        responseType: ts.factory.createTypeReferenceNode("ListResponse"),
+                        itemType: ts.factory.createTypeReferenceNode("Item"),
+                        getItems: ts.factory.createIdentifier("response.items"),
+                        hasNextPage: ts.factory.createIdentifier("response.hasNext"),
+                        loadPage: []
+                    }
+                })
+            });
+            const context = createMockSdkContext();
+            expect(impl.isPaginated(context)).toBe(true);
+        });
+    });
+
+    describe("getOverloads", () => {
+        it("always returns empty array", () => {
+            const impl = createImpl();
+            expect(impl.getOverloads()).toEqual([]);
+        });
+    });
+
+    describe("getSignature", () => {
+        it("returns parameters and return type for basic endpoint", () => {
+            const impl = createImpl({
+                request: createMockRequest({
+                    endpointParameters: [{ name: "userId", type: "string" }]
+                }),
+                response: createMockResponse({
+                    returnType: ts.factory.createTypeReferenceNode("User")
+                })
+            });
+            const context = createMockSdkContext();
+            const sig = impl.getSignature(context);
+            // endpoint param + requestOptions param
+            expect(sig.parameters).toHaveLength(2);
+            expect(sig.parameters[0]?.name).toBe("userId");
+            expect(getTextOfTsNode(sig.returnTypeWithoutPromise)).toBe("User");
+        });
+
+        it("returns paginated return type when cursor pagination present", () => {
+            const impl = createImpl({
+                response: createMockResponse({
+                    returnType: ts.factory.createTypeReferenceNode("ListResponse"),
+                    paginationInfo: {
+                        type: "cursor",
+                        responseType: ts.factory.createTypeReferenceNode("ListResponse"),
+                        itemType: ts.factory.createTypeReferenceNode("Item"),
+                        getItems: ts.factory.createIdentifier("response.items"),
+                        hasNextPage: ts.factory.createIdentifier("response.hasNext"),
+                        loadPage: []
+                    }
+                })
+            });
+            const context = createMockSdkContext();
+            const sig = impl.getSignature(context);
+            expect(getTextOfTsNode(sig.returnTypeWithoutPromise)).toMatchSnapshot();
+        });
+
+        it("returns custom pager return type when custom pagination present", () => {
+            const impl = createImpl({
+                response: createMockResponse({
+                    returnType: ts.factory.createTypeReferenceNode("ListResponse"),
+                    paginationInfo: {
+                        type: "custom",
+                        responseType: ts.factory.createTypeReferenceNode("ListResponse"),
+                        itemType: ts.factory.createTypeReferenceNode("Item"),
+                        getItems: ts.factory.createIdentifier("response.items"),
+                        hasNextPage: ts.factory.createIdentifier("response.hasNext"),
+                        loadPage: []
+                    }
+                })
+            });
+            const context = createMockSdkContext();
+            const sig = impl.getSignature(context);
+            expect(getTextOfTsNode(sig.returnTypeWithoutPromise)).toMatchSnapshot();
+        });
+    });
+
+    describe("getDocs", () => {
+        it("generates docs with endpoint docs and parameter docs", () => {
+            const endpoint = createHttpEndpoint({ docs: "Fetches a user by ID." });
+            const impl = createImpl({
+                endpoint,
+                request: createMockRequest({
+                    endpointParameters: [{ name: "userId", type: "string", docs: "The user's unique identifier." }]
+                })
+            });
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toMatchSnapshot();
+        });
+
+        it("includes @throws annotations for thrown exceptions", () => {
+            const impl = createImpl({
+                response: createMockResponse({
+                    thrownExceptions: ["NotFoundError", "UnauthorizedError"]
+                })
+            });
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toContain("@throws {@link NotFoundError}");
+            expect(docs).toContain("@throws {@link UnauthorizedError}");
+        });
+
+        it("generates docs with no endpoint docs (params only)", () => {
+            const impl = createImpl({
+                request: createMockRequest({
+                    endpointParameters: [{ name: "id", type: "number" }]
+                })
+            });
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toMatchSnapshot();
+        });
+
+        it("includes availability docs when endpoint has availability", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.availability = {
+                status: "DEPRECATED",
+                message: "Use v2 instead"
+            };
+            const impl = createImpl({ endpoint });
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toContain("@deprecated");
+        });
+
+        it("includes requestOptions parameter doc for idempotent endpoint", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.idempotent = true;
+            const impl = createImpl({ endpoint });
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toContain("IdempotentRequestOptions");
+        });
+    });
+
+    describe("getExample", () => {
+        it("returns endpoint invocation example", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const example = impl.getExample({
+                context,
+                example: createMinimalExampleEndpointCall(),
+                opts: { isForComment: true },
+                clientReference: ts.factory.createIdentifier("client")
+            });
+            expect(example).toBeDefined();
+            expect(getTextOfTsNode(example?.endpointInvocation)).toMatchSnapshot();
+        });
+
+        it("returns undefined when example parameters are null", () => {
+            const impl = createImpl({
+                request: createMockRequest({ exampleParameters: undefined })
+            });
+            // Override to return null
+            // biome-ignore lint/suspicious/noExplicitAny: test mock override
+            (impl as any).request.getExampleEndpointParameters = () => undefined;
+            const context = createMockSdkContext();
+            const example = impl.getExample({
+                context,
+                example: createMinimalExampleEndpointCall(),
+                opts: { isForComment: true },
+                clientReference: ts.factory.createIdentifier("client")
+            });
+            expect(example).toBeUndefined();
+        });
+    });
+
+    describe("getStatements", () => {
+        it("generates basic endpoint body (no pagination)", () => {
+            const impl = createImpl({
+                request: createMockRequest({
+                    buildStatements: [
+                        ts.factory.createVariableStatement(
+                            undefined,
+                            ts.factory.createVariableDeclarationList(
+                                [
+                                    ts.factory.createVariableDeclaration(
+                                        "_headers",
+                                        undefined,
+                                        undefined,
+                                        ts.factory.createObjectLiteralExpression([])
+                                    )
+                                ],
+                                ts.NodeFlags.Const
+                            )
+                        )
+                    ]
+                })
+            });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates endpoint body with endpoint metadata", () => {
+            const impl = createImpl({
+                generateEndpointMetadata: true,
+                request: createMockRequest()
+            });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("invokeFetcherAndReturnResponse", () => {
+        it("generates fetcher invocation and response handling", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const stmts = impl.invokeFetcherAndReturnResponse(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("maybeLeverageInvocation", () => {
+        it("returns undefined when endpoint has no pagination", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const result = impl.maybeLeverageInvocation({
+                invocation: ts.factory.createIdentifier("result"),
+                context
+            });
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined when generatePaginatedClients is false", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.pagination = createCursorPagination();
+            const impl = createImpl({ endpoint });
+            const context = createMockSdkContext();
+            // generatePaginatedClients is false by default
+            const result = impl.maybeLeverageInvocation({
+                invocation: ts.factory.createIdentifier("result"),
+                context
+            });
+            expect(result).toBeUndefined();
+        });
+
+        it("returns pagination leverage code when pagination and generatePaginatedClients are both set", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.pagination = createCursorPagination();
+            const impl = createImpl({ endpoint });
+            const context = createMockSdkContext();
+            context.config.generatePaginatedClients = true;
+            const result = impl.maybeLeverageInvocation({
+                invocation: ts.factory.createIdentifier("result"),
+                context
+            });
+            expect(result).toBeDefined();
+            const output = (result as ts.Node[]).map((n) => getTextOfTsNode(n)).join("\n");
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("endpoint property", () => {
+        it("exposes the endpoint from constructor", () => {
+            const endpoint = createHttpEndpoint({ docs: "test endpoint" });
+            const impl = createImpl({ endpoint });
+            expect(impl.endpoint).toBe(endpoint);
+        });
+    });
+
+    describe("response property", () => {
+        it("exposes the response from constructor", () => {
+            const response = createMockResponse();
+            const impl = createImpl({ response });
+            expect(impl.response).toBe(response);
+        });
+    });
+
+    describe("includeCredentialsOnCrossOriginRequests", () => {
+        it("adds withCredentials to fetcher args when enabled", () => {
+            const impl = createImpl({
+                includeCredentialsOnCrossOriginRequests: true
+            });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("text response type", () => {
+        it("sets responseType to text for text response endpoints", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.response = {
+                body: FernIr.HttpResponseBody.text({}),
+                headers: undefined,
+                statusCode: undefined,
+                docs: undefined,
+                v2StatusCodes: undefined
+            };
+            const impl = createImpl({ endpoint });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+    });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IR factory helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function createCursorPagination(): FernIr.Pagination {
+    return FernIr.Pagination.cursor({
+        page: {
+            propertyPath: undefined,
+            property: {
+                name: createNameAndWireValue("cursor"),
+                valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                docs: undefined,
+                availability: undefined,
+                v2Examples: undefined,
+                propertyAccess: undefined
+            }
+        },
+        next: {
+            propertyPath: undefined,
+            property: {
+                name: createNameAndWireValue("nextCursor"),
+                valueType: FernIr.TypeReference.container(
+                    FernIr.ContainerType.optional(FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }))
+                ),
+                docs: undefined,
+                availability: undefined,
+                v2Examples: undefined,
+                propertyAccess: undefined
+            }
+        },
+        results: {
+            propertyPath: undefined,
+            property: {
+                name: createNameAndWireValue("items"),
+                valueType: FernIr.TypeReference.container(
+                    FernIr.ContainerType.list(FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }))
+                ),
+                docs: undefined,
+                availability: undefined,
+                v2Examples: undefined,
+                propertyAccess: undefined
+            }
+        },
+        extendedResults: undefined
+    });
+}
+
+function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
+    return {
+        name: undefined,
+        url: "/test",
+        rootPathParameters: [],
+        endpointPathParameters: [],
+        servicePathParameters: [],
+        endpointHeaders: [],
+        serviceHeaders: [],
+        queryParameters: [],
+        request: undefined,
+        response: {
+            type: "ok",
+            body: undefined
+        },
+        docs: undefined
+    };
+}

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedFileDownloadEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedFileDownloadEndpointImplementation.test.ts
@@ -1,0 +1,456 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode } from "@fern-typescript/commons";
+import { createHttpEndpoint } from "@fern-typescript/test-utils";
+import { ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import type { GeneratedEndpointRequest } from "../endpoint-request/GeneratedEndpointRequest.js";
+import type { GeneratedEndpointResponse } from "../endpoints/default/endpoint-response/GeneratedEndpointResponse.js";
+import { GeneratedFileDownloadEndpointImplementation } from "../endpoints/GeneratedFileDownloadEndpointImplementation.js";
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function serializeStatements(statements: ts.Statement[]): string {
+    return statements.map((s) => getTextOfTsNode(s)).join("\n");
+}
+
+/**
+ * Creates a mock GeneratedEndpointRequest for file download endpoint tests.
+ */
+function createMockRequest(opts?: {
+    endpointParameters?: { name: string; type: string; docs?: string }[];
+    buildStatements?: ts.Statement[];
+    fetcherArgs?: Record<string, ts.Expression>;
+    exampleParameters?: ts.Expression[];
+    exampleImports?: ts.Statement[];
+}): GeneratedEndpointRequest {
+    return {
+        getEndpointParameters: () =>
+            (opts?.endpointParameters ?? []).map((p) => ({
+                name: p.name,
+                type: p.type,
+                hasQuestionToken: false,
+                docs: p.docs
+            })),
+        getBuildRequestStatements: () => opts?.buildStatements ?? [],
+        getFetcherRequestArgs: () => ({
+            headers: opts?.fetcherArgs?.headers,
+            queryParameters: opts?.fetcherArgs?.queryParameters,
+            body: opts?.fetcherArgs?.body,
+            contentType: undefined,
+            requestType: undefined
+        }),
+        getRequestParameter: () => undefined,
+        getReferenceToRequestBody: () => undefined,
+        getReferenceToPathParameter: (key: string) => ts.factory.createIdentifier(key),
+        getReferenceToQueryParameter: (key: string) => ts.factory.createIdentifier(key),
+        getExampleEndpointParameters: () => opts?.exampleParameters ?? [ts.factory.createStringLiteral("example-arg")],
+        getExampleEndpointImports: () => opts?.exampleImports ?? []
+    };
+}
+
+/**
+ * Creates a mock GeneratedEndpointResponse for file download endpoint tests.
+ */
+function createMockResponse(opts?: {
+    returnType?: ts.TypeNode;
+    responseVariableName?: string;
+    returnStatements?: ts.Statement[];
+    thrownExceptions?: string[];
+}): GeneratedEndpointResponse {
+    return {
+        getReturnType: () => opts?.returnType ?? ts.factory.createTypeReferenceNode("ReadableStream"),
+        getResponseVariableName: () => opts?.responseVariableName ?? "_response",
+        getReturnResponseStatements: () =>
+            opts?.returnStatements ?? [ts.factory.createReturnStatement(ts.factory.createIdentifier("_response"))],
+        getNamesOfThrownExceptions: () => opts?.thrownExceptions ?? [],
+        getPaginationInfo: () => undefined
+    };
+}
+
+/**
+ * Creates a mock GeneratedSdkClientClassImpl for file download endpoint tests.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test mock needs to satisfy complex interface
+function createMockClientClass(): any {
+    return {
+        getBaseUrl: () => ts.factory.createIdentifier("this._options.baseUrl"),
+        getReferenceToOptions: () =>
+            ts.factory.createPropertyAccessExpression(ts.factory.createThis(), ts.factory.createIdentifier("_options")),
+        getReferenceToTimeoutInSeconds: () => ts.factory.createIdentifier("this._options.timeoutInSeconds"),
+        getReferenceToMaxRetries: () => ts.factory.createIdentifier("this._options.maxRetries"),
+        getReferenceToAbortSignal: () => ts.factory.createIdentifier("requestOptions?.abortSignal"),
+        getReferenceToFetch: () => undefined,
+        getReferenceToLogger: () => undefined,
+        getReferenceToFetcher: () => ts.factory.createIdentifier("this._options.fetcher"),
+        getReferenceToRequestOptions: () => ts.factory.createTypeReferenceNode("RequestOptions"),
+        getReferenceToMetadataForEndpointSupplier: () => undefined,
+        accessFromRootClient: ({ referenceToRootClient }: { referenceToRootClient: ts.Identifier }) =>
+            ts.factory.createPropertyAccessExpression(referenceToRootClient, ts.factory.createIdentifier("service")),
+        hasAuthProvider: () => false,
+        getGenerateEndpointMetadata: () => false,
+        getReferenceToAuthProviderOrThrow: () => ts.factory.createIdentifier("this._authProvider"),
+        getEnvironment: () => undefined
+    };
+}
+
+/**
+ * Creates a mock SdkContext for file download endpoint tests.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test mock needs to satisfy complex SdkContext interface
+function createMockSdkContext(): any {
+    return {
+        coreUtilities: {
+            fetcher: {
+                EndpointMetadata: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.EndpointMetadata")
+                },
+                fetcher: {
+                    _invoke: (
+                        // biome-ignore lint/suspicious/noExplicitAny: test mock
+                        _args: any,
+                        // biome-ignore lint/suspicious/noExplicitAny: test mock
+                        invokeOpts: any
+                    ) =>
+                        ts.factory.createAwaitExpression(
+                            ts.factory.createCallExpression(
+                                ts.factory.createPropertyAccessExpression(
+                                    invokeOpts.referenceToFetcher,
+                                    ts.factory.createIdentifier("fetch")
+                                ),
+                                undefined,
+                                [ts.factory.createObjectLiteralExpression([], true)]
+                            )
+                        )
+                },
+                BinaryResponse: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.BinaryResponse")
+                }
+            },
+            urlUtils: {
+                join: {
+                    _invoke: (args: ts.Expression[]) =>
+                        ts.factory.createCallExpression(ts.factory.createIdentifier("core.urlJoin"), undefined, args)
+                }
+            },
+            streamUtils: {
+                ReadableStream: {
+                    _getReferenceToType: (typeArg?: ts.TypeNode) =>
+                        typeArg
+                            ? ts.factory.createTypeReferenceNode("ReadableStream", [typeArg])
+                            : ts.factory.createTypeReferenceNode("ReadableStream")
+                },
+                Stream: {
+                    _getReferenceToType: (typeArg?: ts.TypeNode) =>
+                        typeArg
+                            ? ts.factory.createTypeReferenceNode("core.Stream", [typeArg])
+                            : ts.factory.createTypeReferenceNode("core.Stream")
+                }
+            }
+        },
+        externalDependencies: {
+            stream: {
+                Readable: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("Readable")
+                }
+            }
+        }
+    };
+}
+
+/**
+ * Creates a GeneratedFileDownloadEndpointImplementation with configurable options.
+ */
+function createImpl(opts?: {
+    endpoint?: FernIr.HttpEndpoint;
+    request?: GeneratedEndpointRequest;
+    response?: GeneratedEndpointResponse;
+    includeCredentialsOnCrossOriginRequests?: boolean;
+    defaultTimeoutInSeconds?: number | "infinity" | undefined;
+    includeSerdeLayer?: boolean;
+    retainOriginalCasing?: boolean;
+    omitUndefined?: boolean;
+    streamType?: "wrapper" | "web";
+    fileResponseType?: "stream" | "binary-response";
+    generateEndpointMetadata?: boolean;
+    parameterNaming?: "originalName" | "wireValue" | "camelCase" | "snakeCase" | "default";
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    generatedSdkClientClass?: any;
+}): GeneratedFileDownloadEndpointImplementation {
+    return new GeneratedFileDownloadEndpointImplementation({
+        endpoint: opts?.endpoint ?? createHttpEndpoint(),
+        request: opts?.request ?? createMockRequest(),
+        response: opts?.response ?? createMockResponse(),
+        generatedSdkClientClass: opts?.generatedSdkClientClass ?? createMockClientClass(),
+        includeCredentialsOnCrossOriginRequests: opts?.includeCredentialsOnCrossOriginRequests ?? false,
+        defaultTimeoutInSeconds: opts?.defaultTimeoutInSeconds,
+        includeSerdeLayer: opts?.includeSerdeLayer ?? true,
+        retainOriginalCasing: opts?.retainOriginalCasing ?? false,
+        omitUndefined: opts?.omitUndefined ?? false,
+        streamType: opts?.streamType ?? "wrapper",
+        fileResponseType: opts?.fileResponseType ?? "stream",
+        generateEndpointMetadata: opts?.generateEndpointMetadata ?? false,
+        parameterNaming: opts?.parameterNaming ?? "default"
+    });
+}
+
+// ========================== Tests ==========================
+
+describe("GeneratedFileDownloadEndpointImplementation", () => {
+    describe("isPaginated", () => {
+        it("always returns false", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            expect(impl.isPaginated(context)).toBe(false);
+        });
+    });
+
+    describe("getOverloads", () => {
+        it("always returns empty array", () => {
+            const impl = createImpl();
+            expect(impl.getOverloads()).toEqual([]);
+        });
+    });
+
+    describe("maybeLeverageInvocation", () => {
+        it("always returns undefined", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const result = impl.maybeLeverageInvocation({
+                invocation: ts.factory.createIdentifier("result"),
+                context
+            });
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe("getSignature", () => {
+        it("returns parameters and return type for stream file download", () => {
+            const impl = createImpl({
+                request: createMockRequest({
+                    endpointParameters: [{ name: "fileId", type: "string" }]
+                }),
+                response: createMockResponse({
+                    returnType: ts.factory.createTypeReferenceNode("ReadableStream")
+                })
+            });
+            const context = createMockSdkContext();
+            const sig = impl.getSignature(context);
+            expect(sig.parameters).toHaveLength(2);
+            expect(sig.parameters[0]?.name).toBe("fileId");
+            expect(getTextOfTsNode(sig.returnTypeWithoutPromise)).toBe("ReadableStream");
+        });
+
+        it("returns binary-response return type", () => {
+            const impl = createImpl({
+                fileResponseType: "binary-response",
+                response: createMockResponse({
+                    returnType: ts.factory.createTypeReferenceNode("core.BinaryResponse")
+                })
+            });
+            const context = createMockSdkContext();
+            const sig = impl.getSignature(context);
+            expect(getTextOfTsNode(sig.returnTypeWithoutPromise)).toBe("core.BinaryResponse");
+        });
+    });
+
+    describe("getDocs", () => {
+        it("returns undefined when no docs, availability, or exceptions", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toBeUndefined();
+        });
+
+        it("returns endpoint docs when present", () => {
+            const endpoint = createHttpEndpoint({ docs: "Download a file by its ID." });
+            const impl = createImpl({ endpoint });
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toBe("Download a file by its ID.");
+        });
+
+        it("includes @throws annotations for thrown exceptions", () => {
+            const impl = createImpl({
+                response: createMockResponse({
+                    thrownExceptions: ["NotFoundError", "ForbiddenError"]
+                })
+            });
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toContain("@throws {@link NotFoundError}");
+            expect(docs).toContain("@throws {@link ForbiddenError}");
+        });
+
+        it("includes availability docs when deprecated", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.availability = {
+                status: "DEPRECATED",
+                message: "Use downloadV2"
+            };
+            const impl = createImpl({ endpoint });
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toContain("@deprecated");
+        });
+
+        it("combines docs, availability, and exceptions", () => {
+            const endpoint = createHttpEndpoint({ docs: "Download a file." });
+            endpoint.availability = {
+                status: "DEPRECATED",
+                message: undefined
+            };
+            const impl = createImpl({
+                endpoint,
+                response: createMockResponse({ thrownExceptions: ["NotFoundError"] })
+            });
+            const context = createMockSdkContext();
+            const docs = impl.getDocs(context);
+            expect(docs).toMatchSnapshot();
+        });
+    });
+
+    describe("getStatements", () => {
+        it("generates file download endpoint body with stream response type", () => {
+            const impl = createImpl({ fileResponseType: "stream" });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates file download endpoint body with binary-response type", () => {
+            const impl = createImpl({ fileResponseType: "binary-response" });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates endpoint body with endpoint metadata", () => {
+            const impl = createImpl({ generateEndpointMetadata: true });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("includes request build statements", () => {
+            const buildStmt = ts.factory.createVariableStatement(
+                undefined,
+                ts.factory.createVariableDeclarationList(
+                    [
+                        ts.factory.createVariableDeclaration(
+                            "_headers",
+                            undefined,
+                            undefined,
+                            ts.factory.createObjectLiteralExpression([])
+                        )
+                    ],
+                    ts.NodeFlags.Const
+                )
+            );
+            const impl = createImpl({
+                request: createMockRequest({ buildStatements: [buildStmt] })
+            });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toContain("_headers");
+        });
+    });
+
+    describe("invokeFetcher", () => {
+        it("generates fetcher invocation with streaming response type", () => {
+            const impl = createImpl({ fileResponseType: "stream" });
+            const context = createMockSdkContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates fetcher invocation with binary-response type", () => {
+            const impl = createImpl({ fileResponseType: "binary-response" });
+            const context = createMockSdkContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("includes withCredentials when enabled", () => {
+            const impl = createImpl({ includeCredentialsOnCrossOriginRequests: true });
+            const context = createMockSdkContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("getExample", () => {
+        it("returns endpoint invocation example", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const example = impl.getExample({
+                context,
+                example: createMinimalExampleEndpointCall(),
+                opts: { isForComment: true },
+                clientReference: ts.factory.createIdentifier("client")
+            });
+            expect(example).toBeDefined();
+            expect(getTextOfTsNode(example?.endpointInvocation)).toMatchSnapshot();
+        });
+
+        it("returns undefined when example parameters are null", () => {
+            const request = createMockRequest();
+            // biome-ignore lint/suspicious/noExplicitAny: test mock override
+            (request as any).getExampleEndpointParameters = () => undefined;
+            const impl = createImpl({ request });
+            const context = createMockSdkContext();
+            const example = impl.getExample({
+                context,
+                example: createMinimalExampleEndpointCall(),
+                opts: {},
+                clientReference: ts.factory.createIdentifier("client")
+            });
+            expect(example).toBeUndefined();
+        });
+    });
+
+    describe("endpoint and response properties", () => {
+        it("exposes endpoint from constructor", () => {
+            const endpoint = createHttpEndpoint({ docs: "download endpoint" });
+            const impl = createImpl({ endpoint });
+            expect(impl.endpoint).toBe(endpoint);
+        });
+
+        it("exposes response from constructor", () => {
+            const response = createMockResponse();
+            const impl = createImpl({ response });
+            expect(impl.response).toBe(response);
+        });
+    });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IR factory helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
+    return {
+        name: undefined,
+        url: "/download",
+        rootPathParameters: [],
+        endpointPathParameters: [],
+        servicePathParameters: [],
+        endpointHeaders: [],
+        serviceHeaders: [],
+        queryParameters: [],
+        request: undefined,
+        response: {
+            type: "ok",
+            body: undefined
+        },
+        docs: undefined
+    };
+}

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedFileDownloadEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedFileDownloadEndpointImplementation.test.ts
@@ -386,6 +386,14 @@ describe("GeneratedFileDownloadEndpointImplementation", () => {
             const output = serializeStatements(stmts);
             expect(output).toMatchSnapshot();
         });
+
+        it("uses web stream type when streamType is web and fileResponseType is stream", () => {
+            const impl = createImpl({ streamType: "web", fileResponseType: "stream" });
+            const context = createMockSdkContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
     });
 
     describe("getExample", () => {

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedFileDownloadEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedFileDownloadEndpointImplementation.test.ts
@@ -2,7 +2,7 @@ import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
 import { createHttpEndpoint } from "@fern-typescript/test-utils";
 import { ts } from "ts-morph";
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 import type { GeneratedEndpointRequest } from "../endpoint-request/GeneratedEndpointRequest.js";
 import type { GeneratedEndpointResponse } from "../endpoints/default/endpoint-response/GeneratedEndpointResponse.js";
 import { GeneratedFileDownloadEndpointImplementation } from "../endpoints/GeneratedFileDownloadEndpointImplementation.js";
@@ -399,7 +399,8 @@ describe("GeneratedFileDownloadEndpointImplementation", () => {
                 clientReference: ts.factory.createIdentifier("client")
             });
             expect(example).toBeDefined();
-            expect(getTextOfTsNode(example?.endpointInvocation)).toMatchSnapshot();
+            assert(example?.endpointInvocation != null, "Expected endpointInvocation to be defined");
+            expect(getTextOfTsNode(example.endpointInvocation)).toMatchSnapshot();
         });
 
         it("returns undefined when example parameters are null", () => {
@@ -449,7 +450,7 @@ function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
         serviceHeaders: [],
         queryParameters: [],
         request: undefined,
-        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body({ jsonExample: undefined, docs: undefined })),
+        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body(undefined)),
         docs: undefined
     };
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedFileDownloadEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedFileDownloadEndpointImplementation.test.ts
@@ -47,7 +47,8 @@ function createMockRequest(opts?: {
         getReferenceToQueryParameter: (key: string) => ts.factory.createIdentifier(key),
         getExampleEndpointParameters: () => opts?.exampleParameters ?? [ts.factory.createStringLiteral("example-arg")],
         getExampleEndpointImports: () => opts?.exampleImports ?? []
-    };
+        // biome-ignore lint/suspicious/noExplicitAny: test mock for GeneratedEndpointRequest
+    } as any;
 }
 
 /**
@@ -438,6 +439,7 @@ describe("GeneratedFileDownloadEndpointImplementation", () => {
 
 function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
     return {
+        id: undefined,
         name: undefined,
         url: "/download",
         rootPathParameters: [],
@@ -447,10 +449,7 @@ function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
         serviceHeaders: [],
         queryParameters: [],
         request: undefined,
-        response: {
-            type: "ok",
-            body: undefined
-        },
+        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body({ jsonExample: undefined, docs: undefined })),
         docs: undefined
     };
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
@@ -1,7 +1,7 @@
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode, PackageId } from "@fern-typescript/commons";
 import { ErrorResolver, PackageResolver } from "@fern-typescript/resolvers";
-import { createHttpEndpoint, createMinimalIR, createNameAndWireValue } from "@fern-typescript/test-utils";
+import { casingsGenerator, createHttpEndpoint, createMinimalIR, createNameAndWireValue } from "@fern-typescript/test-utils";
 import { ts } from "ts-morph";
 import { assert, describe, expect, it } from "vitest";
 
@@ -281,7 +281,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                 authSchemes: [
                     FernIr.AuthScheme.bearer({
                         key: "bearer",
-                        token: createNameAndWireValue("token"),
+                        token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
                         docs: undefined
                     })
@@ -316,10 +316,12 @@ describe("GeneratedSdkClientClassImpl", () => {
                 authSchemes: [
                     FernIr.AuthScheme.basic({
                         key: "basic",
-                        username: createNameAndWireValue("username"),
+                        username: casingsGenerator.generateName("username"),
                         usernameEnvVar: undefined,
-                        password: createNameAndWireValue("password"),
+                        usernameOmit: undefined,
+                        password: casingsGenerator.generateName("password"),
                         passwordEnvVar: undefined,
+                        passwordOmit: undefined,
                         docs: undefined
                     })
                 ],
@@ -346,7 +348,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                 authSchemes: [
                     FernIr.AuthScheme.bearer({
                         key: "bearer",
-                        token: createNameAndWireValue("token"),
+                        token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
                         docs: undefined
                     }),
@@ -455,7 +457,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                 authSchemes: [
                     FernIr.AuthScheme.bearer({
                         key: "bearer",
-                        token: createNameAndWireValue("token"),
+                        token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
                         docs: undefined
                     })
@@ -492,7 +494,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                 authSchemes: [
                     FernIr.AuthScheme.bearer({
                         key: "bearer",
-                        token: createNameAndWireValue("token"),
+                        token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
                         docs: undefined
                     })
@@ -528,7 +530,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                 authSchemes: [
                     FernIr.AuthScheme.bearer({
                         key: "bearer",
-                        token: createNameAndWireValue("token"),
+                        token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
                         docs: undefined
                     })
@@ -747,7 +749,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                 authSchemes: [
                     FernIr.AuthScheme.bearer({
                         key: "bearer",
-                        token: createNameAndWireValue("token"),
+                        token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
                         docs: undefined
                     }),
@@ -819,6 +821,7 @@ describe("GeneratedSdkClientClassImpl", () => {
 
 function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
     return {
+        id: undefined,
         name: undefined,
         url: "/test",
         rootPathParameters: [],
@@ -828,10 +831,7 @@ function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
         serviceHeaders: [],
         queryParameters: [],
         request: undefined,
-        response: {
-            type: "ok",
-            body: undefined
-        },
+        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body({ jsonExample: undefined, docs: undefined })),
         docs: undefined
     };
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
@@ -1,7 +1,12 @@
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode, PackageId } from "@fern-typescript/commons";
 import { ErrorResolver, PackageResolver } from "@fern-typescript/resolvers";
-import { casingsGenerator, createHttpEndpoint, createMinimalIR, createNameAndWireValue } from "@fern-typescript/test-utils";
+import {
+    casingsGenerator,
+    createHttpEndpoint,
+    createMinimalIR,
+    createNameAndWireValue
+} from "@fern-typescript/test-utils";
 import { ts } from "ts-morph";
 import { assert, describe, expect, it } from "vitest";
 
@@ -831,7 +836,7 @@ function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
         serviceHeaders: [],
         queryParameters: [],
         request: undefined,
-        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body({ jsonExample: undefined, docs: undefined })),
+        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body(undefined)),
         docs: undefined
     };
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
@@ -1,0 +1,837 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode, PackageId } from "@fern-typescript/commons";
+import { ErrorResolver, PackageResolver } from "@fern-typescript/resolvers";
+import { createHttpEndpoint, createMinimalIR, createNameAndWireValue } from "@fern-typescript/test-utils";
+import { ts } from "ts-morph";
+import { assert, describe, expect, it } from "vitest";
+
+import { GeneratedSdkClientClassImpl } from "../GeneratedSdkClientClassImpl.js";
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function serializeExpression(expr: ts.Expression): string {
+    return getTextOfTsNode(expr);
+}
+
+/**
+ * Creates a minimal IR with optional service, auth, headers, and subpackages.
+ */
+function createIR(opts?: {
+    service?: FernIr.HttpService;
+    authSchemes?: FernIr.AuthScheme[];
+    authRequirement?: FernIr.AuthSchemesRequirement;
+    headers?: FernIr.HttpHeader[];
+    variables?: FernIr.VariableDeclaration[];
+    subpackages?: Record<string, FernIr.Subpackage>;
+    rootPackage?: Partial<FernIr.Package>;
+    errors?: Record<string, FernIr.ErrorDeclaration>;
+}): FernIr.IntermediateRepresentation {
+    const ir = createMinimalIR();
+
+    if (opts?.authSchemes || opts?.authRequirement) {
+        ir.auth = {
+            docs: undefined,
+            requirement: opts?.authRequirement ?? "ALL",
+            schemes: opts?.authSchemes ?? []
+        };
+    }
+    if (opts?.headers) {
+        ir.headers = opts.headers;
+    }
+    if (opts?.variables) {
+        ir.variables = opts.variables;
+    }
+    if (opts?.subpackages) {
+        ir.subpackages = opts.subpackages;
+    }
+    if (opts?.errors) {
+        ir.errors = opts.errors;
+    }
+
+    // Set up root package with optional service
+    const serviceId = "service_test";
+    if (opts?.service) {
+        ir.services = { [serviceId]: opts.service };
+        ir.rootPackage = {
+            ...ir.rootPackage,
+            service: serviceId,
+            ...opts?.rootPackage
+        };
+    }
+    if (opts?.rootPackage) {
+        ir.rootPackage = {
+            ...ir.rootPackage,
+            ...opts.rootPackage
+        };
+    }
+
+    return ir;
+}
+
+/**
+ * Creates a mock ImportsManager.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test mock
+function createMockImportsManager(): any {
+    return {
+        addImport: () => undefined,
+        addImportFromRoot: () => undefined
+    };
+}
+
+/**
+ * Creates a mock ExportsManager.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test mock
+function createMockExportsManager(): any {
+    return {
+        addExport: () => undefined,
+        addExportsForFilepath: () => undefined
+    };
+}
+
+/**
+ * Creates a GeneratedSdkClientClassImpl with configurable options.
+ */
+function createClientClass(opts?: {
+    ir?: FernIr.IntermediateRepresentation;
+    isRoot?: boolean;
+    serviceClassName?: string;
+    neverThrowErrors?: boolean;
+    includeCredentialsOnCrossOriginRequests?: boolean;
+    allowCustomFetcher?: boolean;
+    shouldGenerateWebsocketClients?: boolean;
+    requireDefaultEnvironment?: boolean;
+    defaultTimeoutInSeconds?: number | "infinity" | undefined;
+    includeContentHeadersOnFileDownloadResponse?: boolean;
+    includeSerdeLayer?: boolean;
+    retainOriginalCasing?: boolean;
+    inlineFileProperties?: boolean;
+    omitUndefined?: boolean;
+    allowExtraFields?: boolean;
+    streamType?: "wrapper" | "web";
+    fileResponseType?: "stream" | "binary-response";
+    formDataSupport?: "Node16" | "Node18";
+    useDefaultRequestParameterValues?: boolean;
+    generateEndpointMetadata?: boolean;
+    parameterNaming?: "originalName" | "wireValue" | "camelCase" | "snakeCase" | "default";
+    offsetSemantics?: "item-index" | "page-index";
+}): GeneratedSdkClientClassImpl {
+    const ir = opts?.ir ?? createIR();
+    return new GeneratedSdkClientClassImpl({
+        isRoot: opts?.isRoot ?? true,
+        importsManager: createMockImportsManager(),
+        exportsManager: createMockExportsManager(),
+        intermediateRepresentation: ir,
+        packageId: { isRoot: true } as PackageId,
+        serviceClassName: opts?.serviceClassName ?? "TestClient",
+        errorResolver: new ErrorResolver(ir),
+        packageResolver: new PackageResolver(ir),
+        neverThrowErrors: opts?.neverThrowErrors ?? false,
+        includeCredentialsOnCrossOriginRequests: opts?.includeCredentialsOnCrossOriginRequests ?? false,
+        allowCustomFetcher: opts?.allowCustomFetcher ?? false,
+        shouldGenerateWebsocketClients: opts?.shouldGenerateWebsocketClients ?? false,
+        requireDefaultEnvironment: opts?.requireDefaultEnvironment ?? false,
+        defaultTimeoutInSeconds: opts?.defaultTimeoutInSeconds,
+        includeContentHeadersOnFileDownloadResponse: opts?.includeContentHeadersOnFileDownloadResponse ?? false,
+        includeSerdeLayer: opts?.includeSerdeLayer ?? true,
+        retainOriginalCasing: opts?.retainOriginalCasing ?? false,
+        inlineFileProperties: opts?.inlineFileProperties ?? false,
+        omitUndefined: opts?.omitUndefined ?? false,
+        allowExtraFields: opts?.allowExtraFields ?? false,
+        streamType: opts?.streamType ?? "wrapper",
+        fileResponseType: opts?.fileResponseType ?? "stream",
+        formDataSupport: opts?.formDataSupport ?? "Node16",
+        useDefaultRequestParameterValues: opts?.useDefaultRequestParameterValues ?? false,
+        generateEndpointMetadata: opts?.generateEndpointMetadata ?? false,
+        parameterNaming: opts?.parameterNaming ?? "default",
+        offsetSemantics: opts?.offsetSemantics ?? "item-index"
+    });
+}
+
+/**
+ * Creates a minimal mock SdkContext.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test mock needs to satisfy complex SdkContext interface
+function createMockSdkContext(opts?: { ir?: FernIr.IntermediateRepresentation }): any {
+    return {
+        ir: opts?.ir ?? createMinimalIR(),
+        sourceFile: {
+            addModule: () => undefined,
+            addClass: () => undefined
+        },
+        importsManager: createMockImportsManager(),
+        coreUtilities: {
+            fetcher: {
+                EndpointMetadata: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.EndpointMetadata")
+                },
+                fetcher: {
+                    _getReferenceTo: () => ts.factory.createIdentifier("core.fetcher"),
+                    _invoke: (
+                        // biome-ignore lint/suspicious/noExplicitAny: test mock
+                        _args: any,
+                        // biome-ignore lint/suspicious/noExplicitAny: test mock
+                        invokeOpts: any
+                    ) =>
+                        ts.factory.createAwaitExpression(
+                            ts.factory.createCallExpression(
+                                ts.factory.createPropertyAccessExpression(
+                                    invokeOpts.referenceToFetcher,
+                                    ts.factory.createIdentifier("fetch")
+                                ),
+                                undefined,
+                                [ts.factory.createObjectLiteralExpression([], true)]
+                            )
+                        )
+                },
+                Supplier: {
+                    get: (expr: ts.Expression) =>
+                        ts.factory.createAwaitExpression(
+                            ts.factory.createCallExpression(
+                                ts.factory.createIdentifier("core.Supplier.get"),
+                                undefined,
+                                [expr]
+                            )
+                        )
+                },
+                HttpResponsePromise: {
+                    fromPromise: (expr: ts.Expression) =>
+                        ts.factory.createCallExpression(
+                            ts.factory.createIdentifier("core.HttpResponsePromise.fromPromise"),
+                            undefined,
+                            [expr]
+                        ),
+                    _getReferenceToType: (typeArg: ts.TypeNode) =>
+                        ts.factory.createTypeReferenceNode("core.HttpResponsePromise", [typeArg])
+                },
+                RawResponse: {
+                    WithRawResponse: {
+                        _getReferenceToType: (typeArg: ts.TypeNode) =>
+                            ts.factory.createTypeReferenceNode("core.WithRawResponse", [typeArg])
+                    }
+                },
+                BinaryResponse: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.BinaryResponse")
+                }
+            },
+            urlUtils: {
+                join: {
+                    _invoke: (args: ts.Expression[]) =>
+                        ts.factory.createCallExpression(ts.factory.createIdentifier("core.urlJoin"), undefined, args)
+                }
+            }
+        },
+        sdkClientClass: {
+            getReferenceToClientClass: () => ({
+                getExpression: () => ts.factory.createIdentifier("TestClient")
+            }),
+            getReferenceToBaseClientOptions: () => ({
+                getTypeNode: () => ts.factory.createTypeReferenceNode("BaseClientOptions")
+            }),
+            getReferenceToBaseRequestOptions: () => ({
+                getTypeNode: () => ts.factory.createTypeReferenceNode("BaseRequestOptions")
+            }),
+            getReferenceToBaseIdempotentRequestOptions: () => ({
+                getTypeNode: () => ts.factory.createTypeReferenceNode("BaseIdempotentRequestOptions")
+            })
+        },
+        environments: {
+            getGeneratedEnvironments: () => ({
+                getReferenceToDefaultEnvironment: () => undefined,
+                getReferenceToEnvironmentUrl: ({
+                    referenceToEnvironmentValue
+                }: {
+                    referenceToEnvironmentValue: ts.Expression;
+                }) => referenceToEnvironmentValue
+            }),
+            getReferenceToFirstEnvironmentEnum: () => undefined
+        },
+        baseClient: {
+            anyRequiredBaseClientOptions: () => false
+        },
+        versionContext: {
+            getGeneratedVersion: () => undefined
+        },
+        externalDependencies: {
+            stream: {
+                Readable: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("Readable")
+                }
+            }
+        }
+    };
+}
+
+// ========================== Tests ==========================
+
+describe("GeneratedSdkClientClassImpl", () => {
+    describe("constructor", () => {
+        it("creates client class with no service and no auth", () => {
+            const clientClass = createClientClass();
+            expect(clientClass.hasAuthProvider()).toBe(false);
+            expect(clientClass.hasAnyEndpointsWithAuth()).toBe(false);
+            expect(clientClass.getAuthProviderInstance()).toBeUndefined();
+        });
+
+        it("creates client class with bearer auth", () => {
+            const ir = createIR({
+                authSchemes: [
+                    FernIr.AuthScheme.bearer({
+                        key: "bearer",
+                        token: createNameAndWireValue("token"),
+                        tokenEnvVar: undefined,
+                        docs: undefined
+                    })
+                ],
+                authRequirement: "ALL",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [
+                        {
+                            ...createHttpEndpoint(),
+                            auth: true
+                        }
+                    ],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            expect(clientClass.hasAuthProvider()).toBe(true);
+            expect(clientClass.hasAnyEndpointsWithAuth()).toBe(true);
+            expect(clientClass.getAuthProviderInstance()).toBeDefined();
+        });
+
+        it("creates client class with basic auth", () => {
+            const ir = createIR({
+                authSchemes: [
+                    FernIr.AuthScheme.basic({
+                        key: "basic",
+                        username: createNameAndWireValue("username"),
+                        usernameEnvVar: undefined,
+                        password: createNameAndWireValue("password"),
+                        passwordEnvVar: undefined,
+                        docs: undefined
+                    })
+                ],
+                authRequirement: "ALL",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [{ ...createHttpEndpoint(), auth: true }],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            expect(clientClass.hasAuthProvider()).toBe(true);
+        });
+
+        it("creates client class with ANY auth requirement", () => {
+            const ir = createIR({
+                authSchemes: [
+                    FernIr.AuthScheme.bearer({
+                        key: "bearer",
+                        token: createNameAndWireValue("token"),
+                        tokenEnvVar: undefined,
+                        docs: undefined
+                    }),
+                    FernIr.AuthScheme.header({
+                        key: "apiKey",
+                        name: createNameAndWireValue("X-API-Key"),
+                        prefix: undefined,
+                        headerEnvVar: undefined,
+                        valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        docs: undefined
+                    })
+                ],
+                authRequirement: "ANY",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [{ ...createHttpEndpoint(), auth: true }],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            expect(clientClass.hasAuthProvider()).toBe(true);
+        });
+    });
+
+    describe("getGenerateEndpointMetadata", () => {
+        it("returns false by default", () => {
+            const clientClass = createClientClass();
+            expect(clientClass.getGenerateEndpointMetadata()).toBe(false);
+        });
+
+        it("returns true when configured", () => {
+            const clientClass = createClientClass({ generateEndpointMetadata: true });
+            expect(clientClass.getGenerateEndpointMetadata()).toBe(true);
+        });
+    });
+
+    describe("accessFromRootClient", () => {
+        it("returns root client reference when at root package", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.accessFromRootClient({
+                referenceToRootClient: ts.factory.createIdentifier("client")
+            });
+            // Root package has empty fernFilepath.allParts, so no property access chain
+            expect(serializeExpression(ref)).toBe("client");
+        });
+    });
+
+    describe("instantiate", () => {
+        it("creates new expression with options", () => {
+            const clientClass = createClientClass();
+            const expr = clientClass.instantiate({
+                referenceToClient: ts.factory.createIdentifier("TestClient"),
+                referenceToOptions: ts.factory.createIdentifier("options")
+            });
+            expect(serializeExpression(expr)).toBe("new TestClient(options)");
+        });
+    });
+
+    describe("getReferenceToOptions", () => {
+        it("returns this._options", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToOptions();
+            expect(serializeExpression(ref)).toBe("this._options");
+        });
+    });
+
+    describe("getReferenceToFetcher", () => {
+        it("returns core.fetcher when custom fetcher not allowed", () => {
+            const clientClass = createClientClass({ allowCustomFetcher: false });
+            const context = createMockSdkContext();
+            const ref = clientClass.getReferenceToFetcher(context);
+            expect(serializeExpression(ref)).toBe("core.fetcher");
+        });
+
+        it("returns options.fetcher ?? core.fetcher when custom fetcher allowed", () => {
+            const clientClass = createClientClass({ allowCustomFetcher: true });
+            const context = createMockSdkContext();
+            const ref = clientClass.getReferenceToFetcher(context);
+            expect(serializeExpression(ref)).toMatchSnapshot();
+        });
+    });
+
+    describe("getReferenceToFetch", () => {
+        it("returns this._options?.fetch", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToFetch();
+            expect(serializeExpression(ref)).toBe("this._options?.fetch");
+        });
+    });
+
+    describe("getReferenceToAuthProvider", () => {
+        it("returns undefined when no auth provider", () => {
+            const clientClass = createClientClass();
+            expect(clientClass.getReferenceToAuthProvider()).toBeUndefined();
+        });
+
+        it("returns this._options.authProvider when auth is configured", () => {
+            const ir = createIR({
+                authSchemes: [
+                    FernIr.AuthScheme.bearer({
+                        key: "bearer",
+                        token: createNameAndWireValue("token"),
+                        tokenEnvVar: undefined,
+                        docs: undefined
+                    })
+                ],
+                authRequirement: "ALL",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [{ ...createHttpEndpoint(), auth: true }],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            const ref = clientClass.getReferenceToAuthProvider();
+            assert(ref != null, "Expected auth provider reference to be defined");
+            expect(serializeExpression(ref)).toBe("this._options.authProvider");
+        });
+    });
+
+    describe("getReferenceToAuthProviderOrThrow", () => {
+        it("throws when no auth provider", () => {
+            const clientClass = createClientClass();
+            expect(() => clientClass.getReferenceToAuthProviderOrThrow()).toThrow("Auth provider is not available");
+        });
+
+        it("returns reference when auth provider exists", () => {
+            const ir = createIR({
+                authSchemes: [
+                    FernIr.AuthScheme.bearer({
+                        key: "bearer",
+                        token: createNameAndWireValue("token"),
+                        tokenEnvVar: undefined,
+                        docs: undefined
+                    })
+                ],
+                authRequirement: "ALL",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [{ ...createHttpEndpoint(), auth: true }],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            const ref = clientClass.getReferenceToAuthProviderOrThrow();
+            expect(serializeExpression(ref)).toBe("this._options.authProvider");
+        });
+    });
+
+    describe("hasAuthProvider", () => {
+        it("returns false when no auth", () => {
+            const clientClass = createClientClass();
+            expect(clientClass.hasAuthProvider()).toBe(false);
+        });
+
+        it("returns true when auth is configured", () => {
+            const ir = createIR({
+                authSchemes: [
+                    FernIr.AuthScheme.bearer({
+                        key: "bearer",
+                        token: createNameAndWireValue("token"),
+                        tokenEnvVar: undefined,
+                        docs: undefined
+                    })
+                ],
+                authRequirement: "ALL",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [{ ...createHttpEndpoint(), auth: true }],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            expect(clientClass.hasAuthProvider()).toBe(true);
+        });
+    });
+
+    describe("getReferenceToRequestOptions", () => {
+        it("returns non-idempotent type reference for non-idempotent endpoint", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.idempotent = false;
+            const clientClass = createClientClass({ serviceClassName: "MyClient" });
+            const ref = clientClass.getReferenceToRequestOptions(endpoint);
+            expect(getTextOfTsNode(ref)).toBe("MyClient.RequestOptions");
+        });
+
+        it("returns idempotent type reference for idempotent endpoint", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.idempotent = true;
+            const clientClass = createClientClass({ serviceClassName: "MyClient" });
+            const ref = clientClass.getReferenceToRequestOptions(endpoint);
+            expect(getTextOfTsNode(ref)).toBe("MyClient.IdempotentRequestOptions");
+        });
+    });
+
+    describe("getRequestOptionsType", () => {
+        it("returns non-idempotent type string", () => {
+            const clientClass = createClientClass({ serviceClassName: "SdkClient" });
+            expect(clientClass.getRequestOptionsType(false)).toBe("SdkClient.RequestOptions");
+        });
+
+        it("returns idempotent type string", () => {
+            const clientClass = createClientClass({ serviceClassName: "SdkClient" });
+            expect(clientClass.getRequestOptionsType(true)).toBe("SdkClient.IdempotentRequestOptions");
+        });
+    });
+
+    describe("getReferenceToTimeoutInSeconds", () => {
+        it("returns non-nullable property access", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToTimeoutInSeconds({
+                referenceToRequestOptions: ts.factory.createIdentifier("requestOptions"),
+                isNullable: false
+            });
+            expect(serializeExpression(ref)).toBe("requestOptions.timeoutInSeconds");
+        });
+
+        it("returns nullable property access with optional chaining", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToTimeoutInSeconds({
+                referenceToRequestOptions: ts.factory.createIdentifier("requestOptions"),
+                isNullable: true
+            });
+            expect(serializeExpression(ref)).toBe("requestOptions?.timeoutInSeconds");
+        });
+    });
+
+    describe("getReferenceToMaxRetries", () => {
+        it("returns non-nullable property access", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToMaxRetries({
+                referenceToRequestOptions: ts.factory.createIdentifier("requestOptions"),
+                isNullable: false
+            });
+            expect(serializeExpression(ref)).toBe("requestOptions.maxRetries");
+        });
+
+        it("returns nullable property access with optional chaining", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToMaxRetries({
+                referenceToRequestOptions: ts.factory.createIdentifier("requestOptions"),
+                isNullable: true
+            });
+            expect(serializeExpression(ref)).toBe("requestOptions?.maxRetries");
+        });
+    });
+
+    describe("getReferenceToAbortSignal", () => {
+        it("returns optional chaining expression", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToAbortSignal({
+                referenceToRequestOptions: ts.factory.createIdentifier("requestOptions")
+            });
+            expect(serializeExpression(ref)).toBe("requestOptions?.abortSignal");
+        });
+    });
+
+    describe("getReferenceToDefaultTimeoutInSeconds", () => {
+        it("returns this._options?.timeoutInSeconds", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToDefaultTimeoutInSeconds();
+            expect(serializeExpression(ref)).toBe("this._options?.timeoutInSeconds");
+        });
+    });
+
+    describe("getReferenceToDefaultMaxRetries", () => {
+        it("returns this._options?.maxRetries", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToDefaultMaxRetries();
+            expect(serializeExpression(ref)).toBe("this._options?.maxRetries");
+        });
+    });
+
+    describe("getReferenceToLogger", () => {
+        it("returns this._options.logging", () => {
+            const clientClass = createClientClass();
+            const context = createMockSdkContext();
+            const ref = clientClass.getReferenceToLogger(context);
+            expect(serializeExpression(ref)).toBe("this._options.logging");
+        });
+    });
+
+    describe("getReferenceToMetadataForEndpointSupplier", () => {
+        it("returns _metadata identifier", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToMetadataForEndpointSupplier();
+            expect(serializeExpression(ref)).toBe("_metadata");
+        });
+    });
+
+    describe("getReferenceToOption", () => {
+        it("returns this._options.propertyName", () => {
+            const clientClass = createClientClass();
+            const ref = clientClass.getReferenceToOption("apiKey");
+            expect(serializeExpression(ref)).toBe("this._options.apiKey");
+        });
+    });
+
+    describe("getEndpoint", () => {
+        it("returns undefined when no endpoints exist", () => {
+            const clientClass = createClientClass();
+            const context = createMockSdkContext();
+            const endpoint = clientClass.getEndpoint({ context, endpointId: "nonexistent" });
+            expect(endpoint).toBeUndefined();
+        });
+
+        it("finds endpoint by id", () => {
+            const httpEndpoint = createHttpEndpoint();
+            const ir = createIR({
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [httpEndpoint],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            const context = createMockSdkContext({ ir });
+            const endpoint = clientClass.getEndpoint({ context, endpointId: httpEndpoint.id });
+            expect(endpoint).toBeDefined();
+            expect(endpoint?.endpoint.id).toBe(httpEndpoint.id);
+        });
+    });
+
+    describe("invokeEndpoint", () => {
+        it("returns undefined for nonexistent endpoint", () => {
+            const clientClass = createClientClass();
+            const context = createMockSdkContext();
+            const result = clientClass.invokeEndpoint({
+                context,
+                endpointId: "nonexistent",
+                example: createMinimalExampleEndpointCall(),
+                clientReference: ts.factory.createIdentifier("client")
+            });
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe("getBaseUrl", () => {
+        it("returns baseUrl ?? environment reference", () => {
+            const clientClass = createClientClass();
+            const context = createMockSdkContext();
+            const endpoint = createHttpEndpoint();
+            const ref = clientClass.getBaseUrl(endpoint, context);
+            expect(serializeExpression(ref)).toMatchSnapshot();
+        });
+    });
+
+    describe("static constants", () => {
+        it("exposes static property names", () => {
+            expect(GeneratedSdkClientClassImpl.BASE_URL_OPTION_PROPERTY_NAME).toBe("baseUrl");
+            expect(GeneratedSdkClientClassImpl.ENVIRONMENT_OPTION_PROPERTY_NAME).toBe("environment");
+            expect(GeneratedSdkClientClassImpl.OPTIONS_INTERFACE_NAME).toBe("Options");
+            expect(GeneratedSdkClientClassImpl.OPTIONS_PRIVATE_MEMBER).toBe("_options");
+            expect(GeneratedSdkClientClassImpl.METADATA_FOR_TOKEN_SUPPLIER_VAR).toBe("_metadata");
+            expect(GeneratedSdkClientClassImpl.AUTH_PROVIDER_FIELD_NAME).toBe("authProvider");
+            expect(GeneratedSdkClientClassImpl.LOGGING_FIELD_NAME).toBe("logging");
+        });
+    });
+
+    describe("ENDPOINT_SECURITY auth requirement", () => {
+        it("creates routing auth provider for ENDPOINT_SECURITY", () => {
+            const ir = createIR({
+                authSchemes: [
+                    FernIr.AuthScheme.bearer({
+                        key: "bearer",
+                        token: createNameAndWireValue("token"),
+                        tokenEnvVar: undefined,
+                        docs: undefined
+                    }),
+                    FernIr.AuthScheme.header({
+                        key: "apiKey",
+                        name: createNameAndWireValue("X-API-Key"),
+                        prefix: undefined,
+                        headerEnvVar: undefined,
+                        valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        docs: undefined
+                    })
+                ],
+                authRequirement: "ENDPOINT_SECURITY",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [{ ...createHttpEndpoint(), auth: true }],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            expect(clientClass.hasAuthProvider()).toBe(true);
+        });
+    });
+
+    describe("global authorization header conversion", () => {
+        it("converts authorization header to auth scheme", () => {
+            const ir = createIR({
+                headers: [
+                    {
+                        name: createNameAndWireValue("Authorization"),
+                        valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        env: undefined,
+                        docs: undefined,
+                        availability: undefined,
+                        v2Examples: undefined
+                    }
+                ],
+                authRequirement: "ALL",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [{ ...createHttpEndpoint(), auth: true }],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            // The authorization header should be converted to a HeaderAuthScheme
+            expect(clientClass.hasAuthProvider()).toBe(true);
+        });
+    });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IR factory helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
+    return {
+        name: undefined,
+        url: "/test",
+        rootPathParameters: [],
+        endpointPathParameters: [],
+        servicePathParameters: [],
+        endpointHeaders: [],
+        serviceHeaders: [],
+        queryParameters: [],
+        request: undefined,
+        response: {
+            type: "ok",
+            body: undefined
+        },
+        docs: undefined
+    };
+}

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
@@ -868,7 +868,8 @@ describe("GeneratedSdkClientClassImpl", () => {
                             tokenEndpoint: {
                                 endpointReference: {
                                     endpointId: "endpoint_getToken",
-                                    serviceId: "service_auth"
+                                    serviceId: "service_auth",
+                                    subpackageId: undefined
                                 },
                                 requestProperties: {
                                     clientId: {
@@ -893,7 +894,8 @@ describe("GeneratedSdkClientClassImpl", () => {
                                             v2Examples: undefined
                                         })
                                     },
-                                    scopes: undefined
+                                    scopes: undefined,
+                                    customProperties: undefined
                                 },
                                 responseProperties: {
                                     accessToken: {

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
@@ -818,6 +818,227 @@ describe("GeneratedSdkClientClassImpl", () => {
             expect(clientClass.hasAuthProvider()).toBe(true);
         });
     });
+
+    describe("standalone header auth", () => {
+        it("creates header auth provider for single header scheme", () => {
+            const ir = createIR({
+                authSchemes: [
+                    FernIr.AuthScheme.header({
+                        key: "apiKey",
+                        name: createNameAndWireValue("X-API-Key"),
+                        prefix: undefined,
+                        headerEnvVar: undefined,
+                        valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        docs: undefined
+                    })
+                ],
+                authRequirement: "ALL",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [{ ...createHttpEndpoint(), auth: true }],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            expect(clientClass.hasAuthProvider()).toBe(true);
+            expect(clientClass.getAuthProviderInstance()).toBeDefined();
+        });
+    });
+
+    describe("OAuth auth", () => {
+        it("creates OAuth auth provider", () => {
+            const ir = createIR({
+                authSchemes: [
+                    FernIr.AuthScheme.oauth({
+                        key: "oauth",
+                        docs: undefined,
+                        configuration: FernIr.OAuthConfiguration.clientCredentials({
+                            tokenPrefix: undefined,
+                            tokenHeader: undefined,
+                            scopes: undefined,
+                            clientIdEnvVar: undefined,
+                            clientSecretEnvVar: undefined,
+                            tokenEndpoint: {
+                                endpointReference: {
+                                    endpointId: "endpoint_getToken",
+                                    serviceId: "service_auth"
+                                },
+                                requestProperties: {
+                                    clientId: {
+                                        propertyPath: undefined,
+                                        property: FernIr.RequestPropertyValue.body({
+                                            name: createNameAndWireValue("client_id"),
+                                            valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                                            docs: undefined,
+                                            availability: undefined,
+                                            propertyAccess: undefined,
+                                            v2Examples: undefined
+                                        })
+                                    },
+                                    clientSecret: {
+                                        propertyPath: undefined,
+                                        property: FernIr.RequestPropertyValue.body({
+                                            name: createNameAndWireValue("client_secret"),
+                                            valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                                            docs: undefined,
+                                            availability: undefined,
+                                            propertyAccess: undefined,
+                                            v2Examples: undefined
+                                        })
+                                    },
+                                    scopes: undefined
+                                },
+                                responseProperties: {
+                                    accessToken: {
+                                        propertyPath: undefined,
+                                        property: {
+                                            name: createNameAndWireValue("access_token"),
+                                            valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                                            docs: undefined,
+                                            availability: undefined,
+                                            propertyAccess: undefined,
+                                            v2Examples: undefined
+                                        }
+                                    },
+                                    expiresIn: undefined,
+                                    refreshToken: undefined
+                                }
+                            },
+                            refreshEndpoint: undefined
+                        })
+                    })
+                ],
+                authRequirement: "ALL",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [{ ...createHttpEndpoint(), auth: true }],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            expect(clientClass.hasAuthProvider()).toBe(true);
+        });
+    });
+
+    describe("neverThrowErrors", () => {
+        it("creates client class with neverThrowErrors enabled", () => {
+            const ir = createIR({
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [createHttpEndpoint()],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir, neverThrowErrors: true });
+            const context = createMockSdkContext({ ir });
+            const endpoint = clientClass.getEndpoint({
+                context,
+                endpointId: ir.rootPackage.service ? (ir.services[ir.rootPackage.service]?.endpoints[0]?.id ?? "") : ""
+            });
+            expect(endpoint).toBeDefined();
+        });
+    });
+
+    describe("requireDefaultEnvironment", () => {
+        it("throws when requireDefaultEnvironment is true and no default environment", () => {
+            const clientClass = createClientClass({ requireDefaultEnvironment: true });
+            const context = createMockSdkContext();
+            const endpoint = createHttpEndpoint();
+            expect(() => clientClass.getEnvironment(endpoint, context)).toThrow(
+                "Cannot use default environment because none exists"
+            );
+        });
+
+        it("returns default environment when requireDefaultEnvironment is true and default exists", () => {
+            const clientClass = createClientClass({ requireDefaultEnvironment: true });
+            const defaultEnvExpr = ts.factory.createStringLiteral("https://api.example.com");
+            // biome-ignore lint/suspicious/noExplicitAny: test mock override
+            const context: any = {
+                ...createMockSdkContext(),
+                environments: {
+                    getGeneratedEnvironments: () => ({
+                        getReferenceToDefaultEnvironment: () => defaultEnvExpr,
+                        getReferenceToEnvironmentUrl: ({
+                            referenceToEnvironmentValue
+                        }: {
+                            referenceToEnvironmentValue: ts.Expression;
+                        }) => referenceToEnvironmentValue
+                    }),
+                    getReferenceToFirstEnvironmentEnum: () => undefined
+                }
+            };
+            const endpoint = createHttpEndpoint();
+            const ref = clientClass.getEnvironment(endpoint, context);
+            expect(serializeExpression(ref)).toBe('"https://api.example.com"');
+        });
+    });
+
+    describe("getOptionsPropertiesForSnippet", () => {
+        it("includes environment property when no default environment and not requireDefaultEnvironment", () => {
+            const clientClass = createClientClass({ requireDefaultEnvironment: false });
+            const context = createMockSdkContext();
+            const props = clientClass.getOptionsPropertiesForSnippet(context);
+            // Should include environment: "YOUR_BASE_URL" since no default env and no first enum
+            expect(props.length).toBeGreaterThan(0);
+            const envProp = props.find((p) => {
+                const text = getTextOfTsNode(p);
+                return text.includes("environment");
+            });
+            expect(envProp).toBeDefined();
+        });
+
+        it("includes auth snippet properties when auth provider exists", () => {
+            const ir = createIR({
+                authSchemes: [
+                    FernIr.AuthScheme.bearer({
+                        key: "bearer",
+                        token: casingsGenerator.generateName("token"),
+                        tokenEnvVar: undefined,
+                        docs: undefined
+                    })
+                ],
+                authRequirement: "ALL",
+                service: {
+                    availability: undefined,
+                    name: { fernFilepath: { allParts: [], packagePath: [], file: undefined } },
+                    displayName: undefined,
+                    basePath: { head: "", parts: [] },
+                    endpoints: [{ ...createHttpEndpoint(), auth: true }],
+                    headers: [],
+                    pathParameters: [],
+                    encoding: undefined,
+                    transport: undefined,
+                    audiences: undefined
+                }
+            });
+            const clientClass = createClientClass({ ir });
+            const context = createMockSdkContext({ ir });
+            const props = clientClass.getOptionsPropertiesForSnippet(context);
+            // Should include both environment and auth token properties
+            expect(props.length).toBeGreaterThanOrEqual(1);
+        });
+    });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
@@ -2,7 +2,7 @@ import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode, PackageId } from "@fern-typescript/commons";
 import { createHttpEndpoint } from "@fern-typescript/test-utils";
 import { ts } from "ts-morph";
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 import type { GeneratedEndpointRequest } from "../endpoint-request/GeneratedEndpointRequest.js";
 import type { GeneratedEndpointResponse } from "../endpoints/default/endpoint-response/GeneratedEndpointResponse.js";
 import { GeneratedStreamingEndpointImplementation } from "../endpoints/GeneratedStreamingEndpointImplementation.js";
@@ -330,7 +330,8 @@ describe("GeneratedStreamingEndpointImplementation", () => {
                 clientReference: ts.factory.createIdentifier("client")
             });
             expect(example).toBeDefined();
-            expect(getTextOfTsNode(example?.endpointInvocation)).toMatchSnapshot();
+            assert(example?.endpointInvocation != null, "Expected endpointInvocation to be defined");
+            expect(getTextOfTsNode(example.endpointInvocation)).toMatchSnapshot();
         });
 
         it("returns undefined when example parameters are null", () => {
@@ -458,7 +459,7 @@ function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
         serviceHeaders: [],
         queryParameters: [],
         request: undefined,
-        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body({ jsonExample: undefined, docs: undefined })),
+        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body(undefined)),
         docs: undefined
     };
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
@@ -380,6 +380,14 @@ describe("GeneratedStreamingEndpointImplementation", () => {
             const output = serializeStatements(stmts);
             expect(output).toMatchSnapshot();
         });
+
+        it("uses web stream type when streamType is web", () => {
+            const impl = createImpl({ streamType: "web" });
+            const context = createMockSdkContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
     });
 
     describe("SSE response type", () => {
@@ -394,6 +402,33 @@ describe("GeneratedStreamingEndpointImplementation", () => {
                         v2Examples: undefined
                     })
                 ),
+                statusCode: undefined,
+                isWildcardStatusCode: undefined,
+                docs: undefined
+            };
+            const impl = createImpl({ endpoint });
+            const context = createMockSdkContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("uses sse response type for streamParameter SSE endpoints", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.response = {
+                body: FernIr.HttpResponseBody.streamParameter({
+                    streamResponse: FernIr.StreamingResponse.sse({
+                        payload: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        terminator: undefined,
+                        docs: undefined,
+                        v2Examples: undefined
+                    }),
+                    nonStreamResponse: FernIr.NonStreamHttpResponseBody.json({
+                        responseBodyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        docs: undefined,
+                        v2Examples: undefined
+                    })
+                }),
                 statusCode: undefined,
                 isWildcardStatusCode: undefined,
                 docs: undefined

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
@@ -1,0 +1,466 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode, PackageId } from "@fern-typescript/commons";
+import { createHttpEndpoint } from "@fern-typescript/test-utils";
+import { ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import type { GeneratedEndpointRequest } from "../endpoint-request/GeneratedEndpointRequest.js";
+import type { GeneratedEndpointResponse } from "../endpoints/default/endpoint-response/GeneratedEndpointResponse.js";
+import { GeneratedStreamingEndpointImplementation } from "../endpoints/GeneratedStreamingEndpointImplementation.js";
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function serializeStatements(statements: ts.Statement[]): string {
+    return statements.map((s) => getTextOfTsNode(s)).join("\n");
+}
+
+function serializeNodes(nodes: ts.Node[]): string {
+    return nodes.map((n) => getTextOfTsNode(n)).join("\n");
+}
+
+/**
+ * Creates a mock GeneratedEndpointRequest for streaming endpoint tests.
+ */
+function createMockRequest(opts?: {
+    endpointParameters?: { name: string; type: string; docs?: string }[];
+    buildStatements?: ts.Statement[];
+    fetcherArgs?: Record<string, ts.Expression>;
+    exampleParameters?: ts.Expression[];
+    exampleImports?: ts.Statement[];
+}): GeneratedEndpointRequest {
+    return {
+        getEndpointParameters: () =>
+            (opts?.endpointParameters ?? []).map((p) => ({
+                name: p.name,
+                type: p.type,
+                hasQuestionToken: false,
+                docs: p.docs
+            })),
+        getBuildRequestStatements: () => opts?.buildStatements ?? [],
+        getFetcherRequestArgs: () => ({
+            headers: opts?.fetcherArgs?.headers,
+            queryParameters: opts?.fetcherArgs?.queryParameters,
+            body: opts?.fetcherArgs?.body,
+            contentType: undefined,
+            requestType: undefined
+        }),
+        getRequestParameter: () => undefined,
+        getReferenceToRequestBody: () => undefined,
+        getReferenceToPathParameter: (key: string) => ts.factory.createIdentifier(key),
+        getReferenceToQueryParameter: (key: string) => ts.factory.createIdentifier(key),
+        getExampleEndpointParameters: () => opts?.exampleParameters ?? [ts.factory.createStringLiteral("example-arg")],
+        getExampleEndpointImports: () => opts?.exampleImports ?? []
+    };
+}
+
+/**
+ * Creates a mock GeneratedEndpointResponse for streaming endpoint tests.
+ */
+function createMockResponse(opts?: {
+    returnType?: ts.TypeNode;
+    responseVariableName?: string;
+    returnStatements?: ts.Statement[];
+    thrownExceptions?: string[];
+}): GeneratedEndpointResponse {
+    return {
+        getReturnType: () =>
+            opts?.returnType ??
+            ts.factory.createTypeReferenceNode("AsyncIterable", [ts.factory.createTypeReferenceNode("StreamEvent")]),
+        getResponseVariableName: () => opts?.responseVariableName ?? "_response",
+        getReturnResponseStatements: () =>
+            opts?.returnStatements ?? [ts.factory.createReturnStatement(ts.factory.createIdentifier("_response"))],
+        getNamesOfThrownExceptions: () => opts?.thrownExceptions ?? [],
+        getPaginationInfo: () => undefined
+    };
+}
+
+/**
+ * Creates a mock GeneratedSdkClientClassImpl for streaming endpoint tests.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test mock needs to satisfy complex interface
+function createMockClientClass(): any {
+    return {
+        getBaseUrl: () => ts.factory.createIdentifier("this._options.baseUrl"),
+        getReferenceToOptions: () =>
+            ts.factory.createPropertyAccessExpression(ts.factory.createThis(), ts.factory.createIdentifier("_options")),
+        getReferenceToTimeoutInSeconds: () => ts.factory.createIdentifier("this._options.timeoutInSeconds"),
+        getReferenceToMaxRetries: () => ts.factory.createIdentifier("this._options.maxRetries"),
+        getReferenceToAbortSignal: () => ts.factory.createIdentifier("requestOptions?.abortSignal"),
+        getReferenceToFetch: () => undefined,
+        getReferenceToLogger: () => undefined,
+        getReferenceToFetcher: () => ts.factory.createIdentifier("this._options.fetcher"),
+        getReferenceToRequestOptions: () => ts.factory.createTypeReferenceNode("RequestOptions"),
+        getReferenceToMetadataForEndpointSupplier: () => undefined,
+        accessFromRootClient: ({ referenceToRootClient }: { referenceToRootClient: ts.Identifier }) =>
+            ts.factory.createPropertyAccessExpression(referenceToRootClient, ts.factory.createIdentifier("service")),
+        hasAuthProvider: () => false,
+        getGenerateEndpointMetadata: () => false,
+        getReferenceToAuthProviderOrThrow: () => ts.factory.createIdentifier("this._authProvider"),
+        getEnvironment: () => undefined
+    };
+}
+
+/**
+ * Creates a mock SdkContext for streaming endpoint tests.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: test mock needs to satisfy complex SdkContext interface
+function createMockSdkContext(): any {
+    return {
+        coreUtilities: {
+            fetcher: {
+                EndpointMetadata: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.EndpointMetadata")
+                },
+                fetcher: {
+                    _invoke: (
+                        // biome-ignore lint/suspicious/noExplicitAny: test mock
+                        _args: any,
+                        // biome-ignore lint/suspicious/noExplicitAny: test mock
+                        invokeOpts: any
+                    ) =>
+                        ts.factory.createAwaitExpression(
+                            ts.factory.createCallExpression(
+                                ts.factory.createPropertyAccessExpression(
+                                    invokeOpts.referenceToFetcher,
+                                    ts.factory.createIdentifier("fetch")
+                                ),
+                                undefined,
+                                [ts.factory.createObjectLiteralExpression([], true)]
+                            )
+                        )
+                },
+                BinaryResponse: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.BinaryResponse")
+                }
+            },
+            urlUtils: {
+                join: {
+                    _invoke: (args: ts.Expression[]) =>
+                        ts.factory.createCallExpression(ts.factory.createIdentifier("core.urlJoin"), undefined, args)
+                }
+            },
+            streamUtils: {
+                ReadableStream: {
+                    _getReferenceToType: (typeArg?: ts.TypeNode) =>
+                        typeArg
+                            ? ts.factory.createTypeReferenceNode("ReadableStream", [typeArg])
+                            : ts.factory.createTypeReferenceNode("ReadableStream")
+                },
+                Stream: {
+                    _getReferenceToType: (typeArg?: ts.TypeNode) =>
+                        typeArg
+                            ? ts.factory.createTypeReferenceNode("core.Stream", [typeArg])
+                            : ts.factory.createTypeReferenceNode("core.Stream")
+                }
+            }
+        },
+        externalDependencies: {
+            stream: {
+                Readable: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("Readable")
+                }
+            }
+        }
+    };
+}
+
+/**
+ * Creates a GeneratedStreamingEndpointImplementation with configurable options.
+ */
+function createImpl(opts?: {
+    endpoint?: FernIr.HttpEndpoint;
+    request?: GeneratedEndpointRequest;
+    response?: GeneratedEndpointResponse;
+    includeCredentialsOnCrossOriginRequests?: boolean;
+    defaultTimeoutInSeconds?: number | "infinity" | undefined;
+    includeSerdeLayer?: boolean;
+    retainOriginalCasing?: boolean;
+    omitUndefined?: boolean;
+    streamType?: "wrapper" | "web";
+    generateEndpointMetadata?: boolean;
+    parameterNaming?: "originalName" | "wireValue" | "camelCase" | "snakeCase" | "default";
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    generatedSdkClientClass?: any;
+}): GeneratedStreamingEndpointImplementation {
+    return new GeneratedStreamingEndpointImplementation({
+        packageId: { isRoot: true } as PackageId,
+        endpoint: opts?.endpoint ?? createHttpEndpoint(),
+        request: opts?.request ?? createMockRequest(),
+        response: opts?.response ?? createMockResponse(),
+        generatedSdkClientClass: opts?.generatedSdkClientClass ?? createMockClientClass(),
+        includeCredentialsOnCrossOriginRequests: opts?.includeCredentialsOnCrossOriginRequests ?? false,
+        defaultTimeoutInSeconds: opts?.defaultTimeoutInSeconds,
+        includeSerdeLayer: opts?.includeSerdeLayer ?? true,
+        retainOriginalCasing: opts?.retainOriginalCasing ?? false,
+        omitUndefined: opts?.omitUndefined ?? false,
+        streamType: opts?.streamType ?? "wrapper",
+        generateEndpointMetadata: opts?.generateEndpointMetadata ?? false,
+        parameterNaming: opts?.parameterNaming ?? "default"
+    });
+}
+
+// ========================== Tests ==========================
+
+describe("GeneratedStreamingEndpointImplementation", () => {
+    describe("isPaginated", () => {
+        it("always returns false", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            expect(impl.isPaginated(context)).toBe(false);
+        });
+    });
+
+    describe("getOverloads", () => {
+        it("always returns empty array", () => {
+            const impl = createImpl();
+            expect(impl.getOverloads()).toEqual([]);
+        });
+    });
+
+    describe("getSignature", () => {
+        it("returns parameters and streaming return type", () => {
+            const impl = createImpl({
+                request: createMockRequest({
+                    endpointParameters: [{ name: "body", type: "StreamRequest" }]
+                }),
+                response: createMockResponse({
+                    returnType: ts.factory.createTypeReferenceNode("AsyncIterable", [
+                        ts.factory.createTypeReferenceNode("ChatEvent")
+                    ])
+                })
+            });
+            const context = createMockSdkContext();
+            const sig = impl.getSignature(context);
+            // endpoint param + requestOptions
+            expect(sig.parameters).toHaveLength(2);
+            expect(sig.parameters[0]?.name).toBe("body");
+            expect(getTextOfTsNode(sig.returnTypeWithoutPromise)).toMatchSnapshot();
+        });
+    });
+
+    describe("getDocs", () => {
+        it("returns undefined when no docs or availability", () => {
+            const impl = createImpl();
+            const docs = impl.getDocs();
+            expect(docs).toBeUndefined();
+        });
+
+        it("returns endpoint docs when present", () => {
+            const endpoint = createHttpEndpoint({ docs: "Stream chat events in real time." });
+            const impl = createImpl({ endpoint });
+            const docs = impl.getDocs();
+            expect(docs).toBe("Stream chat events in real time.");
+        });
+
+        it("includes availability docs when endpoint is deprecated", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.availability = {
+                status: "DEPRECATED",
+                message: "Use streamV2 instead"
+            };
+            const impl = createImpl({ endpoint });
+            const docs = impl.getDocs();
+            expect(docs).toContain("@deprecated");
+        });
+
+        it("combines availability and endpoint docs", () => {
+            const endpoint = createHttpEndpoint({ docs: "Stream events." });
+            endpoint.availability = {
+                status: "DEPRECATED",
+                message: undefined
+            };
+            const impl = createImpl({ endpoint });
+            const docs = impl.getDocs();
+            expect(docs).toMatchSnapshot();
+        });
+    });
+
+    describe("getStatements", () => {
+        it("generates streaming endpoint body", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("generates streaming endpoint body with endpoint metadata", () => {
+            const impl = createImpl({ generateEndpointMetadata: true });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("includes request build statements", () => {
+            const buildStmt = ts.factory.createVariableStatement(
+                undefined,
+                ts.factory.createVariableDeclarationList(
+                    [
+                        ts.factory.createVariableDeclaration(
+                            "_body",
+                            undefined,
+                            undefined,
+                            ts.factory.createObjectLiteralExpression([])
+                        )
+                    ],
+                    ts.NodeFlags.Const
+                )
+            );
+            const impl = createImpl({
+                request: createMockRequest({ buildStatements: [buildStmt] })
+            });
+            const context = createMockSdkContext();
+            const stmts = impl.getStatements(context);
+            const output = serializeStatements(stmts);
+            expect(output).toContain("_body");
+        });
+    });
+
+    describe("getExample", () => {
+        it("returns endpoint invocation example", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const example = impl.getExample({
+                context,
+                example: createMinimalExampleEndpointCall(),
+                opts: { isForComment: true },
+                clientReference: ts.factory.createIdentifier("client")
+            });
+            expect(example).toBeDefined();
+            expect(getTextOfTsNode(example?.endpointInvocation)).toMatchSnapshot();
+        });
+
+        it("returns undefined when example parameters are null", () => {
+            const request = createMockRequest();
+            // biome-ignore lint/suspicious/noExplicitAny: test mock override
+            (request as any).getExampleEndpointParameters = () => undefined;
+            const impl = createImpl({ request });
+            const context = createMockSdkContext();
+            const example = impl.getExample({
+                context,
+                example: createMinimalExampleEndpointCall(),
+                opts: {},
+                clientReference: ts.factory.createIdentifier("client")
+            });
+            expect(example).toBeUndefined();
+        });
+    });
+
+    describe("maybeLeverageInvocation", () => {
+        it("returns for-await-of pattern for streaming", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const result = impl.maybeLeverageInvocation({
+                invocation: ts.factory.createIdentifier("result"),
+                context
+            });
+            expect(result).toBeDefined();
+            const output = serializeNodes(result);
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("invokeFetcher", () => {
+        it("generates fetcher invocation with streaming response type", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("includes withCredentials when enabled", () => {
+            const impl = createImpl({ includeCredentialsOnCrossOriginRequests: true });
+            const context = createMockSdkContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("SSE response type", () => {
+        it("uses sse response type for SSE streaming endpoints", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.response = {
+                body: FernIr.HttpResponseBody.streaming(
+                    FernIr.StreamingResponse.sse({
+                        payload: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        terminator: undefined,
+                        docs: undefined,
+                        v2Examples: undefined
+                    })
+                ),
+                headers: undefined,
+                statusCode: undefined,
+                docs: undefined,
+                v2StatusCodes: undefined
+            };
+            const impl = createImpl({ endpoint });
+            const context = createMockSdkContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+    });
+
+    describe("endpoint and response properties", () => {
+        it("exposes endpoint from constructor", () => {
+            const endpoint = createHttpEndpoint({ docs: "stream endpoint" });
+            const impl = createImpl({ endpoint });
+            expect(impl.endpoint).toBe(endpoint);
+        });
+
+        it("exposes response from constructor", () => {
+            const response = createMockResponse();
+            const impl = createImpl({ response });
+            expect(impl.response).toBe(response);
+        });
+    });
+
+    describe("delegation methods", () => {
+        it("getReferenceToRequestBody delegates to request", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            expect(impl.getReferenceToRequestBody(context)).toBeUndefined();
+        });
+
+        it("getReferenceToPathParameter delegates to request", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const ref = impl.getReferenceToPathParameter("userId", context);
+            expect(getTextOfTsNode(ref)).toBe("userId");
+        });
+
+        it("getReferenceToQueryParameter delegates to request", () => {
+            const impl = createImpl();
+            const context = createMockSdkContext();
+            const ref = impl.getReferenceToQueryParameter("limit", context);
+            expect(getTextOfTsNode(ref)).toBe("limit");
+        });
+    });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IR factory helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
+    return {
+        name: undefined,
+        url: "/test",
+        rootPathParameters: [],
+        endpointPathParameters: [],
+        servicePathParameters: [],
+        endpointHeaders: [],
+        serviceHeaders: [],
+        queryParameters: [],
+        request: undefined,
+        response: {
+            type: "ok",
+            body: undefined
+        },
+        docs: undefined
+    };
+}

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
@@ -51,7 +51,8 @@ function createMockRequest(opts?: {
         getReferenceToQueryParameter: (key: string) => ts.factory.createIdentifier(key),
         getExampleEndpointParameters: () => opts?.exampleParameters ?? [ts.factory.createStringLiteral("example-arg")],
         getExampleEndpointImports: () => opts?.exampleImports ?? []
-    };
+        // biome-ignore lint/suspicious/noExplicitAny: test mock for GeneratedEndpointRequest
+    } as any;
 }
 
 /**
@@ -392,10 +393,9 @@ describe("GeneratedStreamingEndpointImplementation", () => {
                         v2Examples: undefined
                     })
                 ),
-                headers: undefined,
                 statusCode: undefined,
-                docs: undefined,
-                v2StatusCodes: undefined
+                isWildcardStatusCode: undefined,
+                docs: undefined
             };
             const impl = createImpl({ endpoint });
             const context = createMockSdkContext();
@@ -448,6 +448,7 @@ describe("GeneratedStreamingEndpointImplementation", () => {
 
 function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
     return {
+        id: undefined,
         name: undefined,
         url: "/test",
         rootPathParameters: [],
@@ -457,10 +458,7 @@ function createMinimalExampleEndpointCall(): FernIr.ExampleEndpointCall {
         serviceHeaders: [],
         queryParameters: [],
         request: undefined,
-        response: {
-            type: "ok",
-            body: undefined
-        },
+        response: FernIr.ExampleResponse.ok(FernIr.ExampleEndpointSuccessResponse.body({ jsonExample: undefined, docs: undefined })),
         docs: undefined
     };
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
@@ -423,11 +423,13 @@ describe("GeneratedStreamingEndpointImplementation", () => {
                         docs: undefined,
                         v2Examples: undefined
                     }),
-                    nonStreamResponse: FernIr.NonStreamHttpResponseBody.json({
-                        responseBodyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
-                        docs: undefined,
-                        v2Examples: undefined
-                    })
+                    nonStreamResponse: FernIr.NonStreamHttpResponseBody.json(
+                        FernIr.JsonResponse.response({
+                            responseBodyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                            docs: undefined,
+                            v2Examples: undefined
+                        })
+                    )
                 }),
                 statusCode: undefined,
                 isWildcardStatusCode: undefined,

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedDefaultEndpointImplementation.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedDefaultEndpointImplementation.test.ts.snap
@@ -12,6 +12,13 @@ exports[`GeneratedDefaultEndpointImplementation > getDocs > generates docs with 
 @param {RequestOptions} requestOptions - Request-specific configuration."
 `;
 
+exports[`GeneratedDefaultEndpointImplementation > getDocs > generates multiline parameter docs with proper indentation 1`] = `
+"@param {Options} options - Configuration options.
+                           Includes timeout and retry settings.
+                           See docs for details.
+@param {RequestOptions} requestOptions - Request-specific configuration."
+`;
+
 exports[`GeneratedDefaultEndpointImplementation > getExample > returns endpoint invocation example 1`] = `"await client.service.testEndpoint("example-arg")"`;
 
 exports[`GeneratedDefaultEndpointImplementation > getSignature > returns custom pager return type when custom pagination present 1`] = `"core.CustomPager<Item, ListResponse>"`;
@@ -24,10 +31,47 @@ const _response = await this._options.fetcher.fetch({});
 return _response.body;"
 `;
 
+exports[`GeneratedDefaultEndpointImplementation > getStatements > generates cursor pagination body with requestParameter 1`] = `
+"const list = core.HttpResponsePromise.interceptFunction(async (request: ListUsersRequest): Promise<core.RawResponse.WithRawResponse<void>> => { const _response = await this._options.fetcher.fetch({}); return _response.body; });
+const dataWithRawResponse = await list(request).withRawResponse();
+return new core.Page({});"
+`;
+
+exports[`GeneratedDefaultEndpointImplementation > getStatements > generates custom pagination body with sendRequest and CustomPager 1`] = `
+"const _request = {
+    url: core.urlJoin(this._options.baseUrl, "/test"),
+    method: "POST",
+    timeoutMs: (this._options.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000,
+    maxRetries: this._options.maxRetries ?? this._options?.maxRetries,
+    abortSignal: requestOptions?.abortSignal
+};
+const _sendRequest = async (request: core.Fetcher.Args) => {
+    const _response = await core.fetcher<void>(request);
+    if (_response.ok) {
+        return _response;
+    }
+};
+return core.CustomPager.create({});"
+`;
+
 exports[`GeneratedDefaultEndpointImplementation > getStatements > generates endpoint body with endpoint metadata 1`] = `
 "const _metadata: core.EndpointMetadata = { security: undefined };
 const _response = await this._options.fetcher.fetch({});
 return _response.body;"
+`;
+
+exports[`GeneratedDefaultEndpointImplementation > getStatements > generates offset pagination body with initializeOffset 1`] = `
+"const list = core.HttpResponsePromise.interceptFunction(async (request: ListUsersRequest): Promise<core.RawResponse.WithRawResponse<void>> => { const _response = await this._options.fetcher.fetch({}); return _response.body; });
+let _offset = 0;
+const dataWithRawResponse = await list(request).withRawResponse();
+return new core.Page({});"
+`;
+
+exports[`GeneratedDefaultEndpointImplementation > getStatements > generates offset-step pagination body 1`] = `
+"const list = core.HttpResponsePromise.interceptFunction(async (request: ListUsersRequest): Promise<core.RawResponse.WithRawResponse<void>> => { const _response = await this._options.fetcher.fetch({}); return _response.body; });
+let _page = 1;
+const dataWithRawResponse = await list(request).withRawResponse();
+return new core.Page({});"
 `;
 
 exports[`GeneratedDefaultEndpointImplementation > includeCredentialsOnCrossOriginRequests > adds withCredentials to fetcher args when enabled 1`] = `

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedDefaultEndpointImplementation.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedDefaultEndpointImplementation.test.ts.snap
@@ -1,0 +1,60 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedDefaultEndpointImplementation > getDocs > generates docs with endpoint docs and parameter docs 1`] = `
+"Fetches a user by ID.
+
+@param {string} userId - The user's unique identifier.
+@param {RequestOptions} requestOptions - Request-specific configuration."
+`;
+
+exports[`GeneratedDefaultEndpointImplementation > getDocs > generates docs with no endpoint docs (params only) 1`] = `
+"@param {number} id
+@param {RequestOptions} requestOptions - Request-specific configuration."
+`;
+
+exports[`GeneratedDefaultEndpointImplementation > getExample > returns endpoint invocation example 1`] = `"await client.service.testEndpoint("example-arg")"`;
+
+exports[`GeneratedDefaultEndpointImplementation > getSignature > returns custom pager return type when custom pagination present 1`] = `"core.CustomPager<Item, ListResponse>"`;
+
+exports[`GeneratedDefaultEndpointImplementation > getSignature > returns paginated return type when cursor pagination present 1`] = `"core.Page<Item, ListResponse>"`;
+
+exports[`GeneratedDefaultEndpointImplementation > getStatements > generates basic endpoint body (no pagination) 1`] = `
+"const _headers = {};
+const _response = await this._options.fetcher.fetch({});
+return _response.body;"
+`;
+
+exports[`GeneratedDefaultEndpointImplementation > getStatements > generates endpoint body with endpoint metadata 1`] = `
+"const _metadata: core.EndpointMetadata = { security: undefined };
+const _response = await this._options.fetcher.fetch({});
+return _response.body;"
+`;
+
+exports[`GeneratedDefaultEndpointImplementation > includeCredentialsOnCrossOriginRequests > adds withCredentials to fetcher args when enabled 1`] = `
+"const _response = await this._options.fetcher.fetch({});
+return _response.body;"
+`;
+
+exports[`GeneratedDefaultEndpointImplementation > invokeFetcherAndReturnResponse > generates fetcher invocation and response handling 1`] = `
+"const _response = await this._options.fetcher.fetch({});
+return _response.body;"
+`;
+
+exports[`GeneratedDefaultEndpointImplementation > maybeLeverageInvocation > returns pagination leverage code when pagination and generatePaginatedClients are both set 1`] = `
+"const pageableResponse = result;
+for await (const item of pageableResponse) {
+    console.log(item);
+}
+// Or you can manually iterate page-by-page
+let page = result;
+while (page.hasNextPage()) {
+    page = page.getNextPage();
+}
+// You can also access the underlying response
+const response = page.response;"
+`;
+
+exports[`GeneratedDefaultEndpointImplementation > text response type > sets responseType to text for text response endpoints 1`] = `
+"const _response = await this._options.fetcher.fetch({});
+return _response.body;"
+`;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedFileDownloadEndpointImplementation.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedFileDownloadEndpointImplementation.test.ts.snap
@@ -1,0 +1,33 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedFileDownloadEndpointImplementation > getDocs > combines docs, availability, and exceptions 1`] = `
+"@deprecated
+
+Download a file.
+
+@throws {@link NotFoundError}"
+`;
+
+exports[`GeneratedFileDownloadEndpointImplementation > getExample > returns endpoint invocation example 1`] = `"await client.service.testEndpoint("example-arg")"`;
+
+exports[`GeneratedFileDownloadEndpointImplementation > getStatements > generates endpoint body with endpoint metadata 1`] = `
+"const _metadata: core.EndpointMetadata = { security: undefined };
+const _response = await this._options.fetcher.fetch({});
+return _response;"
+`;
+
+exports[`GeneratedFileDownloadEndpointImplementation > getStatements > generates file download endpoint body with binary-response type 1`] = `
+"const _response = await this._options.fetcher.fetch({});
+return _response;"
+`;
+
+exports[`GeneratedFileDownloadEndpointImplementation > getStatements > generates file download endpoint body with stream response type 1`] = `
+"const _response = await this._options.fetcher.fetch({});
+return _response;"
+`;
+
+exports[`GeneratedFileDownloadEndpointImplementation > invokeFetcher > generates fetcher invocation with binary-response type 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
+
+exports[`GeneratedFileDownloadEndpointImplementation > invokeFetcher > generates fetcher invocation with streaming response type 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
+
+exports[`GeneratedFileDownloadEndpointImplementation > invokeFetcher > includes withCredentials when enabled 1`] = `"const _response = await this._options.fetcher.fetch({});"`;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedFileDownloadEndpointImplementation.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedFileDownloadEndpointImplementation.test.ts.snap
@@ -31,3 +31,5 @@ exports[`GeneratedFileDownloadEndpointImplementation > invokeFetcher > generates
 exports[`GeneratedFileDownloadEndpointImplementation > invokeFetcher > generates fetcher invocation with streaming response type 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
 
 exports[`GeneratedFileDownloadEndpointImplementation > invokeFetcher > includes withCredentials when enabled 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
+
+exports[`GeneratedFileDownloadEndpointImplementation > invokeFetcher > uses web stream type when streamType is web and fileResponseType is stream 1`] = `"const _response = await this._options.fetcher.fetch({});"`;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedSdkClientClassImpl.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedSdkClientClassImpl.test.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedSdkClientClassImpl > getBaseUrl > returns baseUrl ?? environment reference 1`] = `"await core.Supplier.get(this._options.baseUrl) ?? await core.Supplier.get(this._options.environment)"`;
+
+exports[`GeneratedSdkClientClassImpl > getReferenceToFetcher > returns options.fetcher ?? core.fetcher when custom fetcher allowed 1`] = `"this._options.fetcher ?? core.fetcher"`;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedStreamingEndpointImplementation.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedStreamingEndpointImplementation.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`GeneratedStreamingEndpointImplementation > SSE response type > uses sse response type for SSE streaming endpoints 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
 
+exports[`GeneratedStreamingEndpointImplementation > SSE response type > uses sse response type for streamParameter SSE endpoints 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
+
 exports[`GeneratedStreamingEndpointImplementation > getDocs > combines availability and endpoint docs 1`] = `
 "@deprecated
 
@@ -26,6 +28,8 @@ return _response;"
 exports[`GeneratedStreamingEndpointImplementation > invokeFetcher > generates fetcher invocation with streaming response type 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
 
 exports[`GeneratedStreamingEndpointImplementation > invokeFetcher > includes withCredentials when enabled 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
+
+exports[`GeneratedStreamingEndpointImplementation > invokeFetcher > uses web stream type when streamType is web 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
 
 exports[`GeneratedStreamingEndpointImplementation > maybeLeverageInvocation > returns for-await-of pattern for streaming 1`] = `
 "const response = result;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedStreamingEndpointImplementation.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedStreamingEndpointImplementation.test.ts.snap
@@ -1,0 +1,35 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedStreamingEndpointImplementation > SSE response type > uses sse response type for SSE streaming endpoints 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
+
+exports[`GeneratedStreamingEndpointImplementation > getDocs > combines availability and endpoint docs 1`] = `
+"@deprecated
+
+Stream events."
+`;
+
+exports[`GeneratedStreamingEndpointImplementation > getExample > returns endpoint invocation example 1`] = `"await client.service.testEndpoint("example-arg")"`;
+
+exports[`GeneratedStreamingEndpointImplementation > getSignature > returns parameters and streaming return type 1`] = `"AsyncIterable<ChatEvent>"`;
+
+exports[`GeneratedStreamingEndpointImplementation > getStatements > generates streaming endpoint body 1`] = `
+"const _response = await this._options.fetcher.fetch({});
+return _response;"
+`;
+
+exports[`GeneratedStreamingEndpointImplementation > getStatements > generates streaming endpoint body with endpoint metadata 1`] = `
+"const _metadata: core.EndpointMetadata = { security: undefined };
+const _response = await this._options.fetcher.fetch({});
+return _response;"
+`;
+
+exports[`GeneratedStreamingEndpointImplementation > invokeFetcher > generates fetcher invocation with streaming response type 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
+
+exports[`GeneratedStreamingEndpointImplementation > invokeFetcher > includes withCredentials when enabled 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
+
+exports[`GeneratedStreamingEndpointImplementation > maybeLeverageInvocation > returns for-await-of pattern for streaming 1`] = `
+"const response = result;
+for await (const item of response) {
+    console.log(item);
+}"
+`;

--- a/generators/typescript/sdk/test-utils/src/ir-factories.ts
+++ b/generators/typescript/sdk/test-utils/src/ir-factories.ts
@@ -92,8 +92,32 @@ export function createMinimalIR(opts?: {
         },
         services: opts?.services ?? {},
         headers: opts?.headers ?? [],
-        idempotencyHeaders: opts?.idempotencyHeaders ?? []
-        // biome-ignore lint/suspicious/noExplicitAny: minimal IR mock for auth provider tests
+        idempotencyHeaders: opts?.idempotencyHeaders ?? [],
+        errors: {},
+        types: {},
+        subpackages: {},
+        variables: [],
+        rootPackage: {
+            fernFilepath: { allParts: [], packagePath: [], file: undefined },
+            service: undefined,
+            types: [],
+            errors: [],
+            subpackages: [],
+            hasEndpointsInTree: false,
+            docs: undefined,
+            websocket: undefined,
+            webhooks: undefined,
+            navigationConfig: undefined
+        },
+        errorDiscriminationStrategy: FernIr.ErrorDiscriminationStrategy.statusCode(),
+        constants: {
+            errorInstanceIdKey: casingsGenerator.generateName("errorInstanceId")
+        },
+        environments: undefined,
+        pathParameters: [],
+        webhookGroups: {},
+        websocketChannels: {}
+        // biome-ignore lint/suspicious/noExplicitAny: minimal IR mock — some rarely-used fields omitted
     } as any;
 }
 
@@ -255,6 +279,7 @@ export function createHttpEndpoint(opts?: {
     allPathParameters?: FernIr.PathParameter[];
     requestBody?: FernIr.HttpRequestBody;
     sdkRequest?: FernIr.SdkRequest;
+    docs?: string;
 }): FernIr.HttpEndpoint {
     return {
         id: "endpoint_test",
@@ -289,7 +314,7 @@ export function createHttpEndpoint(opts?: {
         audiences: undefined,
         retries: undefined,
         apiPlayground: undefined,
-        docs: undefined,
+        docs: opts?.docs,
         availability: undefined
     };
 }


### PR DESCRIPTION
## Description

Refs: Priority 3 of the TS SDK generator unit testing initiative

Adds 119 unit tests across the 4 Priority 3 endpoint implementation classes — the highest-coupling, highest-confidence components of the SDK client class generator.

**Link to Devin Session:** https://app.devin.ai/sessions/ce25a6da44a14437a2fa92712a187cf6
**Requested by:** @Swimburger

## Changes Made

### New Test Files (4)

| Component | Tests | Snapshots | Key coverage |
|---|---|---|---|
| `GeneratedDefaultEndpointImplementation` | 28 | 14 | Pagination (cursor/custom/offset/offset-step with `requestParameter` and `initializeOffset`), fetcher invocation, URL building, headers, request options, docs generation (multiline params), examples, text response type, credential forwarding, endpoint metadata |
| `GeneratedStreamingEndpointImplementation` | 23 | 12 | SSE response type (via `streaming` and `streamParameter`), `streamType: "web"`, streaming return type, for-await-of leverage pattern, fetcher invocation, docs with availability, delegation methods |
| `GeneratedFileDownloadEndpointImplementation` | 22 | 9 | Stream vs binary-response variants, `streamType: "web"` with stream response, file download body generation, fetcher invocation, docs with deprecation + exceptions, delegation methods |
| `GeneratedSdkClientClassImpl` | 46 | 2 | Constructor with bearer/basic/header/OAuth/ANY/ENDPOINT_SECURITY auth, `neverThrowErrors`, `requireDefaultEnvironment` (throw + success), `getOptionsPropertiesForSnippet` (env + auth), reference accessors (options, fetcher, fetch, auth provider, timeout, retries, abort signal, logger, metadata), request options type, endpoint lookup, baseUrl generation, static constants, global authorization header conversion |

### Shared Test Infrastructure Updates

- **`createMinimalIR()`** in `@fern-typescript/test-utils` expanded with `errors`, `types`, `subpackages`, `rootPackage`, `variables`, `errorDiscriminationStrategy`, `constants`, `environments`, `pathParameters`, `webhookGroups`, `websocketChannels` — required for real `ErrorResolver` and `PackageResolver` instances used in `GeneratedSdkClientClassImpl` tests
- **`createHttpEndpoint()`** now accepts optional `docs` parameter (previously hardcoded to `undefined`)

### Testing approach
- Uses real `PackageResolver` and `ErrorResolver` instances (not mocks) for `GeneratedSdkClientClassImpl`
- Vitest snapshot testing for serialized TS AST output
- `assert()` from vitest for null-narrowing (fails loudly instead of silently skipping)

### Updates since last revision

Added 15 missing permutation tests to cover previously untested code branches:

- **Default endpoint (5 new):** `getStatements` with cursor pagination + `requestParameter`, offset pagination with `initializeOffset`, custom pagination (`CustomPager._create`), offset-step pagination, multiline parameter docs
- **Streaming endpoint (2 new):** `streamParameter` SSE response type (line 259 of source), `streamType: "web"` (exercises `getReadableTypeNode` web branch)
- **File download endpoint (1 new):** `streamType: "web"` combined with `fileResponseType: "stream"`
- **SDK client class (7 new):** standalone header auth (ALL requirement), OAuth auth (`oauth` scheme branch line 420), `neverThrowErrors` (creates `GeneratedNonThrowingEndpointResponse`), `requireDefaultEnvironment` throw + success cases (lines 877-881), `getOptionsPropertiesForSnippet` with/without auth

**CI compile fixes:** Resolved 3 type mismatches against latest IR SDK:
- Added missing `subpackageId` field to `EndpointReference` in OAuth test
- Added missing `customProperties` field to `OAuthAccessTokenRequestProperties`
- Wrapped `NonStreamHttpResponseBody.json()` arg with `FernIr.JsonResponse.response()` factory (the `json` variant now expects the `JsonResponse` union, not a plain `JsonResponseBody` object)

Total: **119 tests, 37 snapshots** (230 tests in full package including Priority 1 utilities)

## Testing


- [x] All 230 tests pass locally (`pnpm --filter @fern-typescript/sdk-client-class-generator run test`)
- [x] All 132 type-generator tests still pass (no regressions from `createMinimalIR` changes)
- [x] Biome lint passes clean (`pnpm run check`)
- [x] All required CI checks passing (compile, test, lint, biome, depcheck, test-ete)

## Human Review Checklist

- [ ] **Permutation coverage completeness**: The new tests cover 15 previously untested branches. Spot-check the branch audit to verify no critical code paths remain untested (e.g., all pagination variants, both `streamType` options, all auth schemes)
- [ ] **IR type fixes correctness**: The 3 CI fixes modified IR object construction (`subpackageId`, `customProperties`, `JsonResponse.response` wrapper). Verify these match real IR patterns from the generator's actual IR input
- [ ] **Mock context coverage**: The 4 test files use `as any` mocks for `SdkContext` and `GeneratedSdkClientClass`. Verify the mocked surface is sufficient for the code paths exercised, especially the new pagination tests (e.g., `coreUtilities.pagination.Page._construct`, `coreUtilities.customPagination.CustomPager._create`)
- [ ] **Snapshot correctness**: Spot-check the new pagination snapshots (`cursor pagination body with requestParameter`, `offset pagination body with initializeOffset`, etc.) against seed output (e.g., `seed/ts-sdk/pagination/`) to confirm structural patterns match
- [ ] **`createMinimalIR` safety**: The expanded factory now includes `errors: {}`, `rootPackage`, etc. Verify this doesn't cause unexpected behavior in other test suites that use this factory (all 132 type-generator tests still pass, but worth verifying no hidden assumptions broken)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
