### PR TITLE
fix(typescript): include root markdown files in output when outputSourceFiles is false

### DIFF
--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -364,12 +364,20 @@ export class PersistedTypescriptProject {
         unzipOutput?: boolean;
         logger: Logger;
     }): Promise<void> {
-        await this.zipDirectoryContents(join(this.directory, this.distDirectory), {
-            logger,
-            destinationPath,
-            zipFilename,
-            unzipOutput
-        });
+        const tmpZipLocation = join(AbsoluteFilePath.of((await tmp.dir()).path), RelativeFilePath.of("output.zip"));
+        const zip = createLoggingExecutable("zip", { cwd: this.directory, logger, doNotPipeOutput: true });
+        
+        // zip dist and md files
+        const distItems = (await readdir(join(this.directory, this.distDirectory))).map(item => join(this.distDirectory, RelativeFilePath.of(item)));
+        const rootItems = (await readdir(this.directory)).filter(item => item.endsWith('.md'));
+        await zip(["-r", tmpZipLocation, ...distItems, ...rootItems]);
+
+        const destinationZip = join(destinationPath, RelativeFilePath.of(zipFilename));
+        await cp(tmpZipLocation, destinationZip);
+        if (unzipOutput) {
+            await decompress(destinationZip, destinationPath, { strip: 0 });
+            await rm(destinationZip);
+        }
     }
 
     private async zipDirectoryContents(


### PR DESCRIPTION
## Summary
Fixes an issue where , , and  are not included in the output artifact when generating TypeScript SDKs with  (the default mode that builds ES and CJS artifacts).

## Problem
Fixes #13549.
The TypeScript generator builds the artifacts and then calls , which delegates to . Because it solely bundles the  (which only contains the compiled  and  files), any documentation files generated in the root of the project directory (such as ) are silently dropped from the final uploaded/downloaded artifact. This is inconsistent with Python and Go, which maintain their doc files.

## Solution
Updated  to explicitly include all  files residing in the root project directory alongside the dist contents. This enables  to preserve standard documentation files in the output ZIP without changing the core TS artifact behavior.