### PR TITLE
feat(cli): Add preview sub-commands

### DIFF
--- a/packages/cli/cli-v2/src/commands/_internal/commandWithSubcommands.ts
+++ b/packages/cli/cli-v2/src/commands/_internal/commandWithSubcommands.ts
@@ -1,0 +1,59 @@
+import type { Argv, BuilderCallback } from "yargs";
+import type { Context } from "../../context/Context.js";
+import type { GlobalArgs } from "../../context/GlobalArgs.js";
+import { withContext } from "../../context/withContext.js";
+
+type CommandHandler<T extends GlobalArgs = GlobalArgs> = (context: Context, args: T) => Promise<void>;
+type CommandAdder = (cli: Argv<GlobalArgs>, parentPath?: string) => void;
+
+/**
+ * Registers a command that has both a default handler and subcommands.
+ *
+ * When invoked without a subcommand, the default handler runs.
+ * When invoked with a recognized subcommand (e.g. `preview list`), that subcommand runs instead.
+ *
+ * This is the "git stash" pattern: `git stash` pushes by default,
+ * while `git stash list` and `git stash drop` are distinct subcommands.
+ *
+ * @example
+ * ```ts
+ * commandWithSubcommands(
+ *     cli,
+ *     "preview",
+ *     "Generate a preview of your documentation site",
+ *     handlePreview,
+ *     (yargs) => yargs.option("instance", { type: "string" }),
+ *     [addListCommand, addDeleteCommand]
+ * );
+ * ```
+ */
+export function commandWithSubcommands<T extends GlobalArgs = GlobalArgs>(
+    cli: Argv<GlobalArgs>,
+    name: string,
+    description: string,
+    handler: CommandHandler<T>,
+    builder: BuilderCallback<GlobalArgs, T> | undefined,
+    subcommands: CommandAdder[]
+): void {
+    cli.command(name, description, (yargs) => {
+        for (const add of subcommands) {
+            add(yargs, name);
+        }
+
+        // Register the default command ($0) so that `fern docs preview [options]`
+        // runs the handler when no subcommand is matched.
+        //
+        // Use `false` as the description to hide it from the commands list in --help output.
+        yargs.command(
+            "$0",
+            false,
+            (inner) => {
+                const configured = inner.version(false);
+                return builder != null ? builder(configured) : configured;
+            },
+            withContext(handler) as unknown as () => void
+        );
+
+        return yargs.version(false).usage(description);
+    });
+}

--- a/packages/cli/cli-v2/src/commands/docs/preview/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/preview/command.ts
@@ -3,8 +3,9 @@ import { GENERATE_COMMAND_TIMEOUT_MS } from "../../../constants.js";
 import type { Context } from "../../../context/Context.js";
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { CliError } from "../../../errors/CliError.js";
-import { command } from "../../_internal/command.js";
+import { commandWithSubcommands } from "../../_internal/commandWithSubcommands.js";
 import { PublishCommand } from "../publish/command.js";
