### PR TITLE
fix(cli): list available groups in error when no group specified

### DIFF
--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -75,13 +75,14 @@ export async function generateWorkspace({
         const groupNames = workspace.generatorsConfiguration.groups.map((g) => g.groupName);
         const longestGroupName = Math.max(...groupNames.map((name) => name.length));
         const currentArgs = process.argv.slice(2).join(" ");
-        let message = `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}:\n`;
-        message += groupNames
-            .map((name) => {
-                const suggestedCommand = `fern ${currentArgs} --${GROUP_CLI_OPTION} ${name}`;
-                return ` › ${chalk.bold(name.padEnd(longestGroupName))}  ${chalk.dim(suggestedCommand)}`;
-            })
-            .join("\n");
+        const message =
+            `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}:\n` +
+            groupNames
+                .map((name) => {
+                    const suggestedCommand = `fern ${currentArgs} --${GROUP_CLI_OPTION} ${name}`;
+                    return ` › ${chalk.bold(name.padEnd(longestGroupName))}  ${chalk.dim(suggestedCommand)}`;
+                })
+                .join("\n");
         return context.failAndThrow(message);
     }
 

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -71,8 +71,9 @@ export async function generateWorkspace({
 
     const groupNameOrDefault = groupName ?? workspace.generatorsConfiguration.defaultGroup;
     if (groupNameOrDefault == null) {
+        const availableGroups = workspace.generatorsConfiguration.groups.map((g) => g.groupName).join(", ");
         return context.failAndThrow(
-            `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}`
+            `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}. Available groups: ${availableGroups}`
         );
     }
 

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -12,6 +12,7 @@ import { runRemoteGenerationForAPIWorkspace } from "@fern-api/remote-workspace-r
 import { TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
+import chalk from "chalk";
 
 import { GROUP_CLI_OPTION } from "../../constants.js";
 import { GenerationMode } from "./generateAPIWorkspaces.js";
@@ -71,10 +72,17 @@ export async function generateWorkspace({
 
     const groupNameOrDefault = groupName ?? workspace.generatorsConfiguration.defaultGroup;
     if (groupNameOrDefault == null) {
-        const availableGroups = workspace.generatorsConfiguration.groups.map((g) => g.groupName).join(", ");
-        return context.failAndThrow(
-            `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}. Available groups: ${availableGroups}`
-        );
+        const groupNames = workspace.generatorsConfiguration.groups.map((g) => g.groupName);
+        const longestGroupName = Math.max(...groupNames.map((name) => name.length));
+        const currentArgs = process.argv.slice(2).join(" ");
+        let message = `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}:\n`;
+        message += groupNames
+            .map((name) => {
+                const suggestedCommand = `fern ${currentArgs} --${GROUP_CLI_OPTION} ${name}`;
+                return ` › ${chalk.bold(name.padEnd(longestGroupName))}  ${chalk.dim(suggestedCommand)}`;
+            })
+            .join("\n");
+        return context.failAndThrow(message);
     }
 
     // Resolve group aliases - if the groupName is an alias, expand it to multiple groups

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.34.1
+  changelogEntry:
+    - summary: |
+        Include available group names in the error message when no group is
+        specified and no default-group is set. The error now lists all groups
+        defined in generators.yml so users can quickly pick the right
+        `--group` value.
+      type: fix
+  createdAt: "2026-03-18"
+  irVersion: 65
+
 - version: 4.34.0
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/generators-yml/updateGeneratorGroup.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/updateGeneratorGroup.ts
@@ -14,8 +14,12 @@ export async function updateGeneratorGroup({
 }): Promise<generatorsYml.GeneratorsConfigurationSchema> {
     if (groupName == null) {
         const availableGroups = Object.keys(generatorsConfiguration.groups ?? {});
-        const groupsList = availableGroups.length > 0 ? `. Available groups: ${availableGroups.join(", ")}` : "";
-        return context.failAndThrow(`No group specified${groupsList}`);
+        if (availableGroups.length > 0) {
+            let message = "No group specified. Use the --group option:\n";
+            message += availableGroups.map((name) => ` › ${name}`).join("\n");
+            return context.failAndThrow(message);
+        }
+        return context.failAndThrow("No group specified.");
     }
     const groups = (generatorsConfiguration.groups ??= {});
 

--- a/packages/cli/configuration-loader/src/generators-yml/updateGeneratorGroup.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/updateGeneratorGroup.ts
@@ -13,7 +13,9 @@ export async function updateGeneratorGroup({
     update: (draft: generatorsYml.GeneratorGroupSchema, groupName: string) => Promise<void>;
 }): Promise<generatorsYml.GeneratorsConfigurationSchema> {
     if (groupName == null) {
-        return context.failAndThrow("No group specified.");
+        const availableGroups = Object.keys(generatorsConfiguration.groups ?? {});
+        const groupsList = availableGroups.length > 0 ? `. Available groups: ${availableGroups.join(", ")}` : "";
+        return context.failAndThrow(`No group specified${groupsList}`);
     }
     const groups = (generatorsConfiguration.groups ??= {});
 

--- a/packages/cli/configuration-loader/src/generators-yml/updateGeneratorGroup.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/updateGeneratorGroup.ts
@@ -15,8 +15,9 @@ export async function updateGeneratorGroup({
     if (groupName == null) {
         const availableGroups = Object.keys(generatorsConfiguration.groups ?? {});
         if (availableGroups.length > 0) {
-            let message = "No group specified. Use the --group option:\n";
-            message += availableGroups.map((name) => ` › ${name}`).join("\n");
+            const message =
+                "No group specified. Use the --group option:\n" +
+                availableGroups.map((name) => ` › ${name}`).join("\n");
             return context.failAndThrow(message);
         }
         return context.failAndThrow("No group specified.");

--- a/packages/cli/ete-tests/src/tests/generate/fixtures/no-default-group/fern/definition/api.yml
+++ b/packages/cli/ete-tests/src/tests/generate/fixtures/no-default-group/fern/definition/api.yml
@@ -1,0 +1,1 @@
+name: test-api

--- a/packages/cli/ete-tests/src/tests/generate/fixtures/no-default-group/fern/fern.config.json
+++ b/packages/cli/ete-tests/src/tests/generate/fixtures/no-default-group/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "test",
+    "version": "*"
+}

--- a/packages/cli/ete-tests/src/tests/generate/fixtures/no-default-group/fern/generators.yml
+++ b/packages/cli/ete-tests/src/tests/generate/fixtures/no-default-group/fern/generators.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+
+groups:
+  sdk:
+    generators:
+      - name: fernapi/fern-typescript-sdk
+        version: 2.3.2
+        config: {}
+        output:
+          location: local-file-system
+          path: ../sdks/typescript
+  docs:
+    generators:
+      - name: fernapi/fern-typescript-sdk
+        version: 2.3.2
+        config: {}
+        output:
+          location: local-file-system
+          path: ../sdks/docs

--- a/packages/cli/ete-tests/src/tests/generate/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate.test.ts
@@ -120,6 +120,19 @@ describe("fern generate", () => {
         });
         expect(stdout).toContain("No docs.yml file found. Please make sure your project has one.");
     }, 180_000);
+
+    it.concurrent("lists available groups when no group specified", async ({ signal }) => {
+        const { stdout, failed } = await runFernCli(["generate", "--local"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("no-default-group")),
+            reject: false,
+            signal
+        });
+        expect(failed).toBe(true);
+        const stripped = stripAnsi(stdout);
+        expect(stripped).toContain("No group specified");
+        expect(stripped).toContain("--group sdk");
+        expect(stripped).toContain("--group docs");
+    }, 90_000);
 });
 
 function extractFilepath(logLine: string): string | null {


### PR DESCRIPTION
## Description

When no `--group` is specified and no `default-group` is set in `generators.yml`, the error message now lists the available groups with copy-pasteable commands, matching the existing `--api` error pattern in `loadProject.ts`.

**Before:**
```
No group specified. Use the --group option, or set "default-group" in generators.yml
```

**After:**
```
No group specified. Use the --group option, or set "default-group" in generators.yml:
 › sdk   fern generate --local --group sdk
 › docs  fern generate --local --group docs
```

## Changes Made

- **`generateAPIWorkspace.ts`**: Replace the plain error with a chalk-formatted listing of available groups. Each group is shown with a copy-pasteable `fern ... --group <name>` command, using `process.argv` to reconstruct the current invocation (same approach as the `--api` error in `loadProject.ts`).
- **`updateGeneratorGroup.ts`**: Same improvement for the configuration-loader code path, using `Object.keys()` since `groups` is a record here. Uses `›` bullet formatting without chalk (chalk is not a dependency of this package). Falls back to the original message when no groups exist.
- **`versions.yml`**: Added changelog entry for CLI v4.34.1.
- **`generate.test.ts`** + **`no-default-group` fixture**: Added e2e test that runs `fern generate --local` against a fixture with two groups (`sdk`, `docs`) and no `default-group`, then verifies the error contains `--group sdk` and `--group docs`.

## Testing

- [x] E2e test added (`lists available groups when no group specified`)
- [x] Manual local testing — built the CLI and ran against the `no-default-group` fixture

### Human Review Checklist
- Verify `process.argv.slice(2).join(" ")` produces a reasonable command reconstruction (it mirrors the existing `--api` pattern in `loadProject.ts`)
- The `configuration-loader` path (`updateGeneratorGroup.ts`) intentionally omits chalk formatting since chalk is not a dependency of that package — the two code paths will produce slightly different output styles

Link to Devin session: https://app.devin.ai/sessions/1d278978cf0b40fab2b4126f69948cd1
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
