### PR TITLE
fix(parser): `respect-readonly-schemas` request/response reachability analysis done as DFS

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertObject.ts
@@ -281,10 +281,14 @@ export function convertObject({
             const resolvedPropertySchema = isReferenceObject(propertySchema)
                 ? context.resolveSchemaReference(propertySchema)
                 : propertySchema;
-            const readonly = resolvedPropertySchema.readOnly;
-            const writeonly = resolvedPropertySchema.writeOnly;
+            const readonly =
+                ("readOnly" in propertySchema && propertySchema.readOnly === true) || resolvedPropertySchema.readOnly;
+            const writeonly =
+                ("writeOnly" in propertySchema && propertySchema.writeOnly === true) ||
+                resolvedPropertySchema.writeOnly;
 
-            const isRequired = allRequired.includes(propertyName) && !readonly;
+            const isRequired =
+                allRequired.includes(propertyName) && (!readonly || context.options.respectReadonlySchemas);
             const isPropertyOptional = !isRequired;
 
             const propertyNameOverride = getExtension<string | undefined>(
@@ -336,6 +340,22 @@ export function convertObject({
                     conflicts[parent.schemaId] = { differentSchema: true };
                 } else if (parentPropertySchema != null) {
                     conflicts[parent.schemaId] = { differentSchema: false };
+                }
+            }
+            // Apply top-level required to inlined allOf properties that may have been
+            // marked optional by their inline member's own (missing) required array.
+            if (
+                allRequired.includes(property.key) &&
+                (property.schema.type === "optional" || property.schema.type === "nullable")
+            ) {
+                const isPropertyReadonly = property.readonly;
+                const isRequired = !isPropertyReadonly || context.options.respectReadonlySchemas;
+                if (isRequired) {
+                    return {
+                        ...property,
+                        schema: property.schema.value,
+                        conflict: conflicts
+                    };
                 }
             }
             return {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly-ref-shared-schema.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly-ref-shared-schema.json
@@ -56,23 +56,8 @@
               "pagination": undefined,
               "path": "/orgs/details",
               "request": {
-                "body": {
-                  "properties": {
-                    "display_name": {
-                      "docs": "Friendly name of this organization.",
-                      "type": "optional<string>",
-                    },
-                    "name": {
-                      "docs": "The name of this organization.",
-                      "type": "optional<string>",
-                    },
-                  },
-                },
+                "body": "UpdateOrgDetailsRequest",
                 "content-type": "application/json",
-                "headers": undefined,
-                "name": "UpdateOrgDetailsRequest",
-                "path-parameters": undefined,
-                "query-parameters": undefined,
               },
               "response": {
                 "docs": "Updated organization details",
@@ -90,6 +75,23 @@
         },
         "types": {
           "GetOrgDetailsResponse": "OrgDetailsRead",
+          "OrgDetails": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "display_name": {
+                "docs": "Friendly name of this organization.",
+                "type": "optional<string>",
+              },
+              "name": {
+                "docs": "The name of this organization.",
+                "type": "optional<string>",
+              },
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
           "OrgDetailsRead": {
             "docs": undefined,
             "inline": undefined,
@@ -121,6 +123,7 @@
               "pattern": "^org_[A-Za-z0-9]{16}$",
             },
           },
+          "UpdateOrgDetailsRequest": "OrgDetails",
           "UpdateOrgDetailsResponse": "OrgDetailsRead",
         },
       },
@@ -151,15 +154,7 @@
         openapi: ../openapi.yml
       display-name: Update organization details
       request:
-        name: UpdateOrgDetailsRequest
-        body:
-          properties:
-            name:
-              type: optional<string>
-              docs: The name of this organization.
-            display_name:
-              type: optional<string>
-              docs: Friendly name of this organization.
+        body: UpdateOrgDetailsRequest
         content-type: application/json
       response:
         docs: Updated organization details
@@ -193,7 +188,18 @@ types:
         docs: Friendly name of this organization.
     source:
       openapi: ../openapi.yml
+  OrgDetails:
+    properties:
+      name:
+        type: optional<string>
+        docs: The name of this organization.
+      display_name:
+        type: optional<string>
+        docs: Friendly name of this organization.
+    source:
+      openapi: ../openapi.yml
   GetOrgDetailsResponse: OrgDetailsRead
+  UpdateOrgDetailsRequest: OrgDetails
   UpdateOrgDetailsResponse: OrgDetailsRead
 ",
     },

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly-schema-references.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly-schema-references.json
@@ -144,7 +144,7 @@
               "openapi": "../openapi.yml",
             },
           },
-          "ConfigMetadataRead": {
+          "ConfigMetadata": {
             "docs": undefined,
             "inline": undefined,
             "properties": {
@@ -170,17 +170,17 @@
                 "docs": "Configuration ID",
                 "type": "optional<string>",
               },
-              "metadata": "optional<ConfigMetadataRead>",
+              "metadata": "optional<ConfigMetadata>",
               "provisioning": {
                 "docs": "Provisioning configuration",
-                "type": "optional<IdpProvisioningConfigRead>",
+                "type": "optional<IdpProvisioningConfig>",
               },
             },
             "source": {
               "openapi": "../openapi.yml",
             },
           },
