### PR TITLE
feat(parser): `coerce-consts-to: enums-coerceable-to-literal` aligns with past behavior

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/options.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/options.ts
@@ -120,10 +120,11 @@ export interface ParseOpenAPIOptions {
     /**
      * Controls how `const` values in OpenAPI specs are represented.
      * - `literals`: Convert const values directly to literals with defaults.
-     * - `enums`: Convert const values to single-element enums (current behavior).
-     * Defaults to `enums`.
+     * - `enums`: Convert const values to single-element enums; blocks transitive coercion via `coerce-enums-to-literals`.
+     * - `enums-coerceable-to-literals`: Convert const values to single-element enums, but allow `coerce-enums-to-literals` to coerce them transitively.
+     * Defaults to `enums-coerceable-to-literals`.
      */
-    coerceConstsTo: "literals" | "enums";
+    coerceConstsTo: "literals" | "enums" | "enums-coerceable-to-literals";
 
     /**
      * If true, treat OpenAPI `type: string, format: byte` as a base64/bytes primitive
@@ -167,7 +168,7 @@ export const DEFAULT_PARSE_OPENAPI_SETTINGS: ParseOpenAPIOptions = {
     pathParameterOrder: generatorsYml.PathParameterOrder.UrlOrder,
     resolveSchemaCollisions: false,
     inferForwardCompatible: false,
-    coerceConstsTo: "enums",
+    coerceConstsTo: "enums-coerceable-to-literals",
     respectByteFormat: false
 };
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -466,8 +466,11 @@ export function convertSchemaObject(
         // const
         // NOTE(patrickthornton): This is an attribute of OpenAPIV3_1.SchemaObject;
         // at some point we should probably migrate to that object altogether.
-        const isFromConst = "const" in schema;
-        if (isFromConst) {
+        const hasConst = "const" in schema;
+        // isFromConst blocks transitive coercion via coerceEnumsToLiterals;
+        // "enums-coerceable-to-literals" allows it by not setting this flag.
+        const isFromConst = hasConst && context.options.coerceConstsTo === "enums";
+        if (hasConst) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `const` is an OpenAPI 3.1 attribute not in the V3 types
             const constValue = (schema as Record<string, unknown>).const;
             if (context.options.coerceConstsTo === "literals") {
@@ -487,7 +490,7 @@ export function convertSchemaObject(
                     });
                 }
             }
-            // Default: coerce to enum (current behavior)
+            // "enums" and "enums-coerceable-to-literals": coerce to enum
             schema.enum = [constValue];
         }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -467,9 +467,9 @@ export function convertSchemaObject(
         // NOTE(patrickthornton): This is an attribute of OpenAPIV3_1.SchemaObject;
         // at some point we should probably migrate to that object altogether.
         const hasConst = "const" in schema;
-        // isFromConst blocks transitive coercion via coerceEnumsToLiterals;
-        // "enums-coerceable-to-literals" allows it by not setting this flag.
-        const isFromConst = hasConst && context.options.coerceConstsTo === "enums";
+        // When coerceConstsTo is "enums", block the coerceEnumsToLiterals path
+        // so const-derived enums stay as enums. "enums-coerceable-to-literals" allows it.
+        const blockConstCoercionToLiteral = hasConst && context.options.coerceConstsTo === "enums";
         if (hasConst) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `const` is an OpenAPI 3.1 attribute not in the V3 types
             const constValue = (schema as Record<string, unknown>).const;
@@ -530,7 +530,7 @@ export function convertSchemaObject(
 
             if (
                 context.options.coerceEnumsToLiterals &&
-                !isFromConst &&
+                !blockConstCoercionToLiteral &&
                 schema.enum.length === 1 &&
                 schema.enum[0] != null &&
                 fernEnum == null

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/anyOf.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/anyOf.json
@@ -106,7 +106,7 @@
     "pathParameterOrder": "url-order",
     "resolveSchemaCollisions": false,
     "inferForwardCompatible": false,
-    "coerceConstsTo": "enums",
+    "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/application-json.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/application-json.json
@@ -86,7 +86,7 @@
     "pathParameterOrder": "url-order",
     "resolveSchemaCollisions": false,
     "inferForwardCompatible": false,
-    "coerceConstsTo": "enums",
+    "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/availability.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/availability.json
@@ -321,7 +321,7 @@
     "pathParameterOrder": "url-order",
     "resolveSchemaCollisions": false,
     "inferForwardCompatible": false,
-    "coerceConstsTo": "enums",
+    "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/const.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/const.json
@@ -120,7 +120,7 @@
     "pathParameterOrder": "url-order",
     "resolveSchemaCollisions": false,
     "inferForwardCompatible": false,
-    "coerceConstsTo": "enums",
+    "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/dates.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/dates.json
@@ -130,7 +130,7 @@
     "pathParameterOrder": "url-order",
     "resolveSchemaCollisions": false,
     "inferForwardCompatible": false,
-    "coerceConstsTo": "enums",
+    "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-schema-reference.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-schema-reference.json
@@ -118,7 +118,7 @@
     "pathParameterOrder": "url-order",
     "resolveSchemaCollisions": false,
     "inferForwardCompatible": false,
-    "coerceConstsTo": "enums",
+    "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/preserve-single-schema-oneof.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/preserve-single-schema-oneof.json
@@ -85,7 +85,7 @@
     "pathParameterOrder": "url-order",
     "resolveSchemaCollisions": false,
     "inferForwardCompatible": false,
-    "coerceConstsTo": "enums",
+    "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/url-reference.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/url-reference.json
@@ -73,7 +73,7 @@
     "pathParameterOrder": "url-order",
     "resolveSchemaCollisions": false,
     "inferForwardCompatible": false,
-    "coerceConstsTo": "enums",
+    "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/const-with-coerce-enums-coerceable-to-literals.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/const-with-coerce-enums-coerceable-to-literals.json
@@ -1,0 +1,262 @@
+{
+  "title": "Pet Store API",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "summary": "Create a new pet",
+      "audiences": [],
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "PostPetsRequest",
+      "request": {
+        "schema": {
+          "generatedName": "PostPetsRequest",
+          "schema": "CreatePetRequest",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Pet created successfully",
+        "schema": {
+          "generatedName": "PostPetsResponse",
+          "schema": "Pet",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 201,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/pets",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "type": {
+                "value": {
+                  "value": "pet",
+                  "type": "string"
+                },
+                "type": "literal"
+              },
+              "name": {
+                "value": {
+                  "value": "Fluffy",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": 123,
+                    "type": "int"
+                  },
+                  "type": "primitive"
+                },
+                "type": {
+                  "value": {
+                    "value": "pet",
+                    "type": "string"
+                  },
+                  "type": "literal"
+                },
+                "name": {
+                  "value": {
+                    "value": "Fluffy",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "status": {
+                  "value": {
+                    "value": "active",
+                    "type": "string"
+                  },
+                  "type": "literal"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "CreatePetRequest": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "createPetRequestType",
+            "key": "type",
+            "schema": {
+              "value": {
+                "value": "pet",
+                "type": "string"
+              },
+              "generatedName": "CreatePetRequestType",
+              "groupName": [],
+              "type": "literal"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "createPetRequestName",
+            "key": "name",
+            "schema": {
+              "schema": {
+                "example": "Fluffy",
+                "type": "string"
+              },
+              "generatedName": "CreatePetRequestName",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "CreatePetRequest",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "Pet": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "petId",
+            "key": "id",
+            "schema": {
+              "schema": {
+                "example": 123,
+                "type": "int"
+              },
+              "generatedName": "PetId",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "petType",
+            "key": "type",
+            "schema": {
+              "value": {
+                "value": "pet",
+                "type": "string"
+              },
+              "generatedName": "PetType",
+              "groupName": [],
+              "type": "literal"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "petName",
+            "key": "name",
+            "schema": {
+              "schema": {
+                "example": "Fluffy",
+                "type": "string"
+              },
+              "generatedName": "PetName",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "petStatus",
+            "key": "status",
+            "schema": {
+              "value": {
+                "value": "active",
+                "type": "string"
+              },
+              "generatedName": "PetStatus",
+              "groupName": [],
+              "type": "literal"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "Pet",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/const-with-coerce-enums-coerceable-to-literals.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/const-with-coerce-enums-coerceable-to-literals.json
@@ -1,0 +1,139 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "createANewPet": {
+              "auth": undefined,
+              "display-name": "Create a new pet",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "name": "Fluffy",
+                    "type": "pet",
+                  },
+                  "response": {
+                    "body": {
+                      "id": 123,
+                      "name": "Fluffy",
+                      "status": "active",
+                      "type": "pet",
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/pets",
+              "request": {
+                "body": {
+                  "properties": {
+                    "name": "string",
+                    "type": "literal<"pet">",
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "CreatePetRequest",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "response": {
+                "docs": "Pet created successfully",
+                "status-code": 201,
+                "type": "Pet",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "Pet": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "id": "integer",
+              "name": "string",
+              "status": "literal<"active">",
+              "type": "literal<"pet">",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    createANewPet:
+      path: /pets
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      display-name: Create a new pet
+      request:
+        name: CreatePetRequest
+        body:
+          properties:
+            type: literal<"pet">
+            name: string
+        content-type: application/json
+      response:
+        docs: Pet created successfully
+        type: Pet
+        status-code: 201
+      examples:
+        - request:
+            type: pet
+            name: Fluffy
+          response:
+            body:
+              id: 123
+              type: pet
+              name: Fluffy
+              status: active
+  source:
+    openapi: ../openapi.yml
+types:
+  Pet:
+    properties:
+      id: integer
+      type: literal<"pet">
+      name: string
+      status: literal<"active">
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Pet Store API",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Pet Store API
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/const-with-coerce-enums-coerceable-to-literals/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/const-with-coerce-enums-coerceable-to-literals/fern/generators.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml
+      settings:
+        coerce-enums-to-literals: true
+        coerce-consts-to: enums-coerceable-to-literals

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/const-with-coerce-enums-coerceable-to-literals/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/const-with-coerce-enums-coerceable-to-literals/openapi.yml
@@ -1,0 +1,57 @@
+openapi: 3.1.0
+info:
+  title: Pet Store API
+  version: 1.0.0
+
+paths:
+  /pets:
+    post:
+      summary: Create a new pet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePetRequest"
+      responses:
+        "201":
+          description: Pet created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+
+components:
+  schemas:
+    CreatePetRequest:
+      type: object
+      required:
+        - type
+        - name
+      properties:
+        type:
+          const: "pet"
+        name:
+          type: string
+          example: "Fluffy"
+
+    Pet:
+      type: object
+      required:
+        - id
+        - type
+        - name
+        - status
+      properties:
+        id:
+          type: integer
+          example: 123
+        type:
+          const: "pet"
+        name:
+          type: string
+          example: "Fluffy"
+        status:
+          type: string
+          enum:
+            - active

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.33.0
+  changelogEntry:
+    - summary: |
+        Add `enums-coerceable-to-literals` option for `coerce-consts-to`, and make
+        it the new default. This behaves like `enums` (const values become
+        single-element enums) but allows `coerce-enums-to-literals` to transitively
+        coerce them to literals, which is consistent with past default behavior. The
+        existing `enums` option continues to block this transitive coercion.
+      type: feat
+  createdAt: "2026-03-17"
+  irVersion: 65
+
 - version: 4.32.2
   changelogEntry:
     - summary: |

--- a/packages/cli/config/src/schemas/settings/BaseApiSettingsSchema.ts
+++ b/packages/cli/config/src/schemas/settings/BaseApiSettingsSchema.ts
@@ -65,10 +65,11 @@ export const BaseApiSettingsSchema = z.object({
     /**
      * Controls how `const` values in OpenAPI specs are represented.
      * - `literals`: Convert const values directly to literals with defaults.
-     * - `enums`: Convert const values to single-element enums (current behavior).
-     * Defaults to `enums`.
+     * - `enums`: Convert const values to single-element enums; blocks transitive coercion via `coerce-enums-to-literals`.
+     * - `enums-coerceable-to-literals`: Convert const values to single-element enums, but allow `coerce-enums-to-literals` to coerce them transitively.
+     * Defaults to `enums-coerceable-to-literals`.
      */
-    coerceConstsTo: z.enum(["literals", "enums"]).optional()
+    coerceConstsTo: z.enum(["literals", "enums", "enums-coerceable-to-literals"]).optional()
 });
 
 export type BaseApiSettingsSchema = z.infer<typeof BaseApiSettingsSchema>;

