### PR TITLE
chore(ci): bump CI actions to Node.js 24 compatible versions

### DIFF
--- a/.github/actions/apply-update-seed-patches/action.yaml
+++ b/.github/actions/apply-update-seed-patches/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ inputs.checkout-ref }}
 

--- a/.github/actions/artifact-seed-metrics/action.yaml
+++ b/.github/actions/artifact-seed-metrics/action.yaml
@@ -31,7 +31,7 @@ runs:
 
     # Save for at least a week to help track slowdowns if/when they show up
     - name: Upload Metrics File
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ${{ steps.create-metrics.outputs.file_name }}
         path: ${{ steps.create-metrics.outputs.file_name }}

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -71,7 +71,7 @@ runs:
     # Upload patch files as artifacts to be applied and committed by caller when all of seed is up to date
     - name: Upload Seed Artifacts
       if: steps.check-changes.outputs.seed-changes-generated == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: seed-${{ inputs.generator-name }}-${{ inputs.index }}.patch
         path: seed-${{ inputs.generator-name }}-${{ inputs.index }}.patch

--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -31,7 +31,7 @@ runs:
       with:
         github_token: ${{ github.token }}
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: "stable"
 

--- a/.github/actions/check-and-run-leftover-seed-tests/action.yaml
+++ b/.github/actions/check-and-run-leftover-seed-tests/action.yaml
@@ -24,7 +24,7 @@ runs:
       with:
         github_token: ${{ github.token }}
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: "stable"
 

--- a/.github/actions/check-for-changed-files/action.yaml
+++ b/.github/actions/check-for-changed-files/action.yaml
@@ -39,7 +39,7 @@ runs:
   steps:
     - name: Check for changes
       id: check-for-changes
-      uses: tj-actions/changed-files@v46
+      uses: tj-actions/changed-files@v47
       with:
         fetch_depth: ${{ inputs.fetch_depth }}
         base_sha: ${{ inputs.base_sha }}

--- a/.github/actions/get-test-matrix/action.yaml
+++ b/.github/actions/get-test-matrix/action.yaml
@@ -38,7 +38,7 @@ runs:
       with:
         github_token: ${{ github.token }}
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: "stable"
 

--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -6,7 +6,7 @@ runs:
 
   steps:
     - name: ⎔ Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v5
 
     - name: ⎔ Setup Node.js
       uses: actions/setup-node@v6
@@ -16,7 +16,7 @@ runs:
         cache: pnpm
 
     - name: ⎔ Cache turbo build
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .turbo
         key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}

--- a/.github/actions/process-grype-vulns/action.yml
+++ b/.github/actions/process-grype-vulns/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Process vulnerabilities and create PR
       id: process-vulns
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         CONTAINER_NAME: ${{ inputs.container_name }}
         IGNORED_CVES: ${{ inputs.ignored_cves }}

--- a/.github/actions/publish-generator/action.yaml
+++ b/.github/actions/publish-generator/action.yaml
@@ -30,13 +30,13 @@ runs:
       uses: ./.github/actions/install
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: fernapi
         password: ${{ inputs.docker-pwd }}
@@ -163,7 +163,7 @@ runs:
 
     - name: Setup Go for snippet package publishing
       if: steps.snippet-info.outputs.snippet_package != ''
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: "stable"
 

--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -68,7 +68,7 @@ runs:
         echo "as-string=$string_result" >> $GITHUB_OUTPUT
 
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Run seed
       uses: ./.github/actions/cached-seed

--- a/.github/actions/update-fern-platform-dependency/action.yml
+++ b/.github/actions/update-fern-platform-dependency/action.yml
@@ -16,9 +16,10 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: "22"
+        package-manager-cache: false
 
     - name: Install pnpm
       shell: bash

--- a/.github/workflows/check-devin-pr-assignee.yml
+++ b/.github/workflows/check-devin-pr-assignee.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'devin-ai-integration[bot]' }}
     steps:
       - name: Auto-assign requester from PR description
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -29,7 +29,7 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/typescript-v2/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Install
         uses: ./.github/actions/install
@@ -41,7 +41,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 
@@ -59,7 +59,7 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/python-v2/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Install
         uses: ./.github/actions/install
