### PR TITLE
fix(python): skip Docker container management when `WIREMOCK_URL` is set

### DIFF
--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -384,6 +384,7 @@ import subprocess
 import pytest
 
 _STARTED: bool = False
+_EXTERNAL: bool = False  # True when using an external WireMock instance (skip container lifecycle)
 _WIREMOCK_URL: str = "http://localhost:8080"  # Default, will be updated after container starts
 _PROJECT_NAME: str = "${projectName}"
 
@@ -410,8 +411,17 @@ def _get_wiremock_port() -> str:
 
 def _start_wiremock() -> None:
     """Starts the WireMock container using docker-compose."""
-    global _STARTED, _WIREMOCK_URL
+    global _STARTED, _EXTERNAL, _WIREMOCK_URL
     if _STARTED:
+        return
+
+    # If WIREMOCK_URL is already set (e.g., by CI/CD pipeline), skip container management
+    existing_url = os.environ.get("WIREMOCK_URL")
+    if existing_url:
+        _WIREMOCK_URL = existing_url
+        _EXTERNAL = True
+        _STARTED = True
+        print(f"\\nUsing external WireMock at {_WIREMOCK_URL} (container management skipped)")
         return
 
     print(f"\\nStarting WireMock container (project: {_PROJECT_NAME})...")
@@ -434,6 +444,10 @@ def _start_wiremock() -> None:
 
 def _stop_wiremock() -> None:
     """Stops and removes the WireMock container."""
