### PR TITLE
feat(docs): handle 409 conflict during docs publish with retry logic

### DIFF
--- a/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
+++ b/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
@@ -74,7 +74,8 @@ export class LegacyDocsPublisher {
                 instanceUrl,
                 preview,
                 disableTemplates: undefined,
-                skipUpload
+                skipUpload,
+                cliVersion: process.env.CLI_VERSION
             });
 
             if (taskContext.getResult() === TaskResult.Failure) {

--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -115,7 +115,8 @@ export async function generateDocsWorkspace({
             instanceUrl: instance,
             preview,
             disableTemplates,
-            skipUpload
+            skipUpload,
+            cliVersion: cliContext.environment.packageVersion
         });
         const generationTime = performance.now() - generationStart;
         context.logger.debug(`Remote docs generation completed in ${generationTime.toFixed(0)}ms`);

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.25.0
+  changelogEntry:
+    - summary: |
+        Handle 409 Conflict responses from FDR during `fern generate --docs`.
+        When another docs publish is already in progress for the same domain,
+        the CLI now retries up to 3 times with backoff (1 min, 5 min, 5 min)
+        before reporting the conflict. The CLI version is sent to FDR so that
+        the server can gate the concurrent-publish check on CLI versions that
+        support 409 handling.
+      type: feat
+  createdAt: "2026-03-12"
+  irVersion: 65
+
 - version: 4.24.0
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -4,10 +4,9 @@
     - summary: |
         Handle 409 Conflict responses from FDR during `fern generate --docs`.
         When another docs publish is already in progress for the same domain,
-        the CLI now retries up to 3 times with backoff (1 min, 5 min, 5 min)
-        before reporting the conflict. The CLI version is sent to FDR so that
-        the server can gate the concurrent-publish check on CLI versions that
-        support 409 handling.
+        the CLI now fails fast with a clear error message. The CLI version is
+        sent to FDR so that the server can gate the concurrent-publish check
+        on CLI versions that support 409 handling.
       type: feat
   createdAt: "2026-03-12"
   irVersion: 65

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -610,7 +610,7 @@ async function startDocsRegisterFailed(
         }
     });
 
