### PR TITLE
feat(typescript): expose `protocols` field on WebSocket ConnectArgs

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
@@ -42,6 +42,7 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
     private static readonly HEADERS_PROPERTY_NAME = "headers";
     private static readonly HEADERS_VARIABLE_NAME = "_headers";
 
+    private static readonly PROTOCOLS_PROPERTY_NAME = "protocols";
     private static readonly RECONNECT_ATTEMPTS_PROPERTY_NAME = "reconnectAttempts";
     private static readonly CONNECTION_TIMEOUT_PROPERTY_NAME = "connectionTimeoutInSeconds";
     private static readonly ABORT_SIGNAL_PROPERTY_NAME = "abortSignal";
@@ -189,6 +190,19 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                     };
                 }),
                 {
+                    name: GeneratedDefaultWebsocketImplementation.PROTOCOLS_PROPERTY_NAME,
+                    type: getTextOfTsNode(
+                        ts.factory.createUnionTypeNode([
+                            ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                            ts.factory.createArrayTypeNode(
+                                ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
+                            )
+                        ])
+                    ),
+                    hasQuestionToken: true,
+                    docs: ["WebSocket subprotocols to use for the connection."]
+                },
+                {
                     name: GeneratedDefaultWebsocketImplementation.ADDITIONAL_QUERY_PARAMETERS_PROPERTY_NAME,
                     type: getTextOfTsNode(
                         ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Record"), [
@@ -301,6 +315,15 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                 )
             );
         }
