### PR TITLE
fix(typescript): handle baseUrlId for single-URL WebSocket environments

### DIFF
--- a/generators/typescript/sdk/environments-generator/src/GeneratedSingleUrlEnvironmentsImpl.ts
+++ b/generators/typescript/sdk/environments-generator/src/GeneratedSingleUrlEnvironmentsImpl.ts
@@ -96,11 +96,9 @@ export class GeneratedSingleUrlEnvironmentsImpl implements GeneratedEnvironments
         referenceToEnvironmentValue: ts.Expression;
         baseUrlId: FernIr.EnvironmentBaseUrlId | undefined;
     }): ts.Expression {
-        if (baseUrlId != null) {
-            throw new Error(
-                `Cannot get reference to single environment URL because baseUrlId is defined ("${baseUrlId}")`
-            );
-        }
+        // For single URL environments, baseUrlId is irrelevant since there's only one URL.
+        // This can happen when an AsyncAPI spec defines a named server (e.g. "production")
+        // which gets converted to a baseUrlId on the WebSocket channel.
         return referenceToEnvironmentValue;
     }
 

--- a/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
+++ b/generators/typescript/sdk/environments-generator/src/__test__/EnvironmentsGenerator.test.ts
@@ -115,19 +115,18 @@ describe("GeneratedSingleUrlEnvironmentsImpl", () => {
         expect(getTextOfTsNode(result)).toBe("env");
     });
 
-    it("getReferenceToEnvironmentUrl throws when baseUrlId is provided", () => {
+    it("getReferenceToEnvironmentUrl ignores baseUrlId for single URL", () => {
         const impl = new GeneratedSingleUrlEnvironmentsImpl({
             environmentEnumName: "MyEnvironment",
             defaultEnvironmentId: undefined,
             environments: singleUrlEnvironments
         });
         const inputExpr = ts.factory.createIdentifier("env");
-        expect(() =>
-            impl.getReferenceToEnvironmentUrl({
-                referenceToEnvironmentValue: inputExpr,
-                baseUrlId: "some-base-url"
-            })
-        ).toThrow();
+        const result = impl.getReferenceToEnvironmentUrl({
+            referenceToEnvironmentValue: inputExpr,
+            baseUrlId: "some-base-url"
+        });
+        expect(getTextOfTsNode(result)).toBe("env");
     });
 
     it("writeToFile generates environment const and type alias", () => {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.56.3
+  changelogEntry:
+    - summary: |
+        Fix TypeScript SDK generator crash when generating WebSocket clients for
+        AsyncAPI specs that define a named server (e.g. `servers.production`) with
+        a single-URL environment. The `baseUrlId` assigned by the Fern IR converter
+        is now silently ignored for single-URL environments since there is only one
+        URL to resolve to.
+      type: fix
+  createdAt: "2026-03-16"
+  irVersion: 65
+
 - version: 3.56.2
   changelogEntry:
     - summary: |

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v2-x-fern-parameter-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v2-x-fern-parameter-name.json
@@ -44,7 +44,7 @@
               "type": "string",
             },
           },
-          "url": "production",
+          "url": undefined,
         },
         "types": {
           "UsersUserIdMessagesPublish": {
@@ -72,7 +72,6 @@
       },
       "rawContents": "channel:
   path: /users/{id}/messages
-  url: production
   auth: false
   path-parameters:
     id:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v3-message-refs.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v3-message-refs.json
@@ -114,7 +114,7 @@
             },
             "model": "string",
           },
-          "url": "production",
+          "url": undefined,
         },
         "imports": {
           "root": "__package__.yml",
@@ -122,7 +122,6 @@
       },
       "rawContents": "channel:
   path: /v1/ws/chat
-  url: production
   auth: false
   docs: Chat channel for testing message references
   query-parameters:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v3-x-fern-sdk-method-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v3-x-fern-sdk-method-name.json
@@ -117,7 +117,7 @@
             },
           },
           "path": "/v1/ws/chat",
-          "url": "production",
+          "url": undefined,
         },
         "imports": {
           "root": "__package__.yml",
@@ -125,7 +125,6 @@
       },
       "rawContents": "channel:
   path: /v1/ws/chat
