### PR TITLE
feat(cli): Add fern docs preview command

### DIFF
--- a/packages/cli/cli-v2/src/commands/docs/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/command.ts
@@ -3,12 +3,14 @@ import type { GlobalArgs } from "../../context/GlobalArgs.js";
 import { commandGroup } from "../_internal/commandGroup.js";
 import { addCheckCommand } from "./check/index.js";
 import { addDevCommand } from "./dev/index.js";
+import { addPreviewCommand } from "./preview/index.js";
 import { addPublishCommand } from "./publish/index.js";
 
 export function addDocsCommand(cli: Argv<GlobalArgs>): void {
     commandGroup(cli, "docs", "Configure, edit, preview, and publish your documentation.", [
         addCheckCommand,
         addDevCommand,
+        addPreviewCommand,
         addPublishCommand
     ]);
 }

--- a/packages/cli/cli-v2/src/commands/docs/preview/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/preview/command.ts
@@ -1,0 +1,62 @@
+import type { Argv } from "yargs";
+import { GENERATE_COMMAND_TIMEOUT_MS } from "../../../constants.js";
+import type { Context } from "../../../context/Context.js";
+import type { GlobalArgs } from "../../../context/GlobalArgs.js";
+import { CliError } from "../../../errors/CliError.js";
+import { command } from "../../_internal/command.js";
+import { PublishCommand } from "../publish/command.js";
+
+export declare namespace PreviewCommand {
+    export interface Args extends GlobalArgs {
+        instance?: string;
+        strict: boolean;
+        "skip-upload": boolean;
+    }
+}
+
+export class PreviewCommand {
+    private readonly publishCommand = new PublishCommand();
+
+    public async handle(context: Context, args: PreviewCommand.Args): Promise<void> {
+        await this.publishCommand.handle(context, {
+            ...args,
+            preview: true,
+            force: true
+        });
+    }
+}
+
+export function addPreviewCommand(cli: Argv<GlobalArgs>, parentPath?: string): void {
+    const cmd = new PreviewCommand();
+    command(
+        cli,
+        "preview",
+        "Generate a preview of your documentation site",
+        async (context, args) => {
+            const timeout = new Promise<never>((_, reject) => {
+                setTimeout(
+                    () => reject(new CliError({ message: "Docs preview timed out after 10 minutes." })),
+                    GENERATE_COMMAND_TIMEOUT_MS
+                ).unref();
+            });
+            await Promise.race([cmd.handle(context, args as PreviewCommand.Args), timeout]);
+        },
+        (yargs) =>
+            yargs
+                .option("instance", {
+                    type: "string",
+                    description: "Select which docs instance to preview"
+                })
+                .option("strict", {
+                    type: "boolean",
+                    default: false,
+                    description: "Treat all validation warnings as errors"
+                })
+                .option("skip-upload", {
+                    type: "boolean",
+                    default: false,
+                    description: "Skip uploading assets during preview generation"
+                }),
+        parentPath
+    );
+}

