### PR TITLE
fix(spring): generate WrappedAlias.java when wrapped-aliases is enabled

### DIFF
--- a/generators/java/spring/src/main/java/com/fern/java/spring/Cli.java
+++ b/generators/java/spring/src/main/java/com/fern/java/spring/Cli.java
@@ -19,6 +19,7 @@ import com.fern.java.generators.ObjectMappersGenerator;
 import com.fern.java.generators.Rfc2822DateTimeDeserializerGenerator;
 import com.fern.java.generators.TypesGenerator;
 import com.fern.java.generators.TypesGenerator.Result;
+import com.fern.java.generators.WrappedAliasGenerator;
 import com.fern.java.output.GeneratedAuthFiles;
 import com.fern.java.output.GeneratedJavaFile;
 import com.fern.java.output.GeneratedObjectMapper;
@@ -107,6 +108,11 @@ public final class Cli extends AbstractGeneratorCli<SpringCustomConfig, SpringCu
 
         NullableNonemptyFilterGenerator nullableNonemptyFilterGenerator = new NullableNonemptyFilterGenerator(context);
         this.addGeneratedFile(nullableNonemptyFilterGenerator.generateFile());
+
+        if (springCustomConfig.wrappedAliases()) {
+            WrappedAliasGenerator wrappedAliasGenerator = new WrappedAliasGenerator(context);
+            this.addGeneratedFile(wrappedAliasGenerator.generateFile());
+        }
 
         ApiExceptionGenerator apiExceptionGenerator = new ApiExceptionGenerator(context);
         GeneratedJavaFile apiException = apiExceptionGenerator.generateFile();

--- a/generators/java/spring/versions.yml
+++ b/generators/java/spring/versions.yml
@@ -1,6 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Generate `WrappedAlias.java` in the Spring generator output when
+        `wrapped-aliases` is enabled (the default). `NullableNonemptyFilter`
+        references `WrappedAlias` for alias-of-optional empty checks, causing
+        compilation errors when the class is missing.
+      type: fix
+  createdAt: "2026-03-13"
+  irVersion: 63
+  version: 2.0.0-rc7
+
+- changelogEntry:
+    - summary: |
         Generate `Nullable.java` and `NullableNonemptyFilter.java` core files
         in the Spring generator output. Previously, only `OptionalNullable.java`
         was generated, but the shared builder and type generation code references


### PR DESCRIPTION
## Description

Follow-up fix to #13472. The Spring generator's `NullableNonemptyFilter` references `WrappedAlias` when `wrapped-aliases` is enabled (the default for Spring), but the Spring generator never produced `WrappedAlias.java`, causing compilation errors like:

```
NullableNonemptyFilter.java:27: error: cannot find symbol
  private boolean isAliasOfOptionalEmpty(WrappedAlias o) {
                                         ^
```

Refs: https://buildwithfern.slack.com/archives/C06UPDFUHU4/p1773270956086899

Link to Devin Session: https://app.devin.ai/sessions/29d998a3392b4944ab8a8d5218ec129a
Requested by: @iamnamananand996

## Changes Made

- Added `WrappedAliasGenerator` to Spring `Cli.java`, gated behind `springCustomConfig.wrappedAliases()` (mirroring the SDK generator's pattern)
- Added `versions.yml` entry for `2.0.0-rc7`

## Testing

- [x] `./gradlew :spring:compileJava` passes
- [ ] Seed tests will need updating (WrappedAlias.java will now appear in all Spring fixtures where `wrappedAliases` defaults to `true`)

## Human Review Checklist

- [ ] Verify there are no **other** core utility classes referenced by the newly generated files (`Nullable`, `NullableNonemptyFilter`, `WrappedAlias`) that the Spring generator still doesn't produce. Compare the SDK generator's `generateClient()` core file section against Spring's to audit for further gaps.
- [ ] Confirm `springCustomConfig.wrappedAliases()` is the correct guard (Spring defaults to `true`; SDK defaults to `false`) — this means WrappedAlias will be generated for Spring by default, which is the intended behavior since `NullableNonemptyFilterGenerator` already conditionally emits `WrappedAlias` references based on the same flag.