### PR TITLE
fix(python): guard optional complex-type params in multipart file uploads with OMIT sentinel

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,20 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.0.4
+  changelogEntry:
+    - summary: |
+        Fix optional complex-type parameters in multipart file upload requests being
+        sent as `"null"` instead of being omitted. When an optional body property
+        (e.g., `Optional[List[str]]`, `Optional[Any]`) defaults to `OMIT`,
+        `json.dumps(jsonable_encoder(OMIT))` was evaluating to the string `"null"`,
+        destroying the OMIT sentinel before `remove_omit_from_dict` could strip it.
+        Optional non-primitive body properties now emit a ternary guard
+        (`json.dumps(...) if prop is not OMIT else OMIT`) so that the OMIT sentinel
+        is preserved and correctly removed from the request data.
+      type: fix
+  createdAt: "2026-03-18"
+  irVersion: 65
+
 - version: 5.0.3
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/request_body_parameters/file_upload_request_body_parameters.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/request_body_parameters/file_upload_request_body_parameters.py
@@ -144,17 +144,22 @@ class FileUploadRequestBodyParameters(AbstractRequestBodyParameters):
                         if self._is_primitive_type(property_as_union.value_type):
                             writer.write_line(f'"{property_as_union.name.wire_value}": {prop_name},')
                         else:
