### PR TITLE
fix(ruby): strip zero-millisecond datetime values from WireMock stubs

### DIFF
--- a/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,6 +1,6 @@
 import { File } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { WireMock } from "@fern-api/mock-utils";
+import { WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
@@ -32,8 +32,46 @@ export class WireTestSetupGenerator {
         return new WireMock().convertToWireMock(ir);
     }
 
+    /**
+     * ISO 8601 datetime pattern that matches values with `.000` milliseconds.
+     * Example: "2008-01-02T00:00:00.000Z" or "2008-01-02T00:00:00.000+05:00"
+     */
+    private static readonly DATETIME_WITH_ZERO_MILLIS_REGEX =
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000(Z|[+-]\d{2}:\d{2})$/;
+
+    /**
+     * Strips ".000" milliseconds from all datetime query parameter values in WireMock stub mappings.
+     * Ruby's DateTime/Time ISO 8601 serialization omits zero fractional seconds, so the SDK
+     * sends e.g. "2024-09-08T12:00:00Z" while mock-utils generates "2024-09-08T12:00:00.000Z"
+     * (via Date.toISOString()). Since WireMock's equalTo matcher is exact-match, the stubs
+     * never fire unless we strip the zero milliseconds.
+     *
+     * Mutates the input in-place for efficiency.
+     */
+    private static stripDatetimeMilliseconds(stubMapping: WireMockStubMapping): void {
+        for (const mapping of stubMapping.mappings) {
+            if (mapping.request.queryParameters) {
+                for (const [, value] of Object.entries(mapping.request.queryParameters)) {
+                    const paramValue = value as { equalTo: string };
+                    if (
+                        paramValue.equalTo != null &&
+                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(paramValue.equalTo)
+                    ) {
+                        paramValue.equalTo = paramValue.equalTo.replace(".000", "");
+                    }
+                }
+            }
+        }
+    }
+
     private generateWireMockConfigFile(): void {
         const wireMockConfigContent = WireTestSetupGenerator.getWiremockConfigContent(this.ir);
+
+        // mock-utils generates datetime values using Date.toISOString() which always includes
+        // ".000Z" milliseconds. Ruby's DateTime/Time ISO 8601 serialization omits fractional
+        // seconds, so the SDK sends e.g. "2024-09-08T12:00:00Z". Strip the zero milliseconds
+        // from WireMock stubs so that equalTo exact-matching works correctly.
+        WireTestSetupGenerator.stripDatetimeMilliseconds(wireMockConfigContent);
 
         // Add OAuth token endpoint mapping if inferred auth is present
         const inferredAuth = this.context.getInferredAuth();

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.1.1
+  changelogEntry:
+    - summary: |
+        Strip zero-millisecond datetime values from WireMock stub query parameters.
+        Ruby's DateTime/Time ISO 8601 serialization omits zero fractional seconds
+        (e.g., `2024-09-08T12:00:00Z`), but mock-utils generates values with `.000Z`
+        (e.g., `2024-09-08T12:00:00.000Z`). WireMock's `equalTo` matcher is exact-match,
+        so the stubs never fired for datetime query parameters. This follows the same
+        pattern used by the Python and PHP generators.
+      type: fix
+  createdAt: "2026-03-17"
+  irVersion: 61
+
 - version: 1.1.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes WireMock datetime format mismatch causing 5 out of 235 Ruby SDK wire tests to fail. Affected tests: `BoardingProcessingAccountsWireTest` (terminal orders list) and `CardPaymentsRefundsWireTest` (refunds list, 4 instances).

## Root Cause

`mock-utils` generates datetime query parameter values using `Date.toISOString()` which always includes `.000Z` milliseconds (e.g., `2024-09-08T12:00:00.000Z`). Ruby's ISO 8601 serialization omits zero fractional seconds (`2024-09-08T12:00:00Z`). WireMock's `equalTo` matcher is exact-match, so the stubs never fire.

## Changes Made

- **`generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts`**: Added `stripDatetimeMilliseconds` static method that strips `.000` from datetime query parameter values in WireMock stubs after generation, following the same pattern used by the Python and PHP generators. No changes to the shared `mock-utils` package.
- **`generators/ruby-v2/sdk/versions.yml`**: Added version `1.1.1` changelog entry for this fix.

- [ ] Updated README.md generator (if applicable)

## Testing

- [x] Lint passes (`pnpm run check`)
- [x] All CI checks pass
- [ ] Ruby wire tests not run locally (require Docker + WireMock + actual SDK build)

## Human Review Checklist

- [ ] Verify the `stripDatetimeMilliseconds` regex correctly handles both `Z` and `+HH:MM` timezone offsets
- [ ] Confirm stripping is applied before the OAuth token endpoint mapping is appended (it is — but the OAuth mapping is a POST with no datetime query params, so ordering is safe regardless)
- [ ] Verify no Ruby SDK datetime query params legitimately need `.000` milliseconds preserved (Ruby's `DateTime#iso8601` / `Time#iso8601` omit zero fractional seconds by default)
- [ ] Note: the method only strips from `queryParameters`, not headers — confirm this matches the failing test scenarios (all 5 failures are on query params `fromDateTime` / `toDateTime`)

Link to Devin session: https://app.devin.ai/sessions/62b148bbfff041228f6d8d254ce9a032
Requested by: @iamnamananand996