-          "IdpProvisioningConfigRead": {
+          "IdpProvisioningConfig": {
             "docs": undefined,
             "inline": undefined,
             "properties": {
@@ -307,7 +307,7 @@ types:
     inline: true
     source:
       openapi: ../openapi.yml
-  IdpProvisioningConfigRead:
+  IdpProvisioningConfig:
     properties:
       enabled:
         type: optional<boolean>
@@ -333,9 +333,9 @@ types:
         type: optional<string>
         docs: Configuration ID
       provisioning:
-        type: optional<IdpProvisioningConfigRead>
+        type: optional<IdpProvisioningConfig>
         docs: Provisioning configuration
-      metadata: optional<ConfigMetadataRead>
+      metadata: optional<ConfigMetadata>
     source:
       openapi: ../openapi.yml
   AttributeMapping:
@@ -351,7 +351,7 @@ types:
         default: false
     source:
       openapi: ../openapi.yml
-  ConfigMetadataRead:
+  ConfigMetadata:
     properties:
       version:
         type: optional<integer>

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly.json
@@ -115,7 +115,7 @@
           },
         },
         "types": {
-          "UserRead": {
+          "User": {
             "docs": undefined,
             "inline": undefined,
             "properties": {
@@ -130,7 +130,18 @@
               },
               "name": "optional<string>",
               "settings": "optional<UserSettingsRead>",
-              "stats": "optional<UserStatsRead>",
+              "stats": "optional<UserStats>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "UserSettings": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "notifications": "optional<boolean>",
+              "theme": "optional<string>",
             },
             "source": {
               "openapi": "../openapi.yml",
@@ -151,18 +162,7 @@
               "openapi": "../openapi.yml",
             },
           },
-          "UserStatsAccountStatus": {
-            "enum": [
-              "active",
-              "suspended",
-              "deleted",
-            ],
-            "inline": true,
-            "source": {
-              "openapi": "../openapi.yml",
-            },
-          },
-          "UserStatsRead": {
+          "UserStats": {
             "docs": undefined,
             "inline": undefined,
             "properties": {
@@ -176,6 +176,17 @@
                 "type": "optional<integer>",
               },
             },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "UserStatsAccountStatus": {
+            "enum": [
+              "active",
+              "suspended",
+              "deleted",
+            ],
+            "inline": true,
             "source": {
               "openapi": "../openapi.yml",
             },
@@ -254,7 +265,7 @@
   source:
     openapi: ../openapi.yml
 types:
-  UserRead:
+  User:
     properties:
       id:
         type: optional<string>
@@ -265,7 +276,7 @@ types:
         type: optional<datetime>
         access: read-only
       settings: optional<UserSettingsRead>
-      stats: optional<UserStatsRead>
+      stats: optional<UserStats>
     source:
       openapi: ../openapi.yml
   UserSettingsRead:
@@ -277,6 +288,12 @@ types:
         access: read-only
     source:
       openapi: ../openapi.yml
+  UserSettings:
+    properties:
+      theme: optional<string>
+      notifications: optional<boolean>
+    source:
+      openapi: ../openapi.yml
   UserStatsAccountStatus:
     enum:
       - active
@@ -285,7 +302,7 @@ types:
     inline: true
     source:
       openapi: ../openapi.yml
-  UserStatsRead:
+  UserStats:
     properties:
       totalLogins:
         type: optional<integer>

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/OpenApiIrConverterContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/OpenApiIrConverterContext.ts
@@ -12,8 +12,8 @@ import {
     SchemaId
 } from "@fern-api/openapi-ir";
 import { TaskContext } from "@fern-api/task-context";
-
 import { ConvertOpenAPIOptions, getConvertOptions } from "./ConvertOpenAPIOptions.js";
+import { SchemaReachability, SchemaVariantPlan } from "./computeSchemaReachability.js";
 import { State } from "./State.js";
 
 export interface OpenApiIrConverterContextOpts {
@@ -73,6 +73,18 @@ export class OpenApiIrConverterContext {
      * Used to resolve schema references correctly when respect-readonly-schemas is enabled.
      */
     private schemaNameMapping: Map<string, string> = new Map();
+
+    /**
+     * The computed variant plan for readonly schema handling.
+     * Set when respectReadonlySchemas is enabled.
+     */
+    private variantPlan: SchemaVariantPlan | undefined;
+
+    /**
+     * The raw reachability sets from graph analysis.
+     * Set when respectReadonlySchemas is enabled.
+     */
+    private reachability: SchemaReachability | undefined;
 
     constructor({
         taskContext,
@@ -304,11 +316,82 @@ export class OpenApiIrConverterContext {
     }
 
     /**
-     * Gets the final name for a schema, or the original name if no mapping exists.
+     * Returns true if the given schema has a read variant name mapping.
      */
-    public getSchemaFinalName(schemaId: string): string {
-        // Fast path: if respect-readonly-schemas is disabled, no schema renaming occurs
+    public hasReadVariant(schemaName: string): boolean {
+        return this.schemaNameMapping.has(schemaName);
+    }
+
+    /**
+     * Sets the variant plan and reachability data, and populates schemaNameMapping
+     * for all schemas that need both Read and Write variants.
+     */
+    public setVariantPlan(plan: SchemaVariantPlan, reachability: SchemaReachability): void {
+        this.variantPlan = plan;
+        this.reachability = reachability;
+
+        // Populate schemaNameMapping for schemas that need both variants
+        const allSchemas: Record<string, Schema>[] = [
+            this.ir.groupedSchemas.rootSchemas,
+            ...Object.values(this.ir.groupedSchemas.namespacedSchemas)
+        ];
+        for (const schemas of allSchemas) {
+            for (const [id, schema] of Object.entries(schemas)) {
+                if (plan.needsBothVariants.has(id) && schema.type === "object") {
+                    const originalName = schema.nameOverride ?? schema.generatedName;
+                    this.schemaNameMapping.set(originalName, `${originalName}Read`);
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns true if the given schema needs both Read and Write variants.
+     */
+    public needsBothVariants(id: SchemaId): boolean {
+        return this.variantPlan?.needsBothVariants.has(id) ?? false;
+    }
+
+    /**
+     * Returns true if the given schema is request-only with readonly properties.
+     */
+    public isRequestOnlyWithReadonly(id: SchemaId): boolean {
+        return this.variantPlan?.requestOnlyWithReadonly.has(id) ?? false;
+    }
+
+    /**
+     * Returns true if the given schema is reachable from response contexts
+     * (i.e., used outside of request bodies).
+     */
+    public isResponseReachable(id: SchemaId): boolean {
+        if (this.reachability == null) {
+            // Fall back to the IR's nonRequestReferencedSchemas if no reachability computed
+            return this.ir.nonRequestReferencedSchemas.has(id);
+        }
+        return this.reachability.responseReachable.has(id);
+    }
+
+    /**
+     * Returns true if the given schema is only reachable from request contexts
+     * (not from responses, errors, parameters, webhooks, or channels).
+     */
+    public isRequestOnly(id: SchemaId): boolean {
+        if (this.reachability == null) {
+            return !this.ir.nonRequestReferencedSchemas.has(id);
+        }
+        return this.reachability.requestReachable.has(id) && !this.reachability.responseReachable.has(id);
+    }
+
+    /**
+     * Gets the final name for a schema based on the variant being built.
+     * variant === "write" → always returns original name
+     * variant === "read" → returns Read variant name if it exists
+     */
+    public getSchemaFinalName(schemaId: string, variant: "read" | "write"): string {
         if (!this.options.respectReadonlySchemas) {
+            return schemaId;
+        }
+        if (variant === "write") {
             return schemaId;
         }
         return this.schemaNameMapping.get(schemaId) ?? schemaId;

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -40,8 +40,6 @@ export function buildEndpoint({
     declarationFile: RelativeFilePath;
     endpoint: Endpoint;
 }): ConvertedEndpoint {
-    const { nonRequestReferencedSchemas } = context.ir;
-
     let schemaIdsToExclude: string[] = [];
 
     const names = new Set<string>();
@@ -174,7 +172,6 @@ export function buildEndpoint({
                     ? pathParameters
                     : undefined,
             queryParameters: Object.keys(queryParameters).length > 0 ? queryParameters : undefined,
-            nonRequestReferencedSchemas: Array.from(nonRequestReferencedSchemas),
             headers: Object.keys(headers).length > 0 ? headers : undefined,
             usedNames: names,
             namespace: maybeEndpointNamespace
@@ -496,7 +493,6 @@ function getRequest({
     generatedRequestName,
     pathParameters,
     queryParameters,
-    nonRequestReferencedSchemas,
     headers,
     usedNames,
     namespace
@@ -509,50 +505,32 @@ function getRequest({
     generatedRequestName: string;
     pathParameters?: Record<string, RawSchemas.HttpPathParameterSchema>;
     queryParameters?: Record<string, RawSchemas.HttpQueryParameterSchema>;
-    nonRequestReferencedSchemas: SchemaId[];
     headers?: Record<string, RawSchemas.HttpHeaderSchema>;
     usedNames: Set<string>;
     namespace: string | undefined;
 }): ConvertedRequest {
     if (request.type === "json" || request.type === "formUrlEncoded") {
         const maybeSchemaId = request.schema.type === "reference" ? request.schema.schema : undefined;
-        let resolvedSchema =
+        const resolvedSchema =
             request.schema.type === "reference" ? context.getSchema(request.schema.schema, namespace) : request.schema;
-
-        // When respectReadonlySchemas is enabled and the schema has readOnly properties on a write endpoint,
-        // inline the properties so readOnly ones can be filtered out
-        let shouldInlineForReadonly = false;
-        // When the request schema is a $ref wrapper (e.g., UpdateOrgDetailsRequest -> OrgDetails),
-        // track the wrapper's name so we can use it instead of the underlying schema's name
-        let readonlyWrapperSchemaName: string | undefined;
-        if (context.options.respectReadonlySchemas && isWriteMethod(endpoint.method)) {
-            let effectiveSchema = resolvedSchema;
-            while (effectiveSchema?.type === "reference") {
-                effectiveSchema = context.getSchema(effectiveSchema.schema, namespace);
-            }
-            if (effectiveSchema?.type === "object" && effectiveSchema.properties.some((p) => p.readonly)) {
-                shouldInlineForReadonly = true;
-                // If the resolved schema was a $ref wrapper pointing to the object with readonly props,
-                // preserve the wrapper's name for the request type
-                if (resolvedSchema?.type === "reference") {
-                    readonlyWrapperSchemaName = resolvedSchema.nameOverride ?? resolvedSchema.generatedName;
-                }
-                resolvedSchema = effectiveSchema;
-            }
-        }
 
         // the request body is referenced if it is not an object or if other parts of the spec
         // refer to the same type
         if (
             resolvedSchema?.type !== "object" ||
-            (maybeSchemaId != null && nonRequestReferencedSchemas.includes(maybeSchemaId) && !shouldInlineForReadonly)
+            (maybeSchemaId != null && context.isResponseReachable(maybeSchemaId))
         ) {
+            // When respectReadonlySchemas is enabled on a write endpoint, resolve schema
+            // references to the write variant (without readOnly properties)
+            const useWriteVariant = context.options.respectReadonlySchemas && isWriteMethod(endpoint.method);
+            const variant: "read" | "write" | undefined = useWriteVariant ? "write" : undefined;
             const requestTypeReference = buildTypeReference({
                 schema: request.schema,
                 fileContainingReference: declarationFile,
                 context,
                 namespace,
-                declarationDepth: 0
+                declarationDepth: 0,
+                variant
             });
             const convertedRequest: ConvertedRequest = {
                 schemaIdsToExclude: [],
@@ -775,11 +753,7 @@ function getRequest({
         }
 
         const convertedRequestValue: RawSchemas.HttpRequestSchema = {
-            name:
-                requestNameOverride ??
-                readonlyWrapperSchemaName ??
-                resolvedSchema.nameOverride ??
-                resolvedSchema.generatedName,
+            name: requestNameOverride ?? resolvedSchema.nameOverride ?? resolvedSchema.generatedName,
             "path-parameters": pathParameters,
             "query-parameters": queryParameters,
             headers,
@@ -792,10 +766,7 @@ function getRequest({
             convertedRequestValue.docs = request.description;
         }
         return {
-            schemaIdsToExclude:
-                maybeSchemaId != null && (!shouldInlineForReadonly || readonlyWrapperSchemaName != null)
-                    ? [maybeSchemaId]
-                    : [],
+            schemaIdsToExclude: maybeSchemaId != null ? [maybeSchemaId] : [],
             value: convertedRequestValue
         };
     } else if (request.type === "octetStream") {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
@@ -9,9 +9,10 @@ import { buildEnvironments } from "./buildEnvironments.js";
 import { buildGlobalHeaders } from "./buildGlobalHeaders.js";
 import { buildIdempotencyHeaders } from "./buildIdempotencyHeaders.js";
 import { buildServices } from "./buildServices.js";
-import { buildTypeDeclaration } from "./buildTypeDeclaration.js";
+import { buildObjectTypeDeclaration, buildTypeDeclaration } from "./buildTypeDeclaration.js";
 import { buildVariables } from "./buildVariables.js";
 import { buildWebhooks } from "./buildWebhooks.js";
+import { computeSchemaReachability, computeVariantPlan } from "./computeSchemaReachability.js";
 import { OpenApiIrConverterContext } from "./OpenApiIrConverterContext.js";
 import { State } from "./State.js";
 import { convertSdkGroupNameToFile } from "./utils/convertSdkGroupName.js";
@@ -30,41 +31,89 @@ function addSchemas({
     context
 }: {
     schemas: Record<string, Schema>;
-    schemaIdsToExclude: string[];
+    schemaIdsToExclude: Set<string>;
     namespace: string | undefined;
     context: OpenApiIrConverterContext;
 }): void {
-    // Phase 1: Pre-compute all final schema names to handle readonly renaming
-    // Skip this phase entirely if respect-readonly-schemas is disabled
-    if (context.options.respectReadonlySchemas) {
-        for (const [id, schema] of Object.entries(schemas)) {
-            if (schemaIdsToExclude.includes(id) || schema.type !== "object") {
-                continue;
-            }
-
-            const originalName = schema.nameOverride ?? schema.generatedName;
-            const hasReadonlyProperties = schema.properties.some((prop) => prop.readonly);
-
-            if (hasReadonlyProperties) {
-                const finalName = `${originalName}Read`;
-                context.setSchemaFinalName(originalName, finalName);
-            }
-        }
-    }
-
-    // Phase 2: Build type declarations using final names
     for (const [id, schema] of Object.entries(schemas)) {
-        if (schemaIdsToExclude.includes(id)) {
+        if (schemaIdsToExclude.has(id)) {
             continue;
         }
 
         const declarationFile = getDeclarationFileForSchema(schema);
+
+        // Variant-plan-based logic for readonly schemas
+        if (context.options.respectReadonlySchemas && context.needsBothVariants(id) && schema.type === "object") {
+            // Generate Read variant (all properties, "Read" suffix)
+            const readDeclaration = buildObjectTypeDeclaration({
+                schema,
+                context,
+                declarationFile,
+                namespace,
+                declarationDepth: 0,
+                variant: "read"
+            });
+            context.builder.addType(declarationFile, {
+                name: readDeclaration.name ?? id,
+                schema: readDeclaration.schema
+            });
+
+            // Generate Write variant (without readOnly properties, original name)
+            const writeDeclaration = buildObjectTypeDeclaration({
+                schema,
+                context,
+                declarationFile,
+                namespace,
+                declarationDepth: 0,
+                skipReadonlyProperties: true,
+                variant: "write"
+            });
+            context.builder.addType(declarationFile, {
+                name: writeDeclaration.name ?? id,
+                schema: writeDeclaration.schema
+            });
+
+            continue;
+        }
+
+        if (
+            context.options.respectReadonlySchemas &&
+            context.isRequestOnlyWithReadonly(id) &&
+            schema.type === "object"
+        ) {
+            // Single Write variant (strip readonly properties)
+            const writeDeclaration = buildObjectTypeDeclaration({
+                schema,
+                context,
+                declarationFile,
+                namespace,
+                declarationDepth: 0,
+                skipReadonlyProperties: true,
+                variant: "write"
+            });
+            context.builder.addType(declarationFile, {
+                name: writeDeclaration.name ?? id,
+                schema: writeDeclaration.schema
+            });
+
+            continue;
+        }
+
+        // Default path: determine variant based on reachability
+        // Request-only schemas resolve references to Write variants,
+        // everything else resolves to Read variants
+        let variant: "read" | "write" | undefined;
+        if (context.options.respectReadonlySchemas) {
+            variant = context.isRequestOnly(id) ? "write" : "read";
+        }
+
         const typeDeclaration = buildTypeDeclaration({
             schema,
             context,
             declarationFile,
             namespace,
-            declarationDepth: 0
+            declarationDepth: 0,
+            variant
         });
 
         // HACKHACK: Skip self-referencing schemas. I'm not sure if this is the right way to do this.
@@ -123,6 +172,15 @@ export function buildFernDefinition(context: OpenApiIrConverterContext): FernDef
         context,
         schemaIdsToExcludeFromServices: convertedServices.schemaIdsToExclude
     });
+
+    // Compute reachability-based variant plan for readonly schema handling
+    if (context.options.respectReadonlySchemas) {
+        const reachability = computeSchemaReachability(context.ir);
+        const variantPlan = computeVariantPlan(context.ir, reachability);
+        context.setVariantPlan(variantPlan, reachability);
+    }
+
+    // Build type declarations
     addSchemas({ schemas: context.ir.groupedSchemas.rootSchemas, schemaIdsToExclude, namespace: undefined, context });
     for (const [namespace, schemas] of Object.entries(context.ir.groupedSchemas.namespacedSchemas)) {
         addSchemas({ schemas, schemaIdsToExclude, namespace, context });
@@ -150,12 +208,12 @@ function getSchemaIdsToExclude({
 }: {
     context: OpenApiIrConverterContext;
     schemaIdsToExcludeFromServices: string[];
-}): string[] {
+}): Set<string> {
     const referencedSchemaIds = context.getReferencedSchemaIds();
     if (referencedSchemaIds == null) {
         // No further filtering is required; we can return the
         // excluded schemas as-is.
-        return schemaIdsToExcludeFromServices;
+        return new Set(schemaIdsToExcludeFromServices);
     }
 
     // Retrieve all the schema IDs, then exclude all the schemas that
@@ -172,5 +230,5 @@ function getSchemaIdsToExclude({
         }
     }
 
-    return Array.from(schemaIdsToExcludeSet);
+    return schemaIdsToExcludeSet;
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeDeclaration.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeDeclaration.ts
@@ -29,7 +29,6 @@ import {
     buildUnknownTypeReference
 } from "./buildTypeReference.js";
 import { OpenApiIrConverterContext } from "./OpenApiIrConverterContext.js";
-import { State } from "./State.js";
 import { convertAvailability } from "./utils/convertAvailability.js";
 import { convertToEncodingSchema } from "./utils/convertToEncodingSchema.js";
 import { convertToSourceSchema } from "./utils/convertToSourceSchema.js";
@@ -45,7 +44,8 @@ export function buildTypeDeclaration({
     context,
     declarationFile,
     namespace,
-    declarationDepth
+    declarationDepth,
+    variant
 }: {
     schema: Schema;
     context: OpenApiIrConverterContext;
@@ -53,6 +53,7 @@ export function buildTypeDeclaration({
     declarationFile: RelativeFilePath;
     namespace: string | undefined;
     declarationDepth: number;
+    variant?: "read" | "write";
 }): ConvertedTypeDeclaration {
     let typeDeclaration: ConvertedTypeDeclaration;
     switch (schema.type) {
@@ -78,7 +79,7 @@ export function buildTypeDeclaration({
             });
             break;
         case "reference":
-            typeDeclaration = buildReferenceTypeDeclaration({ schema, context, declarationFile, namespace });
+            typeDeclaration = buildReferenceTypeDeclaration({ schema, context, declarationFile, namespace, variant });
             break;
         case "unknown":
             typeDeclaration = buildUnknownTypeDeclaration(
@@ -117,7 +118,8 @@ export function buildTypeDeclaration({
                 context,
                 declarationFile,
                 namespace,
-                declarationDepth
+                declarationDepth,
+                variant
             });
             break;
         case "oneOf":
@@ -126,7 +128,8 @@ export function buildTypeDeclaration({
                 context,
                 declarationFile,
                 namespace,
-                declarationDepth
+                declarationDepth,
+                variant
             });
             break;
         default:
@@ -140,20 +143,19 @@ export function buildObjectTypeDeclaration({
     context,
     declarationFile,
     namespace,
-    declarationDepth
+    declarationDepth,
+    skipReadonlyProperties,
+    variant
 }: {
     schema: ObjectSchema;
     context: OpenApiIrConverterContext;
     declarationFile: RelativeFilePath;
     namespace: string | undefined;
     declarationDepth: number;
+    skipReadonlyProperties?: boolean;
+    variant?: "read" | "write";
 }): ConvertedTypeDeclaration {
-    const isInRequestState = context.isInState(State.Request);
-    const respectReadonlySchemas = context.options.respectReadonlySchemas;
-    const endpointMethod = context.getEndpointMethod();
-    const isWriteMethod = endpointMethod === "POST" || endpointMethod === "PUT" || endpointMethod === "PATCH";
-
-    const shouldSkipReadonly = isInRequestState && respectReadonlySchemas && isWriteMethod;
+    const shouldSkipReadonly = skipReadonlyProperties === true || variant === "write";
 
     let readOnlyPropertyPresent = false;
     const properties: Record<string, RawSchemas.ObjectPropertySchema> = {};
@@ -192,7 +194,8 @@ export function buildObjectTypeDeclaration({
             context,
             fileContainingReference: declarationFile,
             namespace,
-            declarationDepth: declarationDepth + 1
+            declarationDepth: declarationDepth + 1,
+            variant
         });
 
         const audiences = property.audiences;
@@ -230,7 +233,8 @@ export function buildObjectTypeDeclaration({
             context,
             fileContainingReference: declarationFile,
             namespace,
-            declarationDepth: declarationDepth + 1
+            declarationDepth: declarationDepth + 1,
+            variant
         });
         extendedSchemas.push(stripNullableWrapperForExtends(getTypeFromTypeReference(allOfTypeReference)));
     }
@@ -247,7 +251,8 @@ export function buildObjectTypeDeclaration({
                     context,
                     fileContainingReference: declarationFile,
                     namespace,
-                    declarationDepth: declarationDepth + 1
+                    declarationDepth: declarationDepth + 1,
+                    variant
                 });
             }
         }
@@ -260,7 +265,8 @@ export function buildObjectTypeDeclaration({
                 context,
                 fileContainingReference: declarationFile,
                 namespace,
-                declarationDepth: declarationDepth + 1
+                declarationDepth: declarationDepth + 1,
+                variant
             });
             extendedSchemas.push(stripNullableWrapperForExtends(getTypeFromTypeReference(extendedSchemaTypeReference)));
         }
@@ -304,13 +310,14 @@ export function buildObjectTypeDeclaration({
     objectTypeDeclaration.inline = getInline(schema, declarationDepth);
 
     const name = schema.nameOverride ?? schema.generatedName;
+    // Only add "Read" suffix when the schema has a read variant registered (i.e., it needs both variants)
     const finalName =
-        readOnlyPropertyPresent && context.options.respectReadonlySchemas && !shouldSkipReadonly ? `${name}Read` : name;
-
-    // Record the final name mapping for reference resolution
-    if (finalName !== name) {
-        context.setSchemaFinalName(name, finalName);
-    }
+        variant === "read" &&
+        readOnlyPropertyPresent &&
+        context.options.respectReadonlySchemas &&
+        context.hasReadVariant(name)
+            ? `${name}Read`
+            : name;
 
     return {
         name: finalName,
@@ -542,12 +549,14 @@ export function buildReferenceTypeDeclaration({
     schema,
     context,
     declarationFile,
-    namespace
+    namespace,
+    variant
 }: {
     schema: ReferencedSchema;
     context: OpenApiIrConverterContext;
     declarationFile: RelativeFilePath;
     namespace: string | undefined;
+    variant?: "read" | "write";
 }): ConvertedTypeDeclaration {
     return {
         name: schema.nameOverride ?? schema.generatedName,
@@ -555,7 +564,8 @@ export function buildReferenceTypeDeclaration({
             schema,
             context,
             fileContainingReference: declarationFile,
-            namespace
+            namespace,
+            variant
         })
     };
 }
@@ -658,13 +668,15 @@ export function buildOneOfTypeDeclaration({
     context,
     declarationFile,
     namespace,
-    declarationDepth
+    declarationDepth,
+    variant
 }: {
     schema: OneOfSchema;
     context: OpenApiIrConverterContext;
     declarationFile: RelativeFilePath;
     namespace: string | undefined;
     declarationDepth: number;
+    variant?: "read" | "write";
 }): ConvertedTypeDeclaration {
     const encoding = schema.encoding != null ? convertToEncodingSchema(schema.encoding) : undefined;
     if (schema.type === "discriminated") {
@@ -675,7 +687,8 @@ export function buildOneOfTypeDeclaration({
                 fileContainingReference: declarationFile,
                 context,
                 namespace,
-                declarationDepth: declarationDepth + 1
+                declarationDepth: declarationDepth + 1,
+                variant
             });
         }
         const union: Record<string, RawSchemas.SingleUnionTypeSchema> = {};
@@ -685,7 +698,8 @@ export function buildOneOfTypeDeclaration({
                 context,
                 fileContainingReference: declarationFile,
                 namespace,
-                declarationDepth: declarationDepth + 1
+                declarationDepth: declarationDepth + 1,
+                variant
             });
         }
         return {
@@ -714,7 +728,8 @@ export function buildOneOfTypeDeclaration({
                 fileContainingReference: declarationFile,
                 context,
                 namespace,
-                declarationDepth: declarationDepth + 1
+                declarationDepth: declarationDepth + 1,
+                variant
             })
         );
     }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeReference.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeReference.ts
@@ -51,7 +51,8 @@ export function buildTypeReference({
     declarationFile = fileContainingReference,
     context,
     namespace,
-    declarationDepth
+    declarationDepth,
+    variant
 }: {
     schema: Schema;
     fileContainingReference: RelativeFilePath;
@@ -59,6 +60,7 @@ export function buildTypeReference({
     context: OpenApiIrConverterContext;
     namespace: string | undefined;
     declarationDepth: number;
+    variant?: "read" | "write";
 }): RawSchemas.TypeReferenceSchema {
     if (context.shouldMarkSchemaAsReferenced()) {
         context.markSchemaAsReferenced(schema, namespace);
@@ -74,7 +76,8 @@ export function buildTypeReference({
                 context,
                 declarationFile,
                 namespace,
-                declarationDepth
+                declarationDepth,
+                variant
             });
         case "map":
             return buildMapTypeReference({
@@ -83,14 +86,16 @@ export function buildTypeReference({
                 context,
                 declarationFile,
                 namespace,
-                declarationDepth
+                declarationDepth,
+                variant
             });
         case "reference":
             return buildReferenceTypeReference({
                 schema,
                 fileContainingReference,
                 context,
-                namespace
+                namespace,
+                variant
             });
         case "unknown":
             return buildUnknownTypeReference();
@@ -101,7 +106,8 @@ export function buildTypeReference({
                 context,
                 declarationFile,
                 namespace,
-                declarationDepth
+                declarationDepth,
+                variant
             });
         case "nullable":
             return buildNullableTypeReference({
@@ -110,7 +116,8 @@ export function buildTypeReference({
                 context,
                 declarationFile,
                 namespace,
-                declarationDepth
+                declarationDepth,
+                variant
             });
         case "enum":
             return buildEnumTypeReference({
@@ -130,7 +137,8 @@ export function buildTypeReference({
                 context,
                 declarationFile,
                 namespace,
-                declarationDepth
+                declarationDepth,
+                variant
             });
         case "oneOf":
             return buildOneOfTypeReference({
@@ -139,7 +147,8 @@ export function buildTypeReference({
                 context,
                 declarationFile,
                 namespace,
-                declarationDepth
+                declarationDepth,
+                variant
             });
         default:
             assertNever(schema);
@@ -447,12 +456,14 @@ function makeUndefinedIfOutsideRange(num: number | undefined, type: "integer" | 
 export function buildReferenceTypeReference({
     schema,
     fileContainingReference,
-    context
+    context,
+    variant
 }: {
     schema: ReferencedSchema;
     fileContainingReference: RelativeFilePath;
     context: OpenApiIrConverterContext;
     namespace: string | undefined;
+    variant?: "read" | "write";
 }): RawSchemas.TypeReferenceSchema {
     // Use schema.namespace (the reference's target namespace) to look up the schema,
     // not the current context's namespace
@@ -462,9 +473,10 @@ export function buildReferenceTypeReference({
     }
 
     const originalSchemaName = getSchemaName(resolvedSchema) ?? schema.schema;
-    const schemaName = context.options.respectReadonlySchemas
-        ? context.getSchemaFinalName(originalSchemaName)
-        : originalSchemaName;
+    const schemaName =
+        context.options.respectReadonlySchemas && variant != null
+            ? context.getSchemaFinalName(originalSchemaName, variant)
+            : originalSchemaName;
     const groupName = getGroupNameForSchema(resolvedSchema);
     const displayName = getDisplayName(resolvedSchema);
     // Use the reference's namespace (schema.namespace) to determine the declaration file,
@@ -502,7 +514,8 @@ export function buildArrayTypeReference({
     declarationFile,
     context,
     namespace,
-    declarationDepth
+    declarationDepth,
+    variant
 }: {
     schema: ArraySchema;
     fileContainingReference: RelativeFilePath;
@@ -510,6 +523,7 @@ export function buildArrayTypeReference({
     context: OpenApiIrConverterContext;
     namespace: string | undefined;
     declarationDepth: number;
+    variant?: "read" | "write";
 }): RawSchemas.TypeReferenceSchema {
     const item = buildTypeReference({
         schema: schema.value,
@@ -517,7 +531,8 @@ export function buildArrayTypeReference({
         declarationFile,
         context,
         namespace,
-        declarationDepth
+        declarationDepth,
+        variant
     });
     const type = `list<${getTypeFromTypeReference(item)}>`;
     if (schema.description == null && schema.title == null) {
@@ -536,7 +551,8 @@ export function buildMapTypeReference({
     declarationFile,
     context,
     namespace,
-    declarationDepth
+    declarationDepth,
+    variant
 }: {
     schema: MapSchema;
     fileContainingReference: RelativeFilePath;
@@ -544,6 +560,7 @@ export function buildMapTypeReference({
     context: OpenApiIrConverterContext;
     namespace: string | undefined;
     declarationDepth: number;
+    variant?: "read" | "write";
 }): RawSchemas.TypeReferenceSchema {
     const keyTypeReference = buildPrimitiveTypeReference(schema.key);
 
@@ -553,7 +570,8 @@ export function buildMapTypeReference({
         declarationFile,
         context,
         namespace,
-        declarationDepth
+        declarationDepth,
+        variant
     });
     const encoding = schema.encoding != null ? convertToEncodingSchema(schema.encoding) : undefined;
     const type = `map<${getTypeFromTypeReference(keyTypeReference)}, ${getTypeFromTypeReference(valueTypeReference)}>`;
@@ -581,7 +599,8 @@ export function buildNullableTypeReference({
     declarationFile,
     context,
     namespace,
-    declarationDepth
+    declarationDepth,
+    variant
 }: {
     schema: NullableSchema;
     fileContainingReference: RelativeFilePath;
@@ -589,6 +608,7 @@ export function buildNullableTypeReference({
     context: OpenApiIrConverterContext;
     namespace: string | undefined;
     declarationDepth: number;
+    variant?: "read" | "write";
 }): RawSchemas.TypeReferenceSchema {
     if (!context.options.respectNullableSchemas) {
         return buildOptionalTypeReference({
@@ -597,7 +617,8 @@ export function buildNullableTypeReference({
             context,
             declarationFile,
             namespace,
-            declarationDepth
+            declarationDepth,
+            variant
         });
     }
 
@@ -607,7 +628,8 @@ export function buildNullableTypeReference({
         declarationFile,
         context,
         namespace,
-        declarationDepth
+        declarationDepth,
+        variant
     });
     const itemType = getTypeFromTypeReference(itemTypeReference);
     const itemDocs = getDocsFromTypeReference(itemTypeReference);
@@ -655,7 +677,8 @@ export function buildOptionalTypeReference({
     declarationFile,
     context,
     namespace,
-    declarationDepth
+    declarationDepth,
+    variant
 }: {
     schema: OptionalSchema;
     fileContainingReference: RelativeFilePath;
@@ -663,6 +686,7 @@ export function buildOptionalTypeReference({
     context: OpenApiIrConverterContext;
     namespace: string | undefined;
     declarationDepth: number;
+    variant?: "read" | "write";
 }): RawSchemas.TypeReferenceSchema {
     const itemTypeReference = buildTypeReference({
         schema: schema.value,
@@ -670,7 +694,8 @@ export function buildOptionalTypeReference({
         declarationFile,
         context,
         namespace,
-        declarationDepth
+        declarationDepth,
+        variant
     });
     const itemType = getTypeFromTypeReference(itemTypeReference);
     const itemDocs = getDocsFromTypeReference(itemTypeReference);
@@ -781,7 +806,8 @@ export function buildObjectTypeReference({
     declarationFile,
     context,
     namespace,
-    declarationDepth
+    declarationDepth,
+    variant
 }: {
     schema: ObjectSchema;
     fileContainingReference: RelativeFilePath;
@@ -789,13 +815,15 @@ export function buildObjectTypeReference({
     context: OpenApiIrConverterContext;
     namespace: string | undefined;
     declarationDepth: number;
+    variant?: "read" | "write";
 }): RawSchemas.TypeReferenceSchema {
     const objectTypeDeclaration = buildObjectTypeDeclaration({
         schema,
         declarationFile,
         context,
         namespace,
-        declarationDepth
+        declarationDepth,
+        variant
     });
     const name = schema.nameOverride ?? schema.generatedName;
     context.builder.addType(declarationFile, {
@@ -819,7 +847,8 @@ export function buildOneOfTypeReference({
     declarationFile,
     context,
     namespace,
-    declarationDepth
+    declarationDepth,
+    variant
 }: {
     schema: OneOfSchema;
     fileContainingReference: RelativeFilePath;
@@ -827,13 +856,15 @@ export function buildOneOfTypeReference({
     context: OpenApiIrConverterContext;
     namespace: string | undefined;
     declarationDepth: number;
+    variant?: "read" | "write";
 }): RawSchemas.TypeReferenceSchema {
     const unionTypeDeclaration = buildOneOfTypeDeclaration({
         schema,
         declarationFile,
         context,
         namespace,
-        declarationDepth
+        declarationDepth,
+        variant
     });
     const name = schema.nameOverride ?? schema.generatedName;
     context.builder.addType(declarationFile, {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/computeSchemaReachability.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/computeSchemaReachability.ts
@@ -1,0 +1,242 @@
+import { assertNever } from "@fern-api/core-utils";
+import { OneOfSchema, OpenApiIntermediateRepresentation, Schema, SchemaId, Schemas } from "@fern-api/openapi-ir";
+
+export interface SchemaReachability {
+    requestReachable: Set<SchemaId>;
+    responseReachable: Set<SchemaId>;
+}
+
+export interface SchemaVariantPlan {
+    /** Has readonly props + reachable from both request and response → generate Read + Write */
+    needsBothVariants: Set<SchemaId>;
+    /** Has readonly props + request only → single Write variant (strip readonly) */
+    requestOnlyWithReadonly: Set<SchemaId>;
+    /** Has readonly props + response only → single type with all props */
+    responseOnlyWithReadonly: Set<SchemaId>;
+}
+
+/**
+ * Performs a DFS over a schema graph, collecting all transitively reachable SchemaIds.
+ */
+function collectReachableSchemaIds(schema: Schema, groupedSchemas: Schemas, visited: Set<SchemaId>): void {
+    switch (schema.type) {
+        case "primitive":
+        case "enum":
+        case "literal":
+        case "unknown":
+            return;
+        case "reference": {
+            const refId = schema.schema;
+            if (visited.has(refId)) {
+                return;
+            }
+            visited.add(refId);
+            const resolved = lookupSchema(refId, schema.namespace, groupedSchemas);
+            if (resolved != null) {
+                collectReachableSchemaIds(resolved, groupedSchemas, visited);
+            }
+            return;
+        }
+        case "object":
+            for (const allOf of schema.allOf) {
+                if (!visited.has(allOf.schema)) {
+                    visited.add(allOf.schema);
+                    const resolved = lookupSchema(allOf.schema, allOf.namespace, groupedSchemas);
+                    if (resolved != null) {
+                        collectReachableSchemaIds(resolved, groupedSchemas, visited);
+                    }
+                }
+            }
+            for (const property of schema.properties) {
+                collectReachableSchemaIds(property.schema, groupedSchemas, visited);
+            }
+            return;
+        case "array":
+        case "map":
+        case "optional":
+        case "nullable":
+            collectReachableSchemaIds(schema.value, groupedSchemas, visited);
+            return;
+        case "oneOf":
+            collectOneOfReachable(schema.value, groupedSchemas, visited);
+            return;
+        default:
+            assertNever(schema);
+    }
+}
+
+function collectOneOfReachable(schema: OneOfSchema, groupedSchemas: Schemas, visited: Set<SchemaId>): void {
+    switch (schema.type) {
+        case "discriminated":
+            for (const subSchema of Object.values(schema.schemas)) {
+                collectReachableSchemaIds(subSchema, groupedSchemas, visited);
+            }
+            for (const commonProp of schema.commonProperties) {
+                collectReachableSchemaIds(commonProp.schema, groupedSchemas, visited);
+            }
+            return;
+        case "undiscriminated":
+            for (const subSchema of schema.schemas) {
+                collectReachableSchemaIds(subSchema, groupedSchemas, visited);
+            }
+            return;
+        default:
+            assertNever(schema);
+    }
+}
+
+function lookupSchema(id: SchemaId, namespace: string | undefined, groupedSchemas: Schemas): Schema | undefined {
+    if (namespace == null) {
+        return groupedSchemas.rootSchemas[id];
+    }
+    return groupedSchemas.namespacedSchemas[namespace]?.[id];
+}
+
+/**
+ * Seeds a target set with all SchemaIds transitively reachable from a root schema.
+ */
+function seedReachable(schema: Schema, groupedSchemas: Schemas, target: Set<SchemaId>): void {
+    collectReachableSchemaIds(schema, groupedSchemas, target);
+}
+
+/**
+ * Computes which schemas are reachable from request contexts vs response contexts
+ * by doing a post-parse graph analysis over the IR.
+ */
+export function computeSchemaReachability(ir: OpenApiIntermediateRepresentation): SchemaReachability {
+    const requestReachable = new Set<SchemaId>();
+    const responseReachable = new Set<SchemaId>();
+    const { groupedSchemas } = ir;
+
+    for (const endpoint of ir.endpoints) {
+        // Request roots
+        if (endpoint.request != null) {
+            switch (endpoint.request.type) {
+                case "json":
+                case "formUrlEncoded":
+                    seedReachable(endpoint.request.schema, groupedSchemas, requestReachable);
+                    break;
+                case "multipart":
+                    for (const prop of endpoint.request.properties) {
+                        if (prop.schema.type === "json") {
+                            seedReachable(prop.schema.value, groupedSchemas, requestReachable);
+                        }
+                    }
+                    break;
+                case "octetStream":
+                    break;
+                default:
+                    assertNever(endpoint.request);
+            }
+        }
+
+        // Response roots
+        if (endpoint.response != null) {
+            switch (endpoint.response.type) {
+                case "json":
+                case "streamingJson":
+                case "streamingSse":
+                    seedReachable(endpoint.response.schema, groupedSchemas, responseReachable);
+                    break;
+                case "file":
+                case "text":
+                case "bytes":
+                case "streamingText":
+                    break;
+                default:
+                    assertNever(endpoint.response);
+            }
+        }
+
+        // Error schemas → response reachable
+        for (const httpError of Object.values(endpoint.errors)) {
+            if (httpError.schema != null) {
+                seedReachable(httpError.schema, groupedSchemas, responseReachable);
+            }
+        }
+
+        // Parameters → response reachable (they are non-request usage)
+        for (const param of endpoint.pathParameters) {
+            seedReachable(param.schema, groupedSchemas, responseReachable);
+        }
+        for (const param of endpoint.queryParameters) {
+            seedReachable(param.schema, groupedSchemas, responseReachable);
+        }
+        for (const header of endpoint.headers) {
+            seedReachable(header.schema, groupedSchemas, responseReachable);
+        }
+    }
+
+    // Webhooks → response reachable
+    for (const webhook of ir.webhooks) {
+        seedReachable(webhook.payload, groupedSchemas, responseReachable);
+    }
+
+    // Channels → response reachable
+    for (const channel of Object.values(ir.channels)) {
+        for (const message of channel.messages) {
+            seedReachable(message.body, groupedSchemas, responseReachable);
+        }
+        // Handshake parameters → response reachable
+        for (const param of channel.handshake.queryParameters) {
+            seedReachable(param.schema, groupedSchemas, responseReachable);
+        }
+        for (const header of channel.handshake.headers) {
+            seedReachable(header.schema, groupedSchemas, responseReachable);
+        }
+        for (const param of channel.handshake.pathParameters) {
+            seedReachable(param.schema, groupedSchemas, responseReachable);
+        }
+    }
+
+    return { requestReachable, responseReachable };
+}
+
+/**
+ * Returns true if the object schema has at least one property marked as readonly.
+ */
+function hasReadonlyProperties(schema: Schema): boolean {
+    if (schema.type !== "object") {
+        return false;
+    }
+    return schema.properties.some((prop) => prop.readonly === true);
+}
+
+/**
+ * Given the reachability sets, computes which schemas need Read/Write variants,
+ * which are request-only with readonly, and which are response-only with readonly.
+ */
+export function computeVariantPlan(
+    ir: OpenApiIntermediateRepresentation,
+    reachability: SchemaReachability
+): SchemaVariantPlan {
+    const needsBothVariants = new Set<SchemaId>();
+    const requestOnlyWithReadonly = new Set<SchemaId>();
+    const responseOnlyWithReadonly = new Set<SchemaId>();
+
+    function classifySchemas(schemas: Record<SchemaId, Schema>): void {
+        for (const [id, schema] of Object.entries(schemas)) {
+            if (!hasReadonlyProperties(schema)) {
+                continue;
+            }
+            const inRequest = reachability.requestReachable.has(id);
+            const inResponse = reachability.responseReachable.has(id);
+
+            if (inRequest && inResponse) {
+                needsBothVariants.add(id);
+            } else if (inRequest && !inResponse) {
+                requestOnlyWithReadonly.add(id);
+            } else if (!inRequest && inResponse) {
+                responseOnlyWithReadonly.add(id);
+            }
+            // If neither: schema is unreferenced by endpoints, keep as-is
+        }
+    }
+
+    classifySchemas(ir.groupedSchemas.rootSchemas);
+    for (const schemas of Object.values(ir.groupedSchemas.namespacedSchemas)) {
+        classifySchemas(schemas);
+    }
+
+    return { needsBothVariants, requestOnlyWithReadonly, responseOnlyWithReadonly };
+}

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,60 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.23.2
+  changelogEntry:
+    - summary: |
+        Redesign `respect-readonly-schemas` to use a post-parse graph-based
+        reachability analysis instead of the previous side-effect-based marking
+        mechanism. When `respect-readonly-schemas` is enabled, the new approach
+        performs a DFS from all endpoint request/response roots to classify
+        schemas as request-only, response-only, or shared, then generates
+        Read/Write variants accordingly. This fixes several structural bugs
+        with the previous design. No behavior change when the option is off.
+      type: fix
+    - summary: |
+        Fix `respect-readonly-schemas` generating required readOnly fields as
+        optional in Read types. When a property is both `readOnly` and in the
+        `required` array, it is now correctly marked required in the generated
+        type.
+      type: fix
+    - summary: |
+        Fix `respect-readonly-schemas` inlining request body `$ref` schemas
+        instead of preserving them as type aliases. Schemas like
+        `UpdateOrganizationDetailsRequestContent` that reference another schema
+        via `$ref` are now kept as `type Foo = Bar` instead of being
+        dereferenced into a standalone interface.
+      type: fix
+    - summary: |
+        Fix `respect-readonly-schemas` generating unnecessary Read/Write
+        variants for schemas only used in responses. Response-only schemas
+        with readOnly properties now generate a single type with all
+        properties instead of splitting into Read and Write variants.
+      type: fix
+    - summary: |
+        Fix `respect-readonly-schemas` resolving response type aliases to the
+        Write variant instead of the Read variant. Schema references in
+        response contexts now correctly resolve to Read variant names.
+      type: fix
+    - summary: |
+        Fix `respect-readonly-schemas` leaking readOnly properties into
+        `allOf`-composed request types. Request types that inherit from schemas
+        with readOnly properties via `allOf` no longer include those properties
+        in Write variants.
+      type: fix
+    - summary: |
+        Fix `allOf` with top-level `required` array not propagating to
+        properties inherited from inline `allOf` members. Properties marked
+        optional by an inline member's own (missing) `required` array are now
+        correctly promoted to required when the outer schema's `required`
+        array includes them.
+      type: fix
+    - summary: |
+        Fix `readOnly` not being detected on `$ref` properties whose
+        referenced schema has `readOnly: true`. The parser now checks both
+        the property-level and resolved schema-level `readOnly` flag.
+      type: fix
+  createdAt: "2026-03-12"
+  irVersion: 65
+
 - version: 4.23.1
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -53,6 +53,7 @@
         the property-level and resolved schema-level `readOnly` flag.
       type: fix
   createdAt: "2026-03-12"
+  irVersion: 65
 
 - version: 4.24.0
   changelogEntry:


### PR DESCRIPTION
## Description
`respect-readonly-schemas` needs to figure out which schemas are reachable from requests, responses, or both to work (since that what determines whether we create Read/Write variants). This was done previously via a side-effect-y marking mechanism during parsing; this PR does it by a quick DFS post-parse, which gets us around a whole host of bugs (here's the full changelog entry):

```
    - summary: |
        Fix `respect-readonly-schemas` generating required readOnly fields as
        optional in Read types. When a property is both `readOnly` and in the
        `required` array, it is now correctly marked required in the generated
        type.
      type: fix
    - summary: |
        Fix `respect-readonly-schemas` inlining request body `$ref` schemas
        instead of preserving them as type aliases. Schemas like
        `UpdateOrganizationDetailsRequestContent` that reference another schema
        via `$ref` are now kept as `type Foo = Bar` instead of being
        dereferenced into a standalone interface.
      type: fix
    - summary: |
        Fix `respect-readonly-schemas` generating unnecessary Read/Write
        variants for schemas only used in responses. Response-only schemas
        with readOnly properties now generate a single type with all
        properties instead of splitting into Read and Write variants.
      type: fix
    - summary: |
        Fix `respect-readonly-schemas` resolving response type aliases to the
        Write variant instead of the Read variant. Schema references in
        response contexts now correctly resolve to Read variant names.
      type: fix
    - summary: |
        Fix `respect-readonly-schemas` leaking readOnly properties into
        `allOf`-composed request types. Request types that inherit from schemas
        with readOnly properties via `allOf` no longer include those properties
        in Write variants.
      type: fix
    - summary: |
        Fix `readOnly` not being detected on `$ref` properties whose
        referenced schema has `readOnly: true`. The parser now checks both
        the property-level and resolved schema-level `readOnly` flag.
      type: fix
```
This PR also resolves a separate issue where the `required` on an `allOf` wasn't propagating correctly to its members if its members were inlined.

## Changes Made
All over the parser; addition of a `computeSchemaReachability.ts` file to handle the DFS. (It won't be touched if `respect-readonly-schemas: false`.

The DFS approach lets us cut down on the number of sets and data abstractions flying around the parser for readOnly support:
```
Added:
  - SchemaReachability — two Sets (requestReachable, responseReachable) populated by DFS from endpoint roots
  - SchemaVariantPlan — three Sets (needsBothVariants, requestOnlyWithReadonly, responseOnlyWithReadonly) derived from reachability + readonly property checks
  - variant: "read" | "write" parameter threaded through buildTypeDeclaration and buildTypeReference call trees

  Cut:
  - resolveToWriteVariant: boolean — mutable flag on the context that was toggled on/off around call sites to control which variant name getSchemaFinalName() returned
  - setResolveToWriteVariant(value) / getSchemaFinalName(schemaId) (no variant param) — replaced by getSchemaFinalName(schemaId, variant)
  - shouldInlineForReadonly / readonlyWrapperSchemaName — local variables in buildEndpoint.ts that chased $ref chains to decide whether to force-inline request bodies
  - nonRequestReferencedSchemas parameter threading — was destructured from context.ir and passed as an array through getRequest(). Replaced by context.isResponseReachable(id) which uses the reachability Set directly
  - precomputeReadonlySchemaNames() (Phase 1 loop) — iterated all object schemas to populate schemaNameMapping based on whether they had readonly properties. Replaced by setVariantPlan() which populates the mapping from the
  needsBothVariants set
  - State-based shouldSkipReadonly in buildObjectTypeDeclaration — used context.isInState(State.Request) + context.getEndpointMethod() + isWriteMethod() to decide at parse time. Replaced by skipReadonlyProperties === true ||
  variant === "write"
``` 

## Testing
The `readonly` `openapi-ir-to-fern-tests` reflect the changes; Auth0's MyOrg SDK, which necessitated this.
- [X] Unit tests added/updated
- [X] Manual testing completed
