### PR TITLE
chore(changelog): Improve TypeScript SDK 3.56.0 changelog with naming config samples

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -112,11 +112,42 @@
 - version: 3.56.0
   changelogEntry:
     - summary: |
-        Add a `naming` configuration object that allows users to independently control the
-        namespace export and PascalCase class/type names (client, error, timeout error,
-        environment, environment URLs, version). When individual overrides are not provided,
-        they are derived from the namespace value using the existing `${PascalCase(namespace)}Suffix`
-        pattern. The existing `namespaceExport` config continues to work for backwards compatibility.
+        Add a `naming` configuration object that gives you fine-grained control over the
+        exported namespace and generated class names (client, error, timeout error,
+        environment, environment URLs, version).
+
+        You can use it as a simple string shorthand to set the namespace:
+        ```yaml
+        # generators.yml
+        groups:
+          ts-sdk:
+            generators:
+              - name: fernapi/fern-typescript-node-sdk
+                config:
+                  naming: acme
+        ```
+
+        Or as a full object to override individual names:
+        ```yaml
+        # generators.yml
+        groups:
+          ts-sdk:
+            generators:
+              - name: fernapi/fern-typescript-node-sdk
+                config:
+                  naming:
+                    namespace: acme
+                    client: AcmeApiClient
+                    error: AcmeApiError
+                    environment: AcmeRegion
+        ```
+
+        When individual overrides are not provided, they are derived from the namespace
+        using the `PascalCase(namespace) + Suffix` pattern (e.g. `namespace: acme` produces
+        `AcmeClient`, `AcmeError`, `AcmeTimeoutError`, `AcmeEnvironment`, `AcmeEnvironmentUrls`,
+        and `AcmeVersion` by default).
+
+        The existing `namespaceExport` config continues to work for backwards compatibility.
       type: feat
   createdAt: "2026-03-13"
   irVersion: 65


### PR DESCRIPTION
## Description

Improves the TypeScript SDK v3.56.0 changelog entry for the `naming` configuration feature by replacing the dense paragraph with actionable code samples.

## Changes Made

- Rewrote the 3.56.0 changelog summary in `generators/typescript/sdk/versions.yml` to include:
  - A YAML example of the **string shorthand** form (`naming: acme`)
  - A YAML example of the **full object** form with individual overrides (`namespace`, `client`, `error`, `environment`)
  - An explicit list of the default derived names (`AcmeClient`, `AcmeError`, etc.)

No functional code changes — changelog text only.

## Human Review Checklist

- [ ] **Verify generator name**: The examples use `fernapi/fern-typescript-node-sdk` — confirm this is the correct name users should reference in `generators.yml` (other entries in the file use `fernapi/fern-typescript-sdk`)
- [ ] Confirm the listed default suffixes (`AcmeClient`, `AcmeError`, `AcmeTimeoutError`, `AcmeEnvironment`, `AcmeEnvironmentUrls`, `AcmeVersion`) match the actual `resolveNaming()` behavior
- [ ] Verify YAML indentation renders correctly in the published changelog

## Testing

- No functional changes; no tests needed

Link to Devin session: https://app.devin.ai/sessions/2800abefce964a0e8cb370f9f364ac0a
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
