### PR TITLE
chore(internal): add unit tests for websocket-type-schema-generator

### DIFF
--- a/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/WebsocketTypeSchemaGenerator.test.ts
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/WebsocketTypeSchemaGenerator.test.ts
@@ -88,7 +88,18 @@ function createMockSdkContext() {
         coreUtilities: {
             zurg: {
                 Schema: {
-                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("Schema"),
+                    _getReferenceToType: ({
+                        rawShape,
+                        parsedShape
+                    }: { rawShape: ts.TypeNode; parsedShape: ts.TypeNode }) =>
+                        ts.factory.createTypeReferenceNode("Schema", [
+                            ts.factory.createTypeReferenceNode(
+                                ts.factory.createIdentifier(getTextOfTsNode(rawShape))
+                            ),
+                            ts.factory.createTypeReferenceNode(
+                                ts.factory.createIdentifier(getTextOfTsNode(parsedShape))
+                            )
+                        ]),
                     _fromExpression: (expr: ts.Expression) => createMockZurgSchema(getTextOfTsNode(expr))
                 },
                 never: () => createMockZurgSchema("z.never"),

--- a/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/WebsocketTypeSchemaGenerator.test.ts
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/WebsocketTypeSchemaGenerator.test.ts
@@ -220,6 +220,18 @@ describe("GeneratedWebsocketResponseSchemaImpl", () => {
             expect(getTextOfTsNode(result)).toMatchSnapshot();
         });
 
+        it("respects omitUndefined flag", () => {
+            const impl = createImpl({
+                includeSerdeLayer: true,
+                omitUndefined: true,
+                receiveMessages: [createMockReceiveMessage()]
+            });
+            const context = createMockSdkContext();
+            const rawRef = ts.factory.createIdentifier("rawData");
+            const result = impl.deserializeResponse(rawRef, context);
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
         it("respects skipResponseValidation flag", () => {
             const impl = createImpl({
                 includeSerdeLayer: true,

--- a/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/WebsocketTypeSchemaGenerator.test.ts
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/WebsocketTypeSchemaGenerator.test.ts
@@ -24,12 +24,32 @@ function createMockReference(name: string): Reference {
 function createMockZurgSchema(name: string): Zurg.Schema {
     return {
         toExpression: () => ts.factory.createIdentifier(name),
-        parse: (ref: ts.Expression, opts?: Record<string, unknown>) =>
-            ts.factory.createCallExpression(
+        parse: (ref: ts.Expression, opts?: Record<string, unknown>) => {
+            const args: ts.Expression[] = [ref];
+            if (opts && Object.keys(opts).length > 0) {
+                args.push(
+                    ts.factory.createObjectLiteralExpression(
+                        Object.entries(opts)
+                            .filter(([, v]) => v !== undefined)
+                            .map(([k, v]) =>
+                                ts.factory.createPropertyAssignment(
+                                    k,
+                                    typeof v === "boolean"
+                                        ? v
+                                            ? ts.factory.createTrue()
+                                            : ts.factory.createFalse()
+                                        : ts.factory.createStringLiteral(String(v))
+                                )
+                            )
+                    )
+                );
+            }
+            return ts.factory.createCallExpression(
                 ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier(name), "parse"),
                 undefined,
-                [ref]
-            ),
+                args
+            );
+        },
         json: (ref: ts.Expression) =>
             ts.factory.createCallExpression(
                 ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier(name), "json"),
@@ -102,7 +122,7 @@ function createMockChannel(name = "testChannel"): FernIr.WebSocketChannel {
     } as any;
 }
 
-function createMockReceiveMessage(bodyTypeName = "ChatMessage"): FernIr.WebSocketMessageBodyReference {
+function createMockReceiveMessage(): FernIr.WebSocketMessageBodyReference {
     return {
         bodyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
         // biome-ignore lint/suspicious/noExplicitAny: test mock

--- a/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/WebsocketTypeSchemaGenerator.test.ts
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/WebsocketTypeSchemaGenerator.test.ts
@@ -1,0 +1,230 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { getTextOfTsNode, PackageId, Reference, Zurg } from "@fern-typescript/commons";
+import { Project, ts } from "ts-morph";
+import { describe, expect, it } from "vitest";
+
+import { GeneratedWebsocketResponseSchemaImpl } from "../GeneratedWebsocketResponseSchemaImpl.js";
+import { WebsocketTypeSchemaGenerator } from "../WebsocketTypeSchemaGenerator.js";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+const MOCK_PACKAGE_ID = "pkg_test" as unknown as PackageId;
+
+function createMockReference(name: string): Reference {
+    return {
+        getExpression: () => ts.factory.createIdentifier(name),
+        getTypeNode: () => ts.factory.createTypeReferenceNode(name),
+        getEntityName: () => ts.factory.createIdentifier(name)
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+    } as any;
+}
+
+function createMockZurgSchema(name: string): Zurg.Schema {
+    return {
+        toExpression: () => ts.factory.createIdentifier(name),
+        parse: (ref: ts.Expression, opts?: Record<string, unknown>) =>
+            ts.factory.createCallExpression(
+                ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier(name), "parse"),
+                undefined,
+                [ref]
+            ),
+        json: (ref: ts.Expression) =>
+            ts.factory.createCallExpression(
+                ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier(name), "json"),
+                undefined,
+                [ref]
+            ),
+        toZurgExpression: () => ({
+            expression: ts.factory.createIdentifier(name),
+            isOptional: false
+        })
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+    } as any;
+}
+
+function createMockSdkContext() {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const sourceFile = project.createSourceFile("test.ts", "");
+    return {
+        sourceFile,
+        type: {
+            getReferenceToType: () => ({
+                typeNode: ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                typeNodeWithoutUndefined: ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                isOptional: false
+            })
+        },
+        typeSchema: {
+            getReferenceToRawType: () => ({
+                typeNode: ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
+            }),
+            getSchemaOfTypeReference: () => createMockZurgSchema("MessageSchema")
+        },
+        websocketTypeSchema: {
+            getReferenceToWebsocketResponseType: () => createMockReference("WebsocketResponse")
+        },
+        coreUtilities: {
+            zurg: {
+                Schema: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("Schema"),
+                    _fromExpression: (expr: ts.Expression) => createMockZurgSchema(getTextOfTsNode(expr))
+                },
+                never: () => createMockZurgSchema("z.never"),
+                undiscriminatedUnion: (schemas: Zurg.Schema[]) =>
+                    createMockZurgSchema(`z.undiscriminatedUnion([${schemas.map(() => "schema").join(", ")}])`)
+            }
+        },
+        logger: {
+            // biome-ignore lint/suspicious/noEmptyBlockStatements: test mock no-op
+            warn: () => {}
+        }
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+    } as any;
+}
+
+function createMockChannel(name = "testChannel"): FernIr.WebSocketChannel {
+    return {
+        name,
+        displayName: undefined,
+        path: { head: "/ws", parts: [] },
+        auth: false,
+        headers: [],
+        queryParameters: [],
+        pathParameters: [],
+        allPathParameters: [],
+        messages: [],
+        examples: [],
+        docs: undefined,
+        availability: undefined
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+    } as any;
+}
+
+function createMockReceiveMessage(bodyTypeName = "ChatMessage"): FernIr.WebSocketMessageBodyReference {
+    return {
+        bodyType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined })
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+    } as any;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// WebsocketTypeSchemaGenerator (factory)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("WebsocketTypeSchemaGenerator", () => {
+    it("creates GeneratedWebsocketResponseSchemaImpl with flags", () => {
+        const generator = new WebsocketTypeSchemaGenerator({
+            includeSerdeLayer: true,
+            omitUndefined: false,
+            skipResponseValidation: false
+        });
+        const result = generator.generateInlinedWebsocketMessageBodySchema({
+            packageId: MOCK_PACKAGE_ID,
+            channel: createMockChannel(),
+            receiveMessages: [],
+            typeName: "TestSchema"
+        });
+        expect(result).toBeDefined();
+    });
+
+    it("passes through all configuration flags", () => {
+        const generator = new WebsocketTypeSchemaGenerator({
+            includeSerdeLayer: false,
+            omitUndefined: true,
+            skipResponseValidation: true
+        });
+        const result = generator.generateInlinedWebsocketMessageBodySchema({
+            packageId: MOCK_PACKAGE_ID,
+            channel: createMockChannel(),
+            receiveMessages: [createMockReceiveMessage()],
+            typeName: "MessageSchema"
+        });
+        expect(result).toBeDefined();
+    });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// GeneratedWebsocketResponseSchemaImpl
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("GeneratedWebsocketResponseSchemaImpl", () => {
+    function createImpl(opts?: {
+        receiveMessages?: FernIr.WebSocketMessageBodyReference[];
+        includeSerdeLayer?: boolean;
+        omitUndefined?: boolean;
+        skipResponseValidation?: boolean;
+        channelName?: string;
+    }) {
+        return new GeneratedWebsocketResponseSchemaImpl({
+            packageId: MOCK_PACKAGE_ID,
+            channel: createMockChannel(opts?.channelName),
+            receiveMessages: opts?.receiveMessages ?? [],
+            typeName: "WebsocketResponseSchema",
+            includeSerdeLayer: opts?.includeSerdeLayer ?? true,
+            omitUndefined: opts?.omitUndefined ?? false,
+            skipResponseValidation: opts?.skipResponseValidation ?? false
+        });
+    }
+
+    describe("deserializeResponse", () => {
+        it("returns raw reference when includeSerdeLayer is false", () => {
+            const impl = createImpl({ includeSerdeLayer: false });
+            const context = createMockSdkContext();
+            const rawRef = ts.factory.createIdentifier("rawData");
+            const result = impl.deserializeResponse(rawRef, context);
+            expect(getTextOfTsNode(result)).toBe("rawData");
+        });
+
+        it("returns parsed expression when includeSerdeLayer is true", () => {
+            const impl = createImpl({
+                includeSerdeLayer: true,
+                receiveMessages: [createMockReceiveMessage()]
+            });
+            const context = createMockSdkContext();
+            const rawRef = ts.factory.createIdentifier("rawData");
+            const result = impl.deserializeResponse(rawRef, context);
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+
+        it("respects skipResponseValidation flag", () => {
+            const impl = createImpl({
+                includeSerdeLayer: true,
+                skipResponseValidation: true,
+                receiveMessages: [createMockReceiveMessage()]
+            });
+            const context = createMockSdkContext();
+            const rawRef = ts.factory.createIdentifier("rawData");
+            const result = impl.deserializeResponse(rawRef, context);
+            expect(getTextOfTsNode(result)).toMatchSnapshot();
+        });
+    });
+
+    describe("writeToFile", () => {
+        it("writes schema for channel with no receive messages", () => {
+            const impl = createImpl({ receiveMessages: [] });
+            const context = createMockSdkContext();
+            impl.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("writes schema for channel with single receive message", () => {
+            const impl = createImpl({
+                receiveMessages: [createMockReceiveMessage()]
+            });
+            const context = createMockSdkContext();
+            impl.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
+        it("writes schema for channel with multiple receive messages", () => {
+            const impl = createImpl({
+                receiveMessages: [createMockReceiveMessage(), createMockReceiveMessage()]
+            });
+            const context = createMockSdkContext();
+            impl.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+    });
+});

--- a/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/WebsocketTypeSchemaGenerator.test.ts
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/WebsocketTypeSchemaGenerator.test.ts
@@ -91,11 +91,12 @@ function createMockSdkContext() {
                     _getReferenceToType: ({
                         rawShape,
                         parsedShape
-                    }: { rawShape: ts.TypeNode; parsedShape: ts.TypeNode }) =>
+                    }: {
+                        rawShape: ts.TypeNode;
+                        parsedShape: ts.TypeNode;
+                    }) =>
                         ts.factory.createTypeReferenceNode("Schema", [
-                            ts.factory.createTypeReferenceNode(
-                                ts.factory.createIdentifier(getTextOfTsNode(rawShape))
-                            ),
+                            ts.factory.createTypeReferenceNode(ts.factory.createIdentifier(getTextOfTsNode(rawShape))),
                             ts.factory.createTypeReferenceNode(
                                 ts.factory.createIdentifier(getTextOfTsNode(parsedShape))
                             )

--- a/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/__snapshots__/WebsocketTypeSchemaGenerator.test.ts.snap
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/__snapshots__/WebsocketTypeSchemaGenerator.test.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > respects omitUndefined flag 1`] = `"WebsocketResponse.parse(rawData, { unrecognizedObjectKeys: "passthrough", allowUnrecognizedUnionMembers: true, allowUnrecognizedEnumValues: true, skipValidation: false, breadcrumbsPrefix: "", omitUndefined: true })"`;
+
 exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > respects skipResponseValidation flag 1`] = `"WebsocketResponse.parse(rawData, { unrecognizedObjectKeys: "passthrough", allowUnrecognizedUnionMembers: true, allowUnrecognizedEnumValues: true, skipValidation: true, breadcrumbsPrefix: "", omitUndefined: false })"`;
 
 exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > returns parsed expression when includeSerdeLayer is true 1`] = `"WebsocketResponse.parse(rawData, { unrecognizedObjectKeys: "passthrough", allowUnrecognizedUnionMembers: true, allowUnrecognizedEnumValues: true, skipValidation: false, breadcrumbsPrefix: "", omitUndefined: false })"`;

--- a/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/__snapshots__/WebsocketTypeSchemaGenerator.test.ts.snap
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/__snapshots__/WebsocketTypeSchemaGenerator.test.ts.snap
@@ -1,0 +1,32 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > respects skipResponseValidation flag 1`] = `"WebsocketResponse.parse(rawData)"`;
+
+exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > returns parsed expression when includeSerdeLayer is true 1`] = `"WebsocketResponse.parse(rawData)"`;
+
+exports[`GeneratedWebsocketResponseSchemaImpl > writeToFile > writes schema for channel with multiple receive messages 1`] = `
+"export const WebsocketResponseSchema: Schema = z.undiscriminatedUnion([schema, schema]);
+
+export declare namespace WebsocketResponseSchema {
+    export type Raw = string | string;
+}
+"
+`;
+
+exports[`GeneratedWebsocketResponseSchemaImpl > writeToFile > writes schema for channel with no receive messages 1`] = `
+"export const WebsocketResponseSchema: Schema = z.never;
+
+export declare namespace WebsocketResponseSchema {
+    export type Raw = never;
+}
+"
+`;
+
+exports[`GeneratedWebsocketResponseSchemaImpl > writeToFile > writes schema for channel with single receive message 1`] = `
+"export const WebsocketResponseSchema: Schema = z.undiscriminatedUnion([schema]);
+
+export declare namespace WebsocketResponseSchema {
+    export type Raw = string;
+}
+"
+`;

--- a/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/__snapshots__/WebsocketTypeSchemaGenerator.test.ts.snap
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/__snapshots__/WebsocketTypeSchemaGenerator.test.ts.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > respects skipResponseValidation flag 1`] = `"WebsocketResponse.parse(rawData)"`;
+exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > respects skipResponseValidation flag 1`] = `"WebsocketResponse.parse(rawData, { unrecognizedObjectKeys: "passthrough", allowUnrecognizedUnionMembers: true, allowUnrecognizedEnumValues: true, skipValidation: true, breadcrumbsPrefix: "", omitUndefined: false })"`;
 
-exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > returns parsed expression when includeSerdeLayer is true 1`] = `"WebsocketResponse.parse(rawData)"`;
+exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > returns parsed expression when includeSerdeLayer is true 1`] = `"WebsocketResponse.parse(rawData, { unrecognizedObjectKeys: "passthrough", allowUnrecognizedUnionMembers: true, allowUnrecognizedEnumValues: true, skipValidation: false, breadcrumbsPrefix: "", omitUndefined: false })"`;
 
 exports[`GeneratedWebsocketResponseSchemaImpl > writeToFile > writes schema for channel with multiple receive messages 1`] = `
 "export const WebsocketResponseSchema: Schema = z.undiscriminatedUnion([schema, schema]);

--- a/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/__snapshots__/WebsocketTypeSchemaGenerator.test.ts.snap
+++ b/generators/typescript/sdk/websocket-type-schema-generator/src/__test__/__snapshots__/WebsocketTypeSchemaGenerator.test.ts.snap
@@ -5,7 +5,7 @@ exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > respects s
 exports[`GeneratedWebsocketResponseSchemaImpl > deserializeResponse > returns parsed expression when includeSerdeLayer is true 1`] = `"WebsocketResponse.parse(rawData, { unrecognizedObjectKeys: "passthrough", allowUnrecognizedUnionMembers: true, allowUnrecognizedEnumValues: true, skipValidation: false, breadcrumbsPrefix: "", omitUndefined: false })"`;
 
 exports[`GeneratedWebsocketResponseSchemaImpl > writeToFile > writes schema for channel with multiple receive messages 1`] = `
-"export const WebsocketResponseSchema: Schema = z.undiscriminatedUnion([schema, schema]);
+"export const WebsocketResponseSchema: Schema<WebsocketResponse.Raw, string | string> = z.undiscriminatedUnion([schema, schema]);
 
 export declare namespace WebsocketResponseSchema {
     export type Raw = string | string;
@@ -14,7 +14,7 @@ export declare namespace WebsocketResponseSchema {
 `;
 
 exports[`GeneratedWebsocketResponseSchemaImpl > writeToFile > writes schema for channel with no receive messages 1`] = `
-"export const WebsocketResponseSchema: Schema = z.never;
+"export const WebsocketResponseSchema: Schema<WebsocketResponse.Raw, never> = z.never;
 
 export declare namespace WebsocketResponseSchema {
     export type Raw = never;
@@ -23,7 +23,7 @@ export declare namespace WebsocketResponseSchema {
 `;
 
 exports[`GeneratedWebsocketResponseSchemaImpl > writeToFile > writes schema for channel with single receive message 1`] = `
-"export const WebsocketResponseSchema: Schema = z.undiscriminatedUnion([schema]);
+"export const WebsocketResponseSchema: Schema<WebsocketResponse.Raw, string> = z.undiscriminatedUnion([schema]);
 
 export declare namespace WebsocketResponseSchema {
     export type Raw = string;

--- a/generators/typescript/sdk/websocket-type-schema-generator/vitest.config.ts
+++ b/generators/typescript/sdk/websocket-type-schema-generator/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@fern-api/configs/vitest/base.mjs";


### PR DESCRIPTION
## Description

Refs: Part of Priority 5 (Niche / Less Critical) unit test initiative for TypeScript SDK generator components.

Adds unit tests for the `websocket-type-schema-generator` package, covering `WebsocketTypeSchemaGenerator` (factory) and `GeneratedWebsocketResponseSchemaImpl` (schema generation and deserialization).

[Link to Devin Session](https://app.devin.ai/sessions/ce25a6da44a14437a2fa92712a187cf6) | Requested by @Swimburger

## Changes Made

- Added `WebsocketTypeSchemaGenerator.test.ts` with **9 tests** and **6 snapshots**:
  - `WebsocketTypeSchemaGenerator`: factory instantiation, configuration flag passthrough
  - `GeneratedWebsocketResponseSchemaImpl.deserializeResponse`: raw passthrough when `includeSerdeLayer=false`, parsed expression when `true`, `skipResponseValidation` flag behavior, `omitUndefined` flag behavior
  - `GeneratedWebsocketResponseSchemaImpl.writeToFile`: empty channel (→ `z.never`), single receive message (→ `z.undiscriminatedUnion([schema])`), multiple receive messages (→ `z.undiscriminatedUnion([schema, schema])`)
- Added `vitest.config.ts` using shared base config
- No `package.json` changes needed — `@fern-fern/ir-sdk` is already a regular dependency

## Updates since last revision

- Added missing permutation test for `omitUndefined: true` in `deserializeResponse` — exercises the `omitUndefined` flag path in `getSchemaOptions()` (source lines 55–61 of `GeneratedWebsocketResponseSchemaImpl.ts`). This brings the total from 8 → **9 tests** and 5 → **6 snapshots**.

## Testing

- [x] Unit tests added (9 tests, 6 snapshots, all passing locally)
- [x] `pnpm test` passes in the package
- [x] CI green (61/61 checks)

## Human Review Checklist

- [ ] **Mock context coverage**: `createMockSdkContext` mocks `type.*`, `typeSchema.*`, `websocketTypeSchema.*`, `coreUtilities.zurg.*`, and `logger.warn`. Verify these cover all `context.*` property accesses in `GeneratedWebsocketResponseSchemaImpl` — any missing access would cause a runtime error in tests rather than a silent skip.
- [ ] **Unused parameter**: `createMockReceiveMessage()` no longer accepts a parameter (cleaned up from earlier iteration) — verify this is consistent with usage.
- [ ] **Snapshot correctness**: Confirm `z.never` for empty channels and `z.undiscriminatedUnion` for non-empty channels matches the real generator behavior (e.g., compare against seed output for websocket channels).
- [ ] **omitUndefined snapshot**: The new snapshot shows `omitUndefined: true` in the parse options object — verify this matches the real `getSchemaOptions()` output structure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