-                            writer.write(f'"{property_as_union.name.wire_value}": ')
-                            writer.write_node(
-                                AST.Expression(
-                                    self._get_json_dumps(
-                                        AST.Expression(
-                                            self._context.core_utilities.jsonable_encoder(AST.Expression(prop_name))
-                                        )
+                            type_hint = self._get_property_type(property)
+                            json_dumps_expr = AST.Expression(
+                                self._get_json_dumps(
+                                    AST.Expression(
+                                        self._context.core_utilities.jsonable_encoder(AST.Expression(prop_name))
                                     )
                                 )
                             )
-                            writer.write_line(",")
+                            if type_hint.is_optional:
+                                writer.write(f'"{property_as_union.name.wire_value}": ')
+                                writer.write_node(json_dumps_expr)
+                                writer.write_line(f" if {prop_name} is not OMIT else OMIT,")
+                            else:
+                                writer.write(f'"{property_as_union.name.wire_value}": ')
+                                writer.write_node(json_dumps_expr)
+                                writer.write_line(",")
             writer.write_line("}")
 
         return AST.Expression(AST.CodeWriter(write))

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/service/raw_client.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/service/raw_client.py
@@ -102,9 +102,13 @@ class RawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "alias_object": json.dumps(jsonable_encoder(alias_object)),
@@ -466,9 +470,13 @@ class RawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "list_of_objects_with_optionals": json.dumps(jsonable_encoder(list_of_objects_with_optionals)),
@@ -635,7 +643,7 @@ class RawServiceClient:
             "with-json-property",
             method="POST",
             data={
-                "json": _json.dumps(jsonable_encoder(json)),
+                "json": _json.dumps(jsonable_encoder(json)) if json is not OMIT else OMIT,
             },
             files={
                 "file": file,
@@ -828,9 +836,13 @@ class AsyncRawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "alias_object": json.dumps(jsonable_encoder(alias_object)),
@@ -1192,9 +1204,13 @@ class AsyncRawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "list_of_objects_with_optionals": json.dumps(jsonable_encoder(list_of_objects_with_optionals)),
@@ -1361,7 +1377,7 @@ class AsyncRawServiceClient:
             "with-json-property",
             method="POST",
             data={
-                "json": _json.dumps(jsonable_encoder(json)),
+                "json": _json.dumps(jsonable_encoder(json)) if json is not OMIT else OMIT,
             },
             files={
                 "file": file,

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/service/raw_client.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/service/raw_client.py
@@ -102,9 +102,13 @@ class RawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "alias_object": json.dumps(jsonable_encoder(alias_object)),
@@ -466,9 +470,13 @@ class RawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "list_of_objects_with_optionals": json.dumps(jsonable_encoder(list_of_objects_with_optionals)),
@@ -635,7 +643,7 @@ class RawServiceClient:
             "with-json-property",
             method="POST",
             data={
-                "json": _json.dumps(jsonable_encoder(json)),
+                "json": _json.dumps(jsonable_encoder(json)) if json is not OMIT else OMIT,
             },
             files={
                 "file": file,
@@ -828,9 +836,13 @@ class AsyncRawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "alias_object": json.dumps(jsonable_encoder(alias_object)),
@@ -1192,9 +1204,13 @@ class AsyncRawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "list_of_objects_with_optionals": json.dumps(jsonable_encoder(list_of_objects_with_optionals)),
@@ -1361,7 +1377,7 @@ class AsyncRawServiceClient:
             "with-json-property",
             method="POST",
             data={
-                "json": _json.dumps(jsonable_encoder(json)),
+                "json": _json.dumps(jsonable_encoder(json)) if json is not OMIT else OMIT,
             },
             files={
                 "file": file,

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/service/raw_client.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/service/raw_client.py
@@ -102,9 +102,13 @@ class RawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "alias_object": json.dumps(jsonable_encoder(alias_object)),
@@ -466,9 +470,13 @@ class RawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "list_of_objects_with_optionals": json.dumps(jsonable_encoder(list_of_objects_with_optionals)),
@@ -635,7 +643,7 @@ class RawServiceClient:
             "with-json-property",
             method="POST",
             data={
-                "json": _json.dumps(jsonable_encoder(json)),
+                "json": _json.dumps(jsonable_encoder(json)) if json is not OMIT else OMIT,
             },
             files={
                 "file": file,
@@ -828,9 +836,13 @@ class AsyncRawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "alias_object": json.dumps(jsonable_encoder(alias_object)),
@@ -1192,9 +1204,13 @@ class AsyncRawServiceClient:
                 "maybe_string": maybe_string,
                 "integer": integer,
                 "maybe_integer": maybe_integer,
-                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings)),
+                "optional_list_of_strings": json.dumps(jsonable_encoder(optional_list_of_strings))
+                if optional_list_of_strings is not OMIT
+                else OMIT,
                 "list_of_objects": json.dumps(jsonable_encoder(list_of_objects)),
-                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata)),
+                "optional_metadata": json.dumps(jsonable_encoder(optional_metadata))
+                if optional_metadata is not OMIT
+                else OMIT,
                 "optional_object_type": optional_object_type,
                 "optional_id": optional_id,
                 "list_of_objects_with_optionals": json.dumps(jsonable_encoder(list_of_objects_with_optionals)),
@@ -1361,7 +1377,7 @@ class AsyncRawServiceClient:
             "with-json-property",
             method="POST",
             data={
-                "json": _json.dumps(jsonable_encoder(json)),
+                "json": _json.dumps(jsonable_encoder(json)) if json is not OMIT else OMIT,
             },
             files={
                 "file": file,


### PR DESCRIPTION
## Description

Linear ticket: Closes FER-9115

Optional complex-type body parameters in multipart file upload requests were always being sent as `"null"` instead of being omitted. When an optional body property (e.g., `Optional[List[str]]`, `Optional[Any]`) defaulted to `OMIT`, the unconditional `json.dumps(jsonable_encoder(OMIT))` call evaluated to the string `"null"`, destroying the OMIT sentinel before `remove_omit_from_dict` could strip it.

## Changes Made

- Modified `get_json_body` in `file_upload_request_body_parameters.py` to compute `type_hint` for each non-primitive body property inside the loop. If `type_hint.is_optional`, the generated code now emits a ternary guard:
  ```python
  "key": json.dumps(jsonable_encoder(prop)) if prop is not OMIT else OMIT,
  ```
  Required (non-optional) params keep the existing unconditional `json.dumps(jsonable_encoder(...))`. This mirrors how `get_files` already handles optionality on content-type body properties (line ~180 of the same file).

- Added version `5.0.4` entry in `generators/python/sdk/versions.yml`

- Regenerated seed snapshots for all 3 `file-upload` fixture variants (`no-custom-config`, `use_typeddict_requests`, `exclude_types_from_init_exports`)

## Important Review Points

- **Core fix is ~10 lines** in `file_upload_request_body_parameters.py` — the rest is auto-generated seed snapshots
- Verify that only **optional** non-primitive params (`optional_list_of_strings`, `optional_metadata`, `json`) gained the OMIT guard, while **required** non-primitive params (`list_of_objects`, `alias_object`, `list_of_alias_object`, `alias_list_of_object`, `list_of_objects_with_optionals`) remain unchanged in the seed output
- Primitive optional params (e.g., `optional_object_type`, `optional_id`) are unaffected because they bypass `json.dumps` and pass the OMIT sentinel through directly, where `remove_omit_from_dict` strips it correctly

## Testing

- [x] Seed tests regenerated and all 3 fixture variants pass (`pnpm seed:local test --generator python-sdk --fixture file-upload`)
- [x] `poetry run pre-commit run -a` passes from `generators/python`
- [x] `pnpm run check` (biome lint) passes

Link to Devin session: https://app.devin.ai/sessions/b3527e4f0c9344a6a93f1902d758a33a
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
