### PR TITLE
chore(internal): add unit tests for sdk-error-generator

### DIFF
--- a/generators/typescript/sdk/sdk-error-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-generator/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
+    "@fern-typescript/test-utils": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/typescript/sdk/sdk-error-generator/src/__test__/SdkErrorGenerator.test.ts
+++ b/generators/typescript/sdk/sdk-error-generator/src/__test__/SdkErrorGenerator.test.ts
@@ -1,0 +1,279 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode, Reference } from "@fern-typescript/commons";
+import { casingsGenerator, createNameAndWireValue } from "@fern-typescript/test-utils";
+import { Project, ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+
+import { GeneratedSdkErrorClassImpl } from "../GeneratedSdkErrorClassImpl.js";
+import { SdkErrorGenerator } from "../SdkErrorGenerator.js";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function createMockReference(name: string): Reference {
+    return {
+        getExpression: () => ts.factory.createIdentifier(name),
+        getTypeNode: () => ts.factory.createTypeReferenceNode(name),
+        getEntityName: () => ts.factory.createIdentifier(name)
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+    } as any;
+}
+
+function createMockSdkContext() {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const sourceFile = project.createSourceFile("test.ts", "");
+    return {
+        sourceFile,
+        type: {
+            getReferenceToType: () => ({
+                typeNode: ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                typeNodeWithoutUndefined: ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                isOptional: false
+            })
+        },
+        coreUtilities: {
+            fetcher: {
+                RawResponse: {
+                    RawResponse: {
+                        _getReferenceToType: () => ts.factory.createTypeReferenceNode("RawResponse")
+                    }
+                }
+            }
+        },
+        sdkError: {
+            getReferenceToError: () => createMockReference("BadRequestError")
+        },
+        genericAPISdkError: {
+            getReferenceToGenericAPISdkError: () => createMockReference("ApiError"),
+            getGeneratedGenericAPISdkError: () => ({
+                buildConstructorArguments: ({
+                    message,
+                    statusCode,
+                    responseBody,
+                    rawResponse
+                }: {
+                    message: ts.Expression | undefined;
+                    statusCode: ts.Expression | undefined;
+                    responseBody: ts.Expression | undefined;
+                    rawResponse: ts.Expression | undefined;
+                }) => {
+                    const props: ts.ObjectLiteralElementLike[] = [];
+                    if (message != null) {
+                        props.push(ts.factory.createPropertyAssignment("message", message));
+                    }
+                    if (statusCode != null) {
+                        props.push(ts.factory.createPropertyAssignment("statusCode", statusCode));
+                    }
+                    if (responseBody != null) {
+                        props.push(ts.factory.createPropertyAssignment("body", responseBody));
+                    }
+                    if (rawResponse != null) {
+                        props.push(ts.factory.createPropertyAssignment("rawResponse", rawResponse));
+                    }
+                    return [ts.factory.createObjectLiteralExpression(props, true)];
+                }
+            })
+        }
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+    } as any;
+}
+
+function createErrorDeclaration(opts?: {
+    type?: FernIr.TypeReference;
+    statusCode?: number;
+    name?: string;
+}): FernIr.ErrorDeclaration {
+    const errorName = opts?.name ?? "BadRequest";
+    return {
+        name: {
+            errorId: `error_${errorName}`,
+            fernFilepath: { allParts: [], packagePath: [], file: undefined },
+            name: casingsGenerator.generateName(errorName)
+        },
+        discriminantValue: createNameAndWireValue(errorName, errorName),
+        type: opts?.type,
+        statusCode: opts?.statusCode ?? 400,
+        docs: undefined,
+        examples: [],
+        v2Examples: undefined,
+        displayName: undefined,
+        isWildcardStatusCode: false,
+        headers: []
+    };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// SdkErrorGenerator (factory)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("SdkErrorGenerator", () => {
+    it("returns undefined when neverThrowErrors is true", () => {
+        const generator = new SdkErrorGenerator({ neverThrowErrors: true });
+        const result = generator.generateError({
+            errorName: "BadRequestError",
+            errorDeclaration: createErrorDeclaration()
+        });
+        expect(result).toBeUndefined();
+    });
+
+    it("returns GeneratedSdkErrorClassImpl when neverThrowErrors is false", () => {
+        const generator = new SdkErrorGenerator({ neverThrowErrors: false });
+        const result = generator.generateError({
+            errorName: "BadRequestError",
+            errorDeclaration: createErrorDeclaration()
+        });
+        expect(result).toBeDefined();
+    });
+
+    it("returns undefined for error with body type when neverThrowErrors is true", () => {
+        const generator = new SdkErrorGenerator({ neverThrowErrors: true });
+        const result = generator.generateError({
+            errorName: "BadRequestError",
+            errorDeclaration: createErrorDeclaration({
+                type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+            })
+        });
+        expect(result).toBeUndefined();
+    });
+
+    it("returns error class for error with body type when neverThrowErrors is false", () => {
+        const generator = new SdkErrorGenerator({ neverThrowErrors: false });
+        const result = generator.generateError({
+            errorName: "BadRequestError",
+            errorDeclaration: createErrorDeclaration({
+                type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+            })
+        });
+        expect(result).toBeDefined();
+    });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// GeneratedSdkErrorClassImpl
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("GeneratedSdkErrorClassImpl", () => {
+    function createErrorClass(opts?: { type?: FernIr.TypeReference; statusCode?: number; name?: string }) {
+        const errorDeclaration = createErrorDeclaration(opts);
+        return new GeneratedSdkErrorClassImpl({
+            errorClassName: `${opts?.name ?? "BadRequest"}Error`,
+            errorDeclaration
+        });
+    }
+
+    describe("writeToFile", () => {
+        it("writes error class without body type", () => {
+            const errorClass = createErrorClass();
+            const context = createMockSdkContext();
+            errorClass.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("writes error class with body type", () => {
+            const errorClass = createErrorClass({
+                type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+            });
+            const context = createMockSdkContext();
+            errorClass.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("writes error class with named body type", () => {
+            const errorClass = createErrorClass({
+                type: FernIr.TypeReference.named({
+                    typeId: "type_ErrorBody",
+                    fernFilepath: { allParts: [], packagePath: [], file: undefined },
+                    name: casingsGenerator.generateName("ErrorBody"),
+                    displayName: undefined,
+                    default: undefined,
+                    inline: undefined
+                })
+            });
+            const context = createMockSdkContext();
+            errorClass.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("writes error class with optional body type", () => {
+            const errorClass = createErrorClass({
+                type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+            });
+            const optionalContext = createMockSdkContext();
+            // Override to return optional type
+            optionalContext.type.getReferenceToType = () => ({
+                typeNode: ts.factory.createUnionTypeNode([
+                    ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                    ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword)
+                ]),
+                typeNodeWithoutUndefined: ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                isOptional: true
+            });
+            errorClass.writeToFile(optionalContext);
+            expect(optionalContext.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("writes error class with custom status code", () => {
+            const errorClass = createErrorClass({
+                statusCode: 404,
+                name: "NotFound"
+            });
+            const context = createMockSdkContext();
+            errorClass.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+    });
+
+    describe("build", () => {
+        it("builds new expression without body", () => {
+            const errorClass = createErrorClass();
+            const context = createMockSdkContext();
+            const result = errorClass.build(context, {
+                referenceToBody: undefined,
+                referenceToRawResponse: undefined
+            });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("builds new expression with body", () => {
+            const errorClass = createErrorClass({
+                type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+            });
+            const context = createMockSdkContext();
+            const result = errorClass.build(context, {
+                referenceToBody: ts.factory.createIdentifier("parsedBody"),
+                referenceToRawResponse: undefined
+            });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("builds new expression with body and rawResponse", () => {
+            const errorClass = createErrorClass({
+                type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+            });
+            const context = createMockSdkContext();
+            const result = errorClass.build(context, {
+                referenceToBody: ts.factory.createIdentifier("parsedBody"),
+                referenceToRawResponse: ts.factory.createIdentifier("rawResp")
+            });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("builds new expression with only rawResponse (no body)", () => {
+            const errorClass = createErrorClass();
+            const context = createMockSdkContext();
+            const result = errorClass.build(context, {
+                referenceToBody: undefined,
+                referenceToRawResponse: ts.factory.createIdentifier("rawResp")
+            });
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+    });
+
+    describe("type property", () => {
+        it("has type === 'class'", () => {
+            const errorClass = createErrorClass();
+            expect(errorClass.type).toBe("class");
+        });
+    });
+});

--- a/generators/typescript/sdk/sdk-error-generator/src/__test__/__snapshots__/SdkErrorGenerator.test.ts.snap
+++ b/generators/typescript/sdk/sdk-error-generator/src/__test__/__snapshots__/SdkErrorGenerator.test.ts.snap
@@ -1,0 +1,107 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedSdkErrorClassImpl > build > builds new expression with body 1`] = `"new BadRequestError(parsedBody)"`;
+
+exports[`GeneratedSdkErrorClassImpl > build > builds new expression with body and rawResponse 1`] = `"new BadRequestError(parsedBody, rawResp)"`;
+
+exports[`GeneratedSdkErrorClassImpl > build > builds new expression with only rawResponse (no body) 1`] = `"new BadRequestError(rawResp)"`;
+
+exports[`GeneratedSdkErrorClassImpl > build > builds new expression without body 1`] = `"new BadRequestError()"`;
+
+exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class with body type 1`] = `
+"export class BadRequestError extends ApiError {
+    constructor(body: string, rawResponse?: RawResponse) {
+        super({
+            message: "BadRequest",
+            statusCode: 400,
+            body: body,
+            rawResponse: rawResponse
+        });
+        Object.setPrototypeOf(this, new.target.prototype);
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+
+        this.name = this.constructor.name;
+    }
+}
+"
+`;
+
+exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class with custom status code 1`] = `
+"export class NotFoundError extends ApiError {
+    constructor(rawResponse?: RawResponse) {
+        super({
+            message: "NotFound",
+            statusCode: 404,
+            rawResponse: rawResponse
+        });
+        Object.setPrototypeOf(this, new.target.prototype);
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+
+        this.name = this.constructor.name;
+    }
+}
+"
+`;
+
+exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class with named body type 1`] = `
+"export class BadRequestError extends ApiError {
+    constructor(body: string, rawResponse?: RawResponse) {
+        super({
+            message: "BadRequest",
+            statusCode: 400,
+            body: body,
+            rawResponse: rawResponse
+        });
+        Object.setPrototypeOf(this, new.target.prototype);
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+
+        this.name = this.constructor.name;
+    }
+}
+"
+`;
+
+exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class with optional body type 1`] = `
+"export class BadRequestError extends ApiError {
+    constructor(body?: string, rawResponse?: RawResponse) {
+        super({
+            message: "BadRequest",
+            statusCode: 400,
+            body: body,
+            rawResponse: rawResponse
+        });
+        Object.setPrototypeOf(this, new.target.prototype);
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+
+        this.name = this.constructor.name;
+    }
+}
+"
+`;
+
+exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class without body type 1`] = `
+"export class BadRequestError extends ApiError {
+    constructor(rawResponse?: RawResponse) {
+        super({
+            message: "BadRequest",
+            statusCode: 400,
+            rawResponse: rawResponse
+        });
+        Object.setPrototypeOf(this, new.target.prototype);
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+
+        this.name = this.constructor.name;
+    }
+}
+"
+`;

--- a/generators/typescript/sdk/sdk-error-generator/vitest.config.ts
+++ b/generators/typescript/sdk/sdk-error-generator/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3109,9 +3109,6 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
-      '@fern-typescript/test-utils':
-        specifier: workspace:*
-        version: link:../../sdk/test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
@@ -3333,9 +3330,6 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
-      '@fern-typescript/test-utils':
-        specifier: workspace:*
-        version: link:../test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
@@ -3498,9 +3492,6 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
-      '@fern-typescript/test-utils':
-        specifier: workspace:*
-        version: link:../test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
@@ -3736,9 +3727,6 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
-      '@fern-typescript/test-utils':
-        specifier: workspace:*
-        version: link:../test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
@@ -3764,9 +3752,6 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
-      '@fern-typescript/test-utils':
-        specifier: workspace:*
-        version: link:../../sdk/test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3109,6 +3109,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-typescript/test-utils':
+        specifier: workspace:*
+        version: link:../../sdk/test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
@@ -3330,6 +3333,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-typescript/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
@@ -3492,6 +3498,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-typescript/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
@@ -3600,6 +3609,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-typescript/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
@@ -3724,6 +3736,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-typescript/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
@@ -3749,6 +3764,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-typescript/test-utils':
+        specifier: workspace:*
+        version: link:../../sdk/test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3


### PR DESCRIPTION
## Description

Refs: Priority 5 (Niche / Less Critical) unit testing initiative for TypeScript SDK generator components.

Adds unit tests for the `sdk-error-generator` package — the first of 6 Priority 5 components. This is part of the ongoing effort to add granular unit tests to individual TS SDK generator components ahead of the planned AST migration.

[Link to Devin Session](https://app.devin.ai/sessions/ce25a6da44a14437a2fa92712a187cf6)
Requested by: @Swimburger

## Changes Made

- Added `SdkErrorGenerator.test.ts` with **14 tests** covering:
  - `SdkErrorGenerator` factory (4 tests): `neverThrowErrors` flag with/without body types
  - `GeneratedSdkErrorClassImpl` (10 tests): `writeToFile` snapshots (no body, body, named body, optional body, custom status code), `build` expressions (no body, with body, body+rawResponse, rawResponse only), type property
- Added `vitest.config.ts` (standard base config reexport)
- Added `@fern-typescript/test-utils` as devDependency

## Testing

- [x] Unit tests added (14 tests, 9 snapshots)
- [x] All tests pass locally (`pnpm test`)
- [x] Biome lint passes (`pnpm run check`)

## Human Review Checklist

- **⚠️ `pnpm-lock.yaml` scope**: The lockfile diff includes `@fern-typescript/test-utils` additions for 5 other packages beyond `sdk-error-generator`. These correspond to upcoming PRs for the remaining Priority 5 components. Verify this doesn't cause issues for packages whose `package.json` hasn't been updated yet in this PR.
- **Mock fidelity**: `createMockSdkContext()` uses `as any` casts. The mock returns `string` for all type references (regardless of actual primitive kind), so snapshots like the "named body type" test show `body: string` rather than a real named type. This is intentional — tests verify structural code generation, not type resolution.
- **`genericAPISdkError.getGeneratedGenericAPISdkError().buildConstructorArguments`** contains a non-trivial reimplementation of the real constructor argument builder. Worth a glance to confirm it matches the real behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
