### PR TITLE
fix(cli): resolve wildcard/latest versions in upgrade migrations

### DIFF
--- a/packages/cli/cli/src/commands/upgrade/__test__/upgrade.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/__test__/upgrade.test.ts
@@ -1103,6 +1103,121 @@ describe("upgrade", () => {
         });
     });
 
+    describe("wildcard and latest version handling", () => {
+        it("should resolve '*' config version to CLI version when rerunning at different version", async () => {
+            mockCliContext.environment.packageVersion = "3.72.0";
+            vi.mocked(isVersionAhead).mockReturnValue(true);
+            process.argv = ["node", "cli.js", "upgrade", "--version", "4.27.0"];
+
+            vi.mocked(loadProjectConfig).mockResolvedValue({
+                version: "*",
+                rawConfig: { version: "*", organization: "test-org" },
+                _absolutePath: "/test/fern/fern.config.json" as AbsoluteFilePath,
+                organization: "test-org"
+            });
+
+            // Mock git to also return * (since that's what's in the config)
+            vi.mocked(loggingExeca).mockResolvedValue({
+                stdout: '{"version":"*"}',
+                stderr: ""
+            } as loggingExeca.ReturnValue);
+
+            await upgrade({
+                cliContext: mockCliContext,
+                includePreReleases: false,
+                targetVersion: "4.27.0",
+                fromVersion: undefined
+            });
+
+            expect(rerunFernCliAtVersion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    version: "4.27.0",
+                    args: expect.arrayContaining(["--from", "3.72.0", "--to", "4.27.0"])
+                })
+            );
+        });
+
+        it("should resolve 'latest' config version to CLI version when rerunning", async () => {
+            mockCliContext.environment.packageVersion = "3.72.0";
+            vi.mocked(isVersionAhead).mockReturnValue(true);
+            process.argv = ["node", "cli.js", "upgrade", "--version", "4.27.0"];
+
+            vi.mocked(loadProjectConfig).mockResolvedValue({
+                version: "latest",
+                rawConfig: { version: "latest", organization: "test-org" },
+                _absolutePath: "/test/fern/fern.config.json" as AbsoluteFilePath,
+                organization: "test-org"
+            });
+
+            vi.mocked(loggingExeca).mockResolvedValue({
+                stdout: '{"version":"latest"}',
+                stderr: ""
+            } as loggingExeca.ReturnValue);
+
+            await upgrade({
+                cliContext: mockCliContext,
+                includePreReleases: false,
+                targetVersion: "4.27.0",
+                fromVersion: undefined
+            });
+
+            expect(rerunFernCliAtVersion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    version: "4.27.0",
+                    args: expect.arrayContaining(["--from", "3.72.0", "--to", "4.27.0"])
+                })
+            );
+        });
+
+        it("should resolve '*' to CLI version when running migrations directly (local dev)", async () => {
+            mockCliContext.environment.packageVersion = "0.0.0";
+
+            vi.mocked(loadProjectConfig).mockResolvedValue({
+                version: "*",
+                rawConfig: { version: "*", organization: "test-org" },
+                _absolutePath: "/test/fern/fern.config.json" as AbsoluteFilePath,
+                organization: "test-org"
+            });
+
+            vi.mocked(loggingExeca).mockResolvedValue({
+                stdout: '{"version":"*"}',
+                stderr: ""
+            } as loggingExeca.ReturnValue);
+
+            await upgrade({
+                cliContext: mockCliContext,
+                includePreReleases: false,
+                targetVersion: "1.2.0",
+                fromVersion: undefined
+            });
+
+            expect(runMigrations).toHaveBeenCalledWith({
+                fromVersion: "0.0.0",
+                toVersion: "1.2.0",
+                context: {},
+                yes: false
+            });
+        });
+
+        it("should resolve '*' passed as --from flag to CLI version", async () => {
+            mockCliContext.environment.packageVersion = "4.27.0";
+
+            await upgrade({
+                cliContext: mockCliContext,
+                includePreReleases: false,
+                targetVersion: "4.27.0",
+                fromVersion: "*"
+            });
+
+            expect(runMigrations).toHaveBeenCalledWith({
+                fromVersion: "4.27.0",
+                toVersion: "4.27.0",
+                context: {},
+                yes: false
+            });
+        });
+    });
+
     describe("--from-git flag", () => {
         beforeEach(() => {
             mockCliContext.environment.packageVersion = "0.0.0"; // Local dev

--- a/packages/cli/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/cli/src/commands/upgrade/upgrade.ts
@@ -214,6 +214,15 @@ async function resolveSourceVersion({
         }
     }
 
+    // Handle wildcard/latest versions - these mean "use whatever CLI version is running"
+    // so the actual source version for migrations is the current CLI version
+    if (resolvedFromVersion === "*" || resolvedFromVersion === "latest") {
+        cliContext.logger.debug(
+            `Source version is "${resolvedFromVersion}", using current CLI version: ${cliContext.environment.packageVersion}`
+        );
+        return cliContext.environment.packageVersion;
+    }
+
     return resolvedFromVersion;
 }
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.27.1
+  changelogEntry:
+    - summary: |
+        Fix `fern upgrade` failing with "Failed to parse version: *" when
+        `fern.config.json` has `"version": "*"` or `"version": "latest"`.
+        The upgrade command now resolves these wildcard versions to the
+        current CLI version before passing them as migration source versions.
+      type: fix
+  createdAt: "2026-03-13"
+  irVersion: 65
+
 - version: 4.27.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes `fern upgrade` crashing with `Failed to parse version: *` when `fern.config.json` uses `"version": "*"` or `"version": "latest"`.

Link to Devin Session: https://app.devin.ai/sessions/9454324cfb934fe5910142ab839973c1
Requested by: @iamnamananand996

## Changes Made

- Added a guard clause at the end of `resolveSourceVersion()` in `upgrade.ts` that detects when the resolved source version is `"*"` or `"latest"` and substitutes `cliContext.environment.packageVersion` (the actual running CLI version) instead. This prevents these unparseable values from being passed as `--from` to the re-run CLI or directly to `runMigrations()`.
- Added 4 unit tests covering: `*` config with rerun path, `latest` config with rerun path, `*` with local dev direct migration, and `*` passed as explicit `--from` flag.
- Added `versions.yml` entry for 4.27.1.

## Root Cause

The `resolveSourceVersion` function falls back to `projectConfig.version` when no `--from` flag, env var, or git history is available. When the config version is `"*"`, this value propagates to `parseVersion()` in semver-utils, which throws because `"*"` doesn't match any semver regex. The existing early-return at line 348 only handles `"*"`/`"latest"` in the "no upgrade available" branch — the "upgrade IS available" branch was unprotected.

## Review Checklist

- [ ] Verify the guard clause at end of `resolveSourceVersion` catches all paths (it's the single exit point, so it should)
- [ ] Note: when `"*"` leaks through as `--from` to the re-run CLI, it resolves to the **target** version (since the re-run CLI IS the target version), producing a from=to no-op migration — this is correct behavior since the initial CLI is responsible for resolving the real source version

## Testing

- [x] Unit tests added (4 new tests in `upgrade.test.ts`, all 51 tests pass)
- [x] Lint passes (`biome check`)