### PR TITLE
fix(python): wrap python-version in quotes in generated CI workflow

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.64.1
+  changelogEntry:
+    - summary: |
+        Wrap `python-version` in quotes in generated GitHub CI workflow so versions like
+        `^3.10` are not misinterpreted as `3.1` by the YAML parser.
+      type: fix
+  createdAt: "2026-03-16"
+  irVersion: 65
+
 - version: 4.64.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -351,7 +351,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: {ci_python_version}
+          python-version: "{ci_python_version}"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -367,7 +367,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: {ci_python_version}
+          python-version: "{ci_python_version}"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -406,7 +406,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: {ci_python_version}
+          python-version: "{ci_python_version}"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -443,7 +443,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: {ci_python_version}
+          python-version: "{ci_python_version}"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -459,7 +459,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: {ci_python_version}
+          python-version: "{ci_python_version}"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -497,7 +497,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: {ci_python_version}
+          python-version: "{ci_python_version}"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1

--- a/seed/python-sdk/exhaustive/no-custom-config/.github/workflows/ci.yml
+++ b/seed/python-sdk/exhaustive/no-custom-config/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.9"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -30,7 +30,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.9"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -50,7 +50,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.9"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1


### PR DESCRIPTION
## Description
When users configure `pyproject_python_version` with a value like `^3.10`, the generated GitHub Actions CI workflow passes it unquoted to `actions/setup-python@v4`. YAML interprets `3.10` as the float `3.1`, which is not a valid Python version and causes CI to fail.

## Changes Made
- **CI workflow template**: Wrapped all `python-version: {ci_python_version}` references in quotes across all job definitions (compile, test, publish) in the generated GitHub Actions workflow

## Testing
- [x] Verified seed fixture `seed/python-sdk/exhaustive/no-custom-config/.github/workflows/ci.yml` reflects the quoted version
- [x] Manual review of generated workflow YAML
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