+    if _EXTERNAL:
+        # Container is managed externally; nothing to tear down.
+        return
+
     print("\\nStopping WireMock container...")
     subprocess.run(
         ["docker", "compose", "-f", _COMPOSE_FILE, "-p", _PROJECT_NAME, "down", "-v"],

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.0.3
+  changelogEntry:
+    - summary: |
+        Skip Docker container management in generated `tests/conftest.py` when the
+        `WIREMOCK_URL` environment variable is already set. This allows wire tests to
+        run in CI/CD pipelines that provide an external WireMock sidecar container
+        without requiring Docker-in-Docker support.
+      type: fix
+  createdAt: "2026-03-17"
+  irVersion: 65
+
 - version: 5.0.2
   changelogEntry:
     - summary: |

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/conftest.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/conftest.py
@@ -15,6 +15,7 @@ import subprocess
 import pytest
 
 _STARTED: bool = False
+_EXTERNAL: bool = False  # True when using an external WireMock instance (skip container lifecycle)
 _WIREMOCK_URL: str = "http://localhost:8080"  # Default, will be updated after container starts
 _PROJECT_NAME: str = "seed-exhaustive"
 
@@ -41,8 +42,17 @@ def _get_wiremock_port() -> str:
 
 def _start_wiremock() -> None:
     """Starts the WireMock container using docker-compose."""
-    global _STARTED, _WIREMOCK_URL
+    global _STARTED, _EXTERNAL, _WIREMOCK_URL
     if _STARTED:
+        return
+
+    # If WIREMOCK_URL is already set (e.g., by CI/CD pipeline), skip container management
+    existing_url = os.environ.get("WIREMOCK_URL")
+    if existing_url:
+        _WIREMOCK_URL = existing_url
+        _EXTERNAL = True
+        _STARTED = True
+        print(f"\nUsing external WireMock at {_WIREMOCK_URL} (container management skipped)")
         return
 
     print(f"\nStarting WireMock container (project: {_PROJECT_NAME})...")
@@ -65,6 +75,10 @@ def _start_wiremock() -> None:
 
 def _stop_wiremock() -> None:
     """Stops and removes the WireMock container."""
+    if _EXTERNAL:
+        # Container is managed externally; nothing to tear down.
+        return
+
     print("\nStopping WireMock container...")
     subprocess.run(
         ["docker", "compose", "-f", _COMPOSE_FILE, "-p", _PROJECT_NAME, "down", "-v"],

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/tests/conftest.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/tests/conftest.py
@@ -15,6 +15,7 @@ import subprocess
 import pytest
 
 _STARTED: bool = False
+_EXTERNAL: bool = False  # True when using an external WireMock instance (skip container lifecycle)
 _WIREMOCK_URL: str = "http://localhost:8080"  # Default, will be updated after container starts
 _PROJECT_NAME: str = "seed-exhaustive"
 
@@ -41,8 +42,17 @@ def _get_wiremock_port() -> str:
 
 def _start_wiremock() -> None:
     """Starts the WireMock container using docker-compose."""
-    global _STARTED, _WIREMOCK_URL
+    global _STARTED, _EXTERNAL, _WIREMOCK_URL
     if _STARTED:
+        return
+
+    # If WIREMOCK_URL is already set (e.g., by CI/CD pipeline), skip container management
+    existing_url = os.environ.get("WIREMOCK_URL")
+    if existing_url:
+        _WIREMOCK_URL = existing_url
+        _EXTERNAL = True
+        _STARTED = True
+        print(f"\nUsing external WireMock at {_WIREMOCK_URL} (container management skipped)")
         return
 
     print(f"\nStarting WireMock container (project: {_PROJECT_NAME})...")
@@ -65,6 +75,10 @@ def _start_wiremock() -> None:
 
 def _stop_wiremock() -> None:
     """Stops and removes the WireMock container."""
+    if _EXTERNAL:
+        # Container is managed externally; nothing to tear down.
+        return
+
     print("\nStopping WireMock container...")
     subprocess.run(
         ["docker", "compose", "-f", _COMPOSE_FILE, "-p", _PROJECT_NAME, "down", "-v"],

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/tests/conftest.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/tests/conftest.py
@@ -15,6 +15,7 @@ import subprocess
 import pytest
 
 _STARTED: bool = False
+_EXTERNAL: bool = False  # True when using an external WireMock instance (skip container lifecycle)
 _WIREMOCK_URL: str = "http://localhost:8080"  # Default, will be updated after container starts
 _PROJECT_NAME: str = "seed-api"
 
@@ -41,8 +42,17 @@ def _get_wiremock_port() -> str:
 
 def _start_wiremock() -> None:
     """Starts the WireMock container using docker-compose."""
-    global _STARTED, _WIREMOCK_URL
+    global _STARTED, _EXTERNAL, _WIREMOCK_URL
     if _STARTED:
+        return
+
+    # If WIREMOCK_URL is already set (e.g., by CI/CD pipeline), skip container management
+    existing_url = os.environ.get("WIREMOCK_URL")
+    if existing_url:
+        _WIREMOCK_URL = existing_url
+        _EXTERNAL = True
+        _STARTED = True
+        print(f"\nUsing external WireMock at {_WIREMOCK_URL} (container management skipped)")
         return
 
     print(f"\nStarting WireMock container (project: {_PROJECT_NAME})...")
@@ -65,6 +75,10 @@ def _start_wiremock() -> None:
 
 def _stop_wiremock() -> None:
     """Stops and removes the WireMock container."""
+    if _EXTERNAL:
+        # Container is managed externally; nothing to tear down.
+        return
+
     print("\nStopping WireMock container...")
     subprocess.run(
         ["docker", "compose", "-f", _COMPOSE_FILE, "-p", _PROJECT_NAME, "down", "-v"],

--- a/seed/python-sdk/server-sent-events/with-wire-tests/tests/conftest.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/tests/conftest.py
@@ -15,6 +15,7 @@ import subprocess
 import pytest
 
 _STARTED: bool = False
+_EXTERNAL: bool = False  # True when using an external WireMock instance (skip container lifecycle)
 _WIREMOCK_URL: str = "http://localhost:8080"  # Default, will be updated after container starts
 _PROJECT_NAME: str = "seed-server-sent-events"
 
@@ -41,8 +42,17 @@ def _get_wiremock_port() -> str:
 
 def _start_wiremock() -> None:
     """Starts the WireMock container using docker-compose."""
-    global _STARTED, _WIREMOCK_URL
+    global _STARTED, _EXTERNAL, _WIREMOCK_URL
     if _STARTED:
+        return
+
+    # If WIREMOCK_URL is already set (e.g., by CI/CD pipeline), skip container management
+    existing_url = os.environ.get("WIREMOCK_URL")
+    if existing_url:
+        _WIREMOCK_URL = existing_url
+        _EXTERNAL = True
+        _STARTED = True
+        print(f"\nUsing external WireMock at {_WIREMOCK_URL} (container management skipped)")
         return
 
     print(f"\nStarting WireMock container (project: {_PROJECT_NAME})...")
@@ -65,6 +75,10 @@ def _start_wiremock() -> None:
 
 def _stop_wiremock() -> None:
     """Stops and removes the WireMock container."""
+    if _EXTERNAL:
+        # Container is managed externally; nothing to tear down.
+        return
+
     print("\nStopping WireMock container...")
     subprocess.run(
         ["docker", "compose", "-f", _COMPOSE_FILE, "-p", _PROJECT_NAME, "down", "-v"],


### PR DESCRIPTION
## Description

The generated `tests/conftest.py` unconditionally starts a WireMock Docker container via `docker-compose`, which fails in CI/CD environments that provide an external WireMock sidecar (e.g., Azure DevOps pipelines) and don't support Docker-in-Docker.

The wire test fixtures (`tests/wire/conftest.py`) already read `WIREMOCK_URL` from the environment, but the container lifecycle plugin ignores it and always attempts Docker operations.

## Changes Made

- Modified `WireTestSetupGenerator.ts` (`buildPytestPluginContent`) to check for an existing `WIREMOCK_URL` env var at the start of `_start_wiremock()` — if set, skip container startup and use the external URL
- Added `_EXTERNAL` flag to also skip `_stop_wiremock()` teardown when using an external instance
- Updated 4 seed test snapshots to reflect the new generated output
- Added `5.0.3` changelog entry in `versions.yml`

This aligns the Python SDK with the PHP, Ruby, and Rust generators which already have this guard.

## Testing

- [x] `pnpm run check` (biome lint) passes
- [ ] Seed snapshot tests should be verified in CI to confirm generated output matches

## Reviewer Checklist

- Verify the template string escaping is correct (`\\n` in the TS template should produce `\n` in the generated Python)
- Confirm seed snapshots are consistent with what `buildPytestPluginContent` would actually emit (the 4 snapshot files should differ only by `_PROJECT_NAME`)

Link to Devin session: https://app.devin.ai/sessions/7f2a74480d5e4b2ab1937090bf7cf2b2
Requested by: @iamnamananand996