### PR TITLE
fix(typescript): add default environment fallback to passthrough fetch for multi-URL environments

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
@@ -876,30 +876,49 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
 
         // Resolve the base URL from either the explicit baseUrl option or the environment.
         // For multi-URL environments (e.g. { ec2: string; s3: string }), the environment is an object,
-        // so we project it to a string via its first base URL property to avoid passing an object where a string is expected.
-        // The property name is read from the IR's baseUrls definition rather than hardcoded.
+        // so we project it to a string via the base URL property that HTTP endpoints use.
+        // This is the same logic regular endpoint methods use (via endpoint.baseUrl → getReferenceToEnvironmentUrl),
+        // ensuring the passthrough fetch resolves to the REST base URL, not a WebSocket or other URL.
         // If the IR defines a default environment, we also fall back to it (matching regular endpoint behavior).
         // For single-URL or no-IR-defined environments, the environment is already a string, so we fall back to it directly.
         const envs = this.intermediateRepresentation.environments?.environments;
         let baseUrlCode: string;
         if (envs != null && envs.type === "multipleBaseUrls") {
-            const firstBaseUrl = envs.baseUrls[0];
-            if (firstBaseUrl == null) {
+            // Find the base URL ID used by the first HTTP endpoint — this is the REST URL.
+            // Falls back to baseUrls[0] if no HTTP endpoints exist (e.g. WebSocket-only APIs).
+            let httpBaseUrlId: string | undefined;
+            for (const service of Object.values(this.intermediateRepresentation.services)) {
+                for (const endpoint of service.endpoints) {
+                    if (endpoint.baseUrl != null) {
+                        httpBaseUrlId = endpoint.baseUrl;
+                        break;
+                    }
+                }
+                if (httpBaseUrlId != null) {
+                    break;
+                }
+            }
+
+            const targetBaseUrl =
+                httpBaseUrlId != null
+                    ? (envs.baseUrls.find((bu) => bu.id === httpBaseUrlId) ?? envs.baseUrls[0])
+                    : envs.baseUrls[0];
+            if (targetBaseUrl == null) {
                 throw new Error("Multi-URL environment has no base URLs defined");
             }
-            const firstBaseUrlName = firstBaseUrl.name.camelCase.unsafeName;
+            const baseUrlName = targetBaseUrl.name.camelCase.unsafeName;
 
-            // Get the default environment reference (e.g. environments.XaiEnvironment.Default) if one exists.
+            // Get the default environment reference (e.g. environments.SdkEnvironment.Production) if one exists.
             // This mirrors getEnvironment() which does: this._options.environment ?? defaultEnvironment
             const defaultEnvExpr = context.environments
                 .getGeneratedEnvironments()
                 .getReferenceToDefaultEnvironment(context);
             const defaultEnvFallback =
-                defaultEnvExpr != null ? ` ?? ${getTextOfTsNode(defaultEnvExpr)}.${firstBaseUrlName}` : "";
+                defaultEnvExpr != null ? ` ?? ${getTextOfTsNode(defaultEnvExpr)}.${baseUrlName}` : "";
 
             baseUrlCode = `baseUrl: this._options.baseUrl ?? (async () => {
         const env = await core.Supplier.get(this._options.environment);
-        return typeof env === "string" ? env : (env as Record<string, string>)?.${firstBaseUrlName}${defaultEnvFallback};
+        return typeof env === "string" ? env : (env as Record<string, string>)?.${baseUrlName}${defaultEnvFallback};
     }),`;
         } else {
             baseUrlCode = "baseUrl: this._options.baseUrl ?? this._options.environment,";

--- a/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
@@ -878,6 +878,7 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
         // For multi-URL environments (e.g. { ec2: string; s3: string }), the environment is an object,
         // so we project it to a string via its first base URL property to avoid passing an object where a string is expected.
         // The property name is read from the IR's baseUrls definition rather than hardcoded.
+        // If the IR defines a default environment, we also fall back to it (matching regular endpoint behavior).
         // For single-URL or no-IR-defined environments, the environment is already a string, so we fall back to it directly.
         const envs = this.intermediateRepresentation.environments?.environments;
         let baseUrlCode: string;
@@ -887,9 +888,18 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
                 throw new Error("Multi-URL environment has no base URLs defined");
             }
             const firstBaseUrlName = firstBaseUrl.name.camelCase.unsafeName;
+
+            // Get the default environment reference (e.g. environments.XaiEnvironment.Default) if one exists.
+            // This mirrors getEnvironment() which does: this._options.environment ?? defaultEnvironment
+            const defaultEnvExpr = context.environments
+                .getGeneratedEnvironments()
+                .getReferenceToDefaultEnvironment(context);
+            const defaultEnvFallback =
+                defaultEnvExpr != null ? ` ?? ${getTextOfTsNode(defaultEnvExpr)}.${firstBaseUrlName}` : "";
+
             baseUrlCode = `baseUrl: this._options.baseUrl ?? (async () => {
         const env = await core.Supplier.get(this._options.environment);
-        return typeof env === "string" ? env : (env as Record<string, string>)?.${firstBaseUrlName};
+        return typeof env === "string" ? env : (env as Record<string, string>)?.${firstBaseUrlName}${defaultEnvFallback};
     }),`;
         } else {
             baseUrlCode = "baseUrl: this._options.baseUrl ?? this._options.environment,";

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.59.2
+  changelogEntry:
+    - summary: |
+        Fix passthrough `fetch()` method failing when no environment is explicitly set on
+        multi-URL environment SDKs (e.g. xAI's `{ base, production }`). When the user relies
+        on the default environment, `Supplier.get(undefined)` returned `undefined` and the
+        IIFE produced no base URL. The generated code now falls back to the IR-defined default
+        environment's first base URL (e.g. `environments.XaiEnvironment.Default.base`),
+        matching how regular endpoint methods resolve their base URL.
+      type: fix
+  createdAt: "2026-03-18"
+  irVersion: 65
+
 - version: 3.59.1
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -3,11 +3,11 @@
   changelogEntry:
     - summary: |
         Fix passthrough `fetch()` method failing when no environment is explicitly set on
-        multi-URL environment SDKs (e.g. xAI's `{ base, production }`). When the user relies
-        on the default environment, `Supplier.get(undefined)` returned `undefined` and the
-        IIFE produced no base URL. The generated code now falls back to the IR-defined default
-        environment's first base URL (e.g. `environments.XaiEnvironment.Default.base`),
-        matching how regular endpoint methods resolve their base URL.
+        multi-URL environment SDKs. When the user relies on the default environment,
+        `Supplier.get(undefined)` returned `undefined` and the IIFE produced no base URL.
+        The generated code now derives the correct base URL property from the IR (using the
+        same base URL that HTTP endpoints resolve to) and falls back to the IR-defined
+        default environment, matching how regular endpoint methods resolve their base URL.
       type: fix
   createdAt: "2026-03-18"
   irVersion: 65

--- a/seed/ts-sdk/multi-url-environment/src/Client.ts
+++ b/seed/ts-sdk/multi-url-environment/src/Client.ts
@@ -5,6 +5,7 @@ import { S3Client } from "./api/resources/s3/client/Client.js";
 import type { BaseClientOptions, BaseRequestOptions } from "./BaseClient.js";
 import { type NormalizedClientOptionsWithAuth, normalizeClientOptionsWithAuth } from "./BaseClient.js";
 import * as core from "./core/index.js";
+import * as environments from "./environments.js";
 
 export declare namespace SeedMultiUrlEnvironmentClient {
     export type Options = BaseClientOptions;
@@ -52,7 +53,10 @@ export class SeedMultiUrlEnvironmentClient {
                     this._options.baseUrl ??
                     (async () => {
                         const env = await core.Supplier.get(this._options.environment);
-                        return typeof env === "string" ? env : (env as Record<string, string>)?.ec2;
+                        return typeof env === "string"
+                            ? env
+                            : ((env as Record<string, string>)?.ec2 ??
+                                  environments.SeedMultiUrlEnvironmentEnvironment.Production.ec2);
                     }),
                 headers: this._options.headers,
                 timeoutInSeconds: this._options.timeoutInSeconds,


### PR DESCRIPTION
## Description

Refs #13591

Fixes a follow-up bug from #13591 where the passthrough `fetch()` method fails with a 404 when the user relies on the SDK's default environment for multi-URL environment SDKs (e.g. `{ base: string; production: string }`).

The root cause: when no environment is explicitly passed, `Supplier.get(undefined)` returns `undefined`, and `(undefined as Record<string, string>)?.base` also returns `undefined` — so there's no base URL and the request fails. Regular endpoint methods don't have this problem because they fall back to the IR-defined default environment (e.g. `this._options.environment ?? environments.SdkEnvironment.Default`), but the passthrough `fetch()` IIFE was missing this fallback.

## Changes Made

- **Generator** (`GeneratedSdkClientClassImpl.ts`):
  - **Derive base URL from HTTP endpoints**: Instead of using `baseUrls[0]` (which depends on YAML declaration order), the generator now finds the first HTTP endpoint's `baseUrl` from the IR and uses the same property. This is the same logic regular endpoint methods use via `endpoint.baseUrl → getReferenceToEnvironmentUrl`, ensuring the passthrough fetch resolves to the REST base URL — not a WebSocket or other URL. Falls back to `baseUrls[0]` only if no HTTP endpoints exist.
  - **Default environment fallback**: Calls `getReferenceToDefaultEnvironment(context)` to get the default environment expression. If one exists, appends it as a `??` fallback on the projected base URL property (e.g. `?.ec2 ?? environments.SdkEnvironment.Production.ec2`). This mirrors how `getEnvironment()` resolves base URLs for regular endpoints.
- **Seed fixture** (`multi-url-environment/src/Client.ts`): Updated to match expected generator output, including the new `environments` import and default env fallback.
- **versions.yml**: Added `3.59.2` changelog entry.

## Testing

- [x] Lint passes (`pnpm run check`)
- [ ] CI seed tests validate generated fixtures match actual generator output

### ⚠️ Human review checklist

- [ ] Verify that calling `getReferenceToDefaultEnvironment(context)` registers the `environments` import via the imports manager — the seed fixture manually adds `import * as environments from "./environments.js"` but this needs to come from the generator automatically
- [ ] Confirm `multi-url-environment-no-default` fixture is unchanged (no fallback since `default-environment: null`) — `defaultEnvExpr` should be `null` in this case and the import should NOT be added
- [ ] Verify the generated code formatting matches the manually updated seed fixture (indentation, line breaks in the ternary)
- [ ] Confirm the HTTP endpoint iteration (`Object.values(this.intermediateRepresentation.services)`) picks the correct base URL when multiple services use different base URLs

Link to Devin session: https://app.devin.ai/sessions/ed2c4e0ca69a40998215e54841424ba7
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
