### PR TITLE
fix(spring): generate Nullable and NullableNonemptyFilter core files

### DIFF
--- a/generators/java/spring/src/main/java/com/fern/java/spring/Cli.java
+++ b/generators/java/spring/src/main/java/com/fern/java/spring/Cli.java
@@ -13,6 +13,8 @@ import com.fern.java.DefaultGeneratorExecClient;
 import com.fern.java.FeatureResolver;
 import com.fern.java.generators.AuthGenerator;
 import com.fern.java.generators.DateTimeDeserializerGenerator;
+import com.fern.java.generators.NullableGenerator;
+import com.fern.java.generators.NullableNonemptyFilterGenerator;
 import com.fern.java.generators.ObjectMappersGenerator;
 import com.fern.java.generators.Rfc2822DateTimeDeserializerGenerator;
 import com.fern.java.generators.TypesGenerator;
@@ -96,9 +98,15 @@ public final class Cli extends AbstractGeneratorCli<SpringCustomConfig, SpringCu
         GeneratedObjectMapper objectMapper = objectMappersGenerator.generateFile();
         this.addGeneratedFile(objectMapper);
 
+        NullableGenerator nullableGenerator = new NullableGenerator(context);
+        this.addGeneratedFile(nullableGenerator.generateFile());
+
         OptionalNullableGenerator optionalNullableGenerator = new OptionalNullableGenerator(context);
         GeneratedJavaFile optionalNullable = optionalNullableGenerator.generateFile();
         this.addGeneratedFile(optionalNullable);
+
+        NullableNonemptyFilterGenerator nullableNonemptyFilterGenerator = new NullableNonemptyFilterGenerator(context);
+        this.addGeneratedFile(nullableNonemptyFilterGenerator.generateFile());
 
         ApiExceptionGenerator apiExceptionGenerator = new ApiExceptionGenerator(context);
         GeneratedJavaFile apiException = apiExceptionGenerator.generateFile();

--- a/generators/java/spring/versions.yml
+++ b/generators/java/spring/versions.yml
@@ -1,6 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Generate `Nullable.java` and `NullableNonemptyFilter.java` core files
+        in the Spring generator output. Previously, only `OptionalNullable.java`
+        was generated, but the shared builder and type generation code references
+        `Nullable` and `NullableNonemptyFilter` for fields using `nullable<T>`,
+        causing missing class compilation errors.
+      type: fix
+  createdAt: "2026-03-13"
+  irVersion: 63
+  version: 2.0.0-rc6
+
+- changelogEntry:
+    - summary: |
         Upgrade IR version to 63.
       type: chore
   createdAt: "2026-01-12"


### PR DESCRIPTION
## Description

Fixes a bug where the Java Spring generator failed to produce `Nullable.java` and `NullableNonemptyFilter.java` core utility files, causing compilation errors when Fern definitions use `nullable<T>` fields (e.g., `crawlSpec: nullable<partners-commons.InputSpec>`).

Link to Devin Session: https://app.devin.ai/sessions/29d998a3392b4944ab8a8d5218ec129a
Requested by: @iamnamananand996

## Changes Made

- Added `NullableGenerator` and `NullableNonemptyFilterGenerator` to the Spring generator's `Cli.java`, matching the pattern already used by the Java SDK generator
- Added `versions.yml` entry for `2.0.0-rc6`

### Root Cause

The shared type generation code (`BuilderGenerator`, `EnrichedObjectProperty`) generates builder setters and getter annotations that reference `Nullable` and `NullableNonemptyFilter` when a field uses `nullable<T>`. The SDK generator already generates both files, but the Spring generator only generated `OptionalNullable.java` — leaving dangling imports in the generated output.

## Testing

- [x] Java Spring generator compiles successfully (`./gradlew :spring:compileJava`)
- [ ] No new unit tests added — this is a straightforward addition of two missing generators that follow the existing SDK pattern

## Review Checklist

- [ ] Verify that always generating `Nullable.java` (unconditionally) matches the intended behavior — the SDK generator also always generates it, so this mirrors that pattern
- [ ] Consider whether any seed/snapshot tests need updating to reflect the new files in Spring output
- [ ] Confirm that `NullableNonemptyFilter` behaves correctly with the Spring generator's default `wrappedAliases: true` (vs. the SDK's default `false`)