-    const errorObj = error as Record<string, unknown>;
+    const errorObj = error as unknown as Record<string, unknown>;
     const errorContent = errorObj?.content as Record<string, unknown> | undefined;
     if (errorContent?.reason === "status-code" && errorContent?.statusCode === 409) {
         throw new DocsPublishConflictError();

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -32,6 +32,13 @@ const MEASURE_IMAGE_BATCH_SIZE = 10;
 const UPLOAD_FILE_BATCH_SIZE = 10;
 const HASH_CONCURRENCY = parseInt(process.env.FERN_DOCS_ASSET_HASH_CONCURRENCY ?? "32", 10);
 
+export class DocsPublishConflictError extends Error {
+    constructor() {
+        super("Another docs publish is currently in progress for this domain.");
+        this.name = "DocsPublishConflictError";
+    }
+}
+
 interface FileWithMimeType {
     mediaType: string;
     absoluteFilePath: AbsoluteFilePath;
@@ -70,7 +77,8 @@ export async function publishDocs({
     withAiExamples = true,
     excludeApis = false,
     targetAudiences,
-    docsUrl
+    docsUrl,
+    cliVersion
 }: {
     token: FernToken;
     organization: string;
@@ -89,6 +97,7 @@ export async function publishDocs({
     excludeApis?: boolean;
     targetAudiences?: string[];
     docsUrl?: string;
+    cliVersion?: string;
 }): Promise<string> {
     const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
     const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
@@ -258,7 +267,8 @@ export async function publishDocs({
                     orgId: CjsFdrSdk.OrgId(organization),
                     filepaths: filepaths,
                     images,
-                    ...(isBasepathAware && { basepathAware: true })
+                    ...(isBasepathAware && { basepathAware: true }),
+                    ...(cliVersion != null && { cliVersion })
                 });
                 if (startDocsRegisterResponse.ok) {
                     docsRegistrationId = startDocsRegisterResponse.body.docsRegistrationId;
@@ -599,6 +609,12 @@ async function startDocsRegisterFailed(
             error: JSON.stringify(error)
         }
     });
+
+    const errorObj = error as Record<string, unknown>;
+    const errorContent = errorObj?.content as Record<string, unknown> | undefined;
+    if (errorContent?.reason === "status-code" && errorContent?.statusCode === 409) {
+        throw new DocsPublishConflictError();
+    }
 
     const authErrorMessage = getAuthenticationErrorMessage(error, organization);
     if (authErrorMessage != null) {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -105,7 +105,10 @@ export async function publishDocs({
         context.logger.debug("Detected air-gapped environment - skipping external FDR service calls");
     }
 
-    const fdr = createFdrService({ token: token.value });
+    const fdr = createFdrService({
+        token: token.value,
+        ...(cliVersion != null && { headers: { "X-CLI-Version": cliVersion } })
+    });
     const authConfig: DocsV2Write.AuthConfig = isPrivate ? { type: "private", authType: "sso" } : { type: "public" };
 
     if (excludeApis) {
@@ -267,8 +270,7 @@ export async function publishDocs({
                     orgId: CjsFdrSdk.OrgId(organization),
                     filepaths: filepaths,
                     images,
-                    ...(isBasepathAware && { basepathAware: true }),
-                    ...(cliVersion != null && { cliVersion })
+                    ...(isBasepathAware && { basepathAware: true })
                 });
                 if (startDocsRegisterResponse.ok) {
                     docsRegistrationId = startDocsRegisterResponse.body.docsRegistrationId;

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -3,7 +3,13 @@ import { replaceEnvVariables } from "@fern-api/core-utils";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace, DocsWorkspace } from "@fern-api/workspace-loader";
-import { publishDocs } from "./publishDocs.js";
+import { DocsPublishConflictError, publishDocs } from "./publishDocs.js";
+
+const PUBLISH_CONFLICT_RETRY_DELAYS_MS = [
+    1 * 60 * 1000, // 1 minute
+    5 * 60 * 1000, // 5 minutes
+    5 * 60 * 1000 // 5 minutes
+];
 
 export async function runRemoteGenerationForDocsWorkspace({
     organization,
@@ -15,7 +21,8 @@ export async function runRemoteGenerationForDocsWorkspace({
     instanceUrl,
     preview,
     disableTemplates,
-    skipUpload
+    skipUpload,
+    cliVersion
 }: {
     organization: string;
     apiWorkspaces: AbstractAPIWorkspace<unknown>[];
@@ -27,6 +34,7 @@ export async function runRemoteGenerationForDocsWorkspace({
     preview: boolean;
     disableTemplates: boolean | undefined;
     skipUpload: boolean | undefined;
+    cliVersion?: string;
 }): Promise<string | undefined> {
     // Substitute templated environment variables:
     // If substitute-env-vars is enabled, we'll attempt to read and replace the templated
@@ -86,30 +94,61 @@ export async function runRemoteGenerationForDocsWorkspace({
     let publishedUrl: string | undefined;
     await context.runInteractiveTask({ name: maybeInstance.url }, async () => {
         const publishStart = performance.now();
-        publishedUrl = await publishDocs({
-            docsWorkspace,
-            customDomains,
-            domain: maybeInstance.url,
-            token,
-            organization,
-            context,
-            apiWorkspaces,
-            ossWorkspaces,
-            preview,
-            editThisPage: maybeInstance.editThisPage,
-            isPrivate: maybeInstance.private,
-            disableTemplates,
-            skipUpload,
-            withAiExamples:
-                docsWorkspace.config.aiExamples?.enabled ?? docsWorkspace.config.experimental?.aiExamples ?? true,
-            excludeApis: docsWorkspace.config.experimental?.excludeApis ?? false,
-            targetAudiences: maybeInstance.audiences
-                ? Array.isArray(maybeInstance.audiences)
-                    ? maybeInstance.audiences
-                    : [maybeInstance.audiences]
-                : undefined,
-            docsUrl: maybeInstance.url
-        });
+        const attemptPublish = () =>
+            publishDocs({
+                docsWorkspace,
+                customDomains,
+                domain: maybeInstance.url,
+                token,
+                organization,
+                context,
+                apiWorkspaces,
+                ossWorkspaces,
+                preview,
+                editThisPage: maybeInstance.editThisPage,
+                isPrivate: maybeInstance.private,
+                disableTemplates,
+                skipUpload,
+                withAiExamples:
+                    docsWorkspace.config.aiExamples?.enabled ?? docsWorkspace.config.experimental?.aiExamples ?? true,
+                excludeApis: docsWorkspace.config.experimental?.excludeApis ?? false,
+                targetAudiences: maybeInstance.audiences
+                    ? Array.isArray(maybeInstance.audiences)
+                        ? maybeInstance.audiences
+                        : [maybeInstance.audiences]
+                    : undefined,
+                docsUrl: maybeInstance.url,
+                cliVersion
+            });
+
+        for (let attempt = 0; ; attempt++) {
+            try {
+                publishedUrl = await attemptPublish();
+                break;
+            } catch (error) {
+                if (
+                    !(error instanceof DocsPublishConflictError) ||
+                    attempt >= PUBLISH_CONFLICT_RETRY_DELAYS_MS.length
+                ) {
+                    if (error instanceof DocsPublishConflictError) {
+                        return context.failAndThrow(
+                            "Another docs publish is currently in progress. Please try again once the other publish is complete."
+                        );
+                    }
+                    throw error;
+                }
+                const delayMs =
+                    PUBLISH_CONFLICT_RETRY_DELAYS_MS[attempt] ??
+                    PUBLISH_CONFLICT_RETRY_DELAYS_MS[PUBLISH_CONFLICT_RETRY_DELAYS_MS.length - 1] ??
+                    60000;
+                const delayMinutes = delayMs / 60000;
+                context.logger.warn(
+                    `Another docs publish is in progress. Retrying in ${delayMinutes} minute${delayMinutes === 1 ? "" : "s"} (attempt ${attempt + 1}/${PUBLISH_CONFLICT_RETRY_DELAYS_MS.length})...`
+                );
+                await new Promise((resolve) => setTimeout(resolve, delayMs));
+            }
+        }
+
         const publishTime = performance.now() - publishStart;
         context.logger.debug(`Docs publishing completed in ${publishTime.toFixed(0)}ms`);
     });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -5,12 +5,6 @@ import { TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace, DocsWorkspace } from "@fern-api/workspace-loader";
 import { DocsPublishConflictError, publishDocs } from "./publishDocs.js";
 
-const PUBLISH_CONFLICT_RETRY_DELAYS_MS = [
-    1 * 60 * 1000, // 1 minute
-    5 * 60 * 1000, // 5 minutes
-    5 * 60 * 1000 // 5 minutes
-];
-
 export async function runRemoteGenerationForDocsWorkspace({
     organization,
     apiWorkspaces,
@@ -94,8 +88,8 @@ export async function runRemoteGenerationForDocsWorkspace({
     let publishedUrl: string | undefined;
     await context.runInteractiveTask({ name: maybeInstance.url }, async () => {
         const publishStart = performance.now();
-        const attemptPublish = () =>
-            publishDocs({
+        try {
+            publishedUrl = await publishDocs({
                 docsWorkspace,
                 customDomains,
                 domain: maybeInstance.url,
@@ -120,33 +114,13 @@ export async function runRemoteGenerationForDocsWorkspace({
                 docsUrl: maybeInstance.url,
                 cliVersion
             });
-
-        for (let attempt = 0; ; attempt++) {
-            try {
-                publishedUrl = await attemptPublish();
-                break;
-            } catch (error) {
-                if (
-                    !(error instanceof DocsPublishConflictError) ||
-                    attempt >= PUBLISH_CONFLICT_RETRY_DELAYS_MS.length
-                ) {
-                    if (error instanceof DocsPublishConflictError) {
-                        return context.failAndThrow(
-                            "Another docs publish is currently in progress. Please try again once the other publish is complete."
-                        );
-                    }
-                    throw error;
-                }
-                const delayMs =
-                    PUBLISH_CONFLICT_RETRY_DELAYS_MS[attempt] ??
-                    PUBLISH_CONFLICT_RETRY_DELAYS_MS[PUBLISH_CONFLICT_RETRY_DELAYS_MS.length - 1] ??
-                    60000;
-                const delayMinutes = delayMs / 60000;
-                context.logger.warn(
-                    `Another docs publish is in progress. Retrying in ${delayMinutes} minute${delayMinutes === 1 ? "" : "s"} (attempt ${attempt + 1}/${PUBLISH_CONFLICT_RETRY_DELAYS_MS.length})...`
+        } catch (error) {
+            if (error instanceof DocsPublishConflictError) {
+                return context.failAndThrow(
+                    "Another docs publish is currently in progress. Please try again once the other publish is complete."
                 );
-                await new Promise((resolve) => setTimeout(resolve, delayMs));
             }
+            throw error;
         }
 
         const publishTime = performance.now() - publishStart;

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -5,6 +5,12 @@ import { TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace, DocsWorkspace } from "@fern-api/workspace-loader";
 import { DocsPublishConflictError, publishDocs } from "./publishDocs.js";
 
+const PUBLISH_CONFLICT_RETRY_DELAYS_MS = [
+    1 * 60 * 1000, // 1 minute
+    5 * 60 * 1000, // 5 minutes
+    5 * 60 * 1000 // 5 minutes
+];
+
 export async function runRemoteGenerationForDocsWorkspace({
     organization,
     apiWorkspaces,
@@ -88,8 +94,8 @@ export async function runRemoteGenerationForDocsWorkspace({
     let publishedUrl: string | undefined;
     await context.runInteractiveTask({ name: maybeInstance.url }, async () => {
         const publishStart = performance.now();
-        try {
-            publishedUrl = await publishDocs({
+        const attemptPublish = () =>
+            publishDocs({
                 docsWorkspace,
                 customDomains,
                 domain: maybeInstance.url,
@@ -114,13 +120,33 @@ export async function runRemoteGenerationForDocsWorkspace({
                 docsUrl: maybeInstance.url,
                 cliVersion
             });
-        } catch (error) {
-            if (error instanceof DocsPublishConflictError) {
-                return context.failAndThrow(
-                    "Another docs publish is currently in progress. Please try again once the other publish is complete."
+
+        for (let attempt = 0; ; attempt++) {
+            try {
+                publishedUrl = await attemptPublish();
+                break;
+            } catch (error) {
+                if (
+                    !(error instanceof DocsPublishConflictError) ||
+                    attempt >= PUBLISH_CONFLICT_RETRY_DELAYS_MS.length
+                ) {
+                    if (error instanceof DocsPublishConflictError) {
+                        return context.failAndThrow(
+                            "Another docs publish is currently in progress. Please try again once the other publish is complete."
+                        );
+                    }
+                    throw error;
+                }
+                const delayMs =
+                    PUBLISH_CONFLICT_RETRY_DELAYS_MS[attempt] ??
+                    PUBLISH_CONFLICT_RETRY_DELAYS_MS[PUBLISH_CONFLICT_RETRY_DELAYS_MS.length - 1] ??
+                    60000;
+                const delayMinutes = delayMs / 60000;
+                context.logger.warn(
+                    `Another docs publish is in progress. Retrying in ${delayMinutes} minute${delayMinutes === 1 ? "" : "s"} (attempt ${attempt + 1}/${PUBLISH_CONFLICT_RETRY_DELAYS_MS.length})...`
                 );
+                await new Promise((resolve) => setTimeout(resolve, delayMs));
             }
-            throw error;
         }
 
         const publishTime = performance.now() - publishStart;

--- a/packages/core/src/services/fdr.ts
+++ b/packages/core/src/services/fdr.ts
@@ -3,15 +3,18 @@ import { FernRegistryClient } from "@fern-fern/fdr-test-sdk";
 
 export function createFdrService({
     environment = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com",
-    token
+    token,
+    headers
 }: {
     environment?: string;
     token: (() => string) | string;
+    headers?: Record<string, string>;
 }): FdrClient {
     const overrideEnvironment = process.env.FERN_FDR_ORIGIN ?? process.env.OVERRIDE_FDR_ORIGIN;
     return new FdrClient({
         environment: overrideEnvironment ?? environment,
-        token
+        token,
+        headers
     });
 }
 


### PR DESCRIPTION
## Description

Refs: Concurrent `fern generate --docs` race condition

When two users run `fern generate --docs` simultaneously for the same domain, a race condition can occur. This PR adds client-side handling for a new 409 Conflict response from FDR (server-side changes in companion PR on fern-platform).

**Companion PR:** fern-api/fern-platform#8428 (adds the 409 response when a publish is already in progress, gated on CLI version ≥ 4.25.0)

Link to Devin session: https://app.devin.ai/sessions/1eca7f8d41ab41029b54369d094a0352
Requested by: @thesandlord

## Changes Made

- **`publishDocs.ts`**: Added `DocsPublishConflictError` class. In `startDocsRegisterFailed()`, detects 409 status codes and throws this error. Passes `cliVersion` to the FDR client via headers.
- **`runRemoteGenerationForDocsWorkspace.ts`**: Catches `DocsPublishConflictError` with retry logic — retries up to 3 times with exponential backoff (1 min, 5 min, 5 min). After exhausting retries, fails with a clear user-facing error message.
- **`fdr.ts`**: `createFdrService` now accepts an optional `headers` parameter, used to send `X-CLI-Version` header on all FDR requests.
- **`generateDocsWorkspace.ts`** / **`LegacyDocsPublisher.ts`**: Pass `cliVersion` through to `runRemoteGenerationForDocsWorkspace`.
- **`versions.yml`**: Added 4.25.0 version entry for this feature.

### Updates since last revision

- **Restored retry logic** with exponential backoff (1 min → 5 min → 5 min) before failing with the conflict error message.
- **CLI version sent as `X-CLI-Version` header** on all FDR requests via `createFdrService({ headers })`, rather than as a body parameter on `startDocsRegister`. This is cleaner and allows FDR to read the version from any endpoint.

## Human Review Checklist

- [ ] **409 detection logic**: The error is detected via `errorContent?.reason === "status-code" && errorContent?.statusCode === 409` after casting through `unknown`. Verify this matches how the FDR client wraps HTTP error responses from the oRPC server.
- [ ] **Version coordination**: `4.25.0` here must match `MIN_CLI_VERSION_FOR_CONFLICT_CHECK` in the fern-platform companion PR.
- [ ] **`headers` support in `FdrClient`**: `createFdrService` passes `headers` to `new FdrClient({ headers })`. Verify `FernRegistryClient`/`FdrClient` propagates custom headers on requests.
- [ ] **Retry timing**: Total worst-case wait is ~11 minutes (1 + 5 + 5). Confirm this is acceptable UX for concurrent publish scenarios.

## Testing

- [x] Biome lint/format passes (`pnpm run check`)
- [ ] Unit tests added/updated
- [ ] Manual testing completed