@@ -71,7 +71,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 
@@ -89,7 +89,7 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/csharp/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Install
         uses: ./.github/actions/install
@@ -101,7 +101,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 
@@ -119,7 +119,7 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/go-v2/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Install
         uses: ./.github/actions/install
@@ -131,7 +131,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 
@@ -149,7 +149,7 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/ruby-v2/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Install
         uses: ./.github/actions/install
@@ -161,7 +161,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 
@@ -179,7 +179,7 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/php/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Install
         uses: ./.github/actions/install
@@ -191,7 +191,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 
@@ -209,7 +209,7 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/swift/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Install
         uses: ./.github/actions/install
@@ -221,7 +221,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 
@@ -239,7 +239,7 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/java-v2/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Install
         uses: ./.github/actions/install
@@ -251,7 +251,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: Seed
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -116,7 +116,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -130,7 +130,7 @@ jobs:
       - name: Verify buf
         run: buf --version
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
           cache-dependency-path: generators/go/go.sum
@@ -174,7 +174,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -186,7 +186,7 @@ jobs:
       - name: Verify buf
         run: buf --version
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
           cache-dependency-path: generators/go/go.sum
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -263,15 +263,16 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20.x"
+          package-manager-cache: false
 
       - name: Assert docs are generated
         env:
@@ -299,15 +300,16 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20.x"
+          package-manager-cache: false
 
       - name: Check API definition is valid
         env:

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -24,7 +24,7 @@ jobs:
       version: ${{ steps.get_version.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 2

--- a/.github/workflows/definitions-validation.yml
+++ b/.github/workflows/definitions-validation.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -47,7 +47,7 @@ jobs:
       - name: Open PR with fixes
         if: steps.check-for-changes.outputs.lint-fixes == 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.ACTIONS_PAT }}
           commit-message: "fix(lint): auto-fix lint issues"

--- a/.github/workflows/go-generator.yml
+++ b/.github/workflows/go-generator.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Compile
         working-directory: ./generators/go
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run Tests
         working-directory: ./generators/go

--- a/.github/workflows/ir-release.yml
+++ b/.github/workflows/ir-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Fern
         run: npm install -g fern-api
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Fern
         run: npm install -g fern-api
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Fern
         run: npm install -g fern-api
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Fern
         run: npm install -g fern-api
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Fern
         run: npm install -g fern-api

--- a/.github/workflows/ir-validation.yml
+++ b/.github/workflows/ir-validation.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/java-generator.yml
+++ b/.github/workflows/java-generator.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           distribution: "adopt"
           java-version: "11"
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           distribution: "adopt"
           java-version: "11"
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           distribution: "adopt"
           java-version: "11"

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -19,7 +19,7 @@ jobs:
     name: Lint PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         with:
           types: |
             fix

