### PR TITLE
fix(typescript): hide Customizing Fetch Client README section when allowCustomFetcher is false

### DIFF
--- a/generators/typescript/sdk/features.yml
+++ b/generators/typescript/sdk/features.yml
@@ -184,7 +184,9 @@ features:
       - Bun 1.0+
       - React Native
 
+      <% if (allowCustomFetcher) { %>
       ### Customizing Fetch Client
 
       The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
       unsupported environment, this provides a way for you to break glass and ensure the SDK works.
+      <% } %>

--- a/generators/typescript/sdk/features.yml
+++ b/generators/typescript/sdk/features.yml
@@ -166,6 +166,12 @@ features:
       benefiting from SDK-level configuration like authentication, retries, timeouts, and logging.
       This is useful for calling API endpoints not yet supported in the SDK.
 
+  - id: CUSTOM_FETCHER
+    advanced: true
+    description: |
+      The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
+      unsupported environment, this provides a way for you to break glass and ensure the SDK works.
+
   - id: RUNTIME_COMPATIBILITY
     advanced: true
     description: |
@@ -183,10 +189,3 @@ features:
       - Deno v1.25+
       - Bun 1.0+
       - React Native
-
-      <% if (allowCustomFetcher) { %>
-      ### Customizing Fetch Client
-
-      The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-      unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-      <% } %>

--- a/generators/typescript/sdk/generator/src/SdkGenerator.ts
+++ b/generators/typescript/sdk/generator/src/SdkGenerator.ts
@@ -560,6 +560,7 @@ export class SdkGenerator {
                 endpointSnippets: this.endpointSnippets,
                 fileResponseType: config.fileResponseType,
                 fetchSupport: config.fetchSupport,
+                allowCustomFetcher: config.allowCustomFetcher,
                 generateSubpackageExports: config.generateSubpackageExports
             }),
             ir: intermediateRepresentation

--- a/generators/typescript/sdk/generator/src/__test__/ReadmeConfigBuilder.test.ts
+++ b/generators/typescript/sdk/generator/src/__test__/ReadmeConfigBuilder.test.ts
@@ -203,6 +203,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -239,6 +240,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -279,6 +281,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -310,6 +313,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -335,6 +339,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -368,6 +373,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -393,6 +399,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -430,6 +437,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -461,6 +469,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -492,6 +501,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "node-fetch",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -523,6 +533,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -573,6 +584,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -602,6 +614,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -636,6 +649,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 
@@ -679,6 +693,7 @@ describe("ReadmeConfigBuilder", () => {
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
                 fetchSupport: "native",
+                allowCustomFetcher: false,
                 generateSubpackageExports: false
             });
 

--- a/generators/typescript/sdk/generator/src/__test__/ReadmeSnippetBuilder.test.ts
+++ b/generators/typescript/sdk/generator/src/__test__/ReadmeSnippetBuilder.test.ts
@@ -173,6 +173,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -201,6 +202,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -225,6 +227,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -248,6 +251,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -275,6 +279,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -306,6 +311,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -334,6 +340,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -360,6 +367,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -387,6 +395,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -400,7 +409,7 @@ describe("ReadmeSnippetBuilder", () => {
 
     // ── Runtime compatibility ──────────────────────────────────────────
     describe("runtime compatibility snippets", () => {
-        it("generates custom fetcher snippet", () => {
+        it("generates custom fetcher snippet when allowCustomFetcher is true", () => {
             const endpoint = createEndpoint("ep1", "createUser");
             const service = createService("svc1", createFernFilepath([]), [endpoint]);
             const endpointSnippet = createEndpointSnippet("ep1", "POST", "await client.createUser();");
@@ -413,6 +422,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -422,6 +432,29 @@ describe("ReadmeSnippetBuilder", () => {
             expect(runtimeSnippets).toHaveLength(1);
             expect(runtimeSnippets[0]).toContain("fetcher:");
             expect(runtimeSnippets[0]).toContain("provide your implementation here");
+        });
+
+        it("returns empty runtime compatibility snippets when allowCustomFetcher is false", () => {
+            const endpoint = createEndpoint("ep1", "createUser");
+            const service = createService("svc1", createFernFilepath([]), [endpoint]);
+            const endpointSnippet = createEndpointSnippet("ep1", "POST", "await client.createUser();");
+
+            const context = createMockSdkContext({
+                services: { svc1: service },
+                packageName: "@acme/sdk"
+            });
+            const builder = new ReadmeSnippetBuilder({
+                context,
+                endpointSnippets: [endpointSnippet],
+                fileResponseType: "stream",
+                allowCustomFetcher: false,
+                generateSubpackageExports: false
+            });
+
+            const snippets = builder.buildReadmeSnippets();
+            const runtimeSnippets = snippets.RUNTIME_COMPATIBILITY;
+            assert(Array.isArray(runtimeSnippets));
+            expect(runtimeSnippets).toHaveLength(0);
         });
     });
 
@@ -440,6 +473,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -475,6 +509,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -506,6 +541,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -548,6 +584,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -584,6 +621,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -607,6 +645,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -644,6 +683,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -668,6 +708,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -707,6 +748,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: true
             });
 
@@ -747,6 +789,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -783,6 +826,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: true
             });
 
@@ -813,6 +857,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -866,6 +911,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -889,6 +935,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -961,6 +1008,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1016,6 +1064,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1056,6 +1105,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1076,6 +1126,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1099,6 +1150,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1122,6 +1174,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1144,6 +1197,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1182,6 +1236,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [snippet1, snippet2],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1206,6 +1261,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [snippetGet, snippetPost],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1247,6 +1303,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [snippet1, snippet2],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1284,6 +1341,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [snippet1, snippet2],
                 fileResponseType: "stream",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 

--- a/generators/typescript/sdk/generator/src/__test__/ReadmeSnippetBuilder.test.ts
+++ b/generators/typescript/sdk/generator/src/__test__/ReadmeSnippetBuilder.test.ts
@@ -407,8 +407,8 @@ describe("ReadmeSnippetBuilder", () => {
         });
     });
 
-    // ── Runtime compatibility ──────────────────────────────────────────
-    describe("runtime compatibility snippets", () => {
+    // ── Custom fetcher ──────────────────────────────────────────────────
+    describe("custom fetcher snippets", () => {
         it("generates custom fetcher snippet when allowCustomFetcher is true", () => {
             const endpoint = createEndpoint("ep1", "createUser");
             const service = createService("svc1", createFernFilepath([]), [endpoint]);
@@ -427,14 +427,14 @@ describe("ReadmeSnippetBuilder", () => {
             });
 
             const snippets = builder.buildReadmeSnippets();
-            const runtimeSnippets = snippets.RUNTIME_COMPATIBILITY;
-            assert(Array.isArray(runtimeSnippets));
-            expect(runtimeSnippets).toHaveLength(1);
-            expect(runtimeSnippets[0]).toContain("fetcher:");
-            expect(runtimeSnippets[0]).toContain("provide your implementation here");
+            const fetcherSnippets = snippets.CUSTOM_FETCHER;
+            assert(Array.isArray(fetcherSnippets));
+            expect(fetcherSnippets).toHaveLength(1);
+            expect(fetcherSnippets[0]).toContain("fetcher:");
+            expect(fetcherSnippets[0]).toContain("provide your implementation here");
         });
 
-        it("returns empty runtime compatibility snippets when allowCustomFetcher is false", () => {
+        it("returns false for custom fetcher snippets when allowCustomFetcher is false", () => {
             const endpoint = createEndpoint("ep1", "createUser");
             const service = createService("svc1", createFernFilepath([]), [endpoint]);
             const endpointSnippet = createEndpointSnippet("ep1", "POST", "await client.createUser();");
@@ -452,9 +452,7 @@ describe("ReadmeSnippetBuilder", () => {
             });
 
             const snippets = builder.buildReadmeSnippets();
-            const runtimeSnippets = snippets.RUNTIME_COMPATIBILITY;
-            assert(Array.isArray(runtimeSnippets));
-            expect(runtimeSnippets).toHaveLength(0);
+            expect(snippets.CUSTOM_FETCHER).toBe(false);
         });
     });
 
@@ -971,6 +969,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "binary-response",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1031,6 +1030,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [endpointSnippet],
                 fileResponseType: "binary-response",
+                allowCustomFetcher: true,
                 generateSubpackageExports: false
             });
 
@@ -1420,6 +1420,7 @@ describe("ReadmeSnippetBuilder", () => {
                 context,
                 endpointSnippets: [snippet1, snippet2, snippet3],
                 fileResponseType: "binary-response",
+                allowCustomFetcher: true,
                 generateSubpackageExports: true
             });
 

--- a/generators/typescript/sdk/generator/src/__test__/__snapshots__/ReadmeConfigBuilder.test.ts.snap
+++ b/generators/typescript/sdk/generator/src/__test__/__snapshots__/ReadmeConfigBuilder.test.ts.snap
@@ -92,7 +92,7 @@ const client = new MySDKClient({
       "description": undefined,
       "id": "RUNTIME_COMPATIBILITY",
       "snippets": [],
-      "snippetsAreOptional": false,
+      "snippetsAreOptional": true,
     },
   ],
   "introduction": "Welcome to Acme SDK",

--- a/generators/typescript/sdk/generator/src/__test__/__snapshots__/ReadmeConfigBuilder.test.ts.snap
+++ b/generators/typescript/sdk/generator/src/__test__/__snapshots__/ReadmeConfigBuilder.test.ts.snap
@@ -91,15 +91,7 @@ const client = new MySDKClient({
       "advanced": false,
       "description": undefined,
       "id": "RUNTIME_COMPATIBILITY",
-      "snippets": [
-        "import { MySDKClient } from "@acme/sdk";
-
-const client = new MySDKClient({
-    ...
-    fetcher: // provide your implementation here
-});
-",
-      ],
+      "snippets": [],
       "snippetsAreOptional": false,
     },
   ],

--- a/generators/typescript/sdk/generator/src/__test__/__snapshots__/ReadmeSnippetBuilder.test.ts.snap
+++ b/generators/typescript/sdk/generator/src/__test__/__snapshots__/ReadmeSnippetBuilder.test.ts.snap
@@ -100,15 +100,7 @@ const request: AcmeSdk.CreateUserRequest = {
 });
 ",
   ],