+import { addDeleteCommand } from "./delete/index.js";
 
 export declare namespace PreviewCommand {
     export interface Args extends GlobalArgs {
@@ -28,7 +29,7 @@ export class PreviewCommand {
 
 export function addPreviewCommand(cli: Argv<GlobalArgs>, parentPath?: string): void {
     const cmd = new PreviewCommand();
-    command(
+    commandWithSubcommands(
         cli,
         "preview",
         "Generate a preview of your documentation site",
@@ -57,6 +58,6 @@ export function addPreviewCommand(cli: Argv<GlobalArgs>, parentPath?: string): v
                     default: false,
                     description: "Skip uploading assets during preview generation"
                 }),
-        parentPath
+        [addDeleteCommand]
     );
 }

--- a/packages/cli/cli-v2/src/commands/docs/preview/delete/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/preview/delete/command.ts
@@ -1,0 +1,91 @@
+import { createFdrService } from "@fern-api/core";
+import chalk from "chalk";
+import type { Argv } from "yargs";
+import type { Context } from "../../../../context/Context.js";
+import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
+import { CliError } from "../../../../errors/CliError.js";
+import { command } from "../../../_internal/command.js";
+
+/**
+ * Preview URLs follow the pattern: {org}-preview-{hash}.docs.buildwithfern.com
+ */
+const PREVIEW_URL_PATTERN = /^[a-z0-9-]+-preview-[a-z0-9-]+\.docs\.buildwithfern\.com$/i;
+
+export declare namespace DeleteCommand {
+    export interface Args extends GlobalArgs {
+        url: string;
+    }
+}
+
+export class DeleteCommand {
+    public async handle(context: Context, args: DeleteCommand.Args): Promise<void> {
+        if (!this.isPreviewUrl(args.url)) {
+            throw new CliError({
+                message:
+                    `Invalid preview URL: ${args.url}\n` +
+                    `  Preview URLs follow the pattern: {org}-preview-{hash}.docs.buildwithfern.com`
+            });
+        }
+
+        const token = await context.getTokenOrPrompt();
+        const fdr = createFdrService({ token: token.value });
+
+        context.stderr.debug(`Deleting preview site: ${args.url}`);
+
+        const deleteResponse = await fdr.docs.v2.write.deleteDocsSite({
+            url: args.url as Parameters<typeof fdr.docs.v2.write.deleteDocsSite>[0]["url"]
+        });
+        if (!deleteResponse.ok) {
+            switch (deleteResponse.error.error) {
+                case "UnauthorizedError":
+                    throw CliError.unauthorized(
+                        "You do not have permissions to delete this preview site. Reach out to support@buildwithfern.com"
+                    );
+                case "DocsNotFoundError":
+                    throw CliError.notFound(`Preview site not found: ${args.url}`);
+                default:
+                    throw new CliError({
+                        message: `Failed to delete preview site: ${args.url}`
+                    });
+            }
+        }
+
+        context.stderr.info(chalk.green(`Successfully deleted preview site: ${args.url}`));
+    }
+
+    private isPreviewUrl(url: string): boolean {
+        let hostname = url.toLowerCase().trim();
+        if (hostname.startsWith("https://")) {
+            hostname = hostname.slice(8);
+        } else if (hostname.startsWith("http://")) {
+            hostname = hostname.slice(7);
+        }
+
+        const slashIndex = hostname.indexOf("/");
+        if (slashIndex !== -1) {
+            hostname = hostname.slice(0, slashIndex);
+        }
+
+        return PREVIEW_URL_PATTERN.test(hostname);
+    }
+}
+
+export function addDeleteCommand(cli: Argv<GlobalArgs>, parentPath?: string): void {
+    const cmd = new DeleteCommand();
+    command(
+        cli,
+        "delete <url>",
+        "Delete a preview deployment",
+        async (context, args) => {
+            await cmd.handle(context, args as DeleteCommand.Args);
+        },
+        (yargs) =>
+            yargs.positional("url", {
+                type: "string",
+                description:
+                    "The FQDN of the preview deployment to delete (e.g. acme-preview-abc123.docs.buildwithfern.com)",
+                demandOption: true
+            }),
+        parentPath
+    );
+}

--- a/packages/cli/cli-v2/src/commands/docs/preview/delete/index.ts
+++ b/packages/cli/cli-v2/src/commands/docs/preview/delete/index.ts
@@ -1,0 +1,1 @@
+export { addDeleteCommand } from "./command.js";


### PR DESCRIPTION
## Description

This adds the `fern docs preview delete` command, which is a sub-command registered on the `fern docs preview` standalone command. This takes inspiration from commands like `git stash` (i.e. the root command is independently functional alongside sub-commands like `git stash list`).

With this, users are presented the following:

```sh
$ fern docs preview --help
Generate a preview of your documentation site

Commands:
  fern docs preview delete <url>  Delete a preview deployment

Options:
  --help         Show help                                                                                     [boolean]
  --log-level    Set log level                    [string] [choices: "debug", "info", "warn", "error"] [default: "info"]
  --instance     Select which docs instance to preview                                                          [string]
  --strict       Treat all validation warnings as errors                                      [boolean] [default: false]
  --skip-upload  Skip uploading assets during preview generation                              [boolean] [default: false]
```

```sh
$ fern docs preview delete --help
Delete a preview deployment

Positionals:
  url  The FQDN of the preview deployment to delete (e.g. acme-preview-abc123.docs.buildwithfern.com)[string] [required]

Options:
  --help       Show help                                                                                       [boolean]
  --log-level  Set log level                      [string] [choices: "debug", "info", "warn", "error"] [default: "info"]
```