--- a/.github/workflows/nightly-seed-metrics.yml
+++ b/.github/workflows/nightly-seed-metrics.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Note: this will trigger to the default branch of the repo, not the workflow_dispatch branch
       - name: Trigger Seed Tests with Metrics
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.ACTIONS_PAT }}
           event-type: seed-test-metrics

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -39,7 +39,7 @@ jobs:
       is_release_bump: ${{ steps.check_versions_yml.outputs.is_release_bump }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
@@ -63,7 +63,7 @@ jobs:
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -119,7 +119,7 @@ jobs:
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 20
@@ -164,7 +164,7 @@ jobs:
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
 
@@ -195,7 +195,7 @@ jobs:
       AUTOPILOT_HOST: ${{ vars.AUTOPILOT_HOST != '' && vars.AUTOPILOT_HOST || 'https://autopilot.buildwithfern.com' }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get CLI version
         id: get_version

--- a/.github/workflows/publish-docs-parsers-sdk.yml
+++ b/.github/workflows/publish-docs-parsers-sdk.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -30,7 +30,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
       has_new_version: ${{ steps.get_version.outputs.has_new_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
     if: needs.check-version.outputs.has_new_version == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -102,7 +102,7 @@ jobs:
     if: needs.check-version.outputs.has_new_version == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: 📥 Install Fern
         run: npm install -g fern-api

--- a/.github/workflows/publish-generator-csharp-model.yml
+++ b/.github/workflows/publish-generator-csharp-model.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-csharp-sdk.yml
+++ b/.github/workflows/publish-generator-csharp-sdk.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-go-model.yml
+++ b/.github/workflows/publish-generator-go-model.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-go-sdk.yml
+++ b/.github/workflows/publish-generator-go-sdk.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-java-model.yml
+++ b/.github/workflows/publish-generator-java-model.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -30,7 +30,7 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-java-spring.yml
+++ b/.github/workflows/publish-generator-java-spring.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -35,7 +35,7 @@ jobs:
       should_publish: ${{ steps.determine_version.outputs.should_publish }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 10
 
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -91,11 +91,12 @@ jobs:
           pnpm turbo run test --filter=${{ env.PACKAGE_NAME }}
 
       - name: Setup Node for npm publish
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
           scope: "@fern-api"
+          package-manager-cache: false
 
       - name: Build and publish generator-migrations
         env:

--- a/.github/workflows/publish-generator-openapi.yml
+++ b/.github/workflows/publish-generator-openapi.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-php-model.yml
+++ b/.github/workflows/publish-generator-php-model.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-php-sdk.yml
+++ b/.github/workflows/publish-generator-php-sdk.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-postman.yml
+++ b/.github/workflows/publish-generator-postman.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-python-fastapi.yml
+++ b/.github/workflows/publish-generator-python-fastapi.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-python-pydantic.yml
+++ b/.github/workflows/publish-generator-python-pydantic.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-python-sdk.yml
+++ b/.github/workflows/publish-generator-python-sdk.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-ruby-sdk.yml
+++ b/.github/workflows/publish-generator-ruby-sdk.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-rust-model.yml
+++ b/.github/workflows/publish-generator-rust-model.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-rust-sdk.yml
+++ b/.github/workflows/publish-generator-rust-sdk.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-swift-sdk.yml
+++ b/.github/workflows/publish-generator-swift-sdk.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-ts-express.yml
+++ b/.github/workflows/publish-generator-ts-express.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-generator-ts-sdk.yml
+++ b/.github/workflows/publish-generator-ts-sdk.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 10

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Fern CLI
         run: npm install -g fern-api

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ inputs.version != null }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
 
@@ -37,7 +37,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 

--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Fern CLI
         run: npm install -g fern-api

--- a/.github/workflows/python-generator.yml
+++ b/.github/workflows/python-generator.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/sdk-ete-tests.yml
+++ b/.github/workflows/sdk-ete-tests.yml
@@ -163,7 +163,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -184,10 +184,10 @@ jobs:
           pnpm turbo run dist:cli --filter @fern-api/go-sdk
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
@@ -355,7 +355,7 @@ jobs:
 
       - name: Comment on PR with branch info
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const testDefinition = '${{ inputs.test-definition }}' || 'exhaustive';

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -46,11 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Fetch Dependabot alerts
         id: fetch-alerts
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PR_BOT_GH_PAT }}
           script: |
@@ -91,7 +91,7 @@ jobs:
       - name: Create PRs and send Slack notifications
         id: create-prs
         if: ${{ steps.fetch-alerts.outputs.alerts_json != '[]' && inputs.scan_only != true }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           # ============================================================
           # DEVIN PROMPT CONFIGURATION
@@ -368,12 +368,12 @@ jobs:
       pull-requests: write
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
           aws-region: "us-east-1"
@@ -416,7 +416,7 @@ jobs:
           grype docker:java-sdk:grype-scan -o json > grype-report.json
 
       - name: Upload grype scan results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: grype-scan-results-java-sdk
           path: grype-report.json

--- a/.github/workflows/seed-dockers.yml
+++ b/.github/workflows/seed-dockers.yml
@@ -58,7 +58,7 @@ jobs:
       php: ${{ steps.set-output.outputs.php }}
       go: ${{ steps.set-output.outputs.go }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
           fetch-tags: false
@@ -153,7 +153,7 @@ jobs:
     outputs:
       sha: ${{ steps.sha.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: sha
         run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
@@ -173,16 +173,16 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: fernapi/ts-seed
           tags: |
@@ -190,13 +190,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.ts
@@ -222,16 +222,16 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: fernapi/java-seed
           tags: |
@@ -239,13 +239,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.java
@@ -271,16 +271,16 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: fernapi/python-seed
           tags: |
@@ -288,13 +288,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.python
@@ -320,16 +320,16 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: fernapi/csharp-seed
           tags: |
@@ -337,13 +337,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.csharp
@@ -369,16 +369,16 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: fernapi/php-seed
           tags: |
@@ -386,13 +386,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.php
@@ -418,16 +418,16 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: fernapi/go-seed
           tags: |
@@ -435,13 +435,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.go
@@ -458,10 +458,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}

--- a/.github/workflows/seed-pr-comment.yml
+++ b/.github/workflows/seed-pr-comment.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Post seed selector comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const marker = '<!-- seed-selector -->';
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Parse checked languages
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const commentBody = context.payload.comment.body;
@@ -193,7 +193,7 @@ jobs:
       - name: Check if we can push to PR branch
         id: check-push
         if: steps.parse.outputs.checked-languages != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prRepoFullName = '${{ steps.parse.outputs.pr-repo-full-name }}';
@@ -208,7 +208,7 @@ jobs:
 
       - name: Checkout PR branch
         if: steps.parse.outputs.checked-languages != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.parse.outputs.pr-ref }}
           fetch-tags: false
@@ -220,7 +220,7 @@ jobs:
 
       - name: Run seed tests for selected languages
         if: steps.parse.outputs.checked-languages != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -55,7 +55,7 @@ jobs:
     if: ${{ needs.get-all-test-matrices.outputs.seed-infrastructure-changed == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -95,7 +95,7 @@ jobs:
       rust-sdk: ${{ steps.create-dynamic-matrix.outputs.rust-sdk-test-matrix }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -104,7 +104,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 
@@ -265,7 +265,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk-v2) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -296,7 +296,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.pydantic) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -326,7 +326,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -357,7 +357,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.fastapi) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -387,7 +387,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.openapi) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -417,7 +417,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.postman) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -447,7 +447,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -477,7 +477,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -507,7 +507,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-spring) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -537,7 +537,7 @@ jobs:
         include: ${{ fromJson(needs.get-all-test-matrices.outputs.ts-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -568,7 +568,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-express) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -599,7 +599,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-model) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -629,7 +629,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -659,7 +659,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-model) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -689,7 +689,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -719,7 +719,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-model) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -749,7 +749,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -779,7 +779,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.swift-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -809,7 +809,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-model) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -839,7 +839,7 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
