### PR TITLE
fix(openapi): preserve endpoint security auth overrides

### DIFF
--- a/packages/cli/api-importers/openapi-to-ir/src/3.1/OpenAPIConverter.ts
+++ b/packages/cli/api-importers/openapi-to-ir/src/3.1/OpenAPIConverter.ts
@@ -1,3 +1,4 @@
+import { visitRawApiAuth } from "@fern-api/fern-definition-schema";
 import { AuthScheme, FernIr, IntermediateRepresentation } from "@fern-api/ir-sdk";
 import { constructHttpPath, convertApiAuth, convertEnvironments } from "@fern-api/ir-utils";
 import { AbstractSpecConverter, Converters, ServersConverter } from "@fern-api/v3-importer-commons";
@@ -313,6 +314,19 @@ export class OpenAPIConverter extends AbstractSpecConverter<OpenAPIConverterCont
 
     private overrideOpenApiAuthWithGeneratorsAuth(): void {
         if (!this.context.authOverrides?.["auth-schemes"]) {
+            return;
+        }
+
+        const shouldOverrideOpenApiSecurity =
+            this.context.authOverrides.auth == null
+                ? true
+                : visitRawApiAuth(this.context.authOverrides.auth, {
+                      single: () => true,
+                      any: () => true,
+                      // endpoint-security means the OpenAPI spec is already the source of truth.
+                      endpointSecurity: () => false
+                  });
+        if (!shouldOverrideOpenApiSecurity) {
             return;
         }
 

--- a/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
+++ b/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
@@ -1,4 +1,4 @@
-import { RawSchemas } from "@fern-api/fern-definition-schema";
+import { RawSchemas, visitRawApiAuth } from "@fern-api/fern-definition-schema";
 import {
     FernIr,
     HttpEndpoint,
@@ -492,9 +492,18 @@ export class OperationConverter extends AbstractOperationConverter {
             return [];
         }
 
-        // When auth overrides are specified, use them instead of OpenAPI security
-        if (this.context.authOverrides?.auth != null) {
-            return this.getDefaultSecurityFromAuthOverrides();
+        const authOverride = this.context.authOverrides?.auth;
+        if (authOverride != null) {
+            const defaultSecurity = visitRawApiAuth(authOverride, {
+                single: () => this.getDefaultSecurityFromAuthOverrides(),
+                any: () => this.getDefaultSecurityFromAuthOverrides(),
+                // endpoint-security means the OpenAPI spec owns per-operation security.
+                endpointSecurity: () => undefined
+            });
+
+            if (defaultSecurity != null) {
+                return defaultSecurity;
+            }
         }
 
         // Fall back to OpenAPI security
@@ -507,7 +516,17 @@ export class OperationConverter extends AbstractOperationConverter {
      * @returns Array of HTTP headers derived from the security schemes
      */
     private shouldApplyDefaultAuthOverrides(): boolean {
-        if (!this.context.authOverrides?.auth) {
+        const authOverride = this.context.authOverrides?.auth;
+        if (authOverride == null) {
+            return false;
+        }
+
+        const shouldApply = visitRawApiAuth(authOverride, {
+            single: () => true,
+            any: () => true,
+            endpointSecurity: () => false
+        });
+        if (!shouldApply) {
             return false;
         }
 

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/endpoint-security-auth-override/generators.yml
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/endpoint-security-auth-override/generators.yml
@@ -1,0 +1,12 @@
+auth-schemes:
+  bearerAuth:
+    scheme: bearer
+    token:
+      name: token
+      env: TEST_BEARER_TOKEN
+
+api:
+  auth:
+    endpoint-security: {}
+  specs:
+    - openapi: openapi.yml

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/endpoint-security-auth-override/openapi.yml
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/endpoint-security-auth-override/openapi.yml
@@ -1,0 +1,69 @@
+openapi: 3.0.3
+info:
+  title: Endpoint Security Auth Override Test API
+  version: 1.0.0
+  description: OpenAPI spec with per-operation security and generators.yml endpoint-security auth.
+
+servers:
+  - url: https://api.example.com/v1
+
+paths:
+  /protected:
+    get:
+      operationId: getProtected
+      summary: Get protected resource
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Protected resource accessed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+
+  /token:
+    post:
+      operationId: createToken
+      summary: Exchange credentials for a token
+      security: []
+      responses:
+        "200":
+          description: Token issued successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - access_token
+                properties:
+                  access_token:
+                    type: string
+                    example: test-token
+
+  /public:
+    get:
+      operationId: getPublic
+      summary: Get public resource
+      responses:
+        "200":
+          description: Public resource accessed successfully
+          content:
+            application/json:
+              schema:
+                type: string
+                example: public data
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT Bearer token authentication

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts
@@ -845,6 +845,89 @@ describe("OpenAPI v3 Parser Pipeline (--from-openapi flag)", () => {
         await expect(intermediateRepresentation).toMatchFileSnapshot("__snapshots__/auth-scheme-override-ir.snap");
     });
 
+    it("should preserve per-operation security when generators.yml uses endpoint-security auth", async () => {
+        const context = createMockTaskContext();
+        const workspace = await loadAPIWorkspace({
+            absolutePathToWorkspace: join(
+                AbsoluteFilePath.of(__dirname),
+                RelativeFilePath.of("fixtures/endpoint-security-auth-override")
+            ),
+            context,
+            cliVersion: "0.0.0",
+            workspaceName: "endpoint-security-auth-override"
+        });
+
+        expect(workspace.didSucceed).toBe(true);
+        assert(workspace.didSucceed);
+
+        if (!(workspace.workspace instanceof OSSWorkspace)) {
+            throw new Error(
+                `Expected OSSWorkspace for OpenAPI processing, got ${workspace.workspace.constructor.name}`
+            );
+        }
+
+        const intermediateRepresentation = await workspace.workspace.getIntermediateRepresentation({
+            context,
+            audiences: { type: "all" },
+            enableUniqueErrorsPerEndpoint: true,
+            generateV1Examples: false,
+            logWarnings: false
+        });
+
+        const fdrApiDefinition = await convertIrToFdrApi({
+            ir: intermediateRepresentation,
+            snippetsConfig: {
+                typescriptSdk: undefined,
+                pythonSdk: undefined,
+                javaSdk: undefined,
+                rubySdk: undefined,
+                goSdk: undefined,
+                csharpSdk: undefined,
+                phpSdk: undefined,
+                swiftSdk: undefined,
+                rustSdk: undefined
+            },
+            playgroundConfig: {
+                oauth: true
+            },
+            context
+        });
+
+        const service = Object.values(intermediateRepresentation.services)[0];
+        expect(service).toBeDefined();
+        assert(service != null);
+
+        const protectedEndpoint = service.endpoints.find((endpoint) => endpoint.name.originalName === "getProtected");
+        const tokenEndpoint = service.endpoints.find((endpoint) => endpoint.name.originalName === "createToken");
+        const publicEndpoint = service.endpoints.find((endpoint) => endpoint.name.originalName === "getPublic");
+
+        expect(protectedEndpoint?.auth).toBe(true);
+        expect(protectedEndpoint?.security).toEqual([{ bearerAuth: [] }]);
+
+        expect(tokenEndpoint?.auth).toBe(false);
+        expect(tokenEndpoint?.security).toEqual([]);
+
+        expect(publicEndpoint?.auth).toBe(false);
+        expect(publicEndpoint?.security).toBeUndefined();
+
+        const fdrEndpoints = fdrApiDefinition.rootPackage.endpoints;
+        const protectedFdrEndpoint = fdrEndpoints.find((endpoint) => endpoint.id === "getProtected");
+        const tokenFdrEndpoint = fdrEndpoints.find((endpoint) => endpoint.id === "createToken");
+        const publicFdrEndpoint = fdrEndpoints.find((endpoint) => endpoint.id === "getPublic");
+
+        expect(protectedFdrEndpoint?.auth).toBe(true);
+        expect(protectedFdrEndpoint?.authV2).toEqual(["bearerAuth"]);
+        expect(protectedFdrEndpoint?.multiAuth).toEqual([{ schemes: ["bearerAuth"] }]);
+
+        expect(tokenFdrEndpoint?.auth).toBe(false);
+        expect(tokenFdrEndpoint?.authV2).toEqual([]);
+        expect(tokenFdrEndpoint?.multiAuth).toEqual([]);
+
+        expect(publicFdrEndpoint?.auth).toBe(false);
+        expect(publicFdrEndpoint?.authV2).toBeUndefined();
+        expect(publicFdrEndpoint?.multiAuth).toBeUndefined();
+    });
+
     it("should handle auth scheme name collision between OpenAPI and generators.yml", async () => {
         // Test what happens when OpenAPI has a security scheme with the same name as generators.yml
         // Both have "bearerAuth" but with different configurations


### PR DESCRIPTION
## Problem
Fern docs currently behave inconsistently when an OpenAPI spec uses per-operation `security` and `generators.yml` uses:

```yml
api:
  auth:
    endpoint-security: {}
```

In that setup, the OpenAPI spec should remain the source of truth for endpoint auth.

In practice, the importer was still treating generator auth overrides like global auth overrides:
- it rewrote `spec.security`
- it removed operation-level `security`
- it synthesized default auth onto endpoints that should stay public

That breaks the docs / API Explorer behavior in exactly the shape we hit downstream:
- protected endpoints can lose their rendered auth metadata
- `security: []` token endpoints can be treated as authenticated
- public endpoints can inherit auth they should not have

## Fix
This change makes `endpoint-security` behave as documented:
- do not rewrite the OpenAPI spec's auth/security when the override mode is `endpoint-security`
- preserve operation-level `security` instead of replacing it with synthesized global auth
- do not apply default auth override behavior to endpoints when `endpoint-security` is configured

## Regression Coverage
Adds a focused fixture/test that exercises the docs-facing case end to end:
- protected endpoint with explicit `security`
- token endpoint with explicit `security: []`
- public endpoint with no auth

The test asserts both layers:
- IR endpoint `auth` / `security`
- FDR endpoint `auth` / `authV2` / `multiAuth`

## Testing
- `pnpm --filter @fern-api/register test -- packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts -t "endpoint-security auth"`
- `pnpm exec biome lint packages/cli/api-importers/openapi-to-ir/src/3.1/OpenAPIConverter.ts packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts`
- `pnpm turbo run compile --filter=@fern-api/openapi-to-ir --filter=@fern-api/register`

## Note
A generated IR fixture in `ir-generator-tests` was also updated because CI's `test` job was rewriting that tracked file and then failing the repo cleanliness check.
