### PR TITLE
fix(typescript): preserve port number in registry URL for .npmrc auth token key

### DIFF
--- a/generators/typescript/express/versions.yml
+++ b/generators/typescript/express/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix npm publish authentication failing when the registry URL includes a port number.
+        The `.npmrc` auth token key was constructed using `URL.hostname` (which strips the port)
+        instead of `URL.host` (which preserves it).
+      type: fix
+  irVersion: 65
+  createdAt: "2026-03-18"
+  version: 0.19.10
+
+- changelogEntry:
+    - summary: |
         Fix README generation in Docker by adding `ca-certificates` to the Debian slim
         base image. Since the switch from Alpine to Debian slim, the container was missing
         CA certificates, causing `git clone` over HTTPS to fail with "server certificate

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.59.3
+  changelogEntry:
+    - summary: |
+        Fix npm publish authentication failing when the registry URL includes a port number.
+        The `.npmrc` auth token key was constructed using `URL.hostname` (which strips the port)
+        instead of `URL.host` (which preserves it). For example, a registry at
+        `http://host.docker.internal:4873` would write the token under
+        `//host.docker.internal/:_authToken` instead of the correct
+        `//host.docker.internal:4873/:_authToken`.
+      type: fix
+  createdAt: "2026-03-18"
+  irVersion: 65
+
 - version: 3.59.2
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -6,7 +6,6 @@ import { execFile } from "child_process";
 import decompress from "decompress";
 import { cp, readdir, rm } from "fs/promises";
 import tmp from "tmp-promise";
-import urlJoin from "url-join";
 import { promisify } from "util";
 
 export declare namespace PersistedTypescriptProject {

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -442,7 +442,7 @@ export class PersistedTypescriptProject {
         });
 
         const parsedRegistryUrl = new URL(publishInfo.registryUrl);
-        const registryUrlWithoutProtocol = urlJoin(parsedRegistryUrl.hostname, parsedRegistryUrl.pathname);
+        const registryUrlWithoutProtocol = urlJoin(parsedRegistryUrl.host, parsedRegistryUrl.pathname);
 
         await npm(["config", "set", `//${registryUrlWithoutProtocol}:_authToken`, publishInfo.token], {
             secrets: [registryUrlWithoutProtocol, publishInfo.token]

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -442,7 +442,7 @@ export class PersistedTypescriptProject {
         });
 
         const parsedRegistryUrl = new URL(publishInfo.registryUrl);
-        const registryUrlWithoutProtocol = urlJoin(parsedRegistryUrl.host, parsedRegistryUrl.pathname);
+        const registryUrlWithoutProtocol = `${parsedRegistryUrl.host}${parsedRegistryUrl.pathname}`;
 
         await npm(["config", "set", `//${registryUrlWithoutProtocol}:_authToken`, publishInfo.token], {
             secrets: [registryUrlWithoutProtocol, publishInfo.token]


### PR DESCRIPTION
## Description

Fixes npm publish authentication failing when the registry URL includes a non-default port number (e.g. `http://host.docker.internal:4873` for a local Verdaccio registry).

## Changes Made

- Replaced `urlJoin(parsedRegistryUrl.hostname, parsedRegistryUrl.pathname)` with `` `${parsedRegistryUrl.host}${parsedRegistryUrl.pathname}` `` in `PersistedTypescriptProject.ts`
  - `URL.hostname` strips the port → broken auth key
  - `urlJoin` with `URL.host` corrupts `host:port` by treating the colon as a protocol prefix (`host.docker.internal://4873/`)
  - Template literal preserves the port correctly
- Added version changelog entries for both the SDK generator (`3.59.3`) and Express generator (`0.19.10`)

**Before:** `//host.docker.internal/:_authToken=<token>` (port stripped, npm can't find the token)
**After:** `//host.docker.internal:4873/:_authToken=<token>` (port preserved, auth succeeds)

This is backwards-compatible: for standard registry URLs without an explicit port (e.g. `https://registry.npmjs.org`), `URL.host` and `URL.hostname` return the same value since default ports (80/443) are omitted by the URL API.

## Testing

- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Verified template literal output for both port and no-port URLs via `node -e`
- [ ] No unit tests added (one-line URL property change with well-documented Node.js API behavior)

## Reviewer Checklist

- [ ] Confirm `` `${parsedRegistryUrl.host}${parsedRegistryUrl.pathname}` `` produces a valid `.npmrc` key (e.g. `host.docker.internal:4873/`)
- [ ] Confirm no regression for standard registries (no explicit port → `.host` === `.hostname`)
- [ ] Confirm no edge cases with `URL.host` for unusual registry URLs (e.g. paths with multiple segments)

Link to Devin session: https://app.devin.ai/sessions/f7ade02fd6b842a7947b6758e79be32e
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
