### PR TITLE
fix(ci): use squash merge for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,7 +25,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         if: ${{contains(steps.metadata.outputs.update-type, 'version-update')}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Description

Fixes the CI failure on dependabot PRs (e.g. [#13540](https://github.com/fern-api/fern/pull/13540)) where the auto-merge job fails with:

> `GraphQL: Merge method merge commits are not allowed on this repository (enablePullRequestAutoMerge)`

## Changes Made

- Changed `gh pr merge --auto --merge` to `gh pr merge --auto --squash` in `.github/workflows/dependabot.yml` to match the repository's allowed merge methods.

## Testing

- [ ] This change can only be verified by a subsequent dependabot PR triggering the workflow.

## Review Checklist

- [ ] Confirm that squash is the intended merge strategy for dependabot PRs on this repo.

---

[Link to Devin Session](https://app.devin.ai/sessions/a4ec2434b62348dab6d7087327f9066d)  
Requested by: @davidkonigsberg