### PR TITLE
fix(go): Basic Auth header not sent when username is empty

### DIFF
--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -426,7 +426,7 @@ func (f *fileWriter) WriteRequestOptionsDefinition(
 				username = authScheme.Basic.Username.PascalCase.UnsafeName
 				password = authScheme.Basic.Password.PascalCase.UnsafeName
 			)
-			f.P(`if r.`, username, ` != "" && r.`, password, ` != "" {`)
+			f.P(`if r.`, username, ` != "" || r.`, password, ` != "" {`)
 			f.P(`header.Set("Authorization", `, `"Basic " + base64.StdEncoding.EncodeToString([]byte(r.`, username, ` + ":" + r.`, password, `)))`)
 			f.P("}")
 		}

--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -426,9 +426,7 @@ func (f *fileWriter) WriteRequestOptionsDefinition(
 				username = authScheme.Basic.Username.PascalCase.UnsafeName
 				password = authScheme.Basic.Password.PascalCase.UnsafeName
 			)
-			f.P(`if r.`, username, ` != "" || r.`, password, ` != "" {`)
 			f.P(`header.Set("Authorization", `, `"Basic " + base64.StdEncoding.EncodeToString([]byte(r.`, username, ` + ":" + r.`, password, `)))`)
-			f.P("}")
 		}
 		if header := authScheme.Header; header != nil {
 			var prefix string

--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -426,7 +426,9 @@ func (f *fileWriter) WriteRequestOptionsDefinition(
 				username = authScheme.Basic.Username.PascalCase.UnsafeName
 				password = authScheme.Basic.Password.PascalCase.UnsafeName
 			)
+			f.P(`if r.`, username, ` != "" || r.`, password, ` != "" {`)
 			f.P(`header.Set("Authorization", `, `"Basic " + base64.StdEncoding.EncodeToString([]byte(r.`, username, ` + ":" + r.`, password, `)))`)
+			f.P("}")
 		}
 		if header := authScheme.Header; header != nil {
 			var prefix string

--- a/generators/go/internal/testdata/sdk/basic/fixtures/core/request_option.go
+++ b/generators/go/internal/testdata/sdk/basic/fixtures/core/request_option.go
@@ -48,7 +48,7 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 // for the request(s).
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
-	if r.Username != "" && r.Password != "" {
+	if r.Username != "" || r.Password != "" {
 		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+": "+r.Password)))
 	}
 	return header

--- a/generators/go/internal/testdata/sdk/basic/fixtures/core/request_option.go
+++ b/generators/go/internal/testdata/sdk/basic/fixtures/core/request_option.go
@@ -48,9 +48,7 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 // for the request(s).
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
-	if r.Username != "" || r.Password != "" {
-		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+": "+r.Password)))
-	}
+	header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+": "+r.Password)))
 	return header
 }
 

--- a/generators/go/internal/testdata/sdk/basic/fixtures/core/request_option.go
+++ b/generators/go/internal/testdata/sdk/basic/fixtures/core/request_option.go
@@ -49,7 +49,7 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
 	if r.Username != "" || r.Password != "" {
-		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+": "+r.Password)))
+		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
 	}
 	return header
 }

--- a/generators/go/internal/testdata/sdk/basic/fixtures/core/request_option.go
+++ b/generators/go/internal/testdata/sdk/basic/fixtures/core/request_option.go
@@ -48,7 +48,9 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 // for the request(s).
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
-	header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+": "+r.Password)))
+	if r.Username != "" || r.Password != "" {
+		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+": "+r.Password)))
+	}
 	return header
 }
 

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.30.2
+  changelogEntry:
+    - summary: |
+        Fix Basic Auth header not being sent when the username is an empty string.
+        Per RFC 7617, an empty user-id is valid in Basic Auth (e.g., `:password`).
+        The condition in `ToHeader()` now uses `||` instead of `&&`, so the
+        Authorization header is set whenever either the username or password is
+        non-empty.
+      type: fix
+  createdAt: "2026-03-16"
+  irVersion: 61
+
 - version: 1.30.1
   changelogEntry:
     - summary: |

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -4,9 +4,9 @@
     - summary: |
         Fix Basic Auth header not being sent when the username is an empty string.
         Per RFC 7617, an empty user-id is valid in Basic Auth (e.g., `:password`).
-        The `if` guard in `ToHeader()` that required both username and password to
-        be non-empty has been removed so the Authorization header is always set
-        when Basic Auth is configured.
+        The condition in `ToHeader()` now uses `||` instead of `&&`, so the
+        Authorization header is set whenever either the username or password is
+        non-empty.
       type: fix
   createdAt: "2026-03-16"
   irVersion: 61

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -4,9 +4,9 @@
     - summary: |
         Fix Basic Auth header not being sent when the username is an empty string.
         Per RFC 7617, an empty user-id is valid in Basic Auth (e.g., `:password`).
-        The condition in `ToHeader()` now uses `||` instead of `&&`, so the
-        Authorization header is set whenever either the username or password is
-        non-empty.
+        The `if` guard in `ToHeader()` that required both username and password to
+        be non-empty has been removed so the Authorization header is always set
+        when Basic Auth is configured.
       type: fix
   createdAt: "2026-03-16"
   irVersion: 61

