### PR TITLE
chore(python): upgrade pytest-asyncio from ^0.23.5 to ^1.0.0 in generated Python SDKs

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.0.1
+  changelogEntry:
+    - summary: |
+        Upgrade `pytest-asyncio` dev dependency from `^0.23.5` to `^1.0.0` in generated
+        `pyproject.toml`. This eliminates deprecation warnings about `asyncio.iscoroutinefunction`,
+        `asyncio.get_event_loop_policy`, and `asyncio.set_event_loop_policy` when running tests
+        on Python 3.14+.
+      type: chore
+  createdAt: "2026-03-16"
+  irVersion: 65
+
 - version: 5.0.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -232,7 +232,7 @@ python = "{self.python_version}"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -13,6 +13,8 @@ from fern_python.codegen.ast.dependency.dependency import (
 )
 from fern_python.codegen.dependency_manager import DependencyManager
 from fern_python.codegen.pypi_classifier_creator import PyPIClassifierMetadataGenerator
+from fern_python.version import get_minimum_compatible_version
+from fern_python.version.python_version import PythonVersion
 
 from fern.generator_exec import (
     BasicLicense,
@@ -225,14 +227,25 @@ packages = [
             if self.enable_wire_tests:
                 wire_test_deps = 'requests = "^2.31.0"\ntypes-requests = "^2.31.0"\n'
 
+            # pytest-asyncio ^1.0.0 fixes Python 3.14+ deprecation warnings but
+            # requires pytest >= 8.2 and Python >= 3.9.  Fall back to the older
+            # pair when the project still supports Python 3.8.
+            min_py = get_minimum_compatible_version(self.python_version)
+            if min_py is not None and min_py.spec >= PythonVersion.PY3_9.spec:
+                pytest_version = "^8.2.0"
+                pytest_asyncio_version = "^1.0.0"
+            else:
+                pytest_version = "^7.4.0"
+                pytest_asyncio_version = "^0.23.5"
+
             return f"""
 [tool.poetry.dependencies]
 python = "{self.python_version}"
 {deps}
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest = "{pytest_version}"
+pytest-asyncio = "{pytest_asyncio_version}"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -13,8 +14,6 @@ from fern_python.codegen.ast.dependency.dependency import (
 )
 from fern_python.codegen.dependency_manager import DependencyManager
 from fern_python.codegen.pypi_classifier_creator import PyPIClassifierMetadataGenerator
-from fern_python.version import get_minimum_compatible_version
-from fern_python.version.python_version import PythonVersion
 
 from fern.generator_exec import (
     BasicLicense,
@@ -230,8 +229,15 @@ packages = [
             # pytest-asyncio ^1.0.0 fixes Python 3.14+ deprecation warnings but
             # requires pytest >= 8.2 and Python >= 3.9.  Fall back to the older
             # pair when the project still supports Python 3.8.
-            min_py = get_minimum_compatible_version(self.python_version)
-            if min_py is not None and min_py.spec >= PythonVersion.PY3_9.spec:
+            #
+            # Extract the minimum minor version from the constraint string
+            # (e.g. "^3.8" -> 8, "^3.8.1" -> 8, "^3.10" -> 10, ">=3.9" -> 9).
+            min_minor = 0
+            match = re.search(r"(\d+)\.(\d+)", self.python_version)
+            if match:
+                min_minor = int(match.group(2))
+
+            if min_minor >= 9:
                 pytest_version = "^8.2.0"
                 pytest_asyncio_version = "^1.0.0"
             else:

--- a/seed/fastapi/examples/generate-package-deps/pyproject.toml
+++ b/seed/fastapi/examples/generate-package-deps/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/fastapi/examples/generate-package-deps/pyproject.toml
+++ b/seed/fastapi/examples/generate-package-deps/pyproject.toml
@@ -49,7 +49,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/accept-header/pyproject.toml
+++ b/seed/pydantic/accept-header/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/accept-header/pyproject.toml
+++ b/seed/pydantic/accept-header/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/alias-extends/no-custom-config/pyproject.toml
+++ b/seed/pydantic/alias-extends/no-custom-config/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/alias-extends/no-custom-config/pyproject.toml
+++ b/seed/pydantic/alias-extends/no-custom-config/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/alias-extends/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/alias-extends/no-inheritance-for-extended-models/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/alias-extends/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/alias-extends/no-inheritance-for-extended-models/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/alias-extends/pyproject.toml
+++ b/seed/pydantic/alias-extends/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest-asyncio = "^0.23.5"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/alias-extends/pyproject.toml
+++ b/seed/pydantic/alias-extends/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/alias/pyproject.toml
+++ b/seed/pydantic/alias/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/alias/pyproject.toml
+++ b/seed/pydantic/alias/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/any-auth/pyproject.toml
+++ b/seed/pydantic/any-auth/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/any-auth/pyproject.toml
+++ b/seed/pydantic/any-auth/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/api-wide-base-path/pyproject.toml
+++ b/seed/pydantic/api-wide-base-path/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/api-wide-base-path/pyproject.toml
+++ b/seed/pydantic/api-wide-base-path/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/audiences/pyproject.toml
+++ b/seed/pydantic/audiences/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/audiences/pyproject.toml
+++ b/seed/pydantic/audiences/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/basic-auth-environment-variables/pyproject.toml
+++ b/seed/pydantic/basic-auth-environment-variables/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/basic-auth-environment-variables/pyproject.toml
+++ b/seed/pydantic/basic-auth-environment-variables/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/basic-auth/pyproject.toml
+++ b/seed/pydantic/basic-auth/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/basic-auth/pyproject.toml
+++ b/seed/pydantic/basic-auth/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/bearer-token-environment-variable/pyproject.toml
+++ b/seed/pydantic/bearer-token-environment-variable/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/bearer-token-environment-variable/pyproject.toml
+++ b/seed/pydantic/bearer-token-environment-variable/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/bytes-download/pyproject.toml
+++ b/seed/pydantic/bytes-download/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/bytes-download/pyproject.toml
+++ b/seed/pydantic/bytes-download/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/bytes-upload/pyproject.toml
+++ b/seed/pydantic/bytes-upload/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/bytes-upload/pyproject.toml
+++ b/seed/pydantic/bytes-upload/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/circular-references-advanced/no-custom-config/pyproject.toml
+++ b/seed/pydantic/circular-references-advanced/no-custom-config/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/circular-references-advanced/no-custom-config/pyproject.toml
+++ b/seed/pydantic/circular-references-advanced/no-custom-config/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/circular-references-advanced/pyproject.toml
+++ b/seed/pydantic/circular-references-advanced/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest-asyncio = "^0.23.5"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/circular-references-advanced/pyproject.toml
+++ b/seed/pydantic/circular-references-advanced/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/circular-references/no-custom-config/pyproject.toml
+++ b/seed/pydantic/circular-references/no-custom-config/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/circular-references/no-custom-config/pyproject.toml
+++ b/seed/pydantic/circular-references/no-custom-config/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/circular-references/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/circular-references/no-inheritance-for-extended-models/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/circular-references/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/circular-references/no-inheritance-for-extended-models/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/circular-references/pyproject.toml
+++ b/seed/pydantic/circular-references/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest-asyncio = "^0.23.5"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/circular-references/pyproject.toml
+++ b/seed/pydantic/circular-references/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/client-side-params/pyproject.toml
+++ b/seed/pydantic/client-side-params/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/client-side-params/pyproject.toml
+++ b/seed/pydantic/client-side-params/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/content-type/pyproject.toml
+++ b/seed/pydantic/content-type/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/content-type/pyproject.toml
+++ b/seed/pydantic/content-type/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/cross-package-type-names/pyproject.toml
+++ b/seed/pydantic/cross-package-type-names/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/cross-package-type-names/pyproject.toml
+++ b/seed/pydantic/cross-package-type-names/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/dollar-string-examples/pyproject.toml
+++ b/seed/pydantic/dollar-string-examples/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/dollar-string-examples/pyproject.toml
+++ b/seed/pydantic/dollar-string-examples/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/empty-clients/pyproject.toml
+++ b/seed/pydantic/empty-clients/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/empty-clients/pyproject.toml
+++ b/seed/pydantic/empty-clients/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/endpoint-security-auth/pyproject.toml
+++ b/seed/pydantic/endpoint-security-auth/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/endpoint-security-auth/pyproject.toml
+++ b/seed/pydantic/endpoint-security-auth/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/enum/pyproject.toml
+++ b/seed/pydantic/enum/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/enum/pyproject.toml
+++ b/seed/pydantic/enum/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/error-property/pyproject.toml
+++ b/seed/pydantic/error-property/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/error-property/pyproject.toml
+++ b/seed/pydantic/error-property/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/errors/pyproject.toml
+++ b/seed/pydantic/errors/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/errors/pyproject.toml
+++ b/seed/pydantic/errors/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/examples/pyproject.toml
+++ b/seed/pydantic/examples/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/examples/pyproject.toml
+++ b/seed/pydantic/examples/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/exhaustive/pydantic-v1/pyproject.toml
+++ b/seed/pydantic/exhaustive/pydantic-v1/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/exhaustive/pydantic-v1/pyproject.toml
+++ b/seed/pydantic/exhaustive/pydantic-v1/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/exhaustive/pydantic-v2/pyproject.toml
+++ b/seed/pydantic/exhaustive/pydantic-v2/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/exhaustive/pydantic-v2/pyproject.toml
+++ b/seed/pydantic/exhaustive/pydantic-v2/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/extends/pyproject.toml
+++ b/seed/pydantic/extends/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/extends/pyproject.toml
+++ b/seed/pydantic/extends/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/extra-properties/pyproject.toml
+++ b/seed/pydantic/extra-properties/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/extra-properties/pyproject.toml
+++ b/seed/pydantic/extra-properties/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/file-download/no-custom-config/pyproject.toml
+++ b/seed/pydantic/file-download/no-custom-config/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/file-download/no-custom-config/pyproject.toml
+++ b/seed/pydantic/file-download/no-custom-config/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/file-download/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/file-download/no-inheritance-for-extended-models/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/file-download/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/file-download/no-inheritance-for-extended-models/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/file-download/pyproject.toml
+++ b/seed/pydantic/file-download/pyproject.toml
@@ -40,7 +40,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest-asyncio = "^0.23.5"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/file-download/pyproject.toml
+++ b/seed/pydantic/file-download/pyproject.toml
@@ -40,7 +40,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/file-upload-openapi/pyproject.toml
+++ b/seed/pydantic/file-upload-openapi/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/file-upload-openapi/pyproject.toml
+++ b/seed/pydantic/file-upload-openapi/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/file-upload/pyproject.toml
+++ b/seed/pydantic/file-upload/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/file-upload/pyproject.toml
+++ b/seed/pydantic/file-upload/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/folders/pyproject.toml
+++ b/seed/pydantic/folders/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/folders/pyproject.toml
+++ b/seed/pydantic/folders/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/header-auth-environment-variable/pyproject.toml
+++ b/seed/pydantic/header-auth-environment-variable/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/header-auth-environment-variable/pyproject.toml
+++ b/seed/pydantic/header-auth-environment-variable/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/header-auth/pyproject.toml
+++ b/seed/pydantic/header-auth/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/header-auth/pyproject.toml
+++ b/seed/pydantic/header-auth/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/http-head/pyproject.toml
+++ b/seed/pydantic/http-head/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/http-head/pyproject.toml
+++ b/seed/pydantic/http-head/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/idempotency-headers/pyproject.toml
+++ b/seed/pydantic/idempotency-headers/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/idempotency-headers/pyproject.toml
+++ b/seed/pydantic/idempotency-headers/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/imdb/pyproject.toml
+++ b/seed/pydantic/imdb/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/imdb/pyproject.toml
+++ b/seed/pydantic/imdb/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/inferred-auth-explicit/pyproject.toml
+++ b/seed/pydantic/inferred-auth-explicit/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/inferred-auth-explicit/pyproject.toml
+++ b/seed/pydantic/inferred-auth-explicit/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/inferred-auth-implicit-api-key/pyproject.toml
+++ b/seed/pydantic/inferred-auth-implicit-api-key/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/inferred-auth-implicit-api-key/pyproject.toml
+++ b/seed/pydantic/inferred-auth-implicit-api-key/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/inferred-auth-implicit-no-expiry/pyproject.toml
+++ b/seed/pydantic/inferred-auth-implicit-no-expiry/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/inferred-auth-implicit-no-expiry/pyproject.toml
+++ b/seed/pydantic/inferred-auth-implicit-no-expiry/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/inferred-auth-implicit-reference/pyproject.toml
+++ b/seed/pydantic/inferred-auth-implicit-reference/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/inferred-auth-implicit-reference/pyproject.toml
+++ b/seed/pydantic/inferred-auth-implicit-reference/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/inferred-auth-implicit/pyproject.toml
+++ b/seed/pydantic/inferred-auth-implicit/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/inferred-auth-implicit/pyproject.toml
+++ b/seed/pydantic/inferred-auth-implicit/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/license/pyproject.toml
+++ b/seed/pydantic/license/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/license/pyproject.toml
+++ b/seed/pydantic/license/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/literal/pyproject.toml
+++ b/seed/pydantic/literal/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/literal/pyproject.toml
+++ b/seed/pydantic/literal/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/literals-unions/pyproject.toml
+++ b/seed/pydantic/literals-unions/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/literals-unions/pyproject.toml
+++ b/seed/pydantic/literals-unions/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/mixed-case/pyproject.toml
+++ b/seed/pydantic/mixed-case/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/mixed-case/pyproject.toml
+++ b/seed/pydantic/mixed-case/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/mixed-file-directory/pyproject.toml
+++ b/seed/pydantic/mixed-file-directory/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/mixed-file-directory/pyproject.toml
+++ b/seed/pydantic/mixed-file-directory/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/multi-line-docs/pyproject.toml
+++ b/seed/pydantic/multi-line-docs/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/multi-line-docs/pyproject.toml
+++ b/seed/pydantic/multi-line-docs/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/multi-url-environment-no-default/pyproject.toml
+++ b/seed/pydantic/multi-url-environment-no-default/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/multi-url-environment-no-default/pyproject.toml
+++ b/seed/pydantic/multi-url-environment-no-default/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/multi-url-environment/pyproject.toml
+++ b/seed/pydantic/multi-url-environment/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/multi-url-environment/pyproject.toml
+++ b/seed/pydantic/multi-url-environment/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/multiple-request-bodies/pyproject.toml
+++ b/seed/pydantic/multiple-request-bodies/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/multiple-request-bodies/pyproject.toml
+++ b/seed/pydantic/multiple-request-bodies/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/no-environment/pyproject.toml
+++ b/seed/pydantic/no-environment/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/no-environment/pyproject.toml
+++ b/seed/pydantic/no-environment/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/no-retries/pyproject.toml
+++ b/seed/pydantic/no-retries/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/no-retries/pyproject.toml
+++ b/seed/pydantic/no-retries/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/nullable-allof-extends/pyproject.toml
+++ b/seed/pydantic/nullable-allof-extends/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/nullable-allof-extends/pyproject.toml
+++ b/seed/pydantic/nullable-allof-extends/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/nullable-optional/pyproject.toml
+++ b/seed/pydantic/nullable-optional/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/nullable-optional/pyproject.toml
+++ b/seed/pydantic/nullable-optional/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/nullable-request-body/pyproject.toml
+++ b/seed/pydantic/nullable-request-body/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/nullable-request-body/pyproject.toml
+++ b/seed/pydantic/nullable-request-body/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/nullable/pyproject.toml
+++ b/seed/pydantic/nullable/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/nullable/pyproject.toml
+++ b/seed/pydantic/nullable/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/oauth-client-credentials-custom/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-custom/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/oauth-client-credentials-custom/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-custom/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/oauth-client-credentials-default/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-default/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/oauth-client-credentials-default/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-default/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/oauth-client-credentials-environment-variables/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-environment-variables/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/oauth-client-credentials-environment-variables/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-environment-variables/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/oauth-client-credentials-mandatory-auth/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-mandatory-auth/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/oauth-client-credentials-mandatory-auth/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-mandatory-auth/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/oauth-client-credentials-nested-root/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-nested-root/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/oauth-client-credentials-nested-root/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-nested-root/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/oauth-client-credentials-reference/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-reference/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/oauth-client-credentials-reference/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-reference/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/oauth-client-credentials-with-variables/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-with-variables/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/oauth-client-credentials-with-variables/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials-with-variables/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/oauth-client-credentials/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/oauth-client-credentials/pyproject.toml
+++ b/seed/pydantic/oauth-client-credentials/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/object/pyproject.toml
+++ b/seed/pydantic/object/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/object/pyproject.toml
+++ b/seed/pydantic/object/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/objects-with-imports/pyproject.toml
+++ b/seed/pydantic/objects-with-imports/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/objects-with-imports/pyproject.toml
+++ b/seed/pydantic/objects-with-imports/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/optional/pyproject.toml
+++ b/seed/pydantic/optional/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/optional/pyproject.toml
+++ b/seed/pydantic/optional/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/package-yml/pyproject.toml
+++ b/seed/pydantic/package-yml/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/package-yml/pyproject.toml
+++ b/seed/pydantic/package-yml/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/pagination-custom/pyproject.toml
+++ b/seed/pydantic/pagination-custom/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/pagination-custom/pyproject.toml
+++ b/seed/pydantic/pagination-custom/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/pagination-uri-path/pyproject.toml
+++ b/seed/pydantic/pagination-uri-path/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/pagination-uri-path/pyproject.toml
+++ b/seed/pydantic/pagination-uri-path/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/pagination/no-custom-config/pyproject.toml
+++ b/seed/pydantic/pagination/no-custom-config/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/pagination/no-custom-config/pyproject.toml
+++ b/seed/pydantic/pagination/no-custom-config/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/pagination/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/pagination/no-inheritance-for-extended-models/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/pagination/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/pagination/no-inheritance-for-extended-models/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/pagination/pyproject.toml
+++ b/seed/pydantic/pagination/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest-asyncio = "^0.23.5"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/pagination/pyproject.toml
+++ b/seed/pydantic/pagination/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/path-parameters/pyproject.toml
+++ b/seed/pydantic/path-parameters/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/path-parameters/pyproject.toml
+++ b/seed/pydantic/path-parameters/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/plain-text/pyproject.toml
+++ b/seed/pydantic/plain-text/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/plain-text/pyproject.toml
+++ b/seed/pydantic/plain-text/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/property-access/pyproject.toml
+++ b/seed/pydantic/property-access/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/property-access/pyproject.toml
+++ b/seed/pydantic/property-access/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/public-object/pyproject.toml
+++ b/seed/pydantic/public-object/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/public-object/pyproject.toml
+++ b/seed/pydantic/public-object/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/query-parameters-openapi-as-objects/pyproject.toml
+++ b/seed/pydantic/query-parameters-openapi-as-objects/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/query-parameters-openapi-as-objects/pyproject.toml
+++ b/seed/pydantic/query-parameters-openapi-as-objects/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/query-parameters-openapi/pyproject.toml
+++ b/seed/pydantic/query-parameters-openapi/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/query-parameters-openapi/pyproject.toml
+++ b/seed/pydantic/query-parameters-openapi/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/query-parameters/pyproject.toml
+++ b/seed/pydantic/query-parameters/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/query-parameters/pyproject.toml
+++ b/seed/pydantic/query-parameters/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/request-parameters/pyproject.toml
+++ b/seed/pydantic/request-parameters/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/request-parameters/pyproject.toml
+++ b/seed/pydantic/request-parameters/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/required-nullable/pyproject.toml
+++ b/seed/pydantic/required-nullable/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/required-nullable/pyproject.toml
+++ b/seed/pydantic/required-nullable/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/reserved-keywords/pyproject.toml
+++ b/seed/pydantic/reserved-keywords/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/reserved-keywords/pyproject.toml
+++ b/seed/pydantic/reserved-keywords/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/response-property/pyproject.toml
+++ b/seed/pydantic/response-property/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/response-property/pyproject.toml
+++ b/seed/pydantic/response-property/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/server-sent-event-examples/pyproject.toml
+++ b/seed/pydantic/server-sent-event-examples/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/server-sent-event-examples/pyproject.toml
+++ b/seed/pydantic/server-sent-event-examples/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/server-sent-events/pyproject.toml
+++ b/seed/pydantic/server-sent-events/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/server-sent-events/pyproject.toml
+++ b/seed/pydantic/server-sent-events/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/server-url-templating/pyproject.toml
+++ b/seed/pydantic/server-url-templating/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/server-url-templating/pyproject.toml
+++ b/seed/pydantic/server-url-templating/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/simple-api/pyproject.toml
+++ b/seed/pydantic/simple-api/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/simple-api/pyproject.toml
+++ b/seed/pydantic/simple-api/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/simple-fhir/no-custom-config/pyproject.toml
+++ b/seed/pydantic/simple-fhir/no-custom-config/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/simple-fhir/no-custom-config/pyproject.toml
+++ b/seed/pydantic/simple-fhir/no-custom-config/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/simple-fhir/pyproject.toml
+++ b/seed/pydantic/simple-fhir/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest-asyncio = "^0.23.5"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/simple-fhir/pyproject.toml
+++ b/seed/pydantic/simple-fhir/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/single-url-environment-default/pyproject.toml
+++ b/seed/pydantic/single-url-environment-default/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/single-url-environment-default/pyproject.toml
+++ b/seed/pydantic/single-url-environment-default/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/single-url-environment-no-default/pyproject.toml
+++ b/seed/pydantic/single-url-environment-no-default/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/single-url-environment-no-default/pyproject.toml
+++ b/seed/pydantic/single-url-environment-no-default/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/streaming-parameter/pyproject.toml
+++ b/seed/pydantic/streaming-parameter/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/streaming-parameter/pyproject.toml
+++ b/seed/pydantic/streaming-parameter/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/streaming/pyproject.toml
+++ b/seed/pydantic/streaming/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/streaming/pyproject.toml
+++ b/seed/pydantic/streaming/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/trace/pyproject.toml
+++ b/seed/pydantic/trace/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/trace/pyproject.toml
+++ b/seed/pydantic/trace/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/undiscriminated-union-with-response-property/pyproject.toml
+++ b/seed/pydantic/undiscriminated-union-with-response-property/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/undiscriminated-union-with-response-property/pyproject.toml
+++ b/seed/pydantic/undiscriminated-union-with-response-property/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/undiscriminated-unions/pyproject.toml
+++ b/seed/pydantic/undiscriminated-unions/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/undiscriminated-unions/pyproject.toml
+++ b/seed/pydantic/undiscriminated-unions/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/unions-with-local-date/pyproject.toml
+++ b/seed/pydantic/unions-with-local-date/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/unions-with-local-date/pyproject.toml
+++ b/seed/pydantic/unions-with-local-date/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/unions/no-custom-config/pyproject.toml
+++ b/seed/pydantic/unions/no-custom-config/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/unions/no-custom-config/pyproject.toml
+++ b/seed/pydantic/unions/no-custom-config/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/unions/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/unions/no-inheritance-for-extended-models/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/unions/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/pydantic/unions/no-inheritance-for-extended-models/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/unions/pyproject.toml
+++ b/seed/pydantic/unions/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest-asyncio = "^0.23.5"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/unions/pyproject.toml
+++ b/seed/pydantic/unions/pyproject.toml
@@ -41,7 +41,7 @@ pydantic-core = "^2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/pydantic/unknown/pyproject.toml
+++ b/seed/pydantic/unknown/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/unknown/pyproject.toml
+++ b/seed/pydantic/unknown/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/url-form-encoded/pyproject.toml
+++ b/seed/pydantic/url-form-encoded/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/url-form-encoded/pyproject.toml
+++ b/seed/pydantic/url-form-encoded/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/validation/pyproject.toml
+++ b/seed/pydantic/validation/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/validation/pyproject.toml
+++ b/seed/pydantic/validation/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/variables/pyproject.toml
+++ b/seed/pydantic/variables/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/variables/pyproject.toml
+++ b/seed/pydantic/variables/pyproject.toml
@@ -46,7 +46,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/version-no-default/pyproject.toml
+++ b/seed/pydantic/version-no-default/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/version-no-default/pyproject.toml
+++ b/seed/pydantic/version-no-default/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/version/pyproject.toml
+++ b/seed/pydantic/version/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/version/pyproject.toml
+++ b/seed/pydantic/version/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/webhook-audience/pyproject.toml
+++ b/seed/pydantic/webhook-audience/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/webhook-audience/pyproject.toml
+++ b/seed/pydantic/webhook-audience/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/webhooks/pyproject.toml
+++ b/seed/pydantic/webhooks/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/webhooks/pyproject.toml
+++ b/seed/pydantic/webhooks/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/websocket-bearer-auth/pyproject.toml
+++ b/seed/pydantic/websocket-bearer-auth/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/websocket-bearer-auth/pyproject.toml
+++ b/seed/pydantic/websocket-bearer-auth/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/websocket-inferred-auth/pyproject.toml
+++ b/seed/pydantic/websocket-inferred-auth/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/websocket-inferred-auth/pyproject.toml
+++ b/seed/pydantic/websocket-inferred-auth/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/pydantic/websocket/pyproject.toml
+++ b/seed/pydantic/websocket/pyproject.toml
@@ -47,7 +47,7 @@ pydantic-core = ">=2.18.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/pydantic/websocket/pyproject.toml
+++ b/seed/pydantic/websocket/pyproject.toml
@@ -48,7 +48,7 @@ pydantic-core = ">=2.18.2"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/accept-header/pyproject.toml
+++ b/seed/python-sdk/accept-header/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/accept-header/pyproject.toml
+++ b/seed/python-sdk/accept-header/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/alias-extends/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/alias-extends/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/alias-extends/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/alias-extends/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/alias-extends/pyproject.toml
+++ b/seed/python-sdk/alias-extends/pyproject.toml
@@ -41,7 +41,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/python-sdk/alias-extends/pyproject.toml
+++ b/seed/python-sdk/alias-extends/pyproject.toml
@@ -40,7 +40,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/alias/pyproject.toml
+++ b/seed/python-sdk/alias/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/alias/pyproject.toml
+++ b/seed/python-sdk/alias/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/any-auth/pyproject.toml
+++ b/seed/python-sdk/any-auth/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/any-auth/pyproject.toml
+++ b/seed/python-sdk/any-auth/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/api-wide-base-path/pyproject.toml
+++ b/seed/python-sdk/api-wide-base-path/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/api-wide-base-path/pyproject.toml
+++ b/seed/python-sdk/api-wide-base-path/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/audiences/pyproject.toml
+++ b/seed/python-sdk/audiences/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/audiences/pyproject.toml
+++ b/seed/python-sdk/audiences/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/basic-auth-environment-variables/pyproject.toml
+++ b/seed/python-sdk/basic-auth-environment-variables/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/basic-auth-environment-variables/pyproject.toml
+++ b/seed/python-sdk/basic-auth-environment-variables/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/basic-auth/pyproject.toml
+++ b/seed/python-sdk/basic-auth/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/basic-auth/pyproject.toml
+++ b/seed/python-sdk/basic-auth/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/bearer-token-environment-variable/pyproject.toml
+++ b/seed/python-sdk/bearer-token-environment-variable/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/bearer-token-environment-variable/pyproject.toml
+++ b/seed/python-sdk/bearer-token-environment-variable/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/bytes-download/pyproject.toml
+++ b/seed/python-sdk/bytes-download/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/bytes-download/pyproject.toml
+++ b/seed/python-sdk/bytes-download/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/bytes-upload/pyproject.toml
+++ b/seed/python-sdk/bytes-upload/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/bytes-upload/pyproject.toml
+++ b/seed/python-sdk/bytes-upload/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/circular-references-advanced/pyproject.toml
+++ b/seed/python-sdk/circular-references-advanced/pyproject.toml
@@ -41,7 +41,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/python-sdk/circular-references-advanced/pyproject.toml
+++ b/seed/python-sdk/circular-references-advanced/pyproject.toml
@@ -40,7 +40,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/circular-references/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/circular-references/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/circular-references/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/circular-references/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/circular-references/pyproject.toml
+++ b/seed/python-sdk/circular-references/pyproject.toml
@@ -41,7 +41,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/python-sdk/circular-references/pyproject.toml
+++ b/seed/python-sdk/circular-references/pyproject.toml
@@ -40,7 +40,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/client-side-params/pyproject.toml
+++ b/seed/python-sdk/client-side-params/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/client-side-params/pyproject.toml
+++ b/seed/python-sdk/client-side-params/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/content-type/pyproject.toml
+++ b/seed/python-sdk/content-type/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/content-type/pyproject.toml
+++ b/seed/python-sdk/content-type/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/cross-package-type-names/pyproject.toml
+++ b/seed/python-sdk/cross-package-type-names/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/cross-package-type-names/pyproject.toml
+++ b/seed/python-sdk/cross-package-type-names/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/dollar-string-examples/pyproject.toml
+++ b/seed/python-sdk/dollar-string-examples/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/dollar-string-examples/pyproject.toml
+++ b/seed/python-sdk/dollar-string-examples/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/empty-clients/pyproject.toml
+++ b/seed/python-sdk/empty-clients/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/empty-clients/pyproject.toml
+++ b/seed/python-sdk/empty-clients/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/endpoint-security-auth/pyproject.toml
+++ b/seed/python-sdk/endpoint-security-auth/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/endpoint-security-auth/pyproject.toml
+++ b/seed/python-sdk/endpoint-security-auth/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/enum/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/enum/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/enum/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/enum/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/enum/pyproject.toml
+++ b/seed/python-sdk/enum/pyproject.toml
@@ -17,7 +17,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.dev-dependencies]
 mypy = "^1.8.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 
 [tool.pytest.ini_options]
 testpaths = [ "tests" ]

--- a/seed/python-sdk/enum/pyproject.toml
+++ b/seed/python-sdk/enum/pyproject.toml
@@ -16,7 +16,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.dev-dependencies]
 mypy = "^1.8.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 
 [tool.pytest.ini_options]

--- a/seed/python-sdk/enum/real-enum-forward-compat/pyproject.toml
+++ b/seed/python-sdk/enum/real-enum-forward-compat/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/enum/real-enum-forward-compat/pyproject.toml
+++ b/seed/python-sdk/enum/real-enum-forward-compat/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/enum/real-enum/pyproject.toml
+++ b/seed/python-sdk/enum/real-enum/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/enum/real-enum/pyproject.toml
+++ b/seed/python-sdk/enum/real-enum/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/enum/strenum/pyproject.toml
+++ b/seed/python-sdk/enum/strenum/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/enum/strenum/pyproject.toml
+++ b/seed/python-sdk/enum/strenum/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/error-property/pyproject.toml
+++ b/seed/python-sdk/error-property/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/error-property/pyproject.toml
+++ b/seed/python-sdk/error-property/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/errors/pyproject.toml
+++ b/seed/python-sdk/errors/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/errors/pyproject.toml
+++ b/seed/python-sdk/errors/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/pyproject.toml
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/pyproject.toml
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/client-filename/pyproject.toml
+++ b/seed/python-sdk/examples/client-filename/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/client-filename/pyproject.toml
+++ b/seed/python-sdk/examples/client-filename/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/legacy-wire-tests/pyproject.toml
+++ b/seed/python-sdk/examples/legacy-wire-tests/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/legacy-wire-tests/pyproject.toml
+++ b/seed/python-sdk/examples/legacy-wire-tests/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/examples/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/examples/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/omit-fern-headers/pyproject.toml
+++ b/seed/python-sdk/examples/omit-fern-headers/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/omit-fern-headers/pyproject.toml
+++ b/seed/python-sdk/examples/omit-fern-headers/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/readme/pyproject.toml
+++ b/seed/python-sdk/examples/readme/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/readme/pyproject.toml
+++ b/seed/python-sdk/examples/readme/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/additional_init_exports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/additional_init_exports/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/additional_init_exports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/additional_init_exports/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/aliases_with_validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/aliases_with_validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/aliases_without_validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/aliases_without_validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/custom-transport/pyproject.toml
+++ b/seed/python-sdk/exhaustive/custom-transport/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/custom-transport/pyproject.toml
+++ b/seed/python-sdk/exhaustive/custom-transport/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/pyproject.toml
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/pyproject.toml
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/pyproject.toml
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/pyproject.toml
@@ -52,7 +52,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/pyproject.toml
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/pyproject.toml
@@ -52,7 +52,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest-asyncio = "^0.23.5"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/eager-imports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/eager-imports/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/eager-imports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/eager-imports/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/extra_dependencies/pyproject.toml
+++ b/seed/python-sdk/exhaustive/extra_dependencies/pyproject.toml
@@ -53,7 +53,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/extra_dependencies/pyproject.toml
+++ b/seed/python-sdk/exhaustive/extra_dependencies/pyproject.toml
@@ -53,7 +53,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest-asyncio = "^0.23.5"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/pyproject.toml
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/pyproject.toml
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/five-second-timeout/pyproject.toml
+++ b/seed/python-sdk/exhaustive/five-second-timeout/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/five-second-timeout/pyproject.toml
+++ b/seed/python-sdk/exhaustive/five-second-timeout/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/pyproject.toml
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/pyproject.toml
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/import-paths/pyproject.toml
+++ b/seed/python-sdk/exhaustive/import-paths/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/import-paths/pyproject.toml
+++ b/seed/python-sdk/exhaustive/import-paths/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/improved_imports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/improved_imports/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/improved_imports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/improved_imports/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/infinite-timeout/pyproject.toml
+++ b/seed/python-sdk/exhaustive/infinite-timeout/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/infinite-timeout/pyproject.toml
+++ b/seed/python-sdk/exhaustive/infinite-timeout/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/inline-path-params/pyproject.toml
+++ b/seed/python-sdk/exhaustive/inline-path-params/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/inline-path-params/pyproject.toml
+++ b/seed/python-sdk/exhaustive/inline-path-params/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/inline_request_params/pyproject.toml
+++ b/seed/python-sdk/exhaustive/inline_request_params/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/inline_request_params/pyproject.toml
+++ b/seed/python-sdk/exhaustive/inline_request_params/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/exhaustive/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/exhaustive/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/package-path/pyproject.toml
+++ b/seed/python-sdk/exhaustive/package-path/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/package-path/pyproject.toml
+++ b/seed/python-sdk/exhaustive/package-path/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-v1/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-v1/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pyproject_extras/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pyproject_extras/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^1.0.0"
+pytest-asyncio = "^0.23.5"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pyproject_extras/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pyproject_extras/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/union-utils/pyproject.toml
+++ b/seed/python-sdk/exhaustive/union-utils/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/union-utils/pyproject.toml
+++ b/seed/python-sdk/exhaustive/union-utils/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/pyproject.toml
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/pyproject.toml
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/extends/pyproject.toml
+++ b/seed/python-sdk/extends/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/extends/pyproject.toml
+++ b/seed/python-sdk/extends/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/extra-properties/pyproject.toml
+++ b/seed/python-sdk/extra-properties/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/extra-properties/pyproject.toml
+++ b/seed/python-sdk/extra-properties/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-download/default-chunk-size/pyproject.toml
+++ b/seed/python-sdk/file-download/default-chunk-size/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-download/default-chunk-size/pyproject.toml
+++ b/seed/python-sdk/file-download/default-chunk-size/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-download/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/file-download/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-download/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/file-download/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-upload-openapi/pyproject.toml
+++ b/seed/python-sdk/file-upload-openapi/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-upload-openapi/pyproject.toml
+++ b/seed/python-sdk/file-upload-openapi/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/pyproject.toml
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/pyproject.toml
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-upload/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/file-upload/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-upload/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/file-upload/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-upload/use_typeddict_requests/pyproject.toml
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-upload/use_typeddict_requests/pyproject.toml
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/folders/pyproject.toml
+++ b/seed/python-sdk/folders/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/folders/pyproject.toml
+++ b/seed/python-sdk/folders/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/header-auth-environment-variable/pyproject.toml
+++ b/seed/python-sdk/header-auth-environment-variable/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/header-auth-environment-variable/pyproject.toml
+++ b/seed/python-sdk/header-auth-environment-variable/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/header-auth/pyproject.toml
+++ b/seed/python-sdk/header-auth/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/header-auth/pyproject.toml
+++ b/seed/python-sdk/header-auth/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/http-head/pyproject.toml
+++ b/seed/python-sdk/http-head/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/http-head/pyproject.toml
+++ b/seed/python-sdk/http-head/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/idempotency-headers/pyproject.toml
+++ b/seed/python-sdk/idempotency-headers/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/idempotency-headers/pyproject.toml
+++ b/seed/python-sdk/idempotency-headers/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/imdb/pyproject.toml
+++ b/seed/python-sdk/imdb/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/imdb/pyproject.toml
+++ b/seed/python-sdk/imdb/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/inferred-auth-explicit/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-explicit/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/inferred-auth-explicit/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-explicit/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/inferred-auth-implicit-api-key/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/inferred-auth-implicit-api-key/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/inferred-auth-implicit-reference/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-reference/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/inferred-auth-implicit-reference/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-reference/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/inferred-auth-implicit/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/inferred-auth-implicit/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/license/pyproject.toml
+++ b/seed/python-sdk/license/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/license/pyproject.toml
+++ b/seed/python-sdk/license/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/literal/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/literal/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/literal/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/literal/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/literal/use_typeddict_requests/pyproject.toml
+++ b/seed/python-sdk/literal/use_typeddict_requests/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/literal/use_typeddict_requests/pyproject.toml
+++ b/seed/python-sdk/literal/use_typeddict_requests/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/literals-unions/pyproject.toml
+++ b/seed/python-sdk/literals-unions/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/literals-unions/pyproject.toml
+++ b/seed/python-sdk/literals-unions/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/mixed-case/pyproject.toml
+++ b/seed/python-sdk/mixed-case/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/mixed-case/pyproject.toml
+++ b/seed/python-sdk/mixed-case/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/pyproject.toml
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/pyproject.toml
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/multi-line-docs/pyproject.toml
+++ b/seed/python-sdk/multi-line-docs/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/multi-line-docs/pyproject.toml
+++ b/seed/python-sdk/multi-line-docs/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/multi-url-environment-no-default/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment-no-default/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/multi-url-environment-no-default/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment-no-default/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/multi-url-environment/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/multi-url-environment/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/multiple-request-bodies/pyproject.toml
+++ b/seed/python-sdk/multiple-request-bodies/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/multiple-request-bodies/pyproject.toml
+++ b/seed/python-sdk/multiple-request-bodies/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/no-environment/pyproject.toml
+++ b/seed/python-sdk/no-environment/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/no-environment/pyproject.toml
+++ b/seed/python-sdk/no-environment/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/no-retries/pyproject.toml
+++ b/seed/python-sdk/no-retries/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/no-retries/pyproject.toml
+++ b/seed/python-sdk/no-retries/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/nullable-allof-extends/pyproject.toml
+++ b/seed/python-sdk/nullable-allof-extends/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/nullable-allof-extends/pyproject.toml
+++ b/seed/python-sdk/nullable-allof-extends/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/nullable-optional/pyproject.toml
+++ b/seed/python-sdk/nullable-optional/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/nullable-optional/pyproject.toml
+++ b/seed/python-sdk/nullable-optional/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/nullable-request-body/pyproject.toml
+++ b/seed/python-sdk/nullable-request-body/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/nullable-request-body/pyproject.toml
+++ b/seed/python-sdk/nullable-request-body/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/nullable/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/nullable/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/nullable/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/nullable/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/nullable/use-typeddict-requests/pyproject.toml
+++ b/seed/python-sdk/nullable/use-typeddict-requests/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/nullable/use-typeddict-requests/pyproject.toml
+++ b/seed/python-sdk/nullable/use-typeddict-requests/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-custom/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-custom/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-custom/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-custom/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-default/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-default/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-default/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-default/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-nested-root/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-nested-root/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-reference/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-reference/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-reference/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-reference/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-with-variables/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-with-variables/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/object/pyproject.toml
+++ b/seed/python-sdk/object/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/object/pyproject.toml
+++ b/seed/python-sdk/object/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/objects-with-imports/pyproject.toml
+++ b/seed/python-sdk/objects-with-imports/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/objects-with-imports/pyproject.toml
+++ b/seed/python-sdk/objects-with-imports/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/optional/pyproject.toml
+++ b/seed/python-sdk/optional/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/optional/pyproject.toml
+++ b/seed/python-sdk/optional/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/package-yml/pyproject.toml
+++ b/seed/python-sdk/package-yml/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/package-yml/pyproject.toml
+++ b/seed/python-sdk/package-yml/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/pagination-custom/pyproject.toml
+++ b/seed/python-sdk/pagination-custom/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/pagination-custom/pyproject.toml
+++ b/seed/python-sdk/pagination-custom/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/pagination-uri-path/pyproject.toml
+++ b/seed/python-sdk/pagination-uri-path/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/pagination-uri-path/pyproject.toml
+++ b/seed/python-sdk/pagination-uri-path/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/pagination/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/pagination/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/pagination/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/pagination/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/pagination/page-index-semantics/pyproject.toml
+++ b/seed/python-sdk/pagination/page-index-semantics/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/pagination/page-index-semantics/pyproject.toml
+++ b/seed/python-sdk/pagination/page-index-semantics/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/path-parameters/pyproject.toml
+++ b/seed/python-sdk/path-parameters/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/path-parameters/pyproject.toml
+++ b/seed/python-sdk/path-parameters/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/plain-text/pyproject.toml
+++ b/seed/python-sdk/plain-text/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/plain-text/pyproject.toml
+++ b/seed/python-sdk/plain-text/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/property-access/pyproject.toml
+++ b/seed/python-sdk/property-access/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/property-access/pyproject.toml
+++ b/seed/python-sdk/property-access/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/public-object/pyproject.toml
+++ b/seed/python-sdk/public-object/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/public-object/pyproject.toml
+++ b/seed/python-sdk/public-object/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-backslash-escape/pyproject.toml
+++ b/seed/python-sdk/python-backslash-escape/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-backslash-escape/pyproject.toml
+++ b/seed/python-sdk/python-backslash-escape/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/pyproject.toml
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/pyproject.toml
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/pyproject.toml
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/pyproject.toml
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/query-parameters/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/query-parameters/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/query-parameters/pyproject.toml
+++ b/seed/python-sdk/query-parameters/pyproject.toml
@@ -41,7 +41,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/python-sdk/query-parameters/pyproject.toml
+++ b/seed/python-sdk/query-parameters/pyproject.toml
@@ -40,7 +40,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/request-parameters/pyproject.toml
+++ b/seed/python-sdk/request-parameters/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/request-parameters/pyproject.toml
+++ b/seed/python-sdk/request-parameters/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/required-nullable/pyproject.toml
+++ b/seed/python-sdk/required-nullable/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/required-nullable/pyproject.toml
+++ b/seed/python-sdk/required-nullable/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/reserved-keywords/pyproject.toml
+++ b/seed/python-sdk/reserved-keywords/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/reserved-keywords/pyproject.toml
+++ b/seed/python-sdk/reserved-keywords/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/response-property/pyproject.toml
+++ b/seed/python-sdk/response-property/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/response-property/pyproject.toml
+++ b/seed/python-sdk/response-property/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/server-sent-event-examples/pyproject.toml
+++ b/seed/python-sdk/server-sent-event-examples/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/server-sent-event-examples/pyproject.toml
+++ b/seed/python-sdk/server-sent-event-examples/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/server-sent-events/pyproject.toml
+++ b/seed/python-sdk/server-sent-events/pyproject.toml
@@ -45,7 +45,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/server-sent-events/pyproject.toml
+++ b/seed/python-sdk/server-sent-events/pyproject.toml
@@ -46,7 +46,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/server-sent-events/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/server-sent-events/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/server-url-templating/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/server-url-templating/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/server-url-templating/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/server-url-templating/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/simple-api/pyproject.toml
+++ b/seed/python-sdk/simple-api/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/simple-api/pyproject.toml
+++ b/seed/python-sdk/simple-api/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/simple-fhir/pyproject.toml
+++ b/seed/python-sdk/simple-fhir/pyproject.toml
@@ -41,7 +41,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/python-sdk/simple-fhir/pyproject.toml
+++ b/seed/python-sdk/simple-fhir/pyproject.toml
@@ -40,7 +40,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/single-url-environment-default/pyproject.toml
+++ b/seed/python-sdk/single-url-environment-default/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/single-url-environment-default/pyproject.toml
+++ b/seed/python-sdk/single-url-environment-default/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/single-url-environment-no-default/pyproject.toml
+++ b/seed/python-sdk/single-url-environment-no-default/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/single-url-environment-no-default/pyproject.toml
+++ b/seed/python-sdk/single-url-environment-no-default/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/streaming-parameter/pyproject.toml
+++ b/seed/python-sdk/streaming-parameter/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/streaming-parameter/pyproject.toml
+++ b/seed/python-sdk/streaming-parameter/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/streaming/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/streaming/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/streaming/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/streaming/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/streaming/skip-pydantic-validation/pyproject.toml
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/streaming/skip-pydantic-validation/pyproject.toml
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/trace/pyproject.toml
+++ b/seed/python-sdk/trace/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/trace/pyproject.toml
+++ b/seed/python-sdk/trace/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/undiscriminated-union-with-response-property/pyproject.toml
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/undiscriminated-union-with-response-property/pyproject.toml
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/undiscriminated-unions/pyproject.toml
+++ b/seed/python-sdk/undiscriminated-unions/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/undiscriminated-unions/pyproject.toml
+++ b/seed/python-sdk/undiscriminated-unions/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/unions-with-local-date/pyproject.toml
+++ b/seed/python-sdk/unions-with-local-date/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unions-with-local-date/pyproject.toml
+++ b/seed/python-sdk/unions-with-local-date/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/unions/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/unions/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unions/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/unions/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/unions/union-naming-v1/pyproject.toml
+++ b/seed/python-sdk/unions/union-naming-v1/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unions/union-naming-v1/pyproject.toml
+++ b/seed/python-sdk/unions/union-naming-v1/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/unions/union-utils/pyproject.toml
+++ b/seed/python-sdk/unions/union-utils/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unions/union-utils/pyproject.toml
+++ b/seed/python-sdk/unions/union-utils/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/unknown/pyproject.toml
+++ b/seed/python-sdk/unknown/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unknown/pyproject.toml
+++ b/seed/python-sdk/unknown/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/url-form-encoded/pyproject.toml
+++ b/seed/python-sdk/url-form-encoded/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/url-form-encoded/pyproject.toml
+++ b/seed/python-sdk/url-form-encoded/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/validation/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/validation/no-custom-config/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/validation/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/validation/no-custom-config/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/validation/with-defaults/pyproject.toml
+++ b/seed/python-sdk/validation/with-defaults/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/validation/with-defaults/pyproject.toml
+++ b/seed/python-sdk/validation/with-defaults/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/variables/pyproject.toml
+++ b/seed/python-sdk/variables/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/variables/pyproject.toml
+++ b/seed/python-sdk/variables/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/version-no-default/pyproject.toml
+++ b/seed/python-sdk/version-no-default/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/version-no-default/pyproject.toml
+++ b/seed/python-sdk/version-no-default/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/version/pyproject.toml
+++ b/seed/python-sdk/version/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/version/pyproject.toml
+++ b/seed/python-sdk/version/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/webhook-audience/pyproject.toml
+++ b/seed/python-sdk/webhook-audience/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/webhook-audience/pyproject.toml
+++ b/seed/python-sdk/webhook-audience/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/webhooks/pyproject.toml
+++ b/seed/python-sdk/webhooks/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/webhooks/pyproject.toml
+++ b/seed/python-sdk/webhooks/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket-bearer-auth/pyproject.toml
+++ b/seed/python-sdk/websocket-bearer-auth/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket-bearer-auth/pyproject.toml
+++ b/seed/python-sdk/websocket-bearer-auth/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket-inferred-auth/pyproject.toml
+++ b/seed/python-sdk/websocket-inferred-auth/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket-inferred-auth/pyproject.toml
+++ b/seed/python-sdk/websocket-inferred-auth/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket/pyproject.toml
+++ b/seed/python-sdk/websocket/pyproject.toml
@@ -40,7 +40,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.dev-dependencies]
 mypy = "1.0.1"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket/pyproject.toml
+++ b/seed/python-sdk/websocket/pyproject.toml
@@ -41,7 +41,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.dev-dependencies]
 mypy = "1.0.1"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "^0.5.6"

--- a/seed/python-sdk/websocket/websocket-base/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-base/pyproject.toml
@@ -49,7 +49,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket/websocket-base/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-base/pyproject.toml
@@ -50,7 +50,7 @@ typing_extensions = ">= 4.0.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/pyproject.toml
@@ -50,7 +50,7 @@ websockets = ">=12.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/pyproject.toml
@@ -51,7 +51,7 @@ websockets = ">=12.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/pyproject.toml
@@ -50,7 +50,7 @@ websockets = ">=12.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
+pytest = "^8.2.0"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/pyproject.toml
@@ -51,7 +51,7 @@ websockets = ">=12.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
 pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
+pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"


### PR DESCRIPTION
## Description

Fixes deprecation warnings (`asyncio.iscoroutinefunction`, `asyncio.get_event_loop_policy`, `asyncio.set_event_loop_policy`) emitted by `pytest-asyncio` when running generated SDK tests on Python 3.14+.

## Changes Made

- Made `pytest` and `pytest-asyncio` dev dependency versions **conditional on the project's minimum Python version** in `generators/python/src/fern_python/codegen/pyproject_toml.py`:
  - **Python ≥ 3.9**: `pytest = "^8.2.0"` + `pytest-asyncio = "^1.0.0"` (fixes the deprecation warnings)
  - **Python < 3.9**: `pytest = "^7.4.0"` + `pytest-asyncio = "^0.23.5"` (unchanged, since pytest-asyncio 1.x requires Python ≥ 3.9)
- Uses regex to extract the minimum minor version directly from the constraint string (e.g. `"^3.8"` → 8, `"^3.8.1"` → 8, `"^3.10"` → 10). This avoids a subtle bug where `get_minimum_compatible_version("^3.8.1")` would return `PY3_9` because `PythonVersionSpec(3, 8)` represents `3.8.0` which doesn't satisfy `>=3.8.1`.
- Updated 283 seed snapshot `pyproject.toml` files (Python ≥ 3.9 projects) with the new versions; 10 Python 3.8 fixtures remain unchanged
- Added `5.0.1` changelog entry in `generators/python/sdk/versions.yml`

## Context

`pytest-asyncio` 1.0.0 (released 2025-05-26) added preliminary Python 3.14 support by replacing deprecated `asyncio` APIs. However, it also raised its minimum requirements to `pytest >= 8.2` and `Python >= 3.9`. Since the default min Python version was just raised to `^3.10` in v5.0.0, the new pair is compatible for the vast majority of generated SDKs. The conditional fallback preserves compatibility for projects that still target Python 3.8.

## Human Review Checklist

- [ ] Verify the regex `re.search(r"(\d+)\.(\d+)", self.python_version)` correctly extracts the minor version for all expected constraint formats (`^3.8`, `^3.8.1`, `>=3.9`, `>=3.10,<4.0`, etc.)
- [ ] Consider whether `min_minor >= 9` is the right threshold vs. `>= 10` (pytest-asyncio 1.x requires Python ≥ 3.9; pytest 8.2 also supports 3.9+, so 9 is correct)
- [ ] Confirm no generated test code uses the `event_loop` fixture (removed in pytest-asyncio 1.0 — grep found no matches)
- [ ] Spot-check a few seed snapshots to confirm Python 3.8 fixtures kept old versions and Python 3.10+ fixtures got new versions

## Testing

- [ ] Seed snapshot files updated to match expected generator output
- [ ] CI seed checks will validate generator output matches snapshots

Link to Devin session: https://app.devin.ai/sessions/e368d1686df147fcadda433d4bcdcd82
Requested by: @jsklan