@@ -1072,7 +1072,7 @@ jobs:
       rust-sdk-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.rust-sdk-allowed-failures-count }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -1081,7 +1081,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
 

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -43,7 +43,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
           cache: false

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branch || github.ref }}
 
@@ -98,14 +98,14 @@ jobs:
         run: pnpm seed:build
 
       - name: Upload Seed CLI
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: seed-cli
           path: packages/seed/dist/
           retention-days: 1
 
       - name: Upload Fern CLI
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: fern-cli
           path: packages/cli/cli/dist/prod/
@@ -128,7 +128,7 @@ jobs:
         generator: ${{ fromJson(needs.determine-generator.outputs.generators) }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branch || github.ref }}
 
@@ -136,13 +136,13 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Download Seed CLI
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: seed-cli
           path: packages/seed/dist/
 
       - name: Download Fern CLI
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: fern-cli
           path: packages/cli/cli/dist/prod/

--- a/.github/workflows/typescript-generator.yml
+++ b/.github/workflows/typescript-generator.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Fern
         run: npm install -g fern-api

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -226,7 +226,7 @@ jobs:
 
     steps:
       - name: Checkout Files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             ${{ matrix.files }}
@@ -307,7 +307,7 @@ jobs:
       rust-sdk: ${{ steps.create-dynamic-matrix.outputs.rust-sdk-test-matrix }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install
         uses: ./.github/actions/install
@@ -365,7 +365,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -399,7 +399,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -433,7 +433,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -467,7 +467,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -501,7 +501,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -535,7 +535,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -569,7 +569,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -603,7 +603,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -637,7 +637,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -671,7 +671,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -705,7 +705,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -740,7 +740,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -774,7 +774,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -808,7 +808,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -842,7 +842,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -876,7 +876,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -910,7 +910,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -944,7 +944,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -978,7 +978,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -1012,7 +1012,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/actions/
@@ -1074,7 +1074,7 @@ jobs:
 
       # Get action file specific to the running branch
       - name: Checkout Action File
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.extract-branch.outputs.branch }}
           sparse-checkout: |
