### PR TITLE
fix(php): use `WIREMOCK_URL` env var in Wire test setUp method

### DIFF
--- a/generators/php/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestGenerator.ts
@@ -128,6 +128,7 @@ export class WireTestGenerator {
             parameters: [],
             body: php.codeblock((writer) => {
                 writer.writeTextStatement("parent::setUp()");
+                writer.writeTextStatement("$wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080'");
 
                 // Build auth parameters
                 const authParams = this.buildAuthParamsForTest();
@@ -174,7 +175,7 @@ export class WireTestGenerator {
                                     name: "Environments"
                                 })
                             );
-                            writer.write(`::custom(${envValues.map((value) => `'${value}'`).join(", ")}),`);
+                            writer.write(`::custom(${envValues.map(() => "$wiremockUrl").join(", ")}),`);
                             if (authParams.length === 0) {
                                 writer.write("\n");
                                 writer.dedent();
@@ -190,7 +191,7 @@ export class WireTestGenerator {
                     }
                     writer.writeLine("options: [");
                     writer.indent();
-                    writer.writeLine("'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',");
+                    writer.writeLine("'baseUrl' => $wiremockUrl,");
                     writer.dedent();
                     writer.write("]");
                     if (authParams.length === 0) {

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.2.1
+  changelogEntry:
+    - summary: |
+        Fix Wire test files to read `WIREMOCK_URL` environment variable instead of
+        hardcoding `http://localhost:8080`. The `setUp()` method now declares a
+        `$wiremockUrl` variable that reads from the environment with a fallback,
+        enabling tests to work with dynamically assigned Docker ports in local
+        development and CI/CD environments.
+      type: fix
+  createdAt: "2026-03-17"
+  irVersion: 62
+
 - version: 2.2.0
   changelogEntry:
     - summary: |

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsContainerWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsContainerWireTest.php
@@ -211,10 +211,11 @@ class EndpointsContainerWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsContentTypeWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsContentTypeWireTest.php
@@ -102,10 +102,11 @@ class EndpointsContentTypeWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsEnumWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsEnumWireTest.php
@@ -38,10 +38,11 @@ class EndpointsEnumWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsHttpMethodsWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsHttpMethodsWireTest.php
@@ -151,10 +151,11 @@ class EndpointsHttpMethodsWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsObjectWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsObjectWireTest.php
@@ -379,10 +379,11 @@ class EndpointsObjectWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsPaginationWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsPaginationWireTest.php
@@ -44,10 +44,11 @@ class EndpointsPaginationWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsParamsWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsParamsWireTest.php
@@ -222,10 +222,11 @@ class EndpointsParamsWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsPrimitiveWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsPrimitiveWireTest.php
@@ -206,10 +206,11 @@ class EndpointsPrimitiveWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsPutWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsPutWireTest.php
@@ -37,10 +37,11 @@ class EndpointsPutWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsUnionWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsUnionWireTest.php
@@ -42,10 +42,11 @@ class EndpointsUnionWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsUrlsWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsUrlsWireTest.php
@@ -96,10 +96,11 @@ class EndpointsUrlsWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/InlinedRequestsWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/InlinedRequestsWireTest.php
@@ -65,10 +65,11 @@ class InlinedRequestsWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/NoAuthWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/NoAuthWireTest.php
@@ -39,10 +39,11 @@ class NoAuthWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/NoReqBodyWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/NoReqBodyWireTest.php
@@ -56,10 +56,11 @@ class NoReqBodyWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/ReqWithHeadersWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/ReqWithHeadersWireTest.php
@@ -42,10 +42,11 @@ class ReqWithHeadersWireTest extends WireMockTestCase
      */
     protected function setUp(): void {
         parent::setUp();
+        $wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080';
         $this->client = new SeedClient(
             token: 'test-token',
         options: [
-            'baseUrl' => getenv('WIREMOCK_URL') ?: 'http://localhost:8080',
+            'baseUrl' => $wiremockUrl,
         ],
         );
     }


### PR DESCRIPTION
## Description

Fixes PHP SDK Wire test files hardcoding `http://localhost:8080` for the WireMock URL instead of reading from the `WIREMOCK_URL` environment variable. This prevented tests from working with dynamically assigned Docker ports in local development and CI/CD environments.

## Changes Made

- Added `$wiremockUrl = getenv('WIREMOCK_URL') ?: 'http://localhost:8080'` variable declaration at the top of the generated `setUp()` method
- **Multi-URL environment path** (the actual bug): Changed `Environments::custom('http://localhost:8080', 'http://localhost:8080')` to `Environments::custom($wiremockUrl, $wiremockUrl)`
- **Single-URL environment path** (refactor): Changed inline `getenv('WIREMOCK_URL') ?: 'http://localhost:8080'` to use the shared `$wiremockUrl` variable
- Added version `2.2.1` entry in `generators/php/sdk/versions.yml`
- Updated all 15 seed snapshot files in `seed/php-sdk/exhaustive/wire-tests/`

## Review Checklist

- [ ] Verify `getMultiUrlEnvironmentForTest()` — its return values are now effectively ignored (only the count of URLs matters for determining the number of `$wiremockUrl` args in `Environments::custom()`). This is intentional but worth confirming.
- [ ] No seed fixture currently exercises the **multi-URL environment** code path, which is the path that was actually broken. The single-URL path already worked. The fix is straightforward but untested in seeds.

## Testing

- [x] Seed tests regenerated and passing (`php-sdk` / `exhaustive` / `wire-tests`)
- [x] Lint (`pnpm run check`) passing

Link to Devin session: https://app.devin.ai/sessions/7681b11c333f4ede905a09ca0a8e40cc
Requested by: @iamnamananand996