--- a/seed/go-sdk/any-auth/core/request_option.go
+++ b/seed/go-sdk/any-auth/core/request_option.go
@@ -64,7 +64,7 @@ func (r *RequestOptions) ToHeader() http.Header {
 	if r.ApiKey != "" {
 		header.Set("X-API-Key", fmt.Sprintf("%v", r.ApiKey))
 	}
-	if r.Username != "" && r.Password != "" {
+	if r.Username != "" || r.Password != "" {
 		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
 	}
 	return header

--- a/seed/go-sdk/any-auth/core/request_option.go
+++ b/seed/go-sdk/any-auth/core/request_option.go
@@ -64,9 +64,7 @@ func (r *RequestOptions) ToHeader() http.Header {
 	if r.ApiKey != "" {
 		header.Set("X-API-Key", fmt.Sprintf("%v", r.ApiKey))
 	}
-	if r.Username != "" || r.Password != "" {
-		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
-	}
+	header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
 	return header
 }
 

--- a/seed/go-sdk/any-auth/core/request_option.go
+++ b/seed/go-sdk/any-auth/core/request_option.go
@@ -64,7 +64,9 @@ func (r *RequestOptions) ToHeader() http.Header {
 	if r.ApiKey != "" {
 		header.Set("X-API-Key", fmt.Sprintf("%v", r.ApiKey))
 	}
-	header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
+	if r.Username != "" || r.Password != "" {
+		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
+	}
 	return header
 }
 

--- a/seed/go-sdk/basic-auth/core/request_option.go
+++ b/seed/go-sdk/basic-auth/core/request_option.go
@@ -49,7 +49,7 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 // for the request(s).
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
-	if r.Username != "" && r.Password != "" {
+	if r.Username != "" || r.Password != "" {
 		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
 	}
 	return header

--- a/seed/go-sdk/basic-auth/core/request_option.go
+++ b/seed/go-sdk/basic-auth/core/request_option.go
@@ -49,9 +49,7 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 // for the request(s).
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
-	if r.Username != "" || r.Password != "" {
-		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
-	}
+	header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
 	return header
 }
 

--- a/seed/go-sdk/basic-auth/core/request_option.go
+++ b/seed/go-sdk/basic-auth/core/request_option.go
@@ -49,7 +49,9 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 // for the request(s).
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
-	header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
+	if r.Username != "" || r.Password != "" {
+		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
+	}
 	return header
 }
 

--- a/seed/go-sdk/endpoint-security-auth/core/request_option.go
+++ b/seed/go-sdk/endpoint-security-auth/core/request_option.go
@@ -64,7 +64,7 @@ func (r *RequestOptions) ToHeader() http.Header {
 	if r.ApiKey != "" {
 		header.Set("X-API-Key", fmt.Sprintf("%v", r.ApiKey))
 	}
-	if r.Username != "" && r.Password != "" {
+	if r.Username != "" || r.Password != "" {
 		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
 	}
 	return header

--- a/seed/go-sdk/endpoint-security-auth/core/request_option.go
+++ b/seed/go-sdk/endpoint-security-auth/core/request_option.go
@@ -64,9 +64,7 @@ func (r *RequestOptions) ToHeader() http.Header {
 	if r.ApiKey != "" {
 		header.Set("X-API-Key", fmt.Sprintf("%v", r.ApiKey))
 	}
-	if r.Username != "" || r.Password != "" {
-		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
-	}
+	header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
 	return header
 }
 

--- a/seed/go-sdk/endpoint-security-auth/core/request_option.go
+++ b/seed/go-sdk/endpoint-security-auth/core/request_option.go
@@ -64,7 +64,9 @@ func (r *RequestOptions) ToHeader() http.Header {
 	if r.ApiKey != "" {
 		header.Set("X-API-Key", fmt.Sprintf("%v", r.ApiKey))
 	}
-	header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
+	if r.Username != "" || r.Password != "" {
+		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password)))
+	}
 	return header
 }
 


### PR DESCRIPTION
## Description

Fixes a bug where `WithBasicAuth("", "my-api-key")` silently dropped the `Authorization` header because the generated `ToHeader()` required **both** username and password to be non-empty (`&&`). Per [RFC 7617](https://www.rfc-editor.org/rfc/rfc7617), an empty user-id is a valid Basic Auth credential (e.g., `:password`).

## Changes Made

- Changed the Basic Auth guard in the Go SDK generator (`sdk.go`) from `&&` to `||`, so the `Authorization` header is set when **either** field is non-empty
- Updated the corresponding test fixture (`testdata/sdk/basic`) and seed outputs (`any-auth`, `basic-auth`, `endpoint-security-auth`)
- Fixed pre-existing `": "` → `":"` (extra space after colon) in the test fixture `testdata/sdk/basic/fixtures/core/request_option.go`, aligning it with the generator output and all seed files per RFC 7617
- Added version `1.30.2` changelog entry in `generators/go/sdk/versions.yml`

## Testing

- [x] Existing Go generator tests pass (`go test ./internal/...`)
- [x] Seed tests pass (CI green on prior push)
- [ ] No new unit test added specifically for the empty-username scenario

## Human Review Checklist

- Verify the `||` semantics cover the desired cases: `WithBasicAuth("", "pass")` ✅ sends header; `WithBasicAuth("user", "")` ✅ sends header; `WithBasicAuth("", "")` ❌ does **not** send header (both fields empty). The reporter noted that supporting fully-empty credentials (`":"`) would require more significant changes.

Link to Devin session: https://app.devin.ai/sessions/860e57bb8f7a47978117231dfb6cf3a0
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