--- a/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
+++ b/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
@@ -94,7 +94,7 @@ export interface APIDefinitionSettings {
     defaultIntegerFormat: generatorsYml.DefaultIntegerFormat | undefined;
     resolveSchemaCollisions: boolean | undefined;
     inferForwardCompatible: boolean | undefined;
-    coerceConstsTo: "literals" | "enums" | undefined;
+    coerceConstsTo: "literals" | "enums" | "enums-coerceable-to-literals" | undefined;
 }
 
 export interface APIDefinitionLocation {

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/BaseApiSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/BaseApiSettingsSchema.ts
@@ -56,8 +56,9 @@ export interface BaseApiSettingsSchema {
     /**
      * Controls how `const` values in OpenAPI specs are represented.
      * - `literals`: Convert const values directly to literals with defaults.
-     * - `enums`: Convert const values to single-element enums (current behavior).
-     * Defaults to `enums`.
+     * - `enums`: Convert const values to single-element enums; blocks transitive coercion via `coerce-enums-to-literals`.
+     * - `enums-coerceable-to-literals`: Convert const values to single-element enums, but allow `coerce-enums-to-literals` to coerce them transitively.
+     * Defaults to `enums-coerceable-to-literals`.
      */
     "coerce-consts-to"?: GeneratorsYml.CoerceConstsTo;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/CoerceConstsTo.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/CoerceConstsTo.ts
@@ -4,5 +4,6 @@
 export const CoerceConstsTo = {
     Literals: "literals",
     Enums: "enums",
+    EnumsCoerceableToLiterals: "enums-coerceable-to-literals",
 } as const;
 export type CoerceConstsTo = (typeof CoerceConstsTo)[keyof typeof CoerceConstsTo];

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/CoerceConstsTo.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/CoerceConstsTo.ts
@@ -7,8 +7,8 @@ import type * as serializers from "../../../index.js";
 export const CoerceConstsTo: core.serialization.Schema<
     serializers.CoerceConstsTo.Raw,
     GeneratorsYml.CoerceConstsTo
-> = core.serialization.enum_(["literals", "enums"]);
+> = core.serialization.enum_(["literals", "enums", "enums-coerceable-to-literals"]);
 
 export declare namespace CoerceConstsTo {
-    export type Raw = "literals" | "enums";
+    export type Raw = "literals" | "enums" | "enums-coerceable-to-literals";
 }

--- a/packages/commons/api-workspace-commons/src/openapi/BaseOpenAPIWorkspace.ts
+++ b/packages/commons/api-workspace-commons/src/openapi/BaseOpenAPIWorkspace.ts
@@ -25,7 +25,7 @@ export declare namespace BaseOpenAPIWorkspace {
         removeDiscriminantsFromSchemas: generatorsYml.RemoveDiscriminantsFromSchemas | undefined;
         defaultIntegerFormat: generatorsYml.DefaultIntegerFormat | undefined;
         pathParameterOrder: generatorsYml.PathParameterOrder | undefined;
-        coerceConstsTo: "literals" | "enums" | undefined;
+        coerceConstsTo: "literals" | "enums" | "enums-coerceable-to-literals" | undefined;
     }
 
     export type Settings = Partial<OpenAPISettings>;
@@ -49,7 +49,7 @@ export abstract class BaseOpenAPIWorkspace extends AbstractAPIWorkspace<BaseOpen
     public readonly removeDiscriminantsFromSchemas: generatorsYml.RemoveDiscriminantsFromSchemas | undefined;
     public readonly defaultIntegerFormat: generatorsYml.DefaultIntegerFormat | undefined;
     public readonly pathParameterOrder: generatorsYml.PathParameterOrder | undefined;
-    public readonly coerceConstsTo: "literals" | "enums" | undefined;
+    public readonly coerceConstsTo: "literals" | "enums" | "enums-coerceable-to-literals" | undefined;
     private readonly converter: FernDefinitionConverter;
 
     constructor(args: BaseOpenAPIWorkspace.Args) {
@@ -140,7 +140,7 @@ export abstract class BaseOpenAPIWorkspaceSync extends AbstractAPIWorkspaceSync<
     public defaultIntegerFormat: generatorsYml.DefaultIntegerFormat | undefined;
     public pathParameterOrder: generatorsYml.PathParameterOrder | undefined;
     public coerceEnumsToLiterals: boolean | undefined;
-    public coerceConstsTo: "literals" | "enums" | undefined;
+    public coerceConstsTo: "literals" | "enums" | "enums-coerceable-to-literals" | undefined;
     private converter: FernDefinitionConverter;
 
     constructor(args: BaseOpenAPIWorkspace.Args) {


### PR DESCRIPTION
## Description
Neither case for the new config flag introduced in https://github.com/fern-api/fern/pull/13525 matched previous behavior exactly; to mitigate a breaking change, we introduce `enums-coerceable-to-literal`, which matches previous behavior (`enums`, but `coerce-enums-to-literals: true` being set will transitively coerce `consts` all the way to `literals`).

## Changes Made
`openapi-ir-parser`.

## Testing
New `openapi-ir-to-fern-tests`.
- [X] Unit tests added/updated
- [X] Manual testing completed