-  url: production
   auth: false
   connect-method-name: createChatConnection
   docs: Chat channel for testing custom method names

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildChannel.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildChannel.ts
@@ -25,8 +25,7 @@ export function buildChannel({
     // This happens when there are only WebSocket servers (no HTTP servers) and only one
     // WebSocket server — buildEnvironments creates a single-URL environment in that case,
     // so a baseUrlId on the channel would be meaningless and can cause generator issues.
-    const hasSingleWebsocketServerOnly =
-        context.ir.servers.length === 0 && context.ir.websocketServers.length <= 1;
+    const hasSingleWebsocketServerOnly = context.ir.servers.length === 0 && context.ir.websocketServers.length <= 1;
     // Generate URL ID based on feature flag:
     // - If groupEnvironmentsByHost is enabled, look up the collision-aware URL ID from the map
     // - Otherwise, use simple server name for backward compatibility

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildChannel.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildChannel.ts
@@ -21,11 +21,18 @@ export function buildChannel({
     declarationFile: RelativeFilePath;
 }): void {
     const firstServer = channel.servers[0];
+    // Don't set a urlId when it would result in a single-URL environment.
+    // This happens when there are only WebSocket servers (no HTTP servers) and only one
+    // WebSocket server — buildEnvironments creates a single-URL environment in that case,
+    // so a baseUrlId on the channel would be meaningless and can cause generator issues.
+    const hasSingleWebsocketServerOnly =
+        context.ir.servers.length === 0 && context.ir.websocketServers.length <= 1;
     // Generate URL ID based on feature flag:
     // - If groupEnvironmentsByHost is enabled, look up the collision-aware URL ID from the map
     // - Otherwise, use simple server name for backward compatibility
+    // - Skip entirely for single-WebSocket-server-only specs (no multi-URL environment)
     const urlId =
-        firstServer != null
+        firstServer != null && !hasSingleWebsocketServerOnly
             ? context.options.groupEnvironmentsByHost
                 ? (context.getUrlId(firstServer.url) ?? generateWebsocketUrlId(firstServer.name, firstServer.url, true))
                 : firstServer.name


### PR DESCRIPTION
## Description

Refs: [Devin Session](https://app.devin.ai/sessions/19f47d4a8e5e4682865ea04fdaab7544)
Requested by: @Swimburger

Fixes a crash in the TypeScript SDK generator when generating WebSocket clients for AsyncAPI specs that define a named server (e.g. `servers.production`) with a single-URL environment. Applies a two-pronged fix: the converter no longer emits an unnecessary `baseUrlId`, and the generator gracefully handles one if it appears.

## Changes Made

**Converter (input-side fix)**
- In `buildChannel.ts`, skip setting `urlId` on the channel when the spec has no HTTP servers and at most one WebSocket server. In this case `buildEnvironments` creates a single-URL environment, so a `baseUrlId` on the channel would be meaningless.

**Generator (defense-in-depth)**
- Removed the error throw in `GeneratedSingleUrlEnvironmentsImpl.getReferenceToEnvironmentUrl()` when `baseUrlId` is non-null
- For single-URL environments, `baseUrlId` is now silently ignored since there's only one URL to resolve to

**Root cause**: When an AsyncAPI spec defines a named server, the Fern IR converter assigns a `baseUrlId` to the WebSocket channel. The WebSocket client generator then passes this `baseUrlId` to `getReferenceToEnvironmentUrl()`. For multi-URL environments, `baseUrlId` selects the correct URL. For single-URL environments, it's irrelevant — but the old code threw an error instead of proceeding.

## Testing

- [x] Unit tests updated — changed the existing test from expecting a throw to expecting the environment value to pass through unchanged
- [x] Snapshot tests updated — 3 AsyncAPI converter snapshots (`asyncapi-v2-x-fern-parameter-name`, `asyncapi-v3-message-refs`, `asyncapi-v3-x-fern-sdk-method-name`) now reflect `url: undefined` instead of `url: "production"` for single-WS-server specs
- [x] Manual testing completed — verified by generating a TypeScript SDK with `shouldGenerateWebsocketClients: true` from an AsyncAPI spec with a named `production` server. Generation succeeds and the produced WebSocket client connects correctly.

## Review Checklist

- [ ] Verify the `hasSingleWebsocketServerOnly` condition in `buildChannel.ts` — it checks `context.ir.servers.length === 0 && context.ir.websocketServers.length <= 1`. Confirm this doesn't inadvertently suppress `urlId` for specs that have multiple WS servers or mixed HTTP+WS servers.
- [ ] Confirm that `url: undefined` in the updated snapshots is correct — these fixtures all define a single `production` WS server with no HTTP servers, so removing the `urlId` is the expected behavior.
- [ ] Confirm the generator-side fix is still valuable as defense-in-depth even with the converter fix in place.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