@@ -1217,7 +1217,7 @@ jobs:
             sdk-name: rust-sdk
     steps:
       - name: Checkout Action File
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/
@@ -1246,7 +1246,7 @@ jobs:
       - name: Create Pull Request
         if: steps.apply-patches.outputs.has-patches == 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           commit-message: "chore(${{ matrix.language-name }}): update ${{ matrix.sdk-name }} seed"

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -37,7 +37,7 @@ jobs:
       - name: Verify buf
         run: buf --version
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "stable"
           cache-dependency-path: generators/go/go.sum

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/validate-ir-version-consistency.yml
+++ b/.github/workflows/validate-ir-version-consistency.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             seed

--- a/.github/workflows/validate-versions-files.yml
+++ b/.github/workflows/validate-versions-files.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             generators

--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch of fern repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
@@ -40,7 +40,7 @@ jobs:
           pnpm seed:local generate changelog cli -o ./changelogs/cli/ --clean-directory
 
       - name: Checkout main branch of docs repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: fern-api/docs
           ref: main
@@ -78,7 +78,7 @@ jobs:
 
       - name: create PR
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           commit-message: "update changelogs"


### PR DESCRIPTION
## Description

Addresses Node.js 20 deprecation warnings in CI by bumping all external GitHub Actions to their latest Node.js 24-compatible major versions. No workflow logic changes — version-only bumps across 67 files.

