### PR TITLE
feat(cli): add --changed-pages flag for docs preview

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -730,6 +730,12 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     default: false,
                     description:
                         "Automatically retry with exponential backoff when receiving 429 Too Many Requests responses"
+                })
+                .option("changed-pages", {
+                    boolean: true,
+                    default: false,
+                    description:
+                        "When used with --preview and --docs, detect changed pages via git diff and output direct preview links to each changed page"
                 }),
         async (argv) => {
             if (argv.api != null && argv.docs != null) {
@@ -821,7 +827,8 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     strictBrokenLinks: argv.strictBrokenLinks,
                     disableTemplates: argv.disableSnippets,
                     noPrompt: !argv.prompt,
-                    skipUpload: argv.skipUpload
+                    skipUpload: argv.skipUpload,
+                    changedPages: argv.changedPages
                 });
             }
             // default to loading api workspace to preserve legacy behavior

--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -19,7 +19,8 @@ export async function generateDocsWorkspace({
     strictBrokenLinks,
     disableTemplates,
     noPrompt,
-    skipUpload
+    skipUpload,
+    changedPages
 }: {
     project: Project;
     cliContext: CliContext;
@@ -30,6 +31,7 @@ export async function generateDocsWorkspace({
     disableTemplates: boolean | undefined;
     noPrompt?: boolean;
     skipUpload: boolean | undefined;
+    changedPages: boolean | undefined;
 }): Promise<void> {
     const docsWorkspace = project.docsWorkspaces;
     if (docsWorkspace == null) {
@@ -116,7 +118,8 @@ export async function generateDocsWorkspace({
             preview,
             disableTemplates,
             skipUpload,
-            cliVersion: cliContext.environment.packageVersion
+            cliVersion: cliContext.environment.packageVersion,
+            changedPages
         });
         const generationTime = performance.now() - generationStart;
         context.logger.debug(`Remote docs generation completed in ${generationTime.toFixed(0)}ms`);

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.28.0
+  changelogEntry:
+    - summary: |
+        Add changed page links to docs preview output. When running
+        `fern generate --docs --preview`, the CLI now detects which docs
+        pages were modified (via git diff) and logs direct preview URLs
+        for each changed page. The returned preview URL also points to
+        the first changed page instead of the site root.
+      type: feat
+  createdAt: "2026-03-13"
+  irVersion: 65
+
 - version: 4.27.0
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,11 +2,11 @@
 - version: 4.28.0
   changelogEntry:
     - summary: |
-        Add changed page links to docs preview output. When running
-        `fern generate --docs --preview`, the CLI now detects which docs
-        pages were modified (via git diff) and logs direct preview URLs
-        for each changed page. The returned preview URL also points to
-        the first changed page instead of the site root.
+        Add `--changed-pages` flag for `fern generate --docs --preview`.
+        When enabled, the CLI detects which docs pages were modified
+        (via git diff) and logs direct preview URLs for each changed
+        page. The returned preview URL also points to the first changed
+        page instead of the site root.
       type: feat
   createdAt: "2026-03-13"
   irVersion: 65

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/getChangedPageSlugs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/getChangedPageSlugs.ts
@@ -159,6 +159,22 @@ export async function getChangedPageSlugs({
         return undefined;
     }
 
+    // Normalize file paths to be relative to the fern project directory.
+    // Git diff returns paths relative to git root (e.g., "myproject/fern/docs/pages/welcome.mdx"),
+    // but the slug resolution API expects paths relative to the fern directory
+    // (e.g., "docs/pages/welcome.mdx" or "fern/docs/pages/welcome.mdx").
+    const docsRelativeToGitRoot = path.relative(gitRoot, docsWorkspacePath);
+    const fernParentRelative = path.dirname(docsRelativeToGitRoot);
+    const normalizedPageFiles = pageFiles.map((file) => {
+        if (fernParentRelative !== "." && file.startsWith(fernParentRelative + "/")) {
+            // Strip everything before the fern directory name
+            return file.slice(fernParentRelative.length + 1);
+        }
+        return file;
+    });
+
+    context.logger.debug(`Normalized page files for slug resolution: ${normalizedPageFiles.join(", ")}`);
+
     try {
         // Normalize the preview URL (strip protocol and path if present)
         let normalizedPreviewUrl = previewUrl;
@@ -174,7 +190,7 @@ export async function getChangedPageSlugs({
 
         const slugResponse = await getSlugForFiles({
             previewUrl: normalizedPreviewUrl,
-            files: pageFiles,
+            files: normalizedPageFiles,
             token
         });
 

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/getChangedPageSlugs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/getChangedPageSlugs.ts
@@ -1,0 +1,197 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { TaskContext } from "@fern-api/task-context";
+import { execSync } from "child_process";
+import path from "path";
+
+interface FileSlugMapping {
+    filePath: string;
+    slug: string | null;
+}
+
+interface GetSlugForFileResponse {
+    mappings: FileSlugMapping[];
+    authed: boolean;
+}
+
+async function getSlugForFiles({
+    previewUrl,
+    files,
+    token
+}: {
+    previewUrl: string;
+    files: string[];
+    token: string;
+}): Promise<GetSlugForFileResponse> {
+    const filesParam = files.join(",");
+    const url = `https://${previewUrl}/api/fern-docs/get-slug-for-file?files=${encodeURIComponent(filesParam)}`;
+
+    const response = await fetch(url, {
+        method: "GET",
+        headers: {
+            FERN_TOKEN: token
+        }
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Failed to get slugs for files: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return (await response.json()) as GetSlugForFileResponse;
+}
+
+function getGitRoot(docsWorkspacePath: AbsoluteFilePath): string | undefined {
+    try {
+        return execSync("git rev-parse --show-toplevel", {
+            cwd: docsWorkspacePath,
+            encoding: "utf-8"
+        }).trim();
+    } catch {
+        return undefined;
+    }
+}
+
+function getChangedFilesFromGit(docsWorkspacePath: AbsoluteFilePath): string[] | undefined {
+    const gitRoot = getGitRoot(docsWorkspacePath);
+    if (gitRoot == null) {
+        return undefined;
+    }
+
+    // In GitHub Actions PR context, GITHUB_BASE_REF is the target branch
+    const baseRef = process.env.GITHUB_BASE_REF;
+
+    try {
+        let diffOutput: string;
+        if (baseRef != null && baseRef.length > 0) {
+            // GitHub Actions: compare against the base branch
+            // First, make sure we have the base ref available
+            try {
+                execSync(`git fetch origin ${baseRef} --depth=1`, {
+                    cwd: gitRoot,
+                    encoding: "utf-8",
+                    stdio: "pipe"
+                });
+            } catch {
+                // fetch may fail if already available or in shallow clone
+            }
+            diffOutput = execSync(`git diff --name-only origin/${baseRef}...HEAD`, {
+                cwd: gitRoot,
+                encoding: "utf-8",
+                stdio: "pipe"
+            });
+        } else {
+            // Fallback: compare against parent commit
+            diffOutput = execSync("git diff --name-only HEAD~1", {
+                cwd: gitRoot,
+                encoding: "utf-8",
+                stdio: "pipe"
+            });
+        }
+
+        return diffOutput
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0);
+    } catch {
+        return undefined;
+    }
+}
+
+function filterDocsFiles(changedFiles: string[], docsWorkspacePath: AbsoluteFilePath, gitRoot: string): string[] {
+    const docsRelative = path.relative(gitRoot, docsWorkspacePath);
+    return changedFiles.filter((file) => {
+        // Only include files within the docs workspace
+        if (!file.startsWith(docsRelative)) {
+            return false;
+        }
+        // Include page files (.mdx, .md) and docs config files
+        const ext = path.extname(file).toLowerCase();
+        return ext === ".mdx" || ext === ".md" || file.endsWith("docs.yml");
+    });
+}
+
+/**
+ * Detects which docs pages changed and resolves their URL slugs using the preview deployment.
+ * Returns an array of slugs for changed pages, or undefined if detection fails.
+ *
+ * This is best-effort: if git commands fail or slug resolution fails,
+ * it returns undefined and the caller should fall back to the base preview URL.
+ */
+export async function getChangedPageSlugs({
+    previewUrl,
+    token,
+    docsWorkspacePath,
+    context
+}: {
+    previewUrl: string;
+    token: string;
+    docsWorkspacePath: AbsoluteFilePath;
+    context: TaskContext;
+}): Promise<string[] | undefined> {
+    const gitRoot = getGitRoot(docsWorkspacePath);
+    if (gitRoot == null) {
+        context.logger.debug("Not a git repository, skipping changed page detection");
+        return undefined;
+    }
+
+    const allChangedFiles = getChangedFilesFromGit(docsWorkspacePath);
+    if (allChangedFiles == null) {
+        context.logger.debug("Could not detect changed files from git");
+        return undefined;
+    }
+
+    const changedDocsFiles = filterDocsFiles(allChangedFiles, docsWorkspacePath, gitRoot);
+    if (changedDocsFiles.length === 0) {
+        context.logger.debug("No changed docs files detected");
+        return undefined;
+    }
+
+    context.logger.debug(`Detected ${changedDocsFiles.length} changed docs file(s): ${changedDocsFiles.join(", ")}`);
+
+    // Filter to only page files (.mdx, .md) for slug resolution — docs.yml changes don't map to slugs
+    const pageFiles = changedDocsFiles.filter((file) => {
+        const ext = path.extname(file).toLowerCase();
+        return ext === ".mdx" || ext === ".md";
+    });
+
+    if (pageFiles.length === 0) {
+        context.logger.debug("Changed docs files are config-only (no page files), skipping slug resolution");
+        return undefined;
+    }
+
+    try {
+        // Normalize the preview URL (strip protocol and path if present)
+        let normalizedPreviewUrl = previewUrl;
+        if (normalizedPreviewUrl.startsWith("https://")) {
+            normalizedPreviewUrl = normalizedPreviewUrl.slice(8);
+        } else if (normalizedPreviewUrl.startsWith("http://")) {
+            normalizedPreviewUrl = normalizedPreviewUrl.slice(7);
+        }
+        const slashIndex = normalizedPreviewUrl.indexOf("/");
+        if (slashIndex !== -1) {
+            normalizedPreviewUrl = normalizedPreviewUrl.slice(0, slashIndex);
+        }
+
+        const slugResponse = await getSlugForFiles({
+            previewUrl: normalizedPreviewUrl,
+            files: pageFiles,
+            token
+        });
+
+        const slugs = slugResponse.mappings
+            .filter((mapping) => mapping.slug != null)
+            .map((mapping) => mapping.slug as string);
+
+        if (slugs.length === 0) {
+            context.logger.debug("No slugs resolved for changed page files");
+            return undefined;
+        }
+
+        return slugs;
+    } catch (error) {
+        context.logger.debug(
+            `Failed to resolve slugs for changed pages: ${error instanceof Error ? error.message : String(error)}`
+        );
+        return undefined;
+    }
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -79,7 +79,8 @@ export async function publishDocs({
     excludeApis = false,
     targetAudiences,
     docsUrl,
-    cliVersion
+    cliVersion,
+    changedPages
 }: {
     token: FernToken;
     organization: string;
@@ -99,6 +100,7 @@ export async function publishDocs({
     targetAudiences?: string[];
     docsUrl?: string;
     cliVersion?: string;
+    changedPages?: boolean;
 }): Promise<string> {
     const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
     const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
@@ -520,8 +522,8 @@ export async function publishDocs({
         const link = terminalLink(url, url);
         context.logger.info(chalk.green(`Published docs to ${link}`));
 
-        // For preview deployments, try to detect changed pages and log direct links
-        if (preview) {
+        // For preview deployments with --changed-pages, detect changed pages and log direct links
+        if (preview && changedPages) {
             try {
                 const changedSlugs = await getChangedPageSlugs({
                     previewUrl: urlToOutput,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -24,6 +24,7 @@ import { readFile } from "fs/promises";
 import { chunk } from "lodash-es";
 import * as mime from "mime-types";
 import terminalLink from "terminal-link";
+import { getChangedPageSlugs } from "./getChangedPageSlugs.js";
 import { getDynamicGeneratorConfig } from "./getDynamicGeneratorConfig.js";
 import { measureImageSizes } from "./measureImageSizes.js";
 import { asyncPool } from "./utils/asyncPool.js";
@@ -518,6 +519,33 @@ export async function publishDocs({
 
         const link = terminalLink(url, url);
         context.logger.info(chalk.green(`Published docs to ${link}`));
+
+        // For preview deployments, try to detect changed pages and log direct links
+        if (preview) {
+            try {
+                const changedSlugs = await getChangedPageSlugs({
+                    previewUrl: urlToOutput,
+                    token: token.value,
+                    docsWorkspacePath: docsWorkspace.absoluteFilePath,
+                    context
+                });
+                if (changedSlugs != null && changedSlugs.length > 0) {
+                    context.logger.info(chalk.cyan("Changed pages:"));
+                    for (const slug of changedSlugs) {
+                        const pageUrl = wrapWithHttps(`${urlToOutput}/${slug}`);
+                        const pageLink = terminalLink(pageUrl, pageUrl);
+                        context.logger.info(chalk.cyan(`  ${pageLink}`));
+                    }
+                    // Return URL pointing to the first changed page
+                    return wrapWithHttps(`${urlToOutput}/${changedSlugs[0]}`);
+                }
+            } catch (error) {
+                context.logger.debug(
+                    `Failed to detect changed pages: ${error instanceof Error ? error.message : String(error)}`
+                );
+            }
+        }
+
         return url;
     } else {
         switch (registerDocsResponse.error.error) {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -22,7 +22,8 @@ export async function runRemoteGenerationForDocsWorkspace({
     preview,
     disableTemplates,
     skipUpload,
-    cliVersion
+    cliVersion,
+    changedPages
 }: {
     organization: string;
     apiWorkspaces: AbstractAPIWorkspace<unknown>[];
@@ -35,6 +36,7 @@ export async function runRemoteGenerationForDocsWorkspace({
     disableTemplates: boolean | undefined;
     skipUpload: boolean | undefined;
     cliVersion?: string;
+    changedPages?: boolean;
 }): Promise<string | undefined> {
     // Substitute templated environment variables:
     // If substitute-env-vars is enabled, we'll attempt to read and replace the templated
@@ -118,7 +120,8 @@ export async function runRemoteGenerationForDocsWorkspace({
                         : [maybeInstance.audiences]
                     : undefined,
                 docsUrl: maybeInstance.url,
-                cliVersion
+                cliVersion,
+                changedPages
             });
 
         for (let attempt = 0; ; attempt++) {


### PR DESCRIPTION
## Description

Closes https://github.com/fern-api/fern/issues/5549

Adds a `--changed-pages` flag to `fern generate --docs --preview` that detects which docs pages were modified (via git diff) and outputs direct preview URLs for each changed page. The returned preview URL also points to the first changed page instead of the site root.

Link to Devin Session: https://app.devin.ai/sessions/cb0a12f48586494b97dff104279db45d
Requested by: @davidkonigsberg

## Changes Made

- Added `--changed-pages` boolean CLI flag to the `generate` command
- Created new `getChangedPageSlugs.ts` utility that:
  - Detects changed files using `git diff` (supports GitHub Actions PR context via `GITHUB_BASE_REF`)
  - Filters to docs files (`.mdx`, `.md`, `docs.yml`) within the workspace
  - Normalizes file paths from git-root-relative to fern-project-relative before calling the slug resolution API
  - Calls the existing `/api/fern-docs/get-slug-for-file` endpoint on the preview deployment to resolve file paths → URL slugs
  - Returns slugs array or `undefined` on failure (best-effort)
- Threaded `changedPages` flag through `generateDocsWorkspace` → `runRemoteGenerationForDocsWorkspace` → `publishDocs`
- In `publishDocs`, when `--changed-pages` is enabled on a preview deployment:
  - Logs direct preview links for each changed page
  - Returns URL pointing to the first changed page instead of the site root
- Added CLI version `4.28.0` entry in `versions.yml`
- [ ] Updated README.md generator (if applicable)

## Testing

- [x] Lint/format checks pass (`pnpm run check`)
- [ ] Unit tests added/updated
- [x] Manual testing completed

Tested locally against the `fern-platform/smoke-test` docs workspace. Modified `welcome.mdx`, ran `fern generate --docs --preview --changed-pages`, and confirmed:
1. The `--changed-pages` flag appears in `--help` output
2. The preview publishes successfully
3. "Changed pages:" section is logged with a direct link to `/home/welcome`

![Testing video](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOiJnb29nbGUtb2F1dGgyfDExNDQ3NzcxMjkzODY5Mjg5MDk4NiIsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19zYmRpcnN4enl4dGN0emFqLzA2YWNjNDQ0LWU3ZTktNDI3Mi1iNmQ1LWNlMjNjNjk4Y2U1OCIsImlhdCI6MTc3MzQxMTgyNiwiZXhwIjoxNzc0MDE2NjI2fQ.5WGeRJ-yvriNbzM_3_JSr6plYK5tDYXimbwpqNjdD3w)

[View original video (rec-8b83b0591720418189d28935703588a1-edited.mp4)](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOiJnb29nbGUtb2F1dGgyfDExNDQ3NzcxMjkzODY5Mjg5MDk4NiIsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19zYmRpcnN4enl4dGN0emFqLzgwNDdkOGZlLTJhNGMtNGFkZS1iODZiLTEwNTFjNDhiYmNkZiIsImlhdCI6MTc3MzQxMTgyNywiZXhwIjoxNzc0MDE2NjI3fQ.0O_cKRqhjiq02Q74gBm3JuyH3pzfNxbLiqqnBmaFc9A)

## ⚠️ Human Review Checklist

- **Path normalization**: `getChangedPageSlugs.ts` strips the parent directory prefix from git-relative paths so they match what `/api/fern-docs/get-slug-for-file` expects (e.g., `smoke-test/fern/docs/pages/welcome.mdx` → `fern/docs/pages/welcome.mdx`). Verify the `fernParentRelative` logic handles edge cases where the fern dir is at the git root (should no-op since `dirname` returns `"."`)
- **Command injection surface**: `GITHUB_BASE_REF` is passed to `execSync` via string interpolation (`git fetch origin ${baseRef}`). In a GitHub Actions context this is controlled, but worth noting
- **API endpoint compatibility**: Verify that `/api/fern-docs/get-slug-for-file` is served on preview deployments
- **Flag validation**: `--changed-pages` silently no-ops if used without `--preview` or `--docs` (no explicit validation error)
- **No unit tests**: All detection is best-effort with graceful fallbacks, but the path normalization and file filtering logic may warrant coverage