### PR TITLE
chore(java): update bundled npm tar from 7.5.10 to 7.5.11

### DIFF
--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -88,15 +88,15 @@ RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     mv package glob && \
     rm glob-11.1.0.tgz
 
-# Patch npm's bundled tar to 7.5.10 to fix GHSA-34x7-hfp2-rc4v, GHSA-r6q2-hw4h-h46w, GHSA-83g3-92jg-28cx,
+# Patch npm's bundled tar to 7.5.11 to fix GHSA-34x7-hfp2-rc4v, GHSA-r6q2-hw4h-h46w, GHSA-83g3-92jg-28cx,
 # GHSA-qffp-2rhf-9h96 (Hardlink Path Traversal via Drive-Relative Linkpath)
 # Note: We use curl instead of npm pack because npm pack depends on tar itself
 RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     rm -rf tar && \
-    curl -sL https://registry.npmjs.org/tar/-/tar-7.5.10.tgz -o tar-7.5.10.tgz && \
-    tar -xzf tar-7.5.10.tgz && \
+    curl -sL https://registry.npmjs.org/tar/-/tar-7.5.11.tgz -o tar-7.5.11.tgz && \
+    tar -xzf tar-7.5.11.tgz && \
     mv package tar && \
-    rm tar-7.5.10.tgz
+    rm tar-7.5.11.tgz
 
 # Patch minimatch to 10.2.3 to fix GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74
 # (ReDoS via combinatorial backtracking in matchOne() and nested *() extglobs)

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.9
+  changelogEntry:
+    - summary: |
+        Update bundled npm tar package from 7.5.10 to 7.5.11.
+      type: chore
+  createdAt: "2026-03-12"
+  irVersion: 65
+
 - version: 3.42.8
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Bumps the bundled npm `tar` package in the Java SDK Docker image from 7.5.10 to 7.5.11.

Requested by: @davidkonigsberg
[Devin Session](https://app.devin.ai/sessions/f52f0ea23abc4b5ca3fbdea3f80adf10)

## Changes Made

- Updated `generators/java/sdk/Dockerfile` to download and install `tar@7.5.11` instead of `tar@7.5.10`
- Added `versions.yml` entry for v3.42.9

## Review Checklist

- [ ] Verify `tar@7.5.11` is published on the npm registry
- [ ] Confirm version bump (3.42.9) and changelog entry format are correct