### PR TITLE
chore(typescript): remove baseUrl from generated test tsconfig.json

### DIFF
--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -316,8 +316,7 @@ export class TestGenerator {
     "extends": "${extendsPath}",
     "compilerOptions": {
         "outDir": null,
-        "rootDir": "..",
-        "baseUrl": ".."${
+        "rootDir": ".."${
             this.testFramework === "vitest"
                 ? `,
             "types": ["vitest/globals"]`

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.53.14
+  changelogEntry:
+    - summary: |
+        Remove `baseUrl` from the generated test `tsconfig.json`. The `baseUrl` compiler
+        option is unnecessary for test compilation and can interfere with module resolution
+        in consuming projects.
+      type: chore
+  createdAt: "2026-03-11"
+  irVersion: 65
+
 - version: 3.53.13
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/accept-header/tests/tsconfig.json
+++ b/seed/ts-sdk/accept-header/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/alias-extends/tests/tsconfig.json
+++ b/seed/ts-sdk/alias-extends/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/alias/tests/tsconfig.json
+++ b/seed/ts-sdk/alias/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/tsconfig.json
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/any-auth/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/any-auth/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/api-wide-base-path/tests/tsconfig.json
+++ b/seed/ts-sdk/api-wide-base-path/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/audiences/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/tsconfig.json
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/tsconfig.json
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/basic-auth/tests/tsconfig.json
+++ b/seed/ts-sdk/basic-auth/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/tsconfig.json
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/bytes-download/tests/tsconfig.json
+++ b/seed/ts-sdk/bytes-download/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/bytes-upload/tests/tsconfig.json
+++ b/seed/ts-sdk/bytes-upload/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/circular-references-advanced/tests/tsconfig.json
+++ b/seed/ts-sdk/circular-references-advanced/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/circular-references/tests/tsconfig.json
+++ b/seed/ts-sdk/circular-references/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/client-side-params/tests/tsconfig.json
+++ b/seed/ts-sdk/client-side-params/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/content-type/tests/tsconfig.json
+++ b/seed/ts-sdk/content-type/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/tests/tsconfig.json
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/dollar-string-examples/tests/tsconfig.json
+++ b/seed/ts-sdk/dollar-string-examples/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/empty-clients/tests/tsconfig.json
+++ b/seed/ts-sdk/empty-clients/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/endpoint-security-auth/tests/tsconfig.json
+++ b/seed/ts-sdk/endpoint-security-auth/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/tsconfig.json
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/enum/forward-compatible-enums/tests/tsconfig.json
+++ b/seed/ts-sdk/enum/forward-compatible-enums/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/enum/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/enum/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/enum/serde/tests/tsconfig.json
+++ b/seed/ts-sdk/enum/serde/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/error-property/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/error-property/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/error-property/union-utils/tests/tsconfig.json
+++ b/seed/ts-sdk/error-property/union-utils/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/errors/tests/tsconfig.json
+++ b/seed/ts-sdk/errors/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/tsconfig.json
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/examples/retain-original-casing/tests/tsconfig.json
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": ".."
     },
     "include": ["../src", "../tests"],
     "exclude": []

--- a/seed/ts-sdk/exhaustive/bigint/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/bigint/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": ".."
     },
     "include": ["../src", "../tests"],
     "exclude": []

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../../../src/test-packagePath", "../../../src/test-packagePath/tests"],

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/use-jest/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": ".."
     },
     "include": ["../src", "../tests"],
     "exclude": []

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/tsconfig.json
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/extends/tests/tsconfig.json
+++ b/seed/ts-sdk/extends/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/extra-properties/tests/tsconfig.json
+++ b/seed/ts-sdk/extra-properties/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/tsconfig.json
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/file-download/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/file-download/stream-wrapper/tests/tsconfig.json
+++ b/seed/ts-sdk/file-download/stream-wrapper/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": ".."
     },
     "include": ["../src", "../tests"],
     "exclude": []

--- a/seed/ts-sdk/file-upload-openapi/tests/tsconfig.json
+++ b/seed/ts-sdk/file-upload-openapi/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/tsconfig.json
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/file-upload/inline/tests/tsconfig.json
+++ b/seed/ts-sdk/file-upload/inline/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/file-upload/serde/tests/tsconfig.json
+++ b/seed/ts-sdk/file-upload/serde/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/file-upload/use-jest/tests/tsconfig.json
+++ b/seed/ts-sdk/file-upload/use-jest/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": ".."
     },
     "include": ["../src", "../tests"],
     "exclude": []

--- a/seed/ts-sdk/file-upload/wrapper/tests/tsconfig.json
+++ b/seed/ts-sdk/file-upload/wrapper/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": ".."
     },
     "include": ["../src", "../tests"],
     "exclude": []

