### PR TITLE
fix(go): Fix Basic Auth header not sent when username is empty

### DIFF
--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -426,7 +426,7 @@ func (f *fileWriter) WriteRequestOptionsDefinition(
 				username = authScheme.Basic.Username.PascalCase.UnsafeName
 				password = authScheme.Basic.Password.PascalCase.UnsafeName
 			)
-			f.P(`if r.`, username, ` != "" && r.`, password, ` != "" {`)
+			f.P(`if r.`, username, ` != "" || r.`, password, ` != "" {`)
 			f.P(`header.Set("Authorization", `, `"Basic " + base64.StdEncoding.EncodeToString([]byte(r.`, username, ` + ":" + r.`, password, `)))`)
 			f.P("}")
 		}

--- a/generators/go/internal/testdata/sdk/basic/fixtures/core/request_option.go
+++ b/generators/go/internal/testdata/sdk/basic/fixtures/core/request_option.go
@@ -48,7 +48,7 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 // for the request(s).
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
-	if r.Username != "" && r.Password != "" {
+	if r.Username != "" || r.Password != "" {
 		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+": "+r.Password)))
 	}
 	return header

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.29.4
+  changelogEntry:
+    - summary: |
+        Fix Basic Auth header not being sent when the username is an empty string.
+        The generated `ToHeader` method now uses `||` instead of `&&` when checking
+        whether to set the Authorization header, so `WithBasicAuth("", "my-api-key")`
+        correctly produces a `Basic` header. Per RFC 7617, an empty user-id is valid.
+      type: fix
+  createdAt: "2026-03-12"
+  irVersion: 61
+
 - version: 1.29.3
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/any-auth/core/request_option.go
+++ b/seed/go-sdk/any-auth/core/request_option.go
@@ -64,7 +64,7 @@ func (r *RequestOptions) ToHeader() http.Header {
 	if r.ApiKey != "" {
 		header.Set("X-API-Key", fmt.Sprintf("%v", r.ApiKey))
 	}
-	if r.Username != "" && r.Password != "" {
+	if r.Username != "" || r.Password != "" {
 		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
 	}
 	return header

--- a/seed/go-sdk/basic-auth/core/request_option.go
+++ b/seed/go-sdk/basic-auth/core/request_option.go
@@ -49,7 +49,7 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 // for the request(s).
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
-	if r.Username != "" && r.Password != "" {
+	if r.Username != "" || r.Password != "" {
 		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
 	}
 	return header

--- a/seed/go-sdk/endpoint-security-auth/core/request_option.go
+++ b/seed/go-sdk/endpoint-security-auth/core/request_option.go
@@ -64,7 +64,7 @@ func (r *RequestOptions) ToHeader() http.Header {
 	if r.ApiKey != "" {
 		header.Set("X-API-Key", fmt.Sprintf("%v", r.ApiKey))
 	}
-	if r.Username != "" && r.Password != "" {
+	if r.Username != "" || r.Password != "" {
 		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
 	}
 	return header


### PR DESCRIPTION
## Description

Refs: Reported via user feedback — [Devin Session](https://app.devin.ai/sessions/84d17585b2c4454ab71b315c938e7758)
Requested by: @iamnamananand996

The generated Go SDK silently drops the `Authorization` header when the Basic Auth username is an empty string. Per [RFC 7617](https://datatracker.ietf.org/doc/html/rfc7617), an empty `user-id` is valid — the credential `:password` is a legitimate Basic Auth pair. Calling `WithBasicAuth("", "my-api-key")` should produce a valid `Basic` header, but the `&&` condition required **both** fields to be non-empty.

## Changes Made

- Changed the Basic Auth guard in the Go SDK generator (`sdk.go`) from `&&` to `||`, so the `Authorization` header is set when **either** username or password is non-empty
- Updated the corresponding test fixture (`testdata/sdk/basic/fixtures/core/request_option.go`)
- Updated all affected seed output files (`seed/go-sdk/basic-auth`, `seed/go-sdk/any-auth`, `seed/go-sdk/endpoint-security-auth`)
- Added version `1.29.4` entry to `generators/go/sdk/versions.yml`

## Testing

- [x] Go generator unit tests pass (`go test ./...`)
- [ ] No new behavioral unit tests added for the empty-username case specifically

## Review Checklist

- **Semantic change**: The `||` condition now also sends the header when only `username` is provided (empty password). Verify this is acceptable per RFC 7617 (it is — `username:` is valid).
- **Pre-existing inconsistency**: The test fixture at `testdata/sdk/basic/fixtures/core/request_option.go` uses `r.Username+": "+r.Password` (space after colon) while seed files use `r.Username+":"+r.Password`. This is **not** introduced by this PR but is worth noting.