### PR TITLE
fix(java): fix formatting of `x-fern-header`-configured security schemas

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -2187,7 +2187,7 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                 maybeConditionalAdditionFlow = maybeConditionalAdditionFlow.addStatement(
                         "builder.addHeader($S, $S + this.$L)",
                         header.getName().getWireValue(),
-                        header.getPrefix().get(),
+                        header.getPrefix().get() + " ",
                         fieldName);
             } else {
                 maybeConditionalAdditionFlow = maybeConditionalAdditionFlow.addStatement(

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/RequestOptionsGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/RequestOptionsGenerator.java
@@ -591,7 +591,7 @@ public final class RequestOptionsGenerator extends AbstractFileGenerator {
 
             String headerValue = "this." + headerName.getName().getCamelCase().getSafeName();
             if (headerPrefix.isPresent()) {
-                headerValue = String.format("\"%s\" + %s", headerPrefix.get(), headerValue);
+                headerValue = String.format("\"%s \" + %s", headerPrefix.get(), headerValue);
             }
 
             getHeadersCodeBlock

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.44.3
+  changelogEntry:
+    - summary: |
+        Fix auth header prefix missing trailing space.
+      type: fix
+  createdAt: "2026-03-18"
+  irVersion: 65
+
 - version: 3.44.2
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/AsyncSeedHeaderTokenClientBuilder.java
+++ b/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/AsyncSeedHeaderTokenClientBuilder.java
@@ -125,7 +125,7 @@ public class AsyncSeedHeaderTokenClientBuilder {
      * }</pre>
      */
     protected void setAuthentication(ClientOptions.Builder builder) {
-        builder.addHeader("x-api-key", "test_prefix" + this.headerTokenAuth);
+        builder.addHeader("x-api-key", "test_prefix " + this.headerTokenAuth);
     }
 
     /**

--- a/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/SeedHeaderTokenClientBuilder.java
+++ b/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/SeedHeaderTokenClientBuilder.java
@@ -125,7 +125,7 @@ public class SeedHeaderTokenClientBuilder {
      * }</pre>
      */
     protected void setAuthentication(ClientOptions.Builder builder) {
-        builder.addHeader("x-api-key", "test_prefix" + this.headerTokenAuth);
+        builder.addHeader("x-api-key", "test_prefix " + this.headerTokenAuth);
     }
 
     /**

--- a/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/core/RequestOptions.java
+++ b/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/core/RequestOptions.java
@@ -52,7 +52,7 @@ public final class RequestOptions {
     public Map<String, String> getHeaders() {
         Map<String, String> headers = new HashMap<>();
         if (this.headerTokenAuth != null) {
-            headers.put("x-api-key", "test_prefix" + this.headerTokenAuth);
+            headers.put("x-api-key", "test_prefix " + this.headerTokenAuth);
         }
         headers.putAll(this.headers);
         this.headerSuppliers.forEach((key, supplier) -> {


### PR DESCRIPTION
## Description
Java SDKs were misformatting `x-fern-header` on a security scheme when there was a `prefix` value (missing space [required by RFC 7235]); this no longer happens.

## Changes Made
Java generator.

## Testing
The `header-auth` seed fixture reflects the changes.
- [X] Unit tests added/updated
- [X] Manual testing completed
