### PR TITLE
feat(cli): log .fernignore paths and add integration tests for fernignore handling

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -4,7 +4,7 @@
     - summary: |
         Log detected .fernignore paths when copying generated files. When a
         .fernignore file is present in the output directory, the CLI now emits
-        an info-level message listing the preserved paths. This improves
+        a debug-level message listing the preserved paths. This improves
         observability for both `fern generate` and `pnpm seed run` workflows.
       type: feat
   createdAt: "2026-03-13"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.27.0
+  changelogEntry:
+    - summary: |
+        Log detected .fernignore paths when copying generated files. When a
+        .fernignore file is present in the output directory, the CLI now emits
+        an info-level message listing the preserved paths. This improves
+        observability for both `fern generate` and `pnpm seed run` workflows.
+      type: feat
+  createdAt: "2026-03-13"
+  irVersion: 65
+
 - version: 4.26.1
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -95,6 +95,17 @@ export class LocalTaskHandler {
         const priorChangelog =
             this.version != null && isAutoVersion(this.version) ? await this.readPriorChangelog(3) : "";
 
+        if (isFernIgnorePresent) {
+            const absolutePathToFernignore = AbsoluteFilePath.of(
+                join(this.absolutePathToLocalOutput, RelativeFilePath.of(FERNIGNORE_FILENAME))
+            );
+            const fernIgnorePaths = await getFernIgnorePaths({ absolutePathToFernignore });
+            const userPaths = fernIgnorePaths.filter((p) => p !== FERNIGNORE_FILENAME);
+            this.context.logger.info(
+                `Detected ${FERNIGNORE_FILENAME} at ${absolutePathToFernignore} — preserving ${userPaths.length} path(s): ${userPaths.join(", ")}`
+            );
+        }
+
         if (isFernIgnorePresent && isExistingGitRepo) {
             await this.copyGeneratedFilesWithFernIgnoreInExistingRepo();
         } else if (isFernIgnorePresent && !isExistingGitRepo) {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -101,7 +101,7 @@ export class LocalTaskHandler {
             );
             const fernIgnorePaths = await getFernIgnorePaths({ absolutePathToFernignore });
             const userPaths = fernIgnorePaths.filter((p) => p !== FERNIGNORE_FILENAME);
-            this.context.logger.info(
+            this.context.logger.debug(
                 `Detected ${FERNIGNORE_FILENAME} at ${absolutePathToFernignore} — preserving ${userPaths.length} path(s): ${userPaths.join(", ")}`
             );
         }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.fernignore.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.fernignore.test.ts
@@ -1,0 +1,227 @@
+import { mkdir, readdir, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Integration tests for .fernignore handling in LocalTaskHandler.copyGeneratedFiles().
+ *
+ * These tests verify that when a .fernignore file is present in the output directory,
+ * files listed in .fernignore are preserved after copying generated files — the same
+ * behavior used by both `fern generate` and `pnpm seed run`.
+ *
+ * The tests use real filesystem operations and git commands to exercise the actual
+ * .fernignore resolution logic (throwaway git repo approach).
+ */
+
+describe("LocalTaskHandler - .fernignore handling", () => {
+    let localOutputDir: string;
+    let tmpOutputDir: string;
+
+    beforeEach(async () => {
+        const base = join(tmpdir(), `fernignore-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        localOutputDir = join(base, "output");
+        tmpOutputDir = join(base, "generated");
+        await mkdir(localOutputDir, { recursive: true });
+        await mkdir(tmpOutputDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        // Clean up both directories
+        const base = join(localOutputDir, "..");
+        await rm(base, { recursive: true, force: true }).catch(() => {
+            // Best-effort cleanup of temp directories
+        });
+    });
+
+    async function createLocalTaskHandler() {
+        // Dynamic import to avoid hoisting issues with mocks from other test files
+        const { LocalTaskHandler } = await import("../LocalTaskHandler.js");
+        const { AbsoluteFilePath } = await import("@fern-api/fs-utils");
+
+        const mockLogger = {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn(),
+            disable: vi.fn(),
+            enable: vi.fn(),
+            trace: vi.fn(),
+            log: vi.fn()
+        };
+
+        return new LocalTaskHandler({
+            context: { logger: mockLogger } as never,
+            absolutePathToLocalOutput: AbsoluteFilePath.of(localOutputDir),
+            absolutePathToTmpOutputDirectory: AbsoluteFilePath.of(tmpOutputDir),
+            absolutePathToTmpSnippetJSON: undefined,
+            absolutePathToLocalSnippetTemplateJSON: undefined,
+            absolutePathToLocalSnippetJSON: undefined,
+            absolutePathToTmpSnippetTemplatesJSON: undefined,
+            version: "1.0.0",
+            ai: undefined,
+            isWhitelabel: false,
+            generatorLanguage: undefined,
+            absolutePathToSpecRepo: undefined
+        });
+    }
+
+    it("preserves files listed in .fernignore when output directory is not a git repo", async () => {
+        // Set up existing output directory with .fernignore and custom files
+        await writeFile(join(localOutputDir, ".fernignore"), "custom_test.py\ncustom_dir/my_file.txt\n");
+        await writeFile(join(localOutputDir, "custom_test.py"), "# my custom test\nassert True\n");
+        await mkdir(join(localOutputDir, "custom_dir"), { recursive: true });
+        await writeFile(join(localOutputDir, "custom_dir", "my_file.txt"), "my custom content\n");
+        await writeFile(join(localOutputDir, "generated_client.py"), "# old generated client\n");
+
+        // Set up generated output (new files from the generator)
+        await writeFile(join(tmpOutputDir, "generated_client.py"), "# NEW generated client\n");
+        await writeFile(join(tmpOutputDir, "new_generated_file.py"), "# new file from generator\n");
+        await writeFile(join(tmpOutputDir, "README.md"), "# Generated README\n");
+
+        const handler = await createLocalTaskHandler();
+        await handler.copyGeneratedFiles();
+
+        // Verify preserved files still have original content
+        const customTestContent = await readFile(join(localOutputDir, "custom_test.py"), "utf-8");
+        expect(customTestContent).toBe("# my custom test\nassert True\n");
+
+        const customDirContent = await readFile(join(localOutputDir, "custom_dir", "my_file.txt"), "utf-8");
+        expect(customDirContent).toBe("my custom content\n");
+
+        // Verify .fernignore itself is preserved
+        const fernignoreContent = await readFile(join(localOutputDir, ".fernignore"), "utf-8");
+        expect(fernignoreContent).toBe("custom_test.py\ncustom_dir/my_file.txt\n");
+
+        // Verify generated files were written
+        const generatedClientContent = await readFile(join(localOutputDir, "generated_client.py"), "utf-8");
+        expect(generatedClientContent).toBe("# NEW generated client\n");
+
+        const newFileContent = await readFile(join(localOutputDir, "new_generated_file.py"), "utf-8");
+        expect(newFileContent).toBe("# new file from generator\n");
+    });
+
+    it("preserves files when generator output also produces a file with a fernignored name", async () => {
+        // Set up: .fernignore protects custom_test.py, but the generator ALSO produces custom_test.py
+        await writeFile(join(localOutputDir, ".fernignore"), "custom_test.py\n");
+        await writeFile(join(localOutputDir, "custom_test.py"), "# ORIGINAL custom content\n");
+        await writeFile(join(localOutputDir, "client.py"), "# old client\n");
+
+        // Generator produces a custom_test.py too (should be ignored in favor of user's version)
+        await writeFile(
+            join(tmpOutputDir, "custom_test.py"),
+            "# GENERATED custom_test.py (should NOT replace user's)\n"
+        );
+        await writeFile(join(tmpOutputDir, "client.py"), "# new client\n");
+        await writeFile(join(tmpOutputDir, "README.md"), "# README\n");
+
+        const handler = await createLocalTaskHandler();
+        await handler.copyGeneratedFiles();
+
+        // User's custom_test.py should be preserved, NOT overwritten by generator's version
+        const customTestContent = await readFile(join(localOutputDir, "custom_test.py"), "utf-8");
+        expect(customTestContent).toBe("# ORIGINAL custom content\n");
+
+        // Generated client.py should be updated
+        const clientContent = await readFile(join(localOutputDir, "client.py"), "utf-8");
+        expect(clientContent).toBe("# new client\n");
+    });
+
+    it("deletes files not in .fernignore that are no longer generated", async () => {
+        // Set up: output has old_file.py which is NOT in .fernignore and NOT regenerated
+        await writeFile(join(localOutputDir, ".fernignore"), "custom_test.py\n");
+        await writeFile(join(localOutputDir, "custom_test.py"), "# my custom test\n");
+        await writeFile(join(localOutputDir, "old_file.py"), "# this should be deleted\n");
+
+        // Generator only produces client.py (not old_file.py)
+        await writeFile(join(tmpOutputDir, "client.py"), "# new client\n");
+        await writeFile(join(tmpOutputDir, "README.md"), "# README\n");
+
+        const handler = await createLocalTaskHandler();
+        await handler.copyGeneratedFiles();
+
+        // custom_test.py should be preserved
+        const customTestContent = await readFile(join(localOutputDir, "custom_test.py"), "utf-8");
+        expect(customTestContent).toBe("# my custom test\n");
+
+        // old_file.py should be gone (not in .fernignore, not regenerated)
+        const files = await readdir(localOutputDir);
+        expect(files).not.toContain("old_file.py");
+
+        // client.py should exist
+        expect(files).toContain("client.py");
+    });
+
+    it("works with glob patterns in .fernignore", async () => {
+        // Set up: .fernignore uses a glob pattern
+        await writeFile(join(localOutputDir, ".fernignore"), "tests/**\n");
+        await mkdir(join(localOutputDir, "tests"), { recursive: true });
+        await writeFile(join(localOutputDir, "tests", "test_one.py"), "# test one\n");
+        await writeFile(join(localOutputDir, "tests", "test_two.py"), "# test two\n");
+        await mkdir(join(localOutputDir, "src"), { recursive: true });
+        await writeFile(join(localOutputDir, "src", "client.py"), "# old\n");
+
+        // Generator produces new src/ files but no tests/
+        await mkdir(join(tmpOutputDir, "src"), { recursive: true });
+        await writeFile(join(tmpOutputDir, "src", "client.py"), "# new client\n");
+        await writeFile(join(tmpOutputDir, "README.md"), "# README\n");
+
+        const handler = await createLocalTaskHandler();
+        await handler.copyGeneratedFiles();
+
+        // tests/ should be preserved by glob pattern
+        const testOneContent = await readFile(join(localOutputDir, "tests", "test_one.py"), "utf-8");
+        expect(testOneContent).toBe("# test one\n");
+
+        const testTwoContent = await readFile(join(localOutputDir, "tests", "test_two.py"), "utf-8");
+        expect(testTwoContent).toBe("# test two\n");
+
+        // src/client.py should be updated
+        const clientContent = await readFile(join(localOutputDir, "src", "client.py"), "utf-8");
+        expect(clientContent).toBe("# new client\n");
+    });
+
+    it("handles .fernignore with comments and blank lines", async () => {
+        await writeFile(
+            join(localOutputDir, ".fernignore"),
+            "# This is a comment\ncustom_test.py\n\n# Another comment\ncustom_config.json\n"
+        );
+        await writeFile(join(localOutputDir, "custom_test.py"), "# custom test\n");
+        await writeFile(join(localOutputDir, "custom_config.json"), '{"custom": true}\n');
+        await writeFile(join(localOutputDir, "old_generated.py"), "# old\n");
+
+        await writeFile(join(tmpOutputDir, "new_generated.py"), "# new\n");
+        await writeFile(join(tmpOutputDir, "README.md"), "# README\n");
+
+        const handler = await createLocalTaskHandler();
+        await handler.copyGeneratedFiles();
+
+        // Both custom files should be preserved
+        const testContent = await readFile(join(localOutputDir, "custom_test.py"), "utf-8");
+        expect(testContent).toBe("# custom test\n");
+
+        const configContent = await readFile(join(localOutputDir, "custom_config.json"), "utf-8");
+        expect(configContent).toBe('{"custom": true}\n');
+
+        // Old generated file should be gone, new one should be there
+        const files = await readdir(localOutputDir);
+        expect(files).not.toContain("old_generated.py");
+        expect(files).toContain("new_generated.py");
+    });
+
+    it("without .fernignore, all old files are replaced", async () => {
+        // No .fernignore — all existing files should be deleted
+        await writeFile(join(localOutputDir, "old_file.py"), "# old\n");
+        await writeFile(join(localOutputDir, "custom_test.py"), "# custom\n");
+
+        await writeFile(join(tmpOutputDir, "new_file.py"), "# new\n");
+
+        const handler = await createLocalTaskHandler();
+        await handler.copyGeneratedFiles();
+
+        const files = await readdir(localOutputDir);
+        expect(files).toContain("new_file.py");
+        expect(files).not.toContain("old_file.py");
+        expect(files).not.toContain("custom_test.py");
+    });
+});


### PR DESCRIPTION
## Description

Refs: Request from @Swimburger to ensure `pnpm seed run` respects `.fernignore` files in the output path.

After tracing the full `seed run` code path (`runWithCustomFixture` → `TestRunner.run()` → `runGenerator()` → `writeFilesToDiskAndRunGenerator()` → `LocalTaskHandler.copyGeneratedFiles()`), the existing `.fernignore` handling in `LocalTaskHandler` already applies to both `fern generate` and `pnpm seed run`. This PR adds observability (debug-level logging when `.fernignore` is detected) and comprehensive integration tests to verify the behavior.

[Link to Devin Session](https://app.devin.ai/sessions/e300dc2c9acf4fa7affeee9b90c279f3)

## Changes Made

- **`LocalTaskHandler.copyGeneratedFiles()`**: Added debug-level log message when `.fernignore` is detected, listing preserved paths. This makes it easy to verify `.fernignore` is being respected during both `fern generate` and `pnpm seed run`.
- **New test file `LocalTaskHandler.fernignore.test.ts`**: 6 integration tests using real filesystem + git operations that verify:
  - Files listed in `.fernignore` are preserved (including nested dirs)
  - User files win when the generator also produces a file with a fernignored name
  - Non-fernignored, non-regenerated files are correctly deleted
  - Glob patterns work (`tests/**`)
  - Comments and blank lines in `.fernignore` are handled
  - Without `.fernignore`, all old files are replaced
- Updated `versions.yml` with 4.27.0 entry

## Human Review Checklist

- [ ] **Double read of `.fernignore`**: The new logging block reads the fernignore file to list paths, then the copy methods (`copyGeneratedFilesWithFernIgnoreInExistingRepo` / `copyGeneratedFilesWithFernIgnoreInTempRepo`) read it again. Acceptable tradeoff for observability, but worth noting.
- [ ] **No changes to `packages/seed/`**: The seed run flow already delegates to `LocalTaskHandler.copyGeneratedFiles()` via `writeFilesToDiskAndRunGenerator()`. Confirm this matches your expectation — the existing code path already handles `.fernignore` correctly.
- [ ] **Tests depend on `git` being available**: The integration tests exercise the real `copyGeneratedFilesWithFernIgnoreInTempRepo` path which shells out to `git init`, `git add`, `git commit`, etc.

## Updates since last revision

- Changed logging from info-level to debug-level per review feedback from @fern-support.

## Testing

- [x] Unit tests added (6 new integration tests in `LocalTaskHandler.fernignore.test.ts`)
- [x] All 183 tests in `local-workspace-runner` pass
- [x] Biome lint passes clean
- [x] All 290 CI checks pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