+
+        // Add protocols binding
+        bindingElements.push(
+            ts.factory.createBindingElement(
+                undefined,
+                undefined,
+                ts.factory.createIdentifier(GeneratedDefaultWebsocketImplementation.PROTOCOLS_PROPERTY_NAME)
+            )
+        );
 
         // Add additional query parameters binding
         bindingElements.push(
@@ -534,7 +557,11 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
 
         return context.coreUtilities.websocket.ReconnectingWebSocket._connect({
             url: context.coreUtilities.urlUtils.join._invoke([baseUrl, url]),
-            protocols: ts.factory.createArrayLiteralExpression([]),
+            protocols: ts.factory.createBinaryExpression(
+                ts.factory.createIdentifier(GeneratedDefaultWebsocketImplementation.PROTOCOLS_PROPERTY_NAME),
+                ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                ts.factory.createArrayLiteralExpression([])
+            ),
             options: ts.factory.createObjectLiteralExpression([
                 ts.factory.createPropertyAssignment(
                     "debug",

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.56.5
+- version: 3.57.0
   changelogEntry:
     - summary: |
         Expose an optional `protocols` field on `RealtimeClient.ConnectArgs` for WebSocket

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.56.5
+  changelogEntry:
+    - summary: |
+        Expose an optional `protocols` field on `RealtimeClient.ConnectArgs` for WebSocket
+        subprotocol negotiation. The `ReconnectingWebSocket` constructor already accepted a
+        `protocols` parameter but it was hardcoded to an empty array. Browser callers can now
+        authenticate via subprotocols (e.g. `xai-client-secret.<token>`) where custom headers
+        are forbidden by the browser security model.
+      type: feat
+  createdAt: "2026-03-16"
+  irVersion: 65
+
 - version: 3.56.4
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/api/resources/realtime/client/Client.ts
@@ -13,6 +13,8 @@ export declare namespace RealtimeClient {
         session_id: string;
         model?: string;
         temperature?: number;
+        /** WebSocket subprotocols to use for the connection. */
+        protocols?: string | string[];
         /** Additional query parameters to send with the websocket connect request. */
         queryParams?: Record<string, unknown>;
         /** Arbitrary headers to send with the websocket connect request. */
@@ -40,6 +42,7 @@ export class RealtimeClient {
             session_id: sessionId,
             model,
             temperature,
+            protocols,
             queryParams,
             headers,
             debug,
@@ -59,7 +62,7 @@ export class RealtimeClient {
                     (await core.Supplier.get(this._options.environment)),
                 `/realtime/${core.url.encodePathParam(sessionId)}`,
             ),
-            protocols: [],
+            protocols: protocols ?? [],
             queryParameters: { ..._queryParams, ...queryParams },
             headers: _headers,
             options: {

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/api/resources/realtimeNoAuth/client/Client.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/api/resources/realtimeNoAuth/client/Client.ts
@@ -11,6 +11,8 @@ export declare namespace RealtimeNoAuthClient {
     export interface ConnectArgs {
         session_id: string;
         model?: string;
+        /** WebSocket subprotocols to use for the connection. */
+        protocols?: string | string[];
         /** Additional query parameters to send with the websocket connect request. */
         queryParams?: Record<string, unknown>;
         /** Arbitrary headers to send with the websocket connect request. */
@@ -37,6 +39,7 @@ export class RealtimeNoAuthClient {
         const {
             session_id: sessionId,
             model,
+            protocols,
             queryParams,
             headers,
             debug,
@@ -54,7 +57,7 @@ export class RealtimeNoAuthClient {
                     (await core.Supplier.get(this._options.environment)),
                 `/realtime-no-auth/${core.url.encodePathParam(sessionId)}`,
             ),
-            protocols: [],
+            protocols: protocols ?? [],
             queryParameters: { ..._queryParams, ...queryParams },
             headers: _headers,
             options: {

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/api/resources/realtime/client/Client.ts
@@ -13,6 +13,8 @@ export declare namespace RealtimeClient {
         session_id: string;
         model?: string;
         temperature?: number;
+        /** WebSocket subprotocols to use for the connection. */
+        protocols?: string | string[];
         /** Additional query parameters to send with the websocket connect request. */
         queryParams?: Record<string, unknown>;
         /** Arbitrary headers to send with the websocket connect request. */
@@ -40,6 +42,7 @@ export class RealtimeClient {
             session_id: sessionId,
             model,
             temperature,
+            protocols,
             queryParams,
             headers,
             debug,
@@ -59,7 +62,7 @@ export class RealtimeClient {
                     (await core.Supplier.get(this._options.environment)),
                 `/realtime/${core.url.encodePathParam(sessionId)}`,
             ),
-            protocols: [],
+            protocols: protocols ?? [],
             queryParameters: { ..._queryParams, ...queryParams },
             headers: _headers,
             options: {

--- a/seed/ts-sdk/websocket/no-serde/src/api/resources/empty/resources/emptyRealtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/api/resources/empty/resources/emptyRealtime/client/Client.ts
@@ -9,6 +9,8 @@ export declare namespace EmptyRealtimeClient {
     export type Options = BaseClientOptions;
 
     export interface ConnectArgs {
+        /** WebSocket subprotocols to use for the connection. */
+        protocols?: string | string[];
         /** Additional query parameters to send with the websocket connect request. */
         queryParams?: Record<string, unknown>;
         /** Arbitrary headers to send with the websocket connect request. */
@@ -32,7 +34,8 @@ export class EmptyRealtimeClient {
     }
 
     public async connect(args: EmptyRealtimeClient.ConnectArgs = {}): Promise<EmptyRealtimeSocket> {
-        const { queryParams, headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
+        const { protocols, queryParams, headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } =
+            args;
         const _headers: Record<string, unknown> = { ...headers };
         const socket = new core.ReconnectingWebSocket({
             url: core.url.join(
@@ -40,7 +43,7 @@ export class EmptyRealtimeClient {
                     (await core.Supplier.get(this._options.environment)),
                 "/empty/realtime/",
             ),
-            protocols: [],
+            protocols: protocols ?? [],
             queryParameters: queryParams ?? {},
             headers: _headers,
             options: {

--- a/seed/ts-sdk/websocket/no-serde/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/api/resources/realtime/client/Client.ts
@@ -13,6 +13,8 @@ export declare namespace RealtimeClient {
         model?: string;
         temperature?: number;
         "language-code"?: string;
+        /** WebSocket subprotocols to use for the connection. */
+        protocols?: string | string[];
         /** Additional query parameters to send with the websocket connect request. */
         queryParams?: Record<string, unknown>;
         /** Arbitrary headers to send with the websocket connect request. */
@@ -41,6 +43,7 @@ export class RealtimeClient {
             model,
             temperature,
             "language-code": languageCode,
+            protocols,
             queryParams,
             headers,
             debug,
@@ -60,7 +63,7 @@ export class RealtimeClient {
                     (await core.Supplier.get(this._options.environment)),
                 `/realtime/${core.url.encodePathParam(sessionId)}`,
             ),
-            protocols: [],
+            protocols: protocols ?? [],
             queryParameters: { ..._queryParams, ...queryParams },
             headers: _headers,
             options: {

--- a/seed/ts-sdk/websocket/serde/src/api/resources/empty/resources/emptyRealtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/serde/src/api/resources/empty/resources/emptyRealtime/client/Client.ts
@@ -9,6 +9,8 @@ export declare namespace EmptyRealtimeClient {
     export type Options = BaseClientOptions;
 
     export interface ConnectArgs {
+        /** WebSocket subprotocols to use for the connection. */
+        protocols?: string | string[];
         /** Additional query parameters to send with the websocket connect request. */
         queryParams?: Record<string, unknown>;
         /** Arbitrary headers to send with the websocket connect request. */
@@ -32,7 +34,8 @@ export class EmptyRealtimeClient {
     }
 
     public async connect(args: EmptyRealtimeClient.ConnectArgs = {}): Promise<EmptyRealtimeSocket> {
-        const { queryParams, headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
+        const { protocols, queryParams, headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } =
+            args;
         const _headers: Record<string, unknown> = { ...headers };
         const socket = new core.ReconnectingWebSocket({
             url: core.url.join(
@@ -40,7 +43,7 @@ export class EmptyRealtimeClient {
                     (await core.Supplier.get(this._options.environment)),
                 "/empty/realtime/",
             ),
-            protocols: [],
+            protocols: protocols ?? [],
             queryParameters: queryParams ?? {},
             headers: _headers,
             options: {

--- a/seed/ts-sdk/websocket/serde/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/serde/src/api/resources/realtime/client/Client.ts
@@ -13,6 +13,8 @@ export declare namespace RealtimeClient {
         model?: string;
         temperature?: number;
         languageCode?: string;
+        /** WebSocket subprotocols to use for the connection. */
+        protocols?: string | string[];
         /** Additional query parameters to send with the websocket connect request. */
         queryParams?: Record<string, unknown>;
         /** Arbitrary headers to send with the websocket connect request. */
@@ -41,6 +43,7 @@ export class RealtimeClient {
             model,
             temperature,
             languageCode,
+            protocols,
             queryParams,
             headers,
             debug,
@@ -60,7 +63,7 @@ export class RealtimeClient {
                     (await core.Supplier.get(this._options.environment)),
                 `/realtime/${core.url.encodePathParam(sessionId)}`,
             ),
-            protocols: [],
+            protocols: protocols ?? [],
             queryParameters: { ..._queryParams, ...queryParams },
             headers: _headers,
             options: {


### PR DESCRIPTION
## Description

The `ReconnectingWebSocket` constructor already accepts a `protocols` parameter for WebSocket subprotocol negotiation, but it was hardcoded to `[]` and never exposed through `ConnectArgs`. This blocks browser usage where custom headers are forbidden by the security model and subprotocols are the only way to authenticate (e.g. `xai-client-secret.<token>` passed as `sec-websocket-protocol`).

## Changes Made

- Add optional `protocols?: string | string[]` field to the generated `ConnectArgs` interface
- Thread `protocols` through destructuring and into the `ReconnectingWebSocket` constructor as `protocols ?? []`
- Bump version to `3.57.0` with changelog entry
- Update all websocket seed snapshots (`websocket`, `websocket-bearer-auth`, `websocket-inferred-auth`)

## Testing

- [x] All 538 unit tests pass (`@fern-typescript/sdk-client-class-generator`)
- [x] Seed tests pass for all 3 websocket fixtures (5 output folders total)
- [x] All CI checks green (63/63)
- [ ] Updated README.md generator (not applicable)

## Key Review Points

1. **Type alignment**: The `string | string[]` type on `ConnectArgs.protocols` matches the existing `ReconnectingWebSocket.Args.protocols` type in `ws.ts:29` — verify these stay in sync.
2. **Field ordering**: `protocols` is placed after API-specific params (path/query/headers from the spec) but before the generic transport options (`queryParams`, `headers`, `debug`, etc.). Confirm this is the desired position.
3. **No breaking changes**: The field is optional and falls back to `[]` via nullish coalescing, preserving existing behavior.

Link to Devin session: https://app.devin.ai/sessions/4734de817b9e46d8b3890bfa620270f8
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