-  "RUNTIME_COMPATIBILITY": [
-    "import { MySDKClient } from "@acme/sdk";
-
-const client = new MySDKClient({
-    ...
-    fetcher: // provide your implementation here
-});
-",
-  ],
+  "RUNTIME_COMPATIBILITY": [],
   "STREAMING_RESPONSE": [
     "const stream = await client.streamEvents();",
   ],

--- a/generators/typescript/sdk/generator/src/__test__/__snapshots__/ReadmeSnippetBuilder.test.ts.snap
+++ b/generators/typescript/sdk/generator/src/__test__/__snapshots__/ReadmeSnippetBuilder.test.ts.snap
@@ -54,6 +54,15 @@ const response = await client.createUser(..., {
 const data = await response.json();
 ",
   ],
+  "CUSTOM_FETCHER": [
+    "import { MySDKClient } from "@acme/sdk";
+
+const client = new MySDKClient({
+    ...
+    fetcher: // provide your implementation here
+});
+",
+  ],
   "EXCEPTION_HANDLING": [
     "import { MySDKError } from "@acme/sdk";
 

--- a/generators/typescript/sdk/generator/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/typescript/sdk/generator/src/readme/ReadmeConfigBuilder.ts
@@ -133,8 +133,7 @@ export class ReadmeConfigBuilder {
 
     private getTemplateVariables(): Record<string, unknown> {
         return {
-            fetchSupport: this.fetchSupport,
-            allowCustomFetcher: this.allowCustomFetcher
+            fetchSupport: this.fetchSupport
         };
     }
 }

--- a/generators/typescript/sdk/generator/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/typescript/sdk/generator/src/readme/ReadmeConfigBuilder.ts
@@ -14,22 +14,26 @@ export class ReadmeConfigBuilder {
     private readonly endpointSnippets: FernGeneratorExec.Endpoint[];
     private readonly fileResponseType: "stream" | "binary-response";
     private readonly fetchSupport: "node-fetch" | "native";
+    private readonly allowCustomFetcher: boolean;
     private readonly generateSubpackageExports: boolean;
 
     constructor({
         endpointSnippets,
         fileResponseType,
         fetchSupport,
+        allowCustomFetcher,
         generateSubpackageExports
     }: {
         endpointSnippets: FernGeneratorExec.Endpoint[];
         fileResponseType: "stream" | "binary-response";
         fetchSupport: "node-fetch" | "native";
+        allowCustomFetcher: boolean;
         generateSubpackageExports: boolean;
     }) {
         this.endpointSnippets = endpointSnippets;
         this.fileResponseType = fileResponseType;
         this.fetchSupport = fetchSupport;
+        this.allowCustomFetcher = allowCustomFetcher;
         this.generateSubpackageExports = generateSubpackageExports;
     }
 
@@ -46,6 +50,7 @@ export class ReadmeConfigBuilder {
             context,
             endpointSnippets: this.endpointSnippets,
             fileResponseType: this.fileResponseType,
+            allowCustomFetcher: this.allowCustomFetcher,
             generateSubpackageExports: this.generateSubpackageExports
         });
         const snippets = readmeSnippetBuilder.buildReadmeSnippets();
@@ -128,7 +133,8 @@ export class ReadmeConfigBuilder {
 
     private getTemplateVariables(): Record<string, unknown> {
         return {
-            fetchSupport: this.fetchSupport
+            fetchSupport: this.fetchSupport,
+            allowCustomFetcher: this.allowCustomFetcher
         };
     }
 }

--- a/generators/typescript/sdk/generator/src/readme/ReadmeConfigBuilder.ts
+++ b/generators/typescript/sdk/generator/src/readme/ReadmeConfigBuilder.ts
@@ -86,13 +86,16 @@ export class ReadmeConfigBuilder {
                 description = authenticationDescription;
             }
 
+            // Features with description-only content (no code snippets) should still be rendered
+            const isDescriptionOnlyFeature = feature.id === "RUNTIME_COMPATIBILITY";
+
             features.push({
                 id: feature.id,
                 advanced: feature.advanced,
                 description,
                 snippets: snippetForFeature === false ? [] : (snippetForFeature ?? []),
                 addendum: feature.addendum ? this.processTemplateText(feature.addendum) : undefined,
-                snippetsAreOptional: isAuthenticationWithDescription
+                snippetsAreOptional: isAuthenticationWithDescription || isDescriptionOnlyFeature
             });
         }
         return {

--- a/generators/typescript/sdk/generator/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/typescript/sdk/generator/src/readme/ReadmeSnippetBuilder.ts
@@ -38,6 +38,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     public static readonly STREAMING_RESPONSE_FEATURE_ID: FernGeneratorCli.FeatureId = "STREAMING_RESPONSE";
     public static readonly LOGGING_FEATURE_ID: FernGeneratorCli.FeatureId = "LOGGING";
     private static readonly CUSTOM_FETCH_FEATURE_ID: FernGeneratorCli.FeatureId = "CUSTOM_FETCH";
+    private static readonly CUSTOM_FETCHER_FEATURE_ID: FernGeneratorCli.FeatureId = "CUSTOM_FETCHER";
 
     private readonly context: SdkContext;
     private readonly isPaginationEnabled: boolean;
@@ -103,6 +104,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             this.buildAdditionalQueryStringParametersSnippets();
         snippets[ReadmeSnippetBuilder.LOGGING_FEATURE_ID] = this.buildLoggingSnippets();
         snippets[ReadmeSnippetBuilder.CUSTOM_FETCH_FEATURE_ID] = this.buildCustomFetchSnippets();
+        snippets[ReadmeSnippetBuilder.CUSTOM_FETCHER_FEATURE_ID] = this.buildCustomFetcherSnippets();
 
         if (this.isPaginationEnabled) {
             const paginationSnippets = this.buildPaginationSnippets();
@@ -544,9 +546,9 @@ const data = await response.json();
         );
     }
 
-    private buildRuntimeCompatibilitySnippets(): string[] {
+    private buildCustomFetcherSnippets(): string[] | false {
         if (!this.allowCustomFetcher) {
-            return [];
+            return false;
         }
         const snippet = this.writeCode(
             code`
@@ -559,6 +561,10 @@ const ${this.clientVariableName} = new ${this.rootClientConstructorName}({
 `
         );
         return [snippet];
+    }
+
+    private buildRuntimeCompatibilitySnippets(): string[] {
+        return [];
     }
 
     private getEndpointsForFeature(featureId: FernIr.FeatureId): EndpointWithFilepath[] {

--- a/generators/typescript/sdk/generator/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/typescript/sdk/generator/src/readme/ReadmeSnippetBuilder.ts
@@ -41,6 +41,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
 
     private readonly context: SdkContext;
     private readonly isPaginationEnabled: boolean;
+    private readonly allowCustomFetcher: boolean;
     private readonly generateSubpackageExports: boolean;
     private readonly endpoints: Record<FernIr.EndpointId, EndpointWithFilepath> = {};
     private readonly snippets: Record<FernIr.EndpointId, string> = {};
@@ -55,17 +56,20 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         context,
         endpointSnippets,
         fileResponseType,
+        allowCustomFetcher,
         generateSubpackageExports
     }: {
         context: SdkContext;
         endpointSnippets: FernGeneratorExec.Endpoint[];
         fileResponseType: "stream" | "binary-response";
+        allowCustomFetcher: boolean;
         generateSubpackageExports: boolean;
     }) {
         super({ endpointSnippets });
         this.context = context;
         this.fileResponseType = fileResponseType;
         this.isPaginationEnabled = context.config.generatePaginatedClients ?? false;
+        this.allowCustomFetcher = allowCustomFetcher;
         this.generateSubpackageExports = generateSubpackageExports;
 
         this.endpoints = this.buildEndpoints();
@@ -541,6 +545,9 @@ const data = await response.json();
     }
 
     private buildRuntimeCompatibilitySnippets(): string[] {
+        if (!this.allowCustomFetcher) {
+            return [];
+        }
         const snippet = this.writeCode(
             code`
 import { ${this.rootClientConstructorName} } from "${this.rootPackageName}";

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.59.1
+  changelogEntry:
+    - summary: |
+        Fix generated README.md including the "Customizing Fetch Client" section
+        under "Runtime Compatibility" even when `allowCustomFetcher` is `false`.
+        The section and its code snippet are now conditionally omitted when the
+        custom fetcher option is disabled.
+      type: fix
+  createdAt: "2026-03-17"
+  irVersion: 65
+
 - version: 3.59.0
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/accept-header/README.md
+++ b/seed/ts-sdk/accept-header/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/accept-header/README.md
+++ b/seed/ts-sdk/accept-header/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedAcceptClient } from "@fern/accept-header";
-
-const client = new SeedAcceptClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/alias-extends/README.md
+++ b/seed/ts-sdk/alias-extends/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -251,34 +250,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedAliasExtendsClient } from "@fern/alias-extends";
-
-const client = new SeedAliasExtendsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/alias-extends/README.md
+++ b/seed/ts-sdk/alias-extends/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -251,6 +252,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/alias/README.md
+++ b/seed/ts-sdk/alias/README.md
@@ -20,7 +20,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -234,34 +233,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedAliasClient } from "@fern/alias";
-
-const client = new SeedAliasClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/alias/README.md
+++ b/seed/ts-sdk/alias/README.md
@@ -20,6 +20,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -234,6 +235,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/README.md
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -294,6 +295,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/README.md
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -294,34 +293,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedAnyAuthClient } from "@fern/any-auth";
-
-const client = new SeedAnyAuthClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/any-auth/no-custom-config/README.md
+++ b/seed/ts-sdk/any-auth/no-custom-config/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -294,6 +295,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/any-auth/no-custom-config/README.md
+++ b/seed/ts-sdk/any-auth/no-custom-config/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -294,34 +293,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedAnyAuthClient } from "@fern/any-auth";
-
-const client = new SeedAnyAuthClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/api-wide-base-path/README.md
+++ b/seed/ts-sdk/api-wide-base-path/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiWideBasePathClient } from "@fern/api-wide-base-path";
-
-const client = new SeedApiWideBasePathClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/api-wide-base-path/README.md
+++ b/seed/ts-sdk/api-wide-base-path/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/audiences/no-custom-config/README.md
+++ b/seed/ts-sdk/audiences/no-custom-config/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -263,6 +264,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/audiences/no-custom-config/README.md
+++ b/seed/ts-sdk/audiences/no-custom-config/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -263,34 +262,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedAudiencesClient } from "@fern/audiences";
-
-const client = new SeedAudiencesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/audiences/with-partner-audience/README.md
+++ b/seed/ts-sdk/audiences/with-partner-audience/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/audiences/with-partner-audience/README.md
+++ b/seed/ts-sdk/audiences/with-partner-audience/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedAudiencesClient } from "@fern/audiences";
-
-const client = new SeedAudiencesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/basic-auth-environment-variables/README.md
+++ b/seed/ts-sdk/basic-auth-environment-variables/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,6 +248,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/basic-auth-environment-variables/README.md
+++ b/seed/ts-sdk/basic-auth-environment-variables/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,34 +246,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedBasicAuthEnvironmentVariablesClient } from "@fern/basic-auth-environment-variables";
-
-const client = new SeedBasicAuthEnvironmentVariablesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/basic-auth/README.md
+++ b/seed/ts-sdk/basic-auth/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,6 +248,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/basic-auth/README.md
+++ b/seed/ts-sdk/basic-auth/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,34 +246,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedBasicAuthClient } from "@fern/basic-auth";
-
-const client = new SeedBasicAuthClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/bearer-token-environment-variable/README.md
+++ b/seed/ts-sdk/bearer-token-environment-variable/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedBearerTokenEnvironmentVariableClient } from "@fern/bearer-token-environment-variable";
-
-const client = new SeedBearerTokenEnvironmentVariableClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/bearer-token-environment-variable/README.md
+++ b/seed/ts-sdk/bearer-token-environment-variable/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/bytes-download/README.md
+++ b/seed/ts-sdk/bytes-download/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -635,6 +636,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/bytes-download/README.md
+++ b/seed/ts-sdk/bytes-download/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -635,34 +634,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedBytesDownloadClient } from "@fern/bytes-download";
-
-const client = new SeedBytesDownloadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/bytes-upload/README.md
+++ b/seed/ts-sdk/bytes-upload/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -292,34 +291,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedBytesUploadClient } from "@fern/bytes-upload";
-
-const client = new SeedBytesUploadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/bytes-upload/README.md
+++ b/seed/ts-sdk/bytes-upload/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -292,6 +293,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/client-side-params/README.md
+++ b/seed/ts-sdk/client-side-params/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -268,6 +269,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/client-side-params/README.md
+++ b/seed/ts-sdk/client-side-params/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -268,34 +267,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedClientSideParamsClient } from "@fern/client-side-params";
-
-const client = new SeedClientSideParamsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/content-type/README.md
+++ b/seed/ts-sdk/content-type/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedContentTypesClient } from "@fern/content-type";
-
-const client = new SeedContentTypesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/content-type/README.md
+++ b/seed/ts-sdk/content-type/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/README.md
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -263,6 +264,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/README.md
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -263,34 +262,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedCrossPackageTypeNamesClient } from "@fern/cross-package-type-names";
-
-const client = new SeedCrossPackageTypeNamesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/README.md
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -263,6 +264,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/README.md
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -263,34 +262,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedCrossPackageTypeNamesClient } from "@fern/cross-package-type-names";
-
-const client = new SeedCrossPackageTypeNamesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/endpoint-security-auth/README.md
+++ b/seed/ts-sdk/endpoint-security-auth/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -294,6 +295,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/endpoint-security-auth/README.md
+++ b/seed/ts-sdk/endpoint-security-auth/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -294,34 +293,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedEndpointSecurityAuthClient } from "@fern/endpoint-security-auth";
-
-const client = new SeedEndpointSecurityAuthClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/README.md
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedEnumClient } from "@fern/enum";
-
-const client = new SeedEnumClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/README.md
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/enum/forward-compatible-enums/README.md
+++ b/seed/ts-sdk/enum/forward-compatible-enums/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedEnumClient } from "@fern/enum";
-
-const client = new SeedEnumClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/enum/forward-compatible-enums/README.md
+++ b/seed/ts-sdk/enum/forward-compatible-enums/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/enum/no-custom-config/README.md
+++ b/seed/ts-sdk/enum/no-custom-config/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedEnumClient } from "@fern/enum";
-
-const client = new SeedEnumClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/enum/no-custom-config/README.md
+++ b/seed/ts-sdk/enum/no-custom-config/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/enum/serde/README.md
+++ b/seed/ts-sdk/enum/serde/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedEnumClient } from "@fern/enum";
-
-const client = new SeedEnumClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/enum/serde/README.md
+++ b/seed/ts-sdk/enum/serde/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/error-property/no-custom-config/README.md
+++ b/seed/ts-sdk/error-property/no-custom-config/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/error-property/no-custom-config/README.md
+++ b/seed/ts-sdk/error-property/no-custom-config/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedErrorPropertyClient } from "@fern/error-property";
-
-const client = new SeedErrorPropertyClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/error-property/union-utils/README.md
+++ b/seed/ts-sdk/error-property/union-utils/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/error-property/union-utils/README.md
+++ b/seed/ts-sdk/error-property/union-utils/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedErrorPropertyClient } from "@fern/error-property";
-
-const client = new SeedErrorPropertyClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/errors/README.md
+++ b/seed/ts-sdk/errors/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,6 +248,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/errors/README.md
+++ b/seed/ts-sdk/errors/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,34 +246,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedErrorsClient } from "@fern/errors";
-
-const client = new SeedErrorsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/examples/examples-with-api-reference/README.md
+++ b/seed/ts-sdk/examples/examples-with-api-reference/README.md
@@ -28,6 +28,7 @@ The CustomName TypeScript library provides convenient access to the CustomName A
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 
 ## Documentation
 
@@ -307,4 +308,19 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 

--- a/seed/ts-sdk/examples/examples-with-api-reference/README.md
+++ b/seed/ts-sdk/examples/examples-with-api-reference/README.md
@@ -28,7 +28,6 @@ The CustomName TypeScript library provides convenient access to the CustomName A
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 
 ## Documentation
 
@@ -307,33 +306,5 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExamplesClient } from "@fern/examples";
-
-const client = new SeedExamplesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 

--- a/seed/ts-sdk/examples/retain-original-casing/README.md
+++ b/seed/ts-sdk/examples/retain-original-casing/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,34 +258,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExamplesClient } from "@fern/examples";
-
-const client = new SeedExamplesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/examples/retain-original-casing/README.md
+++ b/seed/ts-sdk/examples/retain-original-casing/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,6 +260,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/README.md
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/README.md
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/README.md
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/README.md
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/bigint/README.md
+++ b/seed/ts-sdk/exhaustive/bigint/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/bigint/README.md
+++ b/seed/ts-sdk/exhaustive/bigint/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/README.md
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/README.md
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/README.md
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/README.md
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/local-files-no-source/README.md
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Reference
@@ -327,6 +328,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/local-files-no-source/README.md
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Reference
@@ -327,34 +326,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "SeedExhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/multiple-exports/README.md
+++ b/seed/ts-sdk/exhaustive/multiple-exports/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/multiple-exports/README.md
+++ b/seed/ts-sdk/exhaustive/multiple-exports/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/never-throw-errors/README.md
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/never-throw-errors/README.md
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/no-custom-config/README.md
+++ b/seed/ts-sdk/exhaustive/no-custom-config/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/README.md
+++ b/seed/ts-sdk/exhaustive/no-custom-config/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/node-fetch/README.md
+++ b/seed/ts-sdk/exhaustive/node-fetch/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,22 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK defaults to `node-fetch` but will use the global fetch client if present. The SDK works in the following
+runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/node-fetch/README.md
+++ b/seed/ts-sdk/exhaustive/node-fetch/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,35 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK defaults to `node-fetch` but will use the global fetch client if present. The SDK works in the following
-runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/package-path/README.md
+++ b/seed/ts-sdk/exhaustive/package-path/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/package-path/README.md
+++ b/seed/ts-sdk/exhaustive/package-path/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/README.md
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/README.md
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/README.md
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/README.md
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/README.md
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/README.md
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/README.md
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/README.md
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/retain-original-casing/README.md
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/README.md
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/serde-layer/README.md
+++ b/seed/ts-sdk/exhaustive/serde-layer/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/serde-layer/README.md
+++ b/seed/ts-sdk/exhaustive/serde-layer/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/use-jest/README.md
+++ b/seed/ts-sdk/exhaustive/use-jest/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/use-jest/README.md
+++ b/seed/ts-sdk/exhaustive/use-jest/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/README.md
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/README.md
@@ -24,6 +24,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/README.md
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/README.md
@@ -24,7 +24,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExhaustiveClient } from "@fern/exhaustive";
-
-const client = new SeedExhaustiveClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/extends/README.md
+++ b/seed/ts-sdk/extends/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -252,34 +251,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExtendsClient } from "@fern/extends";
-
-const client = new SeedExtendsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/extends/README.md
+++ b/seed/ts-sdk/extends/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -252,6 +253,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/extra-properties/README.md
+++ b/seed/ts-sdk/extra-properties/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -263,6 +264,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/extra-properties/README.md
+++ b/seed/ts-sdk/extra-properties/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -263,34 +262,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedExtraPropertiesClient } from "@fern/extra-properties";
-
-const client = new SeedExtraPropertiesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-download/file-download-response-headers/README.md
+++ b/seed/ts-sdk/file-download/file-download-response-headers/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -635,6 +636,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/file-download/file-download-response-headers/README.md
+++ b/seed/ts-sdk/file-download/file-download-response-headers/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -635,34 +634,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedFileDownloadClient } from "@fern/file-download";
-
-const client = new SeedFileDownloadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-download/no-custom-config/README.md
+++ b/seed/ts-sdk/file-download/no-custom-config/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -635,6 +636,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/file-download/no-custom-config/README.md
+++ b/seed/ts-sdk/file-download/no-custom-config/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -635,34 +634,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedFileDownloadClient } from "@fern/file-download";
-
-const client = new SeedFileDownloadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-download/stream-wrapper/README.md
+++ b/seed/ts-sdk/file-download/stream-wrapper/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedFileDownloadClient } from "@fern/file-download";
-
-const client = new SeedFileDownloadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-download/stream-wrapper/README.md
+++ b/seed/ts-sdk/file-download/stream-wrapper/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/file-upload-openapi/README.md
+++ b/seed/ts-sdk/file-upload-openapi/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -306,6 +307,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/file-upload-openapi/README.md
+++ b/seed/ts-sdk/file-upload-openapi/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -306,34 +305,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/file-upload-openapi";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-upload/form-data-node16/README.md
+++ b/seed/ts-sdk/file-upload/form-data-node16/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,34 +307,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedFileUploadClient } from "@fern/file-upload";
-
-const client = new SeedFileUploadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-upload/form-data-node16/README.md
+++ b/seed/ts-sdk/file-upload/form-data-node16/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,6 +309,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/file-upload/inline/README.md
+++ b/seed/ts-sdk/file-upload/inline/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,34 +307,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedFileUploadClient } from "@fern/file-upload";
-
-const client = new SeedFileUploadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-upload/inline/README.md
+++ b/seed/ts-sdk/file-upload/inline/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,6 +309,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/file-upload/no-custom-config/README.md
+++ b/seed/ts-sdk/file-upload/no-custom-config/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,34 +307,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedFileUploadClient } from "@fern/file-upload";
-
-const client = new SeedFileUploadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-upload/no-custom-config/README.md
+++ b/seed/ts-sdk/file-upload/no-custom-config/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,6 +309,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/file-upload/serde/README.md
+++ b/seed/ts-sdk/file-upload/serde/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,34 +307,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedFileUploadClient } from "@fern/file-upload";
-
-const client = new SeedFileUploadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-upload/serde/README.md
+++ b/seed/ts-sdk/file-upload/serde/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,6 +309,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/file-upload/use-jest/README.md
+++ b/seed/ts-sdk/file-upload/use-jest/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,34 +307,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedFileUploadClient } from "@fern/file-upload";
-
-const client = new SeedFileUploadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-upload/use-jest/README.md
+++ b/seed/ts-sdk/file-upload/use-jest/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,6 +309,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/file-upload/wrapper/README.md
+++ b/seed/ts-sdk/file-upload/wrapper/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,34 +307,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedFileUploadClient } from "@fern/file-upload";
-
-const client = new SeedFileUploadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/file-upload/wrapper/README.md
+++ b/seed/ts-sdk/file-upload/wrapper/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -308,6 +309,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/folders/README.md
+++ b/seed/ts-sdk/folders/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/folders/README.md
+++ b/seed/ts-sdk/folders/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/folders";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/header-auth-environment-variable/README.md
+++ b/seed/ts-sdk/header-auth-environment-variable/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/header-auth-environment-variable/README.md
+++ b/seed/ts-sdk/header-auth-environment-variable/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedHeaderTokenEnvironmentVariableClient } from "@fern/header-auth-environment-variable";
-
-const client = new SeedHeaderTokenEnvironmentVariableClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/header-auth/README.md
+++ b/seed/ts-sdk/header-auth/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedHeaderTokenClient } from "@fern/header-auth";
-
-const client = new SeedHeaderTokenClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/header-auth/README.md
+++ b/seed/ts-sdk/header-auth/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/http-head/README.md
+++ b/seed/ts-sdk/http-head/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,34 +258,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedHttpHeadClient } from "@fern/http-head";
-
-const client = new SeedHttpHeadClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/http-head/README.md
+++ b/seed/ts-sdk/http-head/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,6 +260,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/idempotency-headers/README.md
+++ b/seed/ts-sdk/idempotency-headers/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedIdempotencyHeadersClient } from "@fern/idempotency-headers";
-
-const client = new SeedIdempotencyHeadersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/idempotency-headers/README.md
+++ b/seed/ts-sdk/idempotency-headers/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/imdb/branded-string-aliases/README.md
+++ b/seed/ts-sdk/imdb/branded-string-aliases/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -248,34 +247,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/imdb";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/imdb/branded-string-aliases/README.md
+++ b/seed/ts-sdk/imdb/branded-string-aliases/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -248,6 +249,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/imdb/no-custom-config/README.md
+++ b/seed/ts-sdk/imdb/no-custom-config/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -248,34 +247,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/imdb";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/imdb/no-custom-config/README.md
+++ b/seed/ts-sdk/imdb/no-custom-config/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -248,6 +249,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/imdb/omit-undefined/README.md
+++ b/seed/ts-sdk/imdb/omit-undefined/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -248,34 +247,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/imdb";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/imdb/omit-undefined/README.md
+++ b/seed/ts-sdk/imdb/omit-undefined/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -248,6 +249,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/inferred-auth-explicit/README.md
+++ b/seed/ts-sdk/inferred-auth-explicit/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedInferredAuthExplicitClient } from "@fern/inferred-auth-explicit";
-
-const client = new SeedInferredAuthExplicitClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/inferred-auth-explicit/README.md
+++ b/seed/ts-sdk/inferred-auth-explicit/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/README.md
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,34 +260,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedInferredAuthImplicitApiKeyClient } from "@fern/inferred-auth-implicit-api-key";
-
-const client = new SeedInferredAuthImplicitApiKeyClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/README.md
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,6 +262,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/README.md
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedInferredAuthImplicitNoExpiryClient } from "@fern/inferred-auth-implicit-no-expiry";
-
-const client = new SeedInferredAuthImplicitNoExpiryClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/README.md
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/inferred-auth-implicit/README.md
+++ b/seed/ts-sdk/inferred-auth-implicit/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedInferredAuthImplicitClient } from "@fern/inferred-auth-implicit";
-
-const client = new SeedInferredAuthImplicitClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/inferred-auth-implicit/README.md
+++ b/seed/ts-sdk/inferred-auth-implicit/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/license/README.md
+++ b/seed/ts-sdk/license/README.md
@@ -20,6 +20,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -234,6 +235,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/license/README.md
+++ b/seed/ts-sdk/license/README.md
@@ -20,7 +20,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -234,34 +233,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedLicenseClient } from "@fern/license";
-
-const client = new SeedLicenseClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/literal/README.md
+++ b/seed/ts-sdk/literal/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,34 +260,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedLiteralClient } from "@fern/literal";
-
-const client = new SeedLiteralClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/literal/README.md
+++ b/seed/ts-sdk/literal/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,6 +262,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/mixed-case/no-custom-config/README.md
+++ b/seed/ts-sdk/mixed-case/no-custom-config/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,34 +258,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedMixedCaseClient } from "@fern/mixed-case";
-
-const client = new SeedMixedCaseClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/mixed-case/no-custom-config/README.md
+++ b/seed/ts-sdk/mixed-case/no-custom-config/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,6 +260,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/mixed-case/retain-original-casing/README.md
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,34 +258,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedMixedCaseClient } from "@fern/mixed-case";
-
-const client = new SeedMixedCaseClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/mixed-case/retain-original-casing/README.md
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,6 +260,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/mixed-file-directory/README.md
+++ b/seed/ts-sdk/mixed-file-directory/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,34 +260,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedMixedFileDirectoryClient } from "@fern/mixed-file-directory";
-
-const client = new SeedMixedFileDirectoryClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/mixed-file-directory/README.md
+++ b/seed/ts-sdk/mixed-file-directory/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,6 +262,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/multi-line-docs/README.md
+++ b/seed/ts-sdk/multi-line-docs/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedMultiLineDocsClient } from "@fern/multi-line-docs";
-
-const client = new SeedMultiLineDocsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/multi-line-docs/README.md
+++ b/seed/ts-sdk/multi-line-docs/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/multi-url-environment-no-default/README.md
+++ b/seed/ts-sdk/multi-url-environment-no-default/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,34 +260,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedMultiUrlEnvironmentNoDefaultClient } from "@fern/multi-url-environment-no-default";
-
-const client = new SeedMultiUrlEnvironmentNoDefaultClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/multi-url-environment-no-default/README.md
+++ b/seed/ts-sdk/multi-url-environment-no-default/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,6 +262,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/multi-url-environment/README.md
+++ b/seed/ts-sdk/multi-url-environment/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,34 +260,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedMultiUrlEnvironmentClient } from "@fern/multi-url-environment";
-
-const client = new SeedMultiUrlEnvironmentClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/multi-url-environment/README.md
+++ b/seed/ts-sdk/multi-url-environment/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,6 +262,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/multiple-request-bodies/README.md
+++ b/seed/ts-sdk/multiple-request-bodies/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -294,6 +295,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/multiple-request-bodies/README.md
+++ b/seed/ts-sdk/multiple-request-bodies/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -294,34 +293,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/multiple-request-bodies";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/no-environment/README.md
+++ b/seed/ts-sdk/no-environment/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/no-environment/README.md
+++ b/seed/ts-sdk/no-environment/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedNoEnvironmentClient } from "@fern/no-environment";
-
-const client = new SeedNoEnvironmentClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/no-retries/README.md
+++ b/seed/ts-sdk/no-retries/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedNoRetriesClient } from "@fern/no-retries";
-
-const client = new SeedNoRetriesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/no-retries/README.md
+++ b/seed/ts-sdk/no-retries/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/nullable-allof-extends/README.md
+++ b/seed/ts-sdk/nullable-allof-extends/README.md
@@ -20,7 +20,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -234,34 +233,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/nullable-allof-extends";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/nullable-allof-extends/README.md
+++ b/seed/ts-sdk/nullable-allof-extends/README.md
@@ -20,6 +20,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -234,6 +235,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/nullable-optional/README.md
+++ b/seed/ts-sdk/nullable-optional/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -272,34 +271,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedNullableOptionalClient } from "@fern/nullable-optional";
-
-const client = new SeedNullableOptionalClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/nullable-optional/README.md
+++ b/seed/ts-sdk/nullable-optional/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -272,6 +273,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/nullable-request-body/README.md
+++ b/seed/ts-sdk/nullable-request-body/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/nullable-request-body";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/nullable-request-body/README.md
+++ b/seed/ts-sdk/nullable-request-body/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/nullable/README.md
+++ b/seed/ts-sdk/nullable/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -275,6 +276,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/nullable/README.md
+++ b/seed/ts-sdk/nullable/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -275,34 +274,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedNullableClient } from "@fern/nullable";
-
-const client = new SeedNullableClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-custom/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,6 +298,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-custom/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,34 +296,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedOauthClientCredentialsClient } from "@fern/oauth-client-credentials-custom";
-
-const client = new SeedOauthClientCredentialsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials-default/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-default/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -294,6 +295,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/oauth-client-credentials-default/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-default/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -294,34 +293,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedOauthClientCredentialsDefaultClient } from "@fern/oauth-client-credentials-default";
-
-const client = new SeedOauthClientCredentialsDefaultClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,6 +296,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,34 +294,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedOauthClientCredentialsEnvironmentVariablesClient } from "@fern/oauth-client-credentials-environment-variables";
-
-const client = new SeedOauthClientCredentialsEnvironmentVariablesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,34 +294,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedOauthClientCredentialsMandatoryAuthClient } from "@fern/oauth-client-credentials-mandatory-auth";
-
-const client = new SeedOauthClientCredentialsMandatoryAuthClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,6 +296,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,34 +294,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedOauthClientCredentialsClient } from "@fern/oauth-client-credentials-nested-root";
-
-const client = new SeedOauthClientCredentialsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,6 +296,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,34 +294,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedOauthClientCredentialsClient } from "@fern/oauth-client-credentials-nested-root";
-
-const client = new SeedOauthClientCredentialsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,6 +296,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/oauth-client-credentials-reference/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-reference/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -280,34 +279,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedOauthClientCredentialsReferenceClient } from "@fern/oauth-client-credentials-reference";
-
-const client = new SeedOauthClientCredentialsReferenceClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials-reference/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-reference/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -280,6 +281,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,34 +294,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedOauthClientCredentialsWithVariablesClient } from "@fern/oauth-client-credentials-with-variables";
-
-const client = new SeedOauthClientCredentialsWithVariablesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/README.md
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,6 +296,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/README.md
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,34 +294,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedOauthClientCredentialsClient } from "@fern/oauth-client-credentials";
-
-const client = new SeedOauthClientCredentialsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/README.md
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,6 +296,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/oauth-client-credentials/serde/README.md
+++ b/seed/ts-sdk/oauth-client-credentials/serde/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,34 +294,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedOauthClientCredentialsClient } from "@fern/oauth-client-credentials";
-
-const client = new SeedOauthClientCredentialsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/oauth-client-credentials/serde/README.md
+++ b/seed/ts-sdk/oauth-client-credentials/serde/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -295,6 +296,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/optional/README.md
+++ b/seed/ts-sdk/optional/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -249,34 +248,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedObjectsWithImportsClient } from "@fern/optional";
-
-const client = new SeedObjectsWithImportsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/optional/README.md
+++ b/seed/ts-sdk/optional/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -249,6 +250,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/package-yml/README.md
+++ b/seed/ts-sdk/package-yml/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -248,34 +247,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPackageYmlClient } from "@fern/package-yml";
-
-const client = new SeedPackageYmlClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/package-yml/README.md
+++ b/seed/ts-sdk/package-yml/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -248,6 +249,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/pagination-custom/README.md
+++ b/seed/ts-sdk/pagination-custom/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -303,6 +304,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/pagination-custom/README.md
+++ b/seed/ts-sdk/pagination-custom/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -303,34 +302,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPaginationClient } from "@fern/pagination-custom";
-
-const client = new SeedPaginationClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/pagination-uri-path/README.md
+++ b/seed/ts-sdk/pagination-uri-path/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -281,34 +280,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPaginationUriPathClient } from "@fern/pagination-uri-path";
-
-const client = new SeedPaginationUriPathClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/pagination-uri-path/README.md
+++ b/seed/ts-sdk/pagination-uri-path/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -281,6 +282,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/pagination/no-custom-config/README.md
+++ b/seed/ts-sdk/pagination/no-custom-config/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/pagination/no-custom-config/README.md
+++ b/seed/ts-sdk/pagination/no-custom-config/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPaginationClient } from "@fern/pagination";
-
-const client = new SeedPaginationClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/pagination/page-index-semantics/README.md
+++ b/seed/ts-sdk/pagination/page-index-semantics/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,6 +336,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/pagination/page-index-semantics/README.md
+++ b/seed/ts-sdk/pagination/page-index-semantics/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -335,34 +334,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPaginationClient } from "@fern/pagination";
-
-const client = new SeedPaginationClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/path-parameters/no-custom-config/README.md
+++ b/seed/ts-sdk/path-parameters/no-custom-config/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPathParametersClient } from "@fern/path-parameters";
-
-const client = new SeedPathParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/path-parameters/no-custom-config/README.md
+++ b/seed/ts-sdk/path-parameters/no-custom-config/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/README.md
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPathParametersClient } from "@fern/path-parameters";
-
-const client = new SeedPathParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/README.md
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/README.md
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPathParametersClient } from "@fern/path-parameters";
-
-const client = new SeedPathParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/README.md
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/README.md
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPathParametersClient } from "@fern/path-parameters";
-
-const client = new SeedPathParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/README.md
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/README.md
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPathParametersClient } from "@fern/path-parameters";
-
-const client = new SeedPathParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/README.md
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/README.md
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPathParametersClient } from "@fern/path-parameters";
-
-const client = new SeedPathParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/README.md
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/README.md
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPathParametersClient } from "@fern/path-parameters";
-
-const client = new SeedPathParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/README.md
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/README.md
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPathParametersClient } from "@fern/path-parameters";
-
-const client = new SeedPathParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/README.md
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/path-parameters/retain-original-casing/README.md
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,34 +261,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPathParametersClient } from "@fern/path-parameters";
-
-const client = new SeedPathParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/path-parameters/retain-original-casing/README.md
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -262,6 +263,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/plain-text/README.md
+++ b/seed/ts-sdk/plain-text/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/plain-text/README.md
+++ b/seed/ts-sdk/plain-text/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPlainTextClient } from "@fern/plain-text";
-
-const client = new SeedPlainTextClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/README.md
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/README.md
@@ -20,7 +20,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -241,34 +240,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPropertyAccessClient } from "@fern/property-access";
-
-const client = new SeedPropertyAccessClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/README.md
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/README.md
@@ -20,6 +20,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -241,6 +242,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/property-access/no-custom-config/README.md
+++ b/seed/ts-sdk/property-access/no-custom-config/README.md
@@ -20,7 +20,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedPropertyAccessClient } from "@fern/property-access";
-
-const client = new SeedPropertyAccessClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/property-access/no-custom-config/README.md
+++ b/seed/ts-sdk/property-access/no-custom-config/README.md
@@ -20,6 +20,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/README.md
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -293,6 +294,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/README.md
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -293,34 +292,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/query-parameters-openapi-as-objects";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/query-parameters-openapi/README.md
+++ b/seed/ts-sdk/query-parameters-openapi/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -293,6 +294,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/query-parameters-openapi/README.md
+++ b/seed/ts-sdk/query-parameters-openapi/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -293,34 +292,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/query-parameters-openapi";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/query-parameters/no-custom-config/README.md
+++ b/seed/ts-sdk/query-parameters/no-custom-config/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,6 +298,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/query-parameters/no-custom-config/README.md
+++ b/seed/ts-sdk/query-parameters/no-custom-config/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,34 +296,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedQueryParametersClient } from "@fern/query-parameters";
-
-const client = new SeedQueryParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/README.md
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,6 +298,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/README.md
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,34 +296,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedQueryParametersClient } from "@fern/query-parameters";
-
-const client = new SeedQueryParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/README.md
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,6 +298,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/README.md
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,34 +296,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedQueryParametersClient } from "@fern/query-parameters";
-
-const client = new SeedQueryParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/README.md
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,6 +298,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/README.md
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,34 +296,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedQueryParametersClient } from "@fern/query-parameters";
-
-const client = new SeedQueryParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/README.md
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,6 +298,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/README.md
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,34 +296,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedQueryParametersClient } from "@fern/query-parameters";
-
-const client = new SeedQueryParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/query-parameters/serde/README.md
+++ b/seed/ts-sdk/query-parameters/serde/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,6 +298,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/query-parameters/serde/README.md
+++ b/seed/ts-sdk/query-parameters/serde/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -297,34 +296,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedQueryParametersClient } from "@fern/query-parameters";
-
-const client = new SeedQueryParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/README.md
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/README.md
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedRequestParametersClient } from "@fern/request-parameters";
-
-const client = new SeedRequestParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/request-parameters/no-custom-config/README.md
+++ b/seed/ts-sdk/request-parameters/no-custom-config/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/request-parameters/no-custom-config/README.md
+++ b/seed/ts-sdk/request-parameters/no-custom-config/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedRequestParametersClient } from "@fern/request-parameters";
-
-const client = new SeedRequestParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/README.md
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/README.md
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedRequestParametersClient } from "@fern/request-parameters";
-
-const client = new SeedRequestParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/README.md
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/README.md
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedRequestParametersClient } from "@fern/request-parameters";
-
-const client = new SeedRequestParametersClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/required-nullable/README.md
+++ b/seed/ts-sdk/required-nullable/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -251,34 +250,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/required-nullable";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/required-nullable/README.md
+++ b/seed/ts-sdk/required-nullable/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -251,6 +252,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/reserved-keywords/README.md
+++ b/seed/ts-sdk/reserved-keywords/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,34 +260,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedNurseryApiClient } from "@fern/reserved-keywords";
-
-const client = new SeedNurseryApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/reserved-keywords/README.md
+++ b/seed/ts-sdk/reserved-keywords/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,6 +262,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/response-property/README.md
+++ b/seed/ts-sdk/response-property/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedResponsePropertyClient } from "@fern/response-property";
-
-const client = new SeedResponsePropertyClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/response-property/README.md
+++ b/seed/ts-sdk/response-property/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/server-sent-event-examples/README.md
+++ b/seed/ts-sdk/server-sent-event-examples/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -282,6 +283,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/server-sent-event-examples/README.md
+++ b/seed/ts-sdk/server-sent-event-examples/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -282,34 +281,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedServerSentEventsClient } from "@fern/server-sent-event-examples";
-
-const client = new SeedServerSentEventsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/server-sent-events/README.md
+++ b/seed/ts-sdk/server-sent-events/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -282,6 +283,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/server-sent-events/README.md
+++ b/seed/ts-sdk/server-sent-events/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -282,34 +281,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedServerSentEventsClient } from "@fern/server-sent-events";
-
-const client = new SeedServerSentEventsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/server-url-templating/README.md
+++ b/seed/ts-sdk/server-url-templating/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -251,34 +250,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/server-url-templating";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/server-url-templating/README.md
+++ b/seed/ts-sdk/server-url-templating/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -251,6 +252,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/README.md
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
   - [Custom Fetcher](#custom-fetcher)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -260,6 +261,21 @@ const client = new SeedSimpleApiClient({
     fetcher: // provide your implementation here
 });
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/README.md
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/README.md
@@ -21,7 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
+  - [Custom Fetcher](#custom-fetcher)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,21 +247,7 @@ const response = await client.fetch("/v1/custom/endpoint", {
 const data = await response.json();
 ```
 
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
+### Custom Fetcher
 
 The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
 unsupported environment, this provides a way for you to break glass and ensure the SDK works.

--- a/seed/ts-sdk/simple-api/allow-extra-fields/README.md
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/allow-extra-fields/README.md
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/bundle/README.md
+++ b/seed/ts-sdk/simple-api/bundle/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/bundle/README.md
+++ b/seed/ts-sdk/simple-api/bundle/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/custom-package-json/README.md
+++ b/seed/ts-sdk/simple-api/custom-package-json/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/custom-package-json/README.md
+++ b/seed/ts-sdk/simple-api/custom-package-json/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/jsr/README.md
+++ b/seed/ts-sdk/simple-api/jsr/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/jsr/README.md
+++ b/seed/ts-sdk/simple-api/jsr/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/legacy-exports/README.md
+++ b/seed/ts-sdk/simple-api/legacy-exports/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/legacy-exports/README.md
+++ b/seed/ts-sdk/simple-api/legacy-exports/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/naming-shorthand/README.md
+++ b/seed/ts-sdk/simple-api/naming-shorthand/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/naming-shorthand/README.md
+++ b/seed/ts-sdk/simple-api/naming-shorthand/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { AcmeClient } from "@fern/simple-api";
-
-const client = new AcmeClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/naming/README.md
+++ b/seed/ts-sdk/simple-api/naming/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { AcmeSdkClient } from "@fern/simple-api";
-
-const client = new AcmeSdkClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/naming/README.md
+++ b/seed/ts-sdk/simple-api/naming/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/no-custom-config/README.md
+++ b/seed/ts-sdk/simple-api/no-custom-config/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/no-custom-config/README.md
+++ b/seed/ts-sdk/simple-api/no-custom-config/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/README.md
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/README.md
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/no-scripts/README.md
+++ b/seed/ts-sdk/simple-api/no-scripts/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/no-scripts/README.md
+++ b/seed/ts-sdk/simple-api/no-scripts/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/oidc-token/README.md
+++ b/seed/ts-sdk/simple-api/oidc-token/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/oidc-token/README.md
+++ b/seed/ts-sdk/simple-api/oidc-token/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern-api/dummy";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/omit-fern-headers/README.md
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/omit-fern-headers/README.md
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/use-oxc/README.md
+++ b/seed/ts-sdk/simple-api/use-oxc/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
     - [Access Raw Response Data](#access-raw-response-data)
     - [Logging](#logging)
     - [Custom Fetch](#custom-fetch)
+    - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,6 +254,17 @@ const response = await client.fetch(
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+The SDK works in the following runtimes:
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/use-oxc/README.md
+++ b/seed/ts-sdk/simple-api/use-oxc/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
     - [Access Raw Response Data](#access-raw-response-data)
     - [Logging](#logging)
     - [Custom Fetch](#custom-fetch)
-    - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,31 +252,6 @@ const response = await client.fetch(
 );
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-The SDK works in the following runtimes:
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/use-oxfmt/README.md
+++ b/seed/ts-sdk/simple-api/use-oxfmt/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
     - [Access Raw Response Data](#access-raw-response-data)
     - [Logging](#logging)
     - [Custom Fetch](#custom-fetch)
+    - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,6 +254,17 @@ const response = await client.fetch(
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+The SDK works in the following runtimes:
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/use-oxfmt/README.md
+++ b/seed/ts-sdk/simple-api/use-oxfmt/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
     - [Access Raw Response Data](#access-raw-response-data)
     - [Logging](#logging)
     - [Custom Fetch](#custom-fetch)
-    - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,31 +252,6 @@ const response = await client.fetch(
 );
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-The SDK works in the following runtimes:
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/use-oxlint/README.md
+++ b/seed/ts-sdk/simple-api/use-oxlint/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/use-oxlint/README.md
+++ b/seed/ts-sdk/simple-api/use-oxlint/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/README.md
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
     - [Access Raw Response Data](#access-raw-response-data)
     - [Logging](#logging)
     - [Custom Fetch](#custom-fetch)
+    - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,6 +254,17 @@ const response = await client.fetch(
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+The SDK works in the following runtimes:
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/README.md
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
     - [Access Raw Response Data](#access-raw-response-data)
     - [Logging](#logging)
     - [Custom Fetch](#custom-fetch)
-    - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,31 +252,6 @@ const response = await client.fetch(
 );
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-The SDK works in the following runtimes:
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/use-prettier/README.md
+++ b/seed/ts-sdk/simple-api/use-prettier/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
     - [Access Raw Response Data](#access-raw-response-data)
     - [Logging](#logging)
     - [Custom Fetch](#custom-fetch)
+    - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,6 +254,17 @@ const response = await client.fetch(
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+The SDK works in the following runtimes:
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/use-prettier/README.md
+++ b/seed/ts-sdk/simple-api/use-prettier/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
     - [Access Raw Response Data](#access-raw-response-data)
     - [Logging](#logging)
     - [Custom Fetch](#custom-fetch)
-    - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,31 +252,6 @@ const response = await client.fetch(
 );
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-The SDK works in the following runtimes:
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/use-yarn/README.md
+++ b/seed/ts-sdk/simple-api/use-yarn/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSimpleApiClient } from "@fern/simple-api";
-
-const client = new SeedSimpleApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/simple-api/use-yarn/README.md
+++ b/seed/ts-sdk/simple-api/use-yarn/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-api/use-yarn/package.json
+++ b/seed/ts-sdk/simple-api/use-yarn/package.json
@@ -57,13 +57,13 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "webpack": "^5.97.1",
-        "ts-loader": "^9.5.1",
-        "vitest": "^3.2.4",
-        "msw": "2.11.2",
+        "@biomejs/biome": "2.4.3",
         "@types/node": "^18.19.70",
+        "msw": "2.11.2",
+        "ts-loader": "^9.5.1",
         "typescript": "~5.7.2",
-        "@biomejs/biome": "2.4.3"
+        "vitest": "^3.2.4",
+        "webpack": "^5.97.1"
     },
     "browser": {
         "fs": false,

--- a/seed/ts-sdk/simple-fhir/README.md
+++ b/seed/ts-sdk/simple-fhir/README.md
@@ -20,6 +20,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -234,6 +235,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/simple-fhir/README.md
+++ b/seed/ts-sdk/simple-fhir/README.md
@@ -20,7 +20,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -234,34 +233,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/simple-fhir";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/single-url-environment-default/README.md
+++ b/seed/ts-sdk/single-url-environment-default/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/single-url-environment-default/README.md
+++ b/seed/ts-sdk/single-url-environment-default/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSingleUrlEnvironmentDefaultClient } from "@fern/single-url-environment-default";
-
-const client = new SeedSingleUrlEnvironmentDefaultClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/single-url-environment-no-default/README.md
+++ b/seed/ts-sdk/single-url-environment-no-default/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/single-url-environment-no-default/README.md
+++ b/seed/ts-sdk/single-url-environment-no-default/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedSingleUrlEnvironmentNoDefaultClient } from "@fern/single-url-environment-no-default";
-
-const client = new SeedSingleUrlEnvironmentNoDefaultClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/streaming-parameter/README.md
+++ b/seed/ts-sdk/streaming-parameter/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -265,6 +266,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/streaming-parameter/README.md
+++ b/seed/ts-sdk/streaming-parameter/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -265,34 +264,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedStreamingClient } from "@fern/streaming-parameter";
-
-const client = new SeedStreamingClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/streaming/no-custom-config/README.md
+++ b/seed/ts-sdk/streaming/no-custom-config/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -282,34 +281,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedStreamingClient } from "@fern/streaming";
-
-const client = new SeedStreamingClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/streaming/no-custom-config/README.md
+++ b/seed/ts-sdk/streaming/no-custom-config/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -282,6 +283,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/streaming/serde-layer/README.md
+++ b/seed/ts-sdk/streaming/serde-layer/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -282,34 +281,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedStreamingClient } from "@fern/streaming";
-
-const client = new SeedStreamingClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/streaming/serde-layer/README.md
+++ b/seed/ts-sdk/streaming/serde-layer/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -282,6 +283,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/streaming/wrapper/README.md
+++ b/seed/ts-sdk/streaming/wrapper/README.md
@@ -23,7 +23,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -282,34 +281,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedStreamingClient } from "@fern/streaming";
-
-const client = new SeedStreamingClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/streaming/wrapper/README.md
+++ b/seed/ts-sdk/streaming/wrapper/README.md
@@ -23,6 +23,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -282,6 +283,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/trace/exhaustive/README.md
+++ b/seed/ts-sdk/trace/exhaustive/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,34 +260,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedTraceClient } from "@fern/trace";
-
-const client = new SeedTraceClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/trace/exhaustive/README.md
+++ b/seed/ts-sdk/trace/exhaustive/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,6 +262,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/trace/no-custom-config/README.md
+++ b/seed/ts-sdk/trace/no-custom-config/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,34 +260,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedTraceClient } from "@fern/trace";
-
-const client = new SeedTraceClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/trace/no-custom-config/README.md
+++ b/seed/ts-sdk/trace/no-custom-config/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,6 +262,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/trace/serde-no-throwing/README.md
+++ b/seed/ts-sdk/trace/serde-no-throwing/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,34 +260,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedTraceClient } from "@fern/trace";
-
-const client = new SeedTraceClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/trace/serde-no-throwing/README.md
+++ b/seed/ts-sdk/trace/serde-no-throwing/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,6 +262,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/trace/serde/README.md
+++ b/seed/ts-sdk/trace/serde/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,34 +260,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedTraceClient } from "@fern/trace";
-
-const client = new SeedTraceClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/trace/serde/README.md
+++ b/seed/ts-sdk/trace/serde/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -261,6 +262,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/ts-express-casing/README.md
+++ b/seed/ts-sdk/ts-express-casing/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -263,6 +264,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/ts-express-casing/README.md
+++ b/seed/ts-sdk/ts-express-casing/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -263,34 +262,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/ts-express-casing";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/ts-extra-properties/README.md
+++ b/seed/ts-sdk/ts-extra-properties/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -250,34 +249,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/ts-extra-properties";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/ts-extra-properties/README.md
+++ b/seed/ts-sdk/ts-extra-properties/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -250,6 +251,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/ts-inline-types/inline/README.md
+++ b/seed/ts-sdk/ts-inline-types/inline/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,6 +254,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/ts-inline-types/inline/README.md
+++ b/seed/ts-sdk/ts-inline-types/inline/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,34 +252,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedObjectClient } from "@fern/ts-inline-types";
-
-const client = new SeedObjectClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/ts-inline-types/no-inline/README.md
+++ b/seed/ts-sdk/ts-inline-types/no-inline/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,6 +254,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/ts-inline-types/no-inline/README.md
+++ b/seed/ts-sdk/ts-inline-types/no-inline/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,34 +252,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedObjectClient } from "@fern/ts-inline-types";
-
-const client = new SeedObjectClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/README.md
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/README.md
@@ -20,7 +20,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -234,34 +233,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedUndiscriminatedUnionWithResponsePropertyClient } from "@fern/undiscriminated-union-with-response-property";
-
-const client = new SeedUndiscriminatedUnionWithResponsePropertyClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/README.md
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/README.md
@@ -20,6 +20,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -234,6 +235,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/README.md
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,34 +258,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedUndiscriminatedUnionsClient } from "@fern/undiscriminated-unions";
-
-const client = new SeedUndiscriminatedUnionsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/README.md
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,6 +260,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/README.md
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,34 +258,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedUndiscriminatedUnionsClient } from "@fern/undiscriminated-unions";
-
-const client = new SeedUndiscriminatedUnionsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/README.md
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -259,6 +260,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/unions-with-local-date/README.md
+++ b/seed/ts-sdk/unions-with-local-date/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedUnionsClient } from "@fern/unions-with-local-date";
-
-const client = new SeedUnionsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/unions-with-local-date/README.md
+++ b/seed/ts-sdk/unions-with-local-date/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/unions/README.md
+++ b/seed/ts-sdk/unions/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedUnionsClient } from "@fern/unions";
-
-const client = new SeedUnionsClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/unions/README.md
+++ b/seed/ts-sdk/unions/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/unknown/no-custom-config/README.md
+++ b/seed/ts-sdk/unknown/no-custom-config/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,6 +248,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/unknown/no-custom-config/README.md
+++ b/seed/ts-sdk/unknown/no-custom-config/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,34 +246,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedUnknownAsAnyClient } from "@fern/unknown";
-
-const client = new SeedUnknownAsAnyClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/unknown/unknown-as-any/README.md
+++ b/seed/ts-sdk/unknown/unknown-as-any/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,6 +248,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/unknown/unknown-as-any/README.md
+++ b/seed/ts-sdk/unknown/unknown-as-any/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -247,34 +246,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedUnknownAsAnyClient } from "@fern/unknown";
-
-const client = new SeedUnknownAsAnyClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/url-form-encoded/README.md
+++ b/seed/ts-sdk/url-form-encoded/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -251,34 +250,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedApiClient } from "@fern/url-form-encoded";
-
-const client = new SeedApiClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/url-form-encoded/README.md
+++ b/seed/ts-sdk/url-form-encoded/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -251,6 +252,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/validation/README.md
+++ b/seed/ts-sdk/validation/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,34 +252,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedValidationClient } from "@fern/validation";
-
-const client = new SeedValidationClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/validation/README.md
+++ b/seed/ts-sdk/validation/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -253,6 +254,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/variables/README.md
+++ b/seed/ts-sdk/variables/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/variables/README.md
+++ b/seed/ts-sdk/variables/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedVariablesClient } from "@fern/variables";
-
-const client = new SeedVariablesClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/version-no-default/README.md
+++ b/seed/ts-sdk/version-no-default/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedVersionClient } from "@fern/version-no-default";
-
-const client = new SeedVersionClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/version-no-default/README.md
+++ b/seed/ts-sdk/version-no-default/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/version/README.md
+++ b/seed/ts-sdk/version/README.md
@@ -21,6 +21,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,6 +246,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 

--- a/seed/ts-sdk/version/README.md
+++ b/seed/ts-sdk/version/README.md
@@ -21,7 +21,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -245,34 +244,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedVersionClient } from "@fern/version";
-
-const client = new SeedVersionClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/README.md
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/README.md
@@ -22,7 +22,6 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
-  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,34 +263,6 @@ const response = await client.fetch("/v1/custom/endpoint", {
 });
 
 const data = await response.json();
-```
-
-### Runtime Compatibility
-
-
-The SDK works in the following runtimes:
-
-
-
-- Node.js 18+
-- Vercel
-- Cloudflare Workers
-- Deno v1.25+
-- Bun 1.0+
-- React Native
-
-### Customizing Fetch Client
-
-The SDK provides a way for you to customize the underlying HTTP client / Fetch function. If you're running in an
-unsupported environment, this provides a way for you to break glass and ensure the SDK works.
-
-```typescript
-import { SeedWebsocketAuthClient } from "@fern/websocket-inferred-auth";
-
-const client = new SeedWebsocketAuthClient({
-    ...
-    fetcher: // provide your implementation here
-});
 ```
 
 ## Contributing

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/README.md
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/README.md
@@ -22,6 +22,7 @@ The Seed TypeScript library provides convenient access to the Seed APIs from Typ
   - [Access Raw Response Data](#access-raw-response-data)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
+  - [Runtime Compatibility](#runtime-compatibility)
 - [Contributing](#contributing)
 
 ## Installation
@@ -264,6 +265,21 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+### Runtime Compatibility
+
+
+The SDK works in the following runtimes:
+
+
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Fixes the generated `README.md` including the **"Customizing Fetch Client"** subsection (under "Runtime Compatibility") even when `allowCustomFetcher` is set to `false` in the generator config.

## Changes Made

- **`features.yml`**: Extracted "Customizing Fetch Client" from the `RUNTIME_COMPATIBILITY` feature into a new standalone `CUSTOM_FETCHER` feature. Removed the hardcoded subsection that was always rendered regardless of config.
- **`ReadmeSnippetBuilder.ts`**: Added `allowCustomFetcher` parameter; new `buildCustomFetcherSnippets()` returns `false` when disabled (skipping the feature entirely) or returns the fetcher snippet when enabled. `buildRuntimeCompatibilitySnippets()` now always returns `[]`.
- **`ReadmeConfigBuilder.ts`**: Threads `allowCustomFetcher` through to `ReadmeSnippetBuilder`. Marks `RUNTIME_COMPATIBILITY` as `snippetsAreOptional: true` so the runtime list (Node.js 18+, Vercel, etc.) always renders even without code snippets.
- **`SdkGenerator.ts`**: Passes `config.allowCustomFetcher` when constructing `ReadmeConfigBuilder`
- **`versions.yml`**: Added changelog entry for `3.59.1`

### Approach (per review feedback)

Instead of gating content with EJS conditionals inside the `RUNTIME_COMPATIBILITY` description, `CUSTOM_FETCHER` is now a **separate feature** that is entirely excluded when `allowCustomFetcher` is `false`. This follows the existing pattern where `buildXxxSnippets()` returns `false` to skip a feature altogether.

`RUNTIME_COMPATIBILITY` remains a description-only feature (no code snippets) and is always rendered via `snippetsAreOptional: true`, since the generator-cli's `shouldSkipFeature` would otherwise skip features with empty snippet arrays.

## Testing

- [x] Unit tests updated — all 87 tests pass, snapshots updated
- [x] New test: verifies `CUSTOM_FETCHER` returns `false` when `allowCustomFetcher: false`
- [x] New test: verifies `CUSTOM_FETCHER` returns snippet when `allowCustomFetcher: true`
- [x] Seed test snapshots updated locally — all fixtures pass
  - `simple-api/allow-custom-fetcher`: Both "Custom Fetcher" and "Runtime Compatibility" sections present
  - All other fixtures: "Customizing Fetch Client" subsection + snippet removed; "Runtime Compatibility" section preserved

## Human Review Checklist

- [ ] Confirm the `allow-custom-fetcher` fixture README looks correct — "Custom Fetcher" should appear as its own section alongside "Runtime Compatibility" (no longer nested under it)
- [ ] Verify that using `snippetsAreOptional: true` for `RUNTIME_COMPATIBILITY` is acceptable — this is how description-only features (no code snippets) are kept in the README
- [ ] ~178 seed snapshot files changed — spot-check a few to confirm the diff is just removing the "Customizing Fetch Client" subsection while preserving the runtime list

Link to Devin session: https://app.devin.ai/sessions/2d40379d92ea4a65af373aa3b8af3a1b
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