--- a/seed/ts-sdk/folders/tests/tsconfig.json
+++ b/seed/ts-sdk/folders/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/header-auth-environment-variable/tests/tsconfig.json
+++ b/seed/ts-sdk/header-auth-environment-variable/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/header-auth/tests/tsconfig.json
+++ b/seed/ts-sdk/header-auth/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/http-head/tests/tsconfig.json
+++ b/seed/ts-sdk/http-head/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/idempotency-headers/tests/tsconfig.json
+++ b/seed/ts-sdk/idempotency-headers/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/tsconfig.json
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/imdb/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/imdb/omit-undefined/tests/tsconfig.json
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/inferred-auth-explicit/tests/tsconfig.json
+++ b/seed/ts-sdk/inferred-auth-explicit/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/tests/tsconfig.json
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/tsconfig.json
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/inferred-auth-implicit/tests/tsconfig.json
+++ b/seed/ts-sdk/inferred-auth-implicit/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/license/tests/tsconfig.json
+++ b/seed/ts-sdk/license/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/literal/tests/tsconfig.json
+++ b/seed/ts-sdk/literal/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/literals-unions/tests/tsconfig.json
+++ b/seed/ts-sdk/literals-unions/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/tsconfig.json
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/mixed-file-directory/tests/tsconfig.json
+++ b/seed/ts-sdk/mixed-file-directory/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/multi-line-docs/tests/tsconfig.json
+++ b/seed/ts-sdk/multi-line-docs/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/tsconfig.json
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/multi-url-environment/tests/tsconfig.json
+++ b/seed/ts-sdk/multi-url-environment/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/multiple-request-bodies/tests/tsconfig.json
+++ b/seed/ts-sdk/multiple-request-bodies/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/no-environment/tests/tsconfig.json
+++ b/seed/ts-sdk/no-environment/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/no-retries/tests/tsconfig.json
+++ b/seed/ts-sdk/no-retries/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/nullable-allof-extends/tests/tsconfig.json
+++ b/seed/ts-sdk/nullable-allof-extends/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/nullable-optional/tests/tsconfig.json
+++ b/seed/ts-sdk/nullable-optional/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/nullable-request-body/tests/tsconfig.json
+++ b/seed/ts-sdk/nullable-request-body/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/nullable/tests/tsconfig.json
+++ b/seed/ts-sdk/nullable/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/tsconfig.json
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/tsconfig.json
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/tsconfig.json
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/oauth-client-credentials-reference/tests/tsconfig.json
+++ b/seed/ts-sdk/oauth-client-credentials-reference/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/tsconfig.json
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/oauth-client-credentials/serde/tests/tsconfig.json
+++ b/seed/ts-sdk/oauth-client-credentials/serde/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/object/tests/tsconfig.json
+++ b/seed/ts-sdk/object/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/objects-with-imports/tests/tsconfig.json
+++ b/seed/ts-sdk/objects-with-imports/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/optional/tests/tsconfig.json
+++ b/seed/ts-sdk/optional/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/package-yml/tests/tsconfig.json
+++ b/seed/ts-sdk/package-yml/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/pagination-custom/tests/tsconfig.json
+++ b/seed/ts-sdk/pagination-custom/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/pagination-uri-path/tests/tsconfig.json
+++ b/seed/ts-sdk/pagination-uri-path/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/pagination/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/pagination/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/pagination/page-index-semantics/tests/tsconfig.json
+++ b/seed/ts-sdk/pagination/page-index-semantics/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/path-parameters/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/path-parameters/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/tsconfig.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/tsconfig.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/tsconfig.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/tsconfig.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/tsconfig.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/tsconfig.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/tsconfig.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/tsconfig.json
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/plain-text/tests/tsconfig.json
+++ b/seed/ts-sdk/plain-text/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/tests/tsconfig.json
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/property-access/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/property-access/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/public-object/tests/tsconfig.json
+++ b/seed/ts-sdk/public-object/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/tests/tsconfig.json
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/query-parameters-openapi/tests/tsconfig.json
+++ b/seed/ts-sdk/query-parameters-openapi/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/tsconfig.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/tsconfig.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/tsconfig.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/tsconfig.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/query-parameters/serde/tests/tsconfig.json
+++ b/seed/ts-sdk/query-parameters/serde/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/tsconfig.json
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/tsconfig.json
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": ".."
     },
     "include": ["../src", "../tests"],
     "exclude": []

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/tsconfig.json
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/required-nullable/tests/tsconfig.json
+++ b/seed/ts-sdk/required-nullable/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/reserved-keywords/tests/tsconfig.json
+++ b/seed/ts-sdk/reserved-keywords/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/response-property/tests/tsconfig.json
+++ b/seed/ts-sdk/response-property/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/server-sent-event-examples/tests/tsconfig.json
+++ b/seed/ts-sdk/server-sent-event-examples/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/server-sent-events/tests/tsconfig.json
+++ b/seed/ts-sdk/server-sent-events/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/server-url-templating/tests/tsconfig.json
+++ b/seed/ts-sdk/server-url-templating/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/allow-extra-fields/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/bundle/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/bundle/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/custom-package-json/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/custom-package-json/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/jsr/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/jsr/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/legacy-exports/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/legacy-exports/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
             "types": ["vitest/globals"]
     },
     "include": ["../src","../tests"],

--- a/seed/ts-sdk/simple-api/no-scripts/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/no-scripts/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
             "types": ["vitest/globals"]
     },
     "include": ["../src","../tests"],

--- a/seed/ts-sdk/simple-api/oidc-token/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/oidc-token/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/omit-fern-headers/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/use-oxc/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/use-oxc/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/use-oxfmt/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/use-oxfmt/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/use-oxlint/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/use-oxlint/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/use-prettier/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/use-prettier/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-api/use-yarn/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-api/use-yarn/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/simple-fhir/tests/tsconfig.json
+++ b/seed/ts-sdk/simple-fhir/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/single-url-environment-default/tests/tsconfig.json
+++ b/seed/ts-sdk/single-url-environment-default/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/single-url-environment-no-default/tests/tsconfig.json
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/streaming-parameter/tests/tsconfig.json
+++ b/seed/ts-sdk/streaming-parameter/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/streaming/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/streaming/serde-layer/tests/tsconfig.json
+++ b/seed/ts-sdk/streaming/serde-layer/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/streaming/wrapper/tests/tsconfig.json
+++ b/seed/ts-sdk/streaming/wrapper/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": ".."
     },
     "include": ["../src", "../tests"],
     "exclude": []

--- a/seed/ts-sdk/trace/exhaustive/tests/tsconfig.json
+++ b/seed/ts-sdk/trace/exhaustive/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/trace/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/trace/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/tsconfig.json
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/trace/serde/tests/tsconfig.json
+++ b/seed/ts-sdk/trace/serde/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/ts-express-casing/tests/tsconfig.json
+++ b/seed/ts-sdk/ts-express-casing/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/ts-extra-properties/tests/tsconfig.json
+++ b/seed/ts-sdk/ts-extra-properties/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/ts-inline-types/inline/tests/tsconfig.json
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/tsconfig.json
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/tests/tsconfig.json
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/tsconfig.json
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/unions-with-local-date/tests/tsconfig.json
+++ b/seed/ts-sdk/unions-with-local-date/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/unions/tests/tsconfig.json
+++ b/seed/ts-sdk/unions/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/unknown/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/tsconfig.json
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/url-form-encoded/tests/tsconfig.json
+++ b/seed/ts-sdk/url-form-encoded/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/validation/tests/tsconfig.json
+++ b/seed/ts-sdk/validation/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/variables/tests/tsconfig.json
+++ b/seed/ts-sdk/variables/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/version-no-default/tests/tsconfig.json
+++ b/seed/ts-sdk/version-no-default/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/version/tests/tsconfig.json
+++ b/seed/ts-sdk/version/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/webhook-audience/tests/tsconfig.json
+++ b/seed/ts-sdk/webhook-audience/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/webhooks/no-custom-config/tests/tsconfig.json
+++ b/seed/ts-sdk/webhooks/no-custom-config/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/tests/tsconfig.json
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/tests/tsconfig.json
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/websocket/no-serde/tests/tsconfig.json
+++ b/seed/ts-sdk/websocket/no-serde/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/tsconfig.json
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],

--- a/seed/ts-sdk/websocket/serde/tests/tsconfig.json
+++ b/seed/ts-sdk/websocket/serde/tests/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": null,
         "rootDir": "..",
-        "baseUrl": "..",
         "types": ["vitest/globals"]
     },
     "include": ["../src", "../tests"],


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger

[Link to Devin Session](https://app.devin.ai/sessions/533caf0e55734bf7a4c21f1a15dfdb8a)

Remove the `"baseUrl": ".."` compiler option from the generated `tests/tsconfig.json` in the TypeScript SDK generator.

## Changes Made

- Removed `"baseUrl": ".."` from the test tsconfig template in `TestGenerator.ts`
- Updated all 190 seed `tests/tsconfig.json` fixtures to match the new output
- Added version `3.53.14` changelog entry in `versions.yml`

## Important Review Notes

**Semantic change in `baseUrl` resolution:** Previously, `tests/tsconfig.json` explicitly set `"baseUrl": ".."` (resolving to the project root). With this removal, the test tsconfig now **inherits** `"baseUrl": "src"` from the parent `tsconfig.base.json` (resolving to `<project-root>/src`). This changes the effective `baseUrl` from the project root to the `src/` directory. This should be safe because test files use relative imports (e.g., `../src/...`) rather than bare module specifiers that depend on `baseUrl` resolution — but **CI seed test results should confirm this**.

## Testing

- [ ] CI seed tests should verify no test compilation regressions
- Confirmed pre-existing type errors in the generator are unchanged (not introduced by this PR)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