## Changes Made

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v4 | v5 |
| `actions/download-artifact` | v4 | v5 |
| `actions/github-script` | v7 | v8 |
| `actions/setup-go` | v5 | v6 |
| `actions/setup-java` | v2 | v5 |
| `pnpm/action-setup` | v4 | v5 |
| `aws-actions/configure-aws-credentials` | v5 | v6 |
| `docker/login-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |
| `docker/metadata-action` | v5 | v6 |
| `amannn/action-semantic-pull-request` | v5 | v6 |
| `dependabot/fetch-metadata` | v1 | v2 |
| `peter-evans/create-pull-request` | v5/v7 | v8 |
| `peter-evans/repository-dispatch` | v2 | v4 |
| `tj-actions/changed-files` | v46 | v47 |

**Actions left as-is (no Node.js 24 version available or already current):**
- `EndBug/add-and-commit@v9`, `nick-fields/retry@v3`, `softprops/action-gh-release@v2` — still on Node.js 20, no new major version available
- `PostHog/posthog-github-action@v0.1`, `peter-evans/enable-pull-request-automerge@v3`, `snok/install-poetry@v1`, `bufbuild/buf-setup-action@v1.*` — composite/shell actions, no Node.js runtime dependency
- `dsanders11/json-schema-validate-action@v1.4.0`, `crs-k/stale-branches@v8.2.2`, `actions/stale@v10`, `actions/setup-node@v6` — already on latest / already Node.js 24 compatible

### Breaking change fix: `actions/setup-node@v5` auto-caching

`actions/setup-node@v5` auto-enables caching when a `packageManager` field is present in `package.json`. This repo has `"packageManager": "pnpm@10.28.0"`, which would trigger unwanted caching in standalone `setup-node` steps (separate from the `install` composite action which already uses `@v6` with explicit `cache: pnpm`).

Added `package-manager-cache: false` to all standalone `setup-node@v5` usages:
- `ci.yml` (2 occurrences — Windows test jobs)
- `publish-generator-migrations.yml`
- `update-fern-platform-dependency/action.yml`

### Breaking change analysis for all bumped actions

Each action was verified for removed inputs, newly required inputs, and behavioral changes against our actual usage:

- **`actions/checkout` v4→v5**: Node.js 24 runtime only. Inputs we use (`ref`, `fetch-depth`, `fetch-tags`, `lfs`, `path`, `repository`, `sparse-checkout`, `token`) all unchanged.
- **`actions/setup-node` v4→v5**: ⚠️ Auto-caching breaking change → **fixed** (see above).
- **`actions/cache` v4→v5**: Node.js 24 runtime only. Inputs we use (`key`, `path`, `restore-keys`) unchanged.
- **`actions/upload-artifact` v4→v5**: Node.js 24 runtime only. Inputs we use (`name`, `path`, `retention-days`, `if-no-files-found`) unchanged.
- **`actions/download-artifact` v4→v5**: Breaking change for `artifact-ids` path behavior — we don't use `artifact-ids` (we use `name`, `path`, `pattern`, `merge-multiple`). Safe.
- **`actions/github-script` v7→v8**: Node.js 24 runtime only. Inputs we use (`github-token`, `script`) unchanged.
- **`actions/setup-go` v5→v6**: Node.js 24 runtime only. Inputs we use (`go-version`, `cache`, `cache-dependency-path`) unchanged.
- **`actions/setup-java` v2→v5** _(large jump)_: Only breaking change is Node.js 24 runtime. Inputs we use (`distribution`, `java-version`) are stable across all versions.
- **`pnpm/action-setup` v4→v5**: No inputs used. Safe.
- **`aws-actions/configure-aws-credentials` v5→v6**: Node.js 24 runtime only. Inputs we use (`aws-region`, `role-to-assume`) unchanged.
- **`docker/login-action` v3→v4**: Node.js 24 runtime only. Inputs we use (`username`, `password`) unchanged.
- **`docker/setup-buildx-action` v3→v4**: Removed deprecated `install` input — we don't use any `with:` inputs. Safe.
- **`docker/setup-qemu-action` v3→v4**: Node.js 24 runtime only. No inputs used. Safe.
- **`docker/build-push-action` v6→v7**: Removed deprecated `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs — we don't use them. Inputs we use (`cache-from`, `cache-to`, `context`, `file`, `labels`, `platforms`, `push`, `tags`) unchanged.
- **`docker/metadata-action` v5→v6**: Node.js 24 runtime only. Inputs we use (`images`, `tags`) unchanged.
- **`amannn/action-semantic-pull-request` v5→v6**: Node.js 24 runtime only. Inputs we use (`types`, `scopes`, `requireScope`) unchanged.
- **`dependabot/fetch-metadata` v1→v2**: Node.js runtime only. Input we use (`github-token`) unchanged.
- **`peter-evans/create-pull-request` v5/v7→v8** _(large jump from v5)_: Node.js 24 runtime only. Inputs we use (`token`, `commit-message`, `title`, `body`, `branch`, `path`, `add-paths`, `delete-branch`) stable across all versions.
- **`peter-evans/repository-dispatch` v2→v4**: Node.js 24 runtime only. Inputs we use (`token`, `event-type`, `client-payload`) unchanged.
- **`tj-actions/changed-files` v46→v47**: Node.js 24 runtime upgrade. Inputs we use (`base_sha`, `fetch_depth`, `files`) unchanged.

## Testing
- [x] Lint passes (`biome check`)
- [ ] CI validation — these changes can only be fully validated by running CI on this PR

## Human review checklist
- [ ] Verify `package-manager-cache: false` is applied correctly to all 4 standalone `setup-node@v5` steps
- [ ] Verify `actions/setup-java` v2→v5 jump doesn't affect the Gradle build jobs in `java-generator.yml` (we only use `distribution: adopt` + `java-version: 11`)
- [ ] Verify `peter-evans/create-pull-request` v5→v8 jump in `update-seed.yml` and `write-changelogs-to-docs.yml` — all inputs used (`token`, `commit-message`, `title`, `body`, `branch`, `path`, `add-paths`, `delete-branch`) are still supported
- [ ] Verify `docker/build-push-action` v7 works with existing `cache-from`/`cache-to` patterns in `seed-dockers.yml`

Link to Devin session: https://app.devin.ai/sessions/3838526ec6224c6b9dc01df9ed56530e
Requested by: @davidkonigsberg