### PR TITLE
fix(rust): handle bytes endpoints, query names, and wiremock fixes

### DIFF
--- a/generators/rust/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/rust/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -630,10 +630,18 @@ export class EndpointSnippetGenerator {
         // - Referenced body WITHOUT query params → uses inner type directly
         // - Referenced body WITH query params → creates wrapper type
         // - Inlined body (properties) → creates wrapper type
+        // - Bytes body WITH query params → individual params for each query param + bytes body
         const body = request.body;
         const isReferencedBodyOnly = body != null && !hasQueryParams && body.type === "referenced";
+        const isBytesWithQueryParams = hasQueryParams && body != null &&
+            body.type === "referenced" && body.bodyType.type === "bytes";
 
-        if (isReferencedBodyOnly && body.type === "referenced") {
+        if (isBytesWithQueryParams) {
+            // Bytes endpoints with query params: SDK generates individual &Option<T> params
+            // for each query parameter, then &Vec<u8> for body (not a struct).
+            // This matches SubClientGenerator's addIndividualQueryParameters behavior.
+            args.push(...this.getBytesEndpointArgs({ request, snippet }));
+        } else if (isReferencedBodyOnly && body.type === "referenced") {
             // Use inner type directly - match SDK generator's behavior for referenced body without query params
             const bodyExpr = this.getReferencedRequestBodyPropertyExpression({
                 body: body.bodyType,
@@ -654,6 +662,51 @@ export class EndpointSnippetGenerator {
             args.push(rust.Expression.functionCall("Some", [this.getRequestOptionsWithHeaders({ request, snippet })]));
         } else {
             args.push(rust.Expression.raw("None"));
+        }
+
+        return args;
+    }
+
+    private getBytesEndpointArgs({
+        request,
+        snippet
+    }: {
+        request: FernIr.dynamic.InlinedRequest;
+        snippet: FernIr.dynamic.EndpointSnippetRequest;
+    }): rust.Expression[] {
+        const args: rust.Expression[] = [];
+
+        // Build a map of provided query parameter values
+        const queryParameters = this.context.associateQueryParametersByWireValue({
+            parameters: request.queryParameters ?? [],
+            values: snippet.queryParameters ?? {}
+        });
+        const providedValues = new Map<string, rust.Expression>();
+        for (const qp of queryParameters) {
+            const fieldName = this.context.getPropertyName(qp.name.name);
+            providedValues.set(fieldName, this.context.dynamicTypeLiteralMapper.convert(qp));
+        }
+
+        // Generate individual &Option<T> arguments for each query parameter
+        // Order matches the SDK's addIndividualQueryParameters (definition order)
+        const allQueryParams = request.queryParameters ?? [];
+        for (const param of allQueryParams) {
+            const fieldName = this.context.getPropertyName(param.name.name);
+            const value = providedValues.get(fieldName);
+            if (value != null) {
+                args.push(rust.Expression.referenceOf(value));
+            } else {
+                args.push(rust.Expression.referenceOf(rust.Expression.raw("None")));
+            }
+        }
+
+        // Add bytes body argument: &vec![] for empty, or &bytes for provided value
+        if (snippet.requestBody != null && typeof snippet.requestBody === "string" && snippet.requestBody !== "") {
+            args.push(rust.Expression.referenceOf(
+                rust.Expression.raw(`"${snippet.requestBody}".as_bytes().to_vec()`)
+            ));
+        } else {
+            args.push(rust.Expression.referenceOf(rust.Expression.raw("vec![]")));
         }
 
         return args;

--- a/generators/rust/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/rust/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -73,9 +73,14 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
      * Query requests are synthetic types generated for endpoints with query parameters but no body.
      */
     private preregisterQueryRequestNames(): void {
-        // Loop through all endpoints in the dynamic IR
+        // First pass: collect all query-only endpoints to detect name collisions
+        const queryEndpoints: Array<{
+            endpointId: string;
+            endpoint: FernIr.dynamic.Endpoint;
+            methodName: string;
+        }> = [];
+
         for (const [endpointId, endpoint] of Object.entries(this.ir.endpoints)) {
-            // Check if this is a query-only endpoint (has query parameters but no body)
             const request = endpoint.request;
             if (request.type !== "inlined") {
                 continue;
@@ -85,22 +90,43 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
             const hasBody = request.body != null;
 
             if (hasQueryParams && !hasBody) {
-                // This is a query-only endpoint - register its query request type
                 const methodName = endpoint.declaration.name.pascalCase.safeName;
-                const baseQueryRequestName = `${methodName}QueryRequest`;
-
-                // Register the name in the type registry to handle deduplication
-                // We use a synthetic ID for query requests: "query_request:<endpointId>"
-                const syntheticTypeId = `query_request:${endpointId}`;
-                const deduplicatedName = this.registry.registerSchemaTypeTypeName(
-                    syntheticTypeId,
-                    baseQueryRequestName
-                );
-
-                // Store the mapping from endpoint declaration to deduplicated name
-                const key = this.getEndpointDeclarationKey(endpoint.declaration);
-                this.endpointDeclarationToQueryRequestName.set(key, deduplicatedName);
+                queryEndpoints.push({ endpointId, endpoint, methodName });
             }
+        }
+
+        // Build a set of method names that have collisions (same method name across different services)
+        const methodNameCounts = new Map<string, number>();
+        for (const { methodName } of queryEndpoints) {
+            methodNameCounts.set(methodName, (methodNameCounts.get(methodName) ?? 0) + 1);
+        }
+
+        // Second pass: register with full subpackage prefix when collisions exist
+        for (const { endpointId, endpoint, methodName } of queryEndpoints) {
+            const hasCollision = (methodNameCounts.get(methodName) ?? 0) > 1;
+
+            let baseQueryRequestName: string;
+            if (hasCollision) {
+                // Include full subpackage path to make it unique, matching SDK generator behavior
+                const pathParts = endpoint.declaration.fernFilepath.allParts.map(
+                    (part) => part.pascalCase.safeName
+                );
+                const subpackagePrefix = pathParts.join("");
+                baseQueryRequestName = `${subpackagePrefix}${methodName}QueryRequest`;
+            } else {
+                baseQueryRequestName = `${methodName}QueryRequest`;
+            }
+
+            // Register the name in the type registry to handle deduplication
+            const syntheticTypeId = `query_request:${endpointId}`;
+            const deduplicatedName = this.registry.registerSchemaTypeTypeName(
+                syntheticTypeId,
+                baseQueryRequestName
+            );
+
+            // Store the mapping from endpoint declaration to deduplicated name
+            const key = this.getEndpointDeclarationKey(endpoint.declaration);
+            this.endpointDeclarationToQueryRequestName.set(key, deduplicatedName);
         }
     }
 
@@ -109,18 +135,21 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
      * This helps us look up the typeId when we only have the declaration.
      */
     private getDeclarationKey(declaration: FernIr.dynamic.Declaration): string {
-        const fernFilepath = declaration.fernFilepath.packagePath.join("/");
+        const fernFilepath = declaration.fernFilepath.packagePath
+            .map((part) => part.pascalCase.safeName)
+            .join("/");
         const name = declaration.name.pascalCase.safeName;
         return `${fernFilepath}::${name}`;
     }
 
     /**
      * Create a unique key for an endpoint declaration based on its file path and name.
-     * This helps us look up the query request name when we only have the endpoint declaration.
+     * Uses allParts to include the leaf segment, ensuring unique keys per subpackage.
      */
     private getEndpointDeclarationKey(declaration: FernIr.dynamic.Declaration): string {
-        // Use the same format as getDeclarationKey for consistency
-        const fernFilepath = declaration.fernFilepath.packagePath.join("/");
+        const fernFilepath = declaration.fernFilepath.allParts
+            .map((part) => part.pascalCase.safeName)
+            .join("/");
         const name = declaration.name.pascalCase.safeName;
         return `${fernFilepath}::${name}`;
     }

--- a/generators/rust/model/src/referenced-request-with-query/ReferencedRequestWithQueryGenerator.ts
+++ b/generators/rust/model/src/referenced-request-with-query/ReferencedRequestWithQueryGenerator.ts
@@ -86,13 +86,21 @@ export class ReferencedRequestWithQueryGenerator {
 
     // Helper method to convert query parameters to object properties
     private convertQueryParametersToProperties(queryParams: FernIr.QueryParameter[]): FernIr.ObjectProperty[] {
-        return queryParams.map((queryParam) => ({
-            name: queryParam.name,
-            valueType: queryParam.valueType,
-            docs: queryParam.docs,
-            availability: queryParam.availability,
-            propertyAccess: undefined,
-            v2Examples: undefined
-        }));
+        return queryParams.map((queryParam) => {
+            // For allow-multiple query params, wrap the type in a list using proper IR constructors
+            let valueType = queryParam.valueType;
+            if (queryParam.allowMultiple) {
+                valueType = FernIr.TypeReference.container(FernIr.ContainerType.list(queryParam.valueType));
+            }
+
+            return {
+                name: queryParam.name,
+                valueType,
+                docs: queryParam.docs,
+                availability: queryParam.availability,
+                propertyAccess: undefined,
+                v2Examples: undefined
+            };
+        });
     }
 }

--- a/generators/rust/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/rust/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -39,6 +39,18 @@ export class WireTestSetupGenerator {
         // Post-process mappings to fix unit type responses
         this.fixUnitTypeResponses(wireMockConfigContent);
 
+        // Post-process mappings to strip milliseconds from datetime strings.
+        // The Rust SDK serializes datetimes using chrono's SecondsFormat::Secs,
+        // which produces "2024-01-15T09:30:00Z" (no milliseconds), but
+        // mock-utils' toISOString() produces "2024-01-15T09:30:00.000Z".
+        this.stripDatetimeMilliseconds(wireMockConfigContent);
+
+        // Add fallback mappings for bytes endpoints. mock-utils skips bytes
+        // endpoints entirely, but the SDK generates tests for them. Add a
+        // low-priority mapping (without query params) for each bytes endpoint
+        // by copying the response from a sibling endpoint at the same path.
+        this.addBytesEndpointFallbackMappings(wireMockConfigContent);
+
         const wireMockConfigFile = new File(
             "wiremock-mappings.json",
             RelativeFilePath.of("wiremock"),
@@ -138,6 +150,98 @@ export class WireTestSetupGenerator {
             path = "/" + path;
         }
         return path;
+    }
+
+    private static readonly DATETIME_WITH_ZERO_MILLIS_REGEX =
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000(Z|[+-]\d{2}:\d{2})$/;
+
+    /**
+     * Strip .000 milliseconds from datetime strings in WireMock mappings.
+     * Rust's chrono serializes with SecondsFormat::Secs (no milliseconds),
+     * but JS Date.toISOString() always includes .000.
+     */
+    private stripDatetimeMilliseconds(wireMockConfig: WireMockStubMapping): void {
+        for (const mapping of wireMockConfig.mappings || []) {
+            // Strip from query parameter matchers
+            if (mapping.request.queryParameters) {
+                for (const [_key, matcher] of Object.entries(mapping.request.queryParameters)) {
+                    const m = matcher as { equalTo?: string };
+                    if (m.equalTo && WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(m.equalTo)) {
+                        m.equalTo = m.equalTo.replace(".000", "");
+                    }
+                }
+            }
+            // Strip from response body
+            if (typeof mapping.response.body === "string") {
+                mapping.response.body = mapping.response.body.replace(
+                    /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\.000(Z|[+-]\d{2}:\d{2})/g,
+                    "$1$2"
+                );
+            }
+        }
+    }
+
+    /**
+     * Add fallback WireMock mappings for bytes endpoints.
+     *
+     * mock-utils skips endpoints with requestBody.type === "bytes" so they get
+     * no mapping. When a bytes endpoint shares a URL path with another endpoint
+     * (e.g. transcribe_file and transcribe_url both at POST /v1/listen), the
+     * bytes endpoint's test fails because the only mapping requires specific
+     * query parameters that the bytes test doesn't send.
+     *
+     * This method finds bytes endpoints, locates an existing sibling mapping
+     * at the same method+path, and adds a low-priority copy without query
+     * parameters so the bytes endpoint test can match.
+     */
+    private addBytesEndpointFallbackMappings(wireMockConfig: WireMockStubMapping): void {
+        // Collect bytes endpoints that need fallback mappings
+        const bytesEndpoints: Array<{ method: string; path: string }> = [];
+        for (const service of Object.values(this.ir.services)) {
+            for (const endpoint of service.endpoints) {
+                if (endpoint.requestBody?.type === "bytes") {
+                    const path = this.buildEndpointPath(endpoint);
+                    bytesEndpoints.push({ method: endpoint.method, path });
+                }
+            }
+        }
+
+        if (bytesEndpoints.length === 0) {
+            return;
+        }
+
+        // Index existing mappings by method+path
+        const existingByKey = new Map<string, WireMockMapping>();
+        for (const mapping of wireMockConfig.mappings || []) {
+            const key = `${mapping.request.method}:${mapping.request.urlPathTemplate}`;
+            // Keep the first (highest-priority) mapping for each key
+            if (!existingByKey.has(key)) {
+                existingByKey.set(key, mapping);
+            }
+        }
+
+        // Add fallback for each bytes endpoint
+        for (const { method, path } of bytesEndpoints) {
+            const key = `${method}:${path}`;
+            const sibling = existingByKey.get(key);
+            if (sibling) {
+                // Clone the sibling but strip query parameters and set lower priority
+                const fallback: WireMockMapping = {
+                    ...sibling,
+                    id: `${sibling.id.slice(0, -4)}fb00`,
+                    name: `${sibling.name} (bytes fallback)`,
+                    uuid: `${sibling.uuid.slice(0, -4)}fb00`,
+                    priority: 5,
+                    request: {
+                        method: sibling.request.method,
+                        urlPathTemplate: sibling.request.urlPathTemplate
+                        // No queryParameters — matches any request to this path
+                    },
+                    response: { ...sibling.response }
+                };
+                wireMockConfig.mappings.push(fallback);
+            }
+        }
     }
 
     /**

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.19.4
+  changelogEntry:
+    - summary: |
+        Handle bytes endpoints, query name collisions, and WireMock mapping fixes
+        for wire test generation. Bytes endpoints with query params now generate
+        individual parameter arguments instead of a struct. Query request type names
+        include subpackage prefixes when collisions exist. WireMock mappings strip
+        .000 milliseconds from datetime strings and add fallback mappings for bytes
+        endpoints. Allow-multiple query parameters are now correctly wrapped in list types.
+      type: fix
+  createdAt: "2026-03-12"
+  irVersion: 62
+
 - version: 0.19.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes several wire test generation failures in the Rust SDK generator related to bytes endpoints, query parameter name collisions, and WireMock mapping mismatches.

Requested by: @iamnamananand996
[Link to Devin Session](https://app.devin.ai/sessions/58769ddd62724391871fe7d760f68a3f)

## Changes Made

### Dynamic Snippets — Bytes endpoint support (`EndpointSnippetGenerator.ts`)
- Adds a new code path for bytes endpoints with query params: generates individual `&Option<T>` arguments per query param + `&Vec<u8>` for the body, matching `SubClientGenerator`'s `addIndividualQueryParameters` behavior (previously fell through to the struct-based path, producing incorrect snippets).

### Dynamic Snippets — Query request name collisions (`DynamicSnippetsGeneratorContext.ts`)
- `preregisterQueryRequestNames` now uses a two-pass approach: first collects all query-only endpoints, then prefixes the type name with the full subpackage path when multiple endpoints share the same method name across different services.
- Fixes `getDeclarationKey` to use `part.pascalCase.safeName` instead of joining raw `NameAndWireValue` objects (which would have produced `[object Object]` strings).
- Fixes `getEndpointDeclarationKey` to use `allParts` (includes leaf segment) instead of `packagePath`, ensuring unique keys per subpackage.

### Model — Allow-multiple query params (`ReferencedRequestWithQueryGenerator.ts`)
- `convertQueryParametersToProperties` now wraps the type in `ContainerType.list()` when `queryParam.allowMultiple` is true, so the generated struct field is `Vec<T>` instead of `T`.

### Wire Tests — WireMock post-processing (`WireTestSetupGenerator.ts`)
- **`stripDatetimeMilliseconds`**: Strips `.000` from datetime strings in query matchers and response bodies. Rust's chrono serializes with `SecondsFormat::Secs` (no millis), but JS `toISOString()` always appends `.000`.
- **`addBytesEndpointFallbackMappings`**: mock-utils skips bytes endpoints, so when a bytes endpoint shares a URL path with a sibling (e.g. `transcribe_file` and `transcribe_url` at `POST /v1/listen`), the bytes test has no matching mapping. This adds a low-priority fallback mapping (no query param constraints) cloned from the sibling.

### Version bump
- Bumps `generators/rust/sdk/versions.yml` to **0.19.4**.

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed

## ⚠️ Human Review Checklist
- **`getDeclarationKey` behavioral change**: Previously joined raw objects (likely `[object Object]/...`). Now uses `.pascalCase.safeName`. Verify no existing callers relied on the old (broken) string format for lookups — if any mappings were stored with the old keys, this change could break them.
- **Fallback mapping ID generation**: Uses `sibling.id.slice(0, -4)` + `"fb00"` — fragile if UUIDs/IDs are ever shorter than 4 chars. Worth confirming the WireMock ID format guarantees sufficient length.
- **Datetime regex scope**: `stripDatetimeMilliseconds` only strips `.000` (zero millis). Confirm that non-zero millisecond values from mock-utils won't cause mismatches (should be fine if example fixtures always use whole seconds).
- **Bytes body string check**: `getBytesEndpointArgs` checks `typeof snippet.requestBody === "string"` — verify this holds for all bytes endpoint snippet shapes.