--- a/packages/cli/cli-v2/src/commands/docs/preview/index.ts
+++ b/packages/cli/cli-v2/src/commands/docs/preview/index.ts
@@ -1,0 +1,1 @@
+export { addPreviewCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/docs/publish/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/publish/command.ts
@@ -9,6 +9,7 @@ import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { LegacyProjectAdapter } from "../../../docs/adapter/LegacyProjectAdapter.js";
 import { DocsChecker } from "../../../docs/checker/DocsChecker.js";
 import { LegacyDocsPublisher } from "../../../docs/publisher/LegacyDocsPublisher.js";
+import type { DocsStageOverrides } from "../../../docs/task/DocsTaskGroup.js";
 import { DocsTaskGroup } from "../../../docs/task/DocsTaskGroup.js";
 import { CliError } from "../../../errors/CliError.js";
 import { ValidationError } from "../../../errors/ValidationError.js";
@@ -20,11 +21,36 @@ export declare namespace PublishCommand {
         instance?: string;
         strict: boolean;
         preview: boolean;
+        "skip-upload": boolean;
     }
 }
 
 export class PublishCommand {
     public async handle(context: Context, args: PublishCommand.Args): Promise<void> {
+        const labels = args.preview
+            ? {
+                  title: "Generating preview",
+                  success: "Generated preview",
+                  error: "Failed to generate preview",
+                  interrupt: "Docs preview interrupted"
+              }
+            : {
+                  title: "Publishing docs",
+                  success: "Published docs",
+                  error: "Failed to publish docs",
+                  interrupt: "Docs publish interrupted"
+              };
+
+        const stageOverrides: DocsStageOverrides | undefined = args.preview
+            ? {
+                  publish: {
+                      pending: "Generate preview",
+                      running: "Generating preview...",
+                      success: "Generated preview"
+                  }
+              }
+            : undefined;
+
         const workspace = await context.loadWorkspaceOrThrow();
 
         if (workspace.docs == null) {
@@ -66,7 +92,13 @@ export class PublishCommand {
         const token = await this.getToken(context);
         await context.verifyOrgAccess({ organization: workspace.org, token });
 
-        const taskGroup = await this.setupTaskGroup({ context, instanceUrl, org: workspace.org });
+        const taskGroup = await this.setupTaskGroup({
+            context,
+            instanceUrl,
+            org: workspace.org,
+            title: labels.title,
+            stageOverrides
+        });
         const docsTask = taskGroup.getTask("publish");
         if (docsTask == null) {
             throw new CliError({ message: "Internal error; task 'publish' not found" });
@@ -103,19 +135,21 @@ export class PublishCommand {
             });
             const result = await publisher.publish({
                 instanceUrl,
-                preview: args.preview
+                preview: args.preview,
+                skipUpload: args["skip-upload"] || undefined
             });
             if (!result.success) {
                 docsTask.stage.publish.fail(result.error);
             } else {
                 docsTask.stage.publish.complete();
-                docsTask.complete();
+                const output = result.url != null ? [result.url] : undefined;
+                docsTask.complete(output);
             }
         }
 
         const summary = taskGroup.finish({
-            successMessage: "Published docs",
-            errorMessage: "Failed to publish docs"
+            successMessage: labels.success,
+            errorMessage: labels.error
         });
 
         if (summary.failedCount > 0) {
@@ -184,19 +218,23 @@ export class PublishCommand {
     private async setupTaskGroup({
         context,
         instanceUrl,
-        org
+        org,
+        title,
+        stageOverrides
     }: {
         context: Context;
         instanceUrl: string;
         org: string;
+        title: string;
+        stageOverrides?: DocsStageOverrides;
     }): Promise<DocsTaskGroup> {
         const taskGroup = new DocsTaskGroup({ context });
-        taskGroup.addTask({ id: "publish", name: instanceUrl });
-        await taskGroup.start({ title: "Publishing docs", subtitle: `org: ${org}` });
+        taskGroup.addTask({ id: "publish", name: instanceUrl, stageOverrides });
+        await taskGroup.start({ title, subtitle: `org: ${org}` });
         context.onShutdown(() => {
             taskGroup.finish({
-                successMessage: "Published docs",
-                errorMessage: "Docs publish interrupted"
+                successMessage: title,
+                errorMessage: `${title} interrupted`
             });
         });
         return taskGroup;

--- a/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
+++ b/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
@@ -12,6 +12,7 @@ export declare namespace LegacyDocsPublisher {
     export interface PublishResult {
         success: boolean;
         error?: string;
+        url?: string;
     }
 }
 
@@ -54,14 +55,16 @@ export class LegacyDocsPublisher {
      */
     public async publish({
         instanceUrl,
-        preview
+        preview,
+        skipUpload
     }: {
         instanceUrl: string;
         preview: boolean;
+        skipUpload?: boolean;
     }): Promise<LegacyDocsPublisher.PublishResult> {
         const taskContext = new TaskContextAdapter({ context: this.context, task: this.task });
         try {
-            await runRemoteGenerationForDocsWorkspace({
+            const url = await runRemoteGenerationForDocsWorkspace({
                 organization: this.project.config.organization,
                 apiWorkspaces: this.project.apiWorkspaces,
                 ossWorkspaces: this.ossWorkspaces,
@@ -71,20 +74,20 @@ export class LegacyDocsPublisher {
                 instanceUrl,
                 preview,
                 disableTemplates: undefined,
-                skipUpload: undefined
+                skipUpload
             });
+
+            if (taskContext.getResult() === TaskResult.Failure) {
+                // Don't extract the error message here — it's already in task.logs.
+                return { success: false };
+            }
+
+            return { success: true, url };
         } catch (error) {
             return {
                 success: false,
                 error: error instanceof Error ? error.message : String(error)
             };
         }
-
-        if (taskContext.getResult() === TaskResult.Failure) {
-            // Don't extract the error message here — it's already in task.logs.
-            return { success: false };
-        }
-
-        return { success: true };
     }
 }

--- a/packages/cli/cli-v2/src/docs/task/DocsTaskGroup.ts
+++ b/packages/cli/cli-v2/src/docs/task/DocsTaskGroup.ts
@@ -1,7 +1,12 @@
 import type { Context } from "../../context/Context.js";
 import { TaskGroup } from "../../ui/TaskGroup.js";
 import type { TaskStageDefinition } from "../../ui/TaskStage.js";
+import type { TaskStageLabels } from "../../ui/TaskStageLabels.js";
 import { DocsTask } from "./DocsTask.js";
+import type { DocsTaskStageId } from "./DocsTaskStageId.js";
+
+/** Stage label overrides keyed by stage ID */
+export type DocsStageOverrides = Partial<Record<DocsTaskStageId, Partial<TaskStageLabels>>>;
 
 /**
  * Manages docs publishing tasks with visual progress tracking.
@@ -33,10 +38,20 @@ export class DocsTaskGroup {
         this.taskGroup = new TaskGroup({ context });
     }
 
-    public addTask({ id, name }: { id: string; name?: string }): DocsTask {
+    public addTask({
+        id,
+        name,
+        stageOverrides
+    }: {
+        id: string;
+        name?: string;
+        stageOverrides?: DocsStageOverrides;
+    }): DocsTask {
         const displayName = name ?? id;
         this.taskGroup.addTask({ id, name: displayName });
-        this.taskGroup.setStages(id, this.defaultStages);
+
+        const stages = this.buildStages(stageOverrides);
+        this.taskGroup.setStages(id, stages);
 
         const task = new DocsTask({ taskGroup: this.taskGroup, id });
         this.tasks[id] = task;
@@ -61,6 +76,25 @@ export class DocsTaskGroup {
         return this.taskGroup.complete({
             successMessage,
             errorMessage
+        });
+    }
+
+    /**
+     * Build stage definitions, merging any overrides with defaults.
+     */
+    private buildStages(overrides?: DocsStageOverrides): TaskStageDefinition[] {
+        if (overrides == null) {
+            return this.defaultStages;
+        }
+        return this.defaultStages.map((stage) => {
+            const override = overrides[stage.id as DocsTaskStageId];
+            if (override == null) {
+                return stage;
+            }
+            return {
+                ...stage,
+                labels: { ...stage.labels, ...override }
+            };
         });
     }
 }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1597,7 +1597,7 @@ function addDocsCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
     cli.command("docs", "Commands for managing your docs", (yargs) => {
         addDocsDevCommand(yargs, cliContext);
         addDocsBrokenLinksCommand(yargs, cliContext);
-        addDocsPreviewCommand(yargs, cliContext);
+        addPreviewCommand(yargs, cliContext);
         addDocsDiffCommand(yargs, cliContext);
         addDocsMdCommand(yargs, cliContext);
         return yargs;
@@ -1686,7 +1686,7 @@ function addDocsDiffCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
     );
 }
 
-function addDocsPreviewCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
+function addPreviewCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
     cli.command("preview", "Commands for managing preview deployments", (yargs) => {
         addDocsPreviewListCommand(yargs, cliContext);
         addDocsPreviewDeleteCommand(yargs, cliContext);

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1597,7 +1597,7 @@ function addDocsCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
     cli.command("docs", "Commands for managing your docs", (yargs) => {
         addDocsDevCommand(yargs, cliContext);
         addDocsBrokenLinksCommand(yargs, cliContext);
-        addPreviewCommand(yargs, cliContext);
+        addDocsPreviewCommand(yargs, cliContext);
         addDocsDiffCommand(yargs, cliContext);
         addDocsMdCommand(yargs, cliContext);
         return yargs;
@@ -1686,7 +1686,7 @@ function addDocsDiffCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
     );
 }
 
-function addPreviewCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
+function addDocsPreviewCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
     cli.command("preview", "Commands for managing preview deployments", (yargs) => {
         addDocsPreviewListCommand(yargs, cliContext);
         addDocsPreviewDeleteCommand(yargs, cliContext);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -89,7 +89,7 @@ export async function publishDocs({
     excludeApis?: boolean;
     targetAudiences?: string[];
     docsUrl?: string;
-}): Promise<void> {
+}): Promise<string> {
     const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
     const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
     if (isAirGapped) {
@@ -506,6 +506,7 @@ export async function publishDocs({
 
         const link = terminalLink(url, url);
         context.logger.info(chalk.green(`Published docs to ${link}`));
+        return url;
     } else {
         switch (registerDocsResponse.error.error) {
             case "UnauthorizedError":

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -27,7 +27,7 @@ export async function runRemoteGenerationForDocsWorkspace({
     preview: boolean;
     disableTemplates: boolean | undefined;
     skipUpload: boolean | undefined;
-}): Promise<void> {
+}): Promise<string | undefined> {
     // Substitute templated environment variables:
     // If substitute-env-vars is enabled, we'll attempt to read and replace the templated
     // environment variable even in preview mode. Will bubble up an error if the env var isn't found.
@@ -83,9 +83,10 @@ export async function runRemoteGenerationForDocsWorkspace({
         `Organization: ${organization}, Preview: ${preview}, APIs: ${apiWorkspaces.length}, OSS: ${ossWorkspaces.length}`
     );
 
+    let publishedUrl: string | undefined;
     await context.runInteractiveTask({ name: maybeInstance.url }, async () => {
         const publishStart = performance.now();
-        await publishDocs({
+        publishedUrl = await publishDocs({
             docsWorkspace,
             customDomains,
             domain: maybeInstance.url,
@@ -112,5 +113,5 @@ export async function runRemoteGenerationForDocsWorkspace({
         const publishTime = performance.now() - publishStart;
         context.logger.debug(`Docs publishing completed in ${publishTime.toFixed(0)}ms`);
     });
-    return;
+    return publishedUrl;
 }


### PR DESCRIPTION
## Description

This adds the `fern docs preview` command, which replaces the original `fern generate --docs --preview` command. With this, we can _dramatically_ simplify the set of supported flags, and provide the user a far more clear experience. Plus, a separate command has the added benefit that it's a lot harder to _accidentally_ publish documentation to a production site (i.e. forgetting to specify `--preview` is easier to mess up than typing `fern docs publish`).

With this, we now have a better presentation in the terminal UI:

```sh
$ fern docs preview

◆ Generating preview
  org: amckinney-fern

┌─
│ ✓ https://amckinney-fern.docs.buildwithfern.com 5.9s
│     ✓ Validated docs
│     ✓ Generated preview
│     → https://amckinney-fern-preview-17364dfa-1a3b-43af-adae-48b5caead8cb.docs.buildwithfern.com
└─

✓ Generated preview in 5.9s

Logs written to: /Users/alex/.cache/fern/v1/logs/2026-03-11T20-40-05-260Z.log
```