### PR TITLE
fix(typescript): add isolatedDeclarations type annotation and enable vitest typecheck

### DIFF
--- a/generators/typescript/asIs/tests/mock-server/MockServerPool.ts
+++ b/generators/typescript/asIs/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -176,6 +176,10 @@ export class TestGenerator {
             import { defineConfig } from "vitest/config";
             export default defineConfig({
                 test: {
+                    typecheck: {
+                        enabled: true,
+                        tsconfig: "./${this.relativeTestPath}/tsconfig.json"
+                    },
                     projects: [
                         {
                             test: {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.57.3
+  changelogEntry:
+    - summary: |
+        Add explicit type annotation to `mockServerPool` export in generated test
+        mock-server code to satisfy `--isolatedDeclarations`.
+      type: fix
+    - summary: |
+        Enable vitest typechecking in generated vitest config so that type errors
+        in test and source files are caught when running `vitest`.
+      type: feat
+  createdAt: "2026-03-17"
+  irVersion: 65
+
 - version: 3.57.2
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.57.3
+- version: 3.58.0
   changelogEntry:
     - summary: |
         Add explicit type annotation to `mockServerPool` export in generated test

--- a/seed/ts-sdk/accept-header/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/accept-header/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/accept-header/vitest.config.mts
+++ b/seed/ts-sdk/accept-header/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/alias-extends/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/alias-extends/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/alias-extends/vitest.config.mts
+++ b/seed/ts-sdk/alias-extends/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/alias/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/alias/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/alias/vitest.config.mts
+++ b/seed/ts-sdk/alias/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/vitest.config.mts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/any-auth/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/any-auth/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/any-auth/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/api-wide-base-path/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/api-wide-base-path/vitest.config.mts
+++ b/seed/ts-sdk/api-wide-base-path/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/audiences/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/audiences/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/audiences/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/audiences/with-partner-audience/vitest.config.mts
+++ b/seed/ts-sdk/audiences/with-partner-audience/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/basic-auth-environment-variables/vitest.config.mts
+++ b/seed/ts-sdk/basic-auth-environment-variables/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/basic-auth/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/basic-auth/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/basic-auth/vitest.config.mts
+++ b/seed/ts-sdk/basic-auth/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/bearer-token-environment-variable/vitest.config.mts
+++ b/seed/ts-sdk/bearer-token-environment-variable/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/bytes-download/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/bytes-download/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/bytes-download/vitest.config.mts
+++ b/seed/ts-sdk/bytes-download/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/bytes-upload/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/bytes-upload/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/bytes-upload/vitest.config.mts
+++ b/seed/ts-sdk/bytes-upload/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/circular-references-advanced/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/circular-references-advanced/vitest.config.mts
+++ b/seed/ts-sdk/circular-references-advanced/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/circular-references/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/circular-references/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/circular-references/vitest.config.mts
+++ b/seed/ts-sdk/circular-references/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/client-side-params/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/client-side-params/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/client-side-params/vitest.config.mts
+++ b/seed/ts-sdk/client-side-params/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/content-type/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/content-type/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/content-type/vitest.config.mts
+++ b/seed/ts-sdk/content-type/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/vitest.config.mts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/dollar-string-examples/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/dollar-string-examples/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/dollar-string-examples/vitest.config.mts
+++ b/seed/ts-sdk/dollar-string-examples/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/empty-clients/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/empty-clients/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/empty-clients/vitest.config.mts
+++ b/seed/ts-sdk/empty-clients/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/endpoint-security-auth/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/endpoint-security-auth/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/endpoint-security-auth/vitest.config.mts
+++ b/seed/ts-sdk/endpoint-security-auth/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/vitest.config.mts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/enum/forward-compatible-enums/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/enum/forward-compatible-enums/vitest.config.mts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/enum/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/enum/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/enum/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/enum/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/enum/serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/enum/serde/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/enum/serde/vitest.config.mts
+++ b/seed/ts-sdk/enum/serde/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/error-property/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/error-property/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/error-property/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/error-property/union-utils/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/error-property/union-utils/vitest.config.mts
+++ b/seed/ts-sdk/error-property/union-utils/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/errors/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/errors/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/errors/vitest.config.mts
+++ b/seed/ts-sdk/errors/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/examples/examples-with-api-reference/vitest.config.mts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/examples/retain-original-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/examples/retain-original-casing/vitest.config.mts
+++ b/seed/ts-sdk/examples/retain-original-casing/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/bigint/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/multiple-exports/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/never-throw-errors/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/node-fetch/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/node-fetch/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/package-path/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/package-path/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./src/test-packagePath/tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/retain-original-casing/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/serde-layer/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/serde-layer/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/use-jest/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/exhaustive/with-audiences/vitest.config.mts
+++ b/seed/ts-sdk/exhaustive/with-audiences/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/extends/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/extends/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/extends/vitest.config.mts
+++ b/seed/ts-sdk/extends/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/extra-properties/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/extra-properties/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/extra-properties/vitest.config.mts
+++ b/seed/ts-sdk/extra-properties/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/file-download/file-download-response-headers/vitest.config.mts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/file-download/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/file-download/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/file-download/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/file-download/stream-wrapper/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/file-upload-openapi/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-upload-openapi/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/file-upload-openapi/vitest.config.mts
+++ b/seed/ts-sdk/file-upload-openapi/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/file-upload/form-data-node16/vitest.config.mts
+++ b/seed/ts-sdk/file-upload/form-data-node16/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/file-upload/inline/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/file-upload/inline/vitest.config.mts
+++ b/seed/ts-sdk/file-upload/inline/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/file-upload/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/file-upload/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/file-upload/serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/file-upload/serde/vitest.config.mts
+++ b/seed/ts-sdk/file-upload/serde/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/file-upload/use-jest/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-upload/use-jest/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/file-upload/wrapper/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/file-upload/wrapper/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/folders/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/folders/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/folders/vitest.config.mts
+++ b/seed/ts-sdk/folders/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/header-auth-environment-variable/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/header-auth-environment-variable/vitest.config.mts
+++ b/seed/ts-sdk/header-auth-environment-variable/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/header-auth/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/header-auth/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/header-auth/vitest.config.mts
+++ b/seed/ts-sdk/header-auth/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/http-head/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/http-head/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/http-head/vitest.config.mts
+++ b/seed/ts-sdk/http-head/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/idempotency-headers/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/idempotency-headers/vitest.config.mts
+++ b/seed/ts-sdk/idempotency-headers/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/imdb/branded-string-aliases/vitest.config.mts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/imdb/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/imdb/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/imdb/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/imdb/omit-undefined/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/imdb/omit-undefined/vitest.config.mts
+++ b/seed/ts-sdk/imdb/omit-undefined/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/inferred-auth-explicit/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/inferred-auth-explicit/vitest.config.mts
+++ b/seed/ts-sdk/inferred-auth-explicit/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/vitest.config.mts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/vitest.config.mts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/inferred-auth-implicit/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/inferred-auth-implicit/vitest.config.mts
+++ b/seed/ts-sdk/inferred-auth-implicit/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/license/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/license/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/license/vitest.config.mts
+++ b/seed/ts-sdk/license/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/literal/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/literal/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/literal/vitest.config.mts
+++ b/seed/ts-sdk/literal/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/literals-unions/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/literals-unions/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/literals-unions/vitest.config.mts
+++ b/seed/ts-sdk/literals-unions/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/mixed-case/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/mixed-case/retain-original-casing/vitest.config.mts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/mixed-file-directory/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/mixed-file-directory/vitest.config.mts
+++ b/seed/ts-sdk/mixed-file-directory/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/multi-line-docs/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/multi-line-docs/vitest.config.mts
+++ b/seed/ts-sdk/multi-line-docs/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/multi-url-environment-no-default/vitest.config.mts
+++ b/seed/ts-sdk/multi-url-environment-no-default/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/multi-url-environment/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/multi-url-environment/vitest.config.mts
+++ b/seed/ts-sdk/multi-url-environment/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/multiple-request-bodies/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/multiple-request-bodies/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/multiple-request-bodies/vitest.config.mts
+++ b/seed/ts-sdk/multiple-request-bodies/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/no-environment/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/no-environment/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/no-environment/vitest.config.mts
+++ b/seed/ts-sdk/no-environment/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/no-retries/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/no-retries/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/no-retries/vitest.config.mts
+++ b/seed/ts-sdk/no-retries/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/nullable-allof-extends/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/nullable-allof-extends/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/nullable-allof-extends/vitest.config.mts
+++ b/seed/ts-sdk/nullable-allof-extends/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/nullable-optional/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/nullable-optional/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/nullable-optional/vitest.config.mts
+++ b/seed/ts-sdk/nullable-optional/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/nullable-request-body/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/nullable-request-body/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/nullable-request-body/vitest.config.mts
+++ b/seed/ts-sdk/nullable-request-body/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/nullable/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/nullable/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/nullable/vitest.config.mts
+++ b/seed/ts-sdk/nullable/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/oauth-client-credentials-custom/vitest.config.mts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/oauth-client-credentials-default/vitest.config.mts
+++ b/seed/ts-sdk/oauth-client-credentials-default/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/vitest.config.mts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/oauth-client-credentials-reference/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/oauth-client-credentials-reference/vitest.config.mts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/vitest.config.mts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/oauth-client-credentials/serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/oauth-client-credentials/serde/vitest.config.mts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/object/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/object/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/object/vitest.config.mts
+++ b/seed/ts-sdk/object/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/objects-with-imports/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/objects-with-imports/vitest.config.mts
+++ b/seed/ts-sdk/objects-with-imports/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/optional/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/optional/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/optional/vitest.config.mts
+++ b/seed/ts-sdk/optional/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/package-yml/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/package-yml/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/package-yml/vitest.config.mts
+++ b/seed/ts-sdk/package-yml/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/pagination-custom/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/pagination-custom/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/pagination-custom/vitest.config.mts
+++ b/seed/ts-sdk/pagination-custom/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/pagination-uri-path/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/pagination-uri-path/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/pagination-uri-path/vitest.config.mts
+++ b/seed/ts-sdk/pagination-uri-path/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/pagination/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/pagination/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/pagination/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/pagination/page-index-semantics/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/pagination/page-index-semantics/vitest.config.mts
+++ b/seed/ts-sdk/pagination/page-index-semantics/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/path-parameters/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/path-parameters/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/vitest.config.mts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/vitest.config.mts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/vitest.config.mts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/vitest.config.mts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/vitest.config.mts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/vitest.config.mts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/vitest.config.mts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/path-parameters/retain-original-casing/vitest.config.mts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/plain-text/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/plain-text/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/plain-text/vitest.config.mts
+++ b/seed/ts-sdk/plain-text/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/vitest.config.mts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/property-access/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/property-access/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/property-access/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/public-object/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/public-object/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/public-object/vitest.config.mts
+++ b/seed/ts-sdk/public-object/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/vitest.config.mts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/query-parameters-openapi/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/query-parameters-openapi/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/query-parameters-openapi/vitest.config.mts
+++ b/seed/ts-sdk/query-parameters-openapi/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/query-parameters/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/vitest.config.mts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/vitest.config.mts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/vitest.config.mts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/vitest.config.mts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/query-parameters/serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/query-parameters/serde/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/query-parameters/serde/vitest.config.mts
+++ b/seed/ts-sdk/query-parameters/serde/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/vitest.config.mts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/request-parameters/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/vitest.config.mts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/required-nullable/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/required-nullable/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/required-nullable/vitest.config.mts
+++ b/seed/ts-sdk/required-nullable/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/reserved-keywords/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/reserved-keywords/vitest.config.mts
+++ b/seed/ts-sdk/reserved-keywords/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/response-property/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/response-property/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/response-property/vitest.config.mts
+++ b/seed/ts-sdk/response-property/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/server-sent-event-examples/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/server-sent-event-examples/vitest.config.mts
+++ b/seed/ts-sdk/server-sent-event-examples/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/server-sent-events/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/server-sent-events/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/server-sent-events/vitest.config.mts
+++ b/seed/ts-sdk/server-sent-events/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/server-url-templating/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/server-url-templating/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/server-url-templating/vitest.config.mts
+++ b/seed/ts-sdk/server-url-templating/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/allow-extra-fields/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/allow-extra-fields/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/bundle/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/bundle/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/bundle/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/bundle/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/custom-package-json/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/custom-package-json/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/custom-package-json/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/jsr/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/jsr/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/jsr/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/jsr/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/legacy-exports/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/legacy-exports/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/legacy-exports/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/naming-shorthand/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/naming-shorthand/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/naming/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/naming/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/naming/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/naming/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/vitest.config.mts
@@ -3,6 +3,10 @@
             import { defineConfig } from "vitest/config";
             export default defineConfig({
                 test: {
+                    typecheck: {
+                        enabled: true,
+                        tsconfig: "./tests/tsconfig.json",
+                    },
                     projects: [
                         {
                             test: {

--- a/seed/ts-sdk/simple-api/no-scripts/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/no-scripts/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/no-scripts/vitest.config.mts
@@ -3,6 +3,10 @@
             import { defineConfig } from "vitest/config";
             export default defineConfig({
                 test: {
+                    typecheck: {
+                        enabled: true,
+                        tsconfig: "./tests/tsconfig.json",
+                    },
                     projects: [
                         {
                             test: {

--- a/seed/ts-sdk/simple-api/oidc-token/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/oidc-token/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/oidc-token/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/omit-fern-headers/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/omit-fern-headers/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/use-oxc/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/use-oxc/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/use-oxc/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/use-oxfmt/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/use-oxfmt/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/use-oxlint/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/use-oxlint/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/use-oxlint/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/use-prettier/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/use-prettier/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/use-prettier/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-api/use-yarn/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-api/use-yarn/vitest.config.mts
+++ b/seed/ts-sdk/simple-api/use-yarn/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/simple-fhir/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/simple-fhir/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/simple-fhir/vitest.config.mts
+++ b/seed/ts-sdk/simple-fhir/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/single-url-environment-default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/single-url-environment-default/vitest.config.mts
+++ b/seed/ts-sdk/single-url-environment-default/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/single-url-environment-no-default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/single-url-environment-no-default/vitest.config.mts
+++ b/seed/ts-sdk/single-url-environment-no-default/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/streaming-parameter/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/streaming-parameter/vitest.config.mts
+++ b/seed/ts-sdk/streaming-parameter/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/streaming/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/streaming/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/streaming/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/streaming/serde-layer/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/streaming/serde-layer/vitest.config.mts
+++ b/seed/ts-sdk/streaming/serde-layer/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/streaming/wrapper/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/trace/exhaustive/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/trace/exhaustive/vitest.config.mts
+++ b/seed/ts-sdk/trace/exhaustive/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/trace/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/trace/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/trace/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/trace/serde-no-throwing/vitest.config.mts
+++ b/seed/ts-sdk/trace/serde-no-throwing/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/trace/serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/trace/serde/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/trace/serde/vitest.config.mts
+++ b/seed/ts-sdk/trace/serde/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/ts-express-casing/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/ts-express-casing/vitest.config.mts
+++ b/seed/ts-sdk/ts-express-casing/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/ts-extra-properties/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/ts-extra-properties/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/ts-extra-properties/vitest.config.mts
+++ b/seed/ts-sdk/ts-extra-properties/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/ts-inline-types/inline/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/ts-inline-types/inline/vitest.config.mts
+++ b/seed/ts-sdk/ts-inline-types/inline/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/ts-inline-types/no-inline/vitest.config.mts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/vitest.config.mts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/vitest.config.mts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/unions-with-local-date/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/unions-with-local-date/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/unions-with-local-date/vitest.config.mts
+++ b/seed/ts-sdk/unions-with-local-date/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/unions/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/unions/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/unions/vitest.config.mts
+++ b/seed/ts-sdk/unions/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/unknown/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/unknown/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/unknown/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/unknown/unknown-as-any/vitest.config.mts
+++ b/seed/ts-sdk/unknown/unknown-as-any/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/url-form-encoded/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/url-form-encoded/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/url-form-encoded/vitest.config.mts
+++ b/seed/ts-sdk/url-form-encoded/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/validation/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/validation/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/validation/vitest.config.mts
+++ b/seed/ts-sdk/validation/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/variables/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/variables/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/variables/vitest.config.mts
+++ b/seed/ts-sdk/variables/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/version-no-default/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/version-no-default/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/version-no-default/vitest.config.mts
+++ b/seed/ts-sdk/version-no-default/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/version/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/version/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/version/vitest.config.mts
+++ b/seed/ts-sdk/version/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/webhook-audience/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/webhook-audience/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/webhook-audience/vitest.config.mts
+++ b/seed/ts-sdk/webhook-audience/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/webhooks/no-custom-config/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/webhooks/no-custom-config/vitest.config.mts
+++ b/seed/ts-sdk/webhooks/no-custom-config/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/vitest.config.mts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/vitest.config.mts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/websocket/no-serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/websocket/no-serde/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/websocket/no-serde/vitest.config.mts
+++ b/seed/ts-sdk/websocket/no-serde/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/websocket/no-websocket-clients/vitest.config.mts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {

--- a/seed/ts-sdk/websocket/serde/tests/mock-server/MockServerPool.ts
+++ b/seed/ts-sdk/websocket/serde/tests/mock-server/MockServerPool.ts
@@ -103,4 +103,4 @@ class MockServerPool {
     }
 }
 
-export const mockServerPool = new MockServerPool();
+export const mockServerPool: MockServerPool = new MockServerPool();

--- a/seed/ts-sdk/websocket/serde/vitest.config.mts
+++ b/seed/ts-sdk/websocket/serde/vitest.config.mts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tests/tsconfig.json",
+        },
         projects: [
             {
                 test: {


### PR DESCRIPTION
## Description

Fixes TS9010 (`--isolatedDeclarations`) error on `MockServerPool.ts` line 106 and enables vitest typechecking in generated TypeScript SDK test configs.

## Changes Made

- **`MockServerPool.ts` (template + 192 seed snapshots):** Add explicit type annotation to exported `mockServerPool` constant (`export const mockServerPool: MockServerPool = ...`) to satisfy `--isolatedDeclarations`.
- **`TestGenerator.ts`:** Add `typecheck: { enabled: true, tsconfig: "./<testPath>/tsconfig.json" }` to the generated `vitest.config.mts` so that `vitest` runs `tsc` alongside runtime tests, catching type errors in both source and test files.
- **184 seed `vitest.config.mts` snapshots:** Updated to include the new `typecheck` block.
- **`versions.yml`:** Added v3.57.3 changelog entry.

## Review Checklist

- [x] Verify that the `typecheck.tsconfig` path resolves correctly for non-standard `relativeTestPath` values (e.g., `exhaustive/package-path` uses `./src/test-packagePath/tests/tsconfig.json`)
- [x] Seed snapshot diffs are purely mechanical (batch sed/script updates) — CI will validate they match generator output
- [x] Note: vitest `typecheck` is marked experimental in vitest docs but simply shells out to `tsc`

## Testing

- [x] `pnpm run check` (biome lint) passes
- [ ] CI seed snapshot validation will confirm generator output matches updated snapshots

Link to Devin session: https://app.devin.ai/sessions/adbf0f83665a44248272b9b3b075ed70
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
