### PR TITLE
chore(seed): suppress verbose docker/build output unless --log-level debug

### DIFF
--- a/packages/cli/generation/local-generation/docker-utils/src/runDocker.ts
+++ b/packages/cli/generation/local-generation/docker-utils/src/runDocker.ts
@@ -174,7 +174,7 @@ export async function startContainer({
     imageName,
     runner
 }: {
-    logger: Logger;
+    logger?: Logger;
     imageName: string;
     runner?: ContainerRunner;
 }): Promise<string> {
@@ -331,7 +331,7 @@ export async function stopContainer({
     containerId,
     runner
 }: {
-    logger: Logger;
+    logger?: Logger;
     containerId: string;
     runner?: ContainerRunner;
 }): Promise<void> {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -6,7 +6,7 @@ import {
     startContainer,
     stopContainer
 } from "@fern-api/docker-utils";
-import { Logger } from "@fern-api/logger";
+import { Logger, LogLevel } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import {
     CONTAINER_CODEGEN_OUTPUT_DIRECTORY,
@@ -48,7 +48,7 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
      * Starts the pool of long-lived containers and inspects the image for its entrypoint.
      * Must be called before any `execute()` calls.
      */
-    public async start(logger: Logger): Promise<void> {
+    public async start(logger: Logger, logLevel?: LogLevel): Promise<void> {
         // Get the image entrypoint before starting (since we override it with /bin/sh)
         this.entrypoint = await this.getImageEntrypoint(logger);
 
@@ -86,7 +86,8 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             throw error;
         }
 
-        logger.info(
+        const logFn = logLevel === LogLevel.Debug || logLevel === LogLevel.Trace ? logger.info : logger.debug;
+        logFn(
             `Started ${this.containers.length} reusable container(s) from image ${this.imageName}: ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
         );
     }
@@ -280,7 +281,7 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
     /**
      * Stops and removes all containers in the pool.
      */
-    public async stop(logger: Logger): Promise<void> {
+    public async stop(logger: Logger, logLevel?: LogLevel): Promise<void> {
         const stopPromises = this.containers.map(async (containerId) => {
             await stopContainer({
                 logger,
@@ -289,7 +290,8 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             });
         });
         await Promise.all(stopPromises);
-        logger.info(
+        const logFn = logLevel === LogLevel.Debug || logLevel === LogLevel.Trace ? logger.info : logger.debug;
+        logFn(
             `Stopped ${this.containers.length} reusable container(s): ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
         );
         this.containers = [];

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -49,15 +49,21 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
      * Must be called before any `execute()` calls.
      */
     public async start(logger: Logger, logLevel?: LogLevel): Promise<void> {
+        const isDebug = logLevel === LogLevel.Debug || logLevel === LogLevel.Trace;
+        // Only pass logger to docker operations when in debug mode;
+        // CONSOLE_LOGGER outputs all levels including debug, so passing it
+        // causes noisy "+ docker run ..." lines from loggingExeca.
+        const dockerLogger = isDebug ? logger : undefined;
+
         // Get the image entrypoint before starting (since we override it with /bin/sh)
-        this.entrypoint = await this.getImageEntrypoint(logger);
+        this.entrypoint = await this.getImageEntrypoint(dockerLogger);
 
         // Start N containers in parallel
         const startPromises = [];
         for (let i = 0; i < this.poolSize; i++) {
             startPromises.push(
                 startContainer({
-                    logger,
+                    logger: dockerLogger,
                     imageName: this.imageName,
                     runner: this.runner
                 })
@@ -73,7 +79,7 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             for (const result of settledPromises) {
                 if (result.status === "fulfilled") {
                     await stopContainer({
-                        logger,
+                        logger: dockerLogger,
                         containerId: result.value,
                         runner: this.runner
                     }).catch((cleanupErr) => {
@@ -86,12 +92,8 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             throw error;
         }
 
-        if (logLevel === LogLevel.Debug || logLevel === LogLevel.Trace) {
+        if (isDebug) {
             logger.info(
-                `Started ${this.containers.length} reusable container(s) from image ${this.imageName}: ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
-            );
-        } else {
-            logger.debug(
                 `Started ${this.containers.length} reusable container(s) from image ${this.imageName}: ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
             );
         }
@@ -287,20 +289,18 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
      * Stops and removes all containers in the pool.
      */
     public async stop(logger: Logger, logLevel?: LogLevel): Promise<void> {
+        const isDebug = logLevel === LogLevel.Debug || logLevel === LogLevel.Trace;
+        const dockerLogger = isDebug ? logger : undefined;
         const stopPromises = this.containers.map(async (containerId) => {
             await stopContainer({
-                logger,
+                logger: dockerLogger,
                 containerId,
                 runner: this.runner
             });
         });
         await Promise.all(stopPromises);
-        if (logLevel === LogLevel.Debug || logLevel === LogLevel.Trace) {
+        if (isDebug) {
             logger.info(
-                `Stopped ${this.containers.length} reusable container(s): ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
-            );
-        } else {
-            logger.debug(
                 `Stopped ${this.containers.length} reusable container(s): ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
             );
         }
@@ -308,7 +308,7 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
         this.availableContainers = [];
     }
 
-    private async getImageEntrypoint(logger: Logger): Promise<string[]> {
+    private async getImageEntrypoint(logger: Logger | undefined): Promise<string[]> {
         const { stdout, stderr, exitCode } = await loggingExeca(
             logger,
             this.runner,
@@ -329,7 +329,7 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
                 return entrypoint;
             }
         } catch (e) {
-            logger.warn(`Failed to parse entrypoint for image ${this.imageName}: ${e}`);
+            logger?.warn(`Failed to parse entrypoint for image ${this.imageName}: ${e}`);
         }
 
         throw new Error(

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -86,10 +86,15 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             throw error;
         }
 
-        const logFn = logLevel === LogLevel.Debug || logLevel === LogLevel.Trace ? logger.info : logger.debug;
-        logFn(
-            `Started ${this.containers.length} reusable container(s) from image ${this.imageName}: ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
-        );
+        if (logLevel === LogLevel.Debug || logLevel === LogLevel.Trace) {
+            logger.info(
+                `Started ${this.containers.length} reusable container(s) from image ${this.imageName}: ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
+            );
+        } else {
+            logger.debug(
+                `Started ${this.containers.length} reusable container(s) from image ${this.imageName}: ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
+            );
+        }
     }
 
     public async execute(args: ExecutionEnvironment.ExecuteArgs): Promise<void> {
@@ -290,10 +295,15 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             });
         });
         await Promise.all(stopPromises);
-        const logFn = logLevel === LogLevel.Debug || logLevel === LogLevel.Trace ? logger.info : logger.debug;
-        logFn(
-            `Stopped ${this.containers.length} reusable container(s): ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
-        );
+        if (logLevel === LogLevel.Debug || logLevel === LogLevel.Trace) {
+            logger.info(
+                `Stopped ${this.containers.length} reusable container(s): ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
+            );
+        } else {
+            logger.debug(
+                `Stopped ${this.containers.length} reusable container(s): ${this.containers.map((id) => id.substring(0, 12)).join(", ")}`
+            );
+        }
         this.containers = [];
         this.availableContainers = [];
     }

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -329,7 +329,8 @@ function addTestCommand(cli: Argv) {
                         scriptRunner,
                         keepContainer: false, // not used for local
                         inspect: argv.inspect,
-                        workspaceCache: new WorkspaceCache()
+                        workspaceCache: new WorkspaceCache(),
+                        logLevel: argv["log-level"]
                     });
                 } else {
                     scriptRunner = new ContainerScriptRunner(
@@ -349,7 +350,8 @@ function addTestCommand(cli: Argv) {
                         inspect: argv.inspect,
                         runner: argv.containerRuntime as "docker" | "podman" | undefined,
                         parallelism: argv.parallel,
-                        workspaceCache: new WorkspaceCache()
+                        workspaceCache: new WorkspaceCache(),
+                        logLevel: argv["log-level"]
                     });
                 }
 

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -69,7 +69,8 @@ export async function runWithCustomFixture({
             skipScripts,
             scriptRunner,
             keepContainer,
-            inspect
+            inspect,
+            logLevel
         });
     } else {
         testRunner = new ContainerTestRunner({
@@ -80,7 +81,8 @@ export async function runWithCustomFixture({
             keepContainer,
             scriptRunner,
             inspect,
-            parallelism: 1
+            parallelism: 1,
+            logLevel
         });
     }
 

--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -161,8 +161,9 @@ export class ContainerScriptRunner extends ScriptRunner {
     }
 
     public async stop(): Promise<void> {
+        const logger = this.shouldStreamOutput() ? this.context.logger : undefined;
         for (const script of this.scripts) {
-            await loggingExeca(this.context.logger, this.runner, ["kill", script.containerId], {
+            await loggingExeca(logger, this.runner, ["kill", script.containerId], {
                 doNotPipeOutput: !this.shouldStreamOutput()
             });
         }
@@ -261,7 +262,8 @@ export class ContainerScriptRunner extends ScriptRunner {
 
     private async buildFernCli(context: TaskContext): Promise<AbsoluteFilePath> {
         const rootDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("../../.."));
-        await loggingExeca(context.logger, "pnpm", ["fern:build"], {
+        const logger = this.shouldStreamOutput() ? context.logger : undefined;
+        await loggingExeca(logger, "pnpm", ["fern:build"], {
             cwd: rootDir,
             doNotPipeOutput: !this.shouldStreamOutput()
         });
@@ -271,10 +273,11 @@ export class ContainerScriptRunner extends ScriptRunner {
     private async startContainers(context: TaskContext): Promise<void> {
         const absoluteFilePathToFernCli = await this.buildFernCli(context);
         const cliVolumeBind = `${absoluteFilePathToFernCli}:/fern`;
+        const logger = this.shouldStreamOutput() ? context.logger : undefined;
         // Start running a container for each script instance
         for (const script of this.workspace.workspaceConfig.scripts ?? []) {
             const startSeedCommand = await loggingExeca(
-                context.logger,
+                logger,
                 this.runner,
                 [
                     "run",

--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -163,7 +163,7 @@ export class ContainerScriptRunner extends ScriptRunner {
     public async stop(): Promise<void> {
         for (const script of this.scripts) {
             await loggingExeca(this.context.logger, this.runner, ["kill", script.containerId], {
-                doNotPipeOutput: false
+                doNotPipeOutput: !this.shouldStreamOutput()
             });
         }
     }
@@ -261,7 +261,10 @@ export class ContainerScriptRunner extends ScriptRunner {
 
     private async buildFernCli(context: TaskContext): Promise<AbsoluteFilePath> {
         const rootDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("../../.."));
-        await loggingExeca(context.logger, "pnpm", ["fern:build"], { cwd: rootDir });
+        await loggingExeca(context.logger, "pnpm", ["fern:build"], {
+            cwd: rootDir,
+            doNotPipeOutput: !this.shouldStreamOutput()
+        });
         return join(rootDir, RelativeFilePath.of("packages/cli/cli/dist/prod"));
     }
 
@@ -286,7 +289,7 @@ export class ContainerScriptRunner extends ScriptRunner {
                     "/bin/sh"
                 ],
                 {
-                    doNotPipeOutput: false
+                    doNotPipeOutput: !this.shouldStreamOutput()
                 }
             );
             const containerId = startSeedCommand.stdout;

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -50,9 +50,12 @@ export class ContainerTestRunner extends TestRunner {
         if (containerCommands == null) {
             throw new Error(`Failed. No ${this.runner} command for ${this.generator.workspaceName}`);
         }
+        if (!this.shouldPipeOutput()) {
+            CONSOLE_LOGGER.info(`Building container for ${this.generator.workspaceName}...`);
+        }
         const containerBuildReturn = await runScript({
             commands: containerCommands,
-            logger: CONSOLE_LOGGER,
+            logger: this.shouldPipeOutput() ? CONSOLE_LOGGER : undefined,
             workingDir: path.dirname(path.dirname(this.generator.absolutePathToWorkspace)),
             doNotPipeOutput: !this.shouldPipeOutput()
         });
@@ -69,6 +72,9 @@ export class ContainerTestRunner extends TestRunner {
             runner: this.runner,
             poolSize: this.parallelism
         });
+        if (!this.shouldPipeOutput()) {
+            CONSOLE_LOGGER.info(`Starting ${this.parallelism} container(s)...`);
+        }
         await this.reusableContainer.start(CONSOLE_LOGGER, this.logLevel);
     }
 

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -4,7 +4,7 @@ import {
     ReusableContainerExecutionEnvironment,
     runContainerizedGenerationForSeed
 } from "@fern-api/local-workspace-runner";
-import { CONSOLE_LOGGER } from "@fern-api/logger";
+import { CONSOLE_LOGGER, LogLevel } from "@fern-api/logger";
 import path from "path";
 
 import { runScript } from "../../../runScript.js";
@@ -54,7 +54,7 @@ export class ContainerTestRunner extends TestRunner {
             commands: containerCommands,
             logger: CONSOLE_LOGGER,
             workingDir: path.dirname(path.dirname(this.generator.absolutePathToWorkspace)),
-            doNotPipeOutput: false
+            doNotPipeOutput: !this.shouldPipeOutput()
         });
         if (containerBuildReturn.exitCode !== 0) {
             throw new Error(`Failed to build the container for ${this.generator.workspaceName}.`);
@@ -69,12 +69,12 @@ export class ContainerTestRunner extends TestRunner {
             runner: this.runner,
             poolSize: this.parallelism
         });
-        await this.reusableContainer.start(CONSOLE_LOGGER);
+        await this.reusableContainer.start(CONSOLE_LOGGER, this.logLevel);
     }
 
     public async cleanup(): Promise<void> {
         if (this.reusableContainer != null) {
-            await this.reusableContainer.stop(CONSOLE_LOGGER);
+            await this.reusableContainer.stop(CONSOLE_LOGGER, this.logLevel);
             this.reusableContainer = undefined;
         }
     }

--- a/packages/seed/src/commands/test/test-runner/LocalTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/LocalTestRunner.ts
@@ -18,7 +18,7 @@ export class LocalTestRunner extends TestRunner {
         );
         const result = await runScript({
             commands: localConfig.buildCommand,
-            doNotPipeOutput: false,
+            doNotPipeOutput: !this.shouldPipeOutput(),
             logger: CONSOLE_LOGGER,
             workingDir
         });

--- a/packages/seed/src/commands/test/test-runner/LocalTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/LocalTestRunner.ts
@@ -19,7 +19,7 @@ export class LocalTestRunner extends TestRunner {
         const result = await runScript({
             commands: localConfig.buildCommand,
             doNotPipeOutput: !this.shouldPipeOutput(),
-            logger: CONSOLE_LOGGER,
+            logger: this.shouldPipeOutput() ? CONSOLE_LOGGER : undefined,
             workingDir
         });
         if (result.exitCode !== 0) {

--- a/packages/seed/src/commands/test/test-runner/TestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/TestRunner.ts
@@ -1,6 +1,7 @@
 import { FernWorkspace } from "@fern-api/api-workspace-commons";
 import { APIS_DIRECTORY, FERN_DIRECTORY, GeneratorInvocation, generatorsYml } from "@fern-api/configuration";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { LogLevel } from "@fern-api/logger";
 import { TaskContext, TaskResult } from "@fern-api/task-context";
 import { getBaseOpenAPIWorkspaceSettingsFromGeneratorInvocation } from "@fern-api/workspace-loader";
 import path from "path";
@@ -25,6 +26,7 @@ export declare namespace TestRunner {
         keepContainer: boolean;
         inspect: boolean;
         workspaceCache?: WorkspaceCache;
+        logLevel: LogLevel;
     }
 
     interface RunArgs {
@@ -126,6 +128,7 @@ export abstract class TestRunner {
     private readonly keepContainer: boolean;
     private scriptRunner: ScriptRunner | undefined;
     private readonly workspaceCache: WorkspaceCache | undefined;
+    protected readonly logLevel: LogLevel;
 
     constructor({
         generator,
@@ -134,7 +137,8 @@ export abstract class TestRunner {
         skipScripts,
         keepContainer,
         scriptRunner,
-        workspaceCache
+        workspaceCache,
+        logLevel
     }: TestRunner.Args) {
         this.generator = generator;
         this.lock = lock;
@@ -143,6 +147,11 @@ export abstract class TestRunner {
         this.keepContainer = keepContainer;
         this.scriptRunner = scriptRunner;
         this.workspaceCache = workspaceCache;
+        this.logLevel = logLevel;
+    }
+
+    protected shouldPipeOutput(): boolean {
+        return this.logLevel === LogLevel.Debug || this.logLevel === LogLevel.Trace;
     }
 
     public abstract build(): Promise<void>;

--- a/packages/seed/src/runScript.ts
+++ b/packages/seed/src/runScript.ts
@@ -12,7 +12,7 @@ export async function runScript({
 }: {
     commands: string[];
     workingDir: string;
-    logger: Logger;
+    logger?: Logger;
     doNotPipeOutput: boolean;
     env?: Record<string, string>;
 }): Promise<loggingExeca.ReturnValue> {


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger ([Devin session](https://app.devin.ai/sessions/8397e364fd904e389a3896665794ffdf))

When running `pnpm seed test`, there is a lot of noisy output from turbo builds, docker builds, and container spin-up/kill (`+ docker run ...`, `+ docker rm -f ...`, `+ bash ...`, `Started N reusable container(s)`, etc.). This PR suppresses all of that output unless `--log-level debug` is passed, and adds brief progress messages in its place.

### Expected output (default log level)
```
Building container for ts-sdk...
Starting 14 container(s)...
[ts-sdk:object]:  Running generator...
[ts-sdk:object]:  Started.
...
1/1 test cases passed
```

### Expected output (`--log-level debug`)
All previous verbose output (docker commands, container IDs, etc.) remains visible.

## Changes Made

- Added `logLevel` to `TestRunner.Args` and threaded it through to `ContainerTestRunner`, `LocalTestRunner`, `runWithCustomFixture`, and `cli.ts`
- Added `shouldPipeOutput()` helper on `TestRunner` — returns `true` only for debug/trace log levels
- **Suppressed `loggingExeca` debug lines**: `CONSOLE_LOGGER` outputs all levels (including debug), so `loggingExeca`'s `logger?.debug("+ command")` lines were always visible. Fixed by passing `undefined` as the logger when not in debug mode:
  - `ContainerTestRunner.build()` → `runScript()` (docker build)
  - `LocalTestRunner.build()` → `runScript()` (local build)
  - `ContainerScriptRunner.stop()` (docker kill)
  - `ContainerScriptRunner.buildFernCli()` (turbo/pnpm build)
  - `ContainerScriptRunner.startContainers()` (docker run)
  - `ReusableContainerExecutionEnvironment.start()` → `startContainer()` / `getImageEntrypoint()`
  - `ReusableContainerExecutionEnvironment.stop()` → `stopContainer()`
- Made `logger` optional in `startContainer()`, `stopContainer()` (docker-utils), `runScript()`, and `getImageEntrypoint()`
- Suppressed "Started/Stopped N reusable container(s)" info messages in non-debug mode
- Added brief progress messages in non-debug mode: `"Building container for X..."` and `"Starting N container(s)..."`

## Human Review Checklist

- [ ] **Silent build failures**: When builds fail in non-debug mode, the thrown error message (e.g. "Failed to build the container for X") is shown but NOT the underlying build stdout/stderr. Consider whether output should be captured and logged on failure even in non-debug mode.
- [ ] **`logger?.warn` in `getImageEntrypoint`**: Changed from `logger.warn(...)` to `logger?.warn(...)` — entrypoint parse warnings are silently swallowed in non-debug mode. Is this acceptable?
- [ ] **Optional logger in docker-utils**: `startContainer` and `stopContainer` now accept `logger?: Logger`. Verify no existing callers outside seed are affected by this type change (should be backward compatible since it widens the type).
- [ ] **Spinner follow-up**: User requested a spinner — current implementation uses simple `console.info` messages. May want a follow-up to add a proper spinner (e.g. `ora`) to the seed package.

## Testing

- [x] Lint/typecheck passes (`pnpm run check`)
- [ ] Manual testing: run `pnpm seed test --generator ts-sdk --fixture object` with and without `--log-level debug` to verify output behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
