### PR TITLE
fix(java): union matching, dynamic snippet handling of required fields, readme fixes

### DIFF
--- a/generators/java-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/java-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -544,16 +544,49 @@ exports[`snippets (default) > multi-url-environment > 'Unrecognized environment'
 `;
 
 exports[`snippets (default) > nullable > 'Body properties' 1`] = `
-"[
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "status"
-    ],
-    "message": "\\"type\\" is not a recognized parameter for this endpoint"
-  }
-]"
+"package com.example.usage;
+
+import com.acme.acme.AcmeAcmeClient;
+import com.acme.acme.core.Nullable;
+import com.acme.acme.types.CreateUserRequest;
+import com.acme.acme.types.Metadata;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+
+AcmeAcmeClient client = AcmeAcmeClient
+    .builder()
+    .url("https://api.example.com")
+    .build();
+
+client.nullable().createUser(
+    CreateUserRequest
+        .builder()
+        .username("john.doe")
+        .avatar(
+            Nullable.ofNull()
+        )
+        .tags(
+            Optional.of(
+                Arrays.asList("admin")
+            )
+        )
+        .metadata(
+            Metadata
+                .builder()
+                .createdAt(OffsetDateTime.parse("1980-01-01T00:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("1980-01-01T00:00:00Z"))
+                .avatar(
+                    Nullable.ofNull()
+                )
+                .activated(
+                    Nullable.ofNull()
+                )
+                .build()
+        )
+        .build()
+);
+"
 `;
 
 exports[`snippets (default) > nullable > 'Invalid null value' 1`] = `

--- a/generators/java-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/java-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -544,49 +544,16 @@ exports[`snippets (default) > multi-url-environment > 'Unrecognized environment'
 `;
 
 exports[`snippets (default) > nullable > 'Body properties' 1`] = `
-"package com.example.usage;
-
-import com.acme.acme.AcmeAcmeClient;
-import com.acme.acme.core.Nullable;
-import com.acme.acme.types.CreateUserRequest;
-import com.acme.acme.types.Metadata;
-import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.Optional;
-
-AcmeAcmeClient client = AcmeAcmeClient
-    .builder()
-    .url("https://api.example.com")
-    .build();
-
-client.nullable().createUser(
-    CreateUserRequest
-        .builder()
-        .username("john.doe")
-        .avatar(
-            Nullable.ofNull()
-        )
-        .tags(
-            Optional.of(
-                Arrays.asList("admin")
-            )
-        )
-        .metadata(
-            Metadata
-                .builder()
-                .createdAt(OffsetDateTime.parse("1980-01-01T00:00:00Z"))
-                .updatedAt(OffsetDateTime.parse("1980-01-01T00:00:00Z"))
-                .avatar(
-                    Nullable.ofNull()
-                )
-                .activated(
-                    Nullable.ofNull()
-                )
-                .build()
-        )
-        .build()
-);
-"
+"[
+  {
+    "severity": "CRITICAL",
+    "path": [
+      "requestBody",
+      "status"
+    ],
+    "message": "\\"type\\" is not a recognized parameter for this endpoint"
+  }
+]"
 `;
 
 exports[`snippets (default) > nullable > 'Invalid null value' 1`] = `
@@ -629,6 +596,8 @@ AcmeAcmeClient client = AcmeAcmeClient
 client.createUser(
     User
         .builder()
+        .id("string")
+        .email("string")
         .password("password")
         .profile(
             UserProfile
@@ -637,6 +606,7 @@ client.createUser(
                 .verification(
                     UserProfileVerification
                         .builder()
+                        .verified("string")
                         .build()
                 )
                 .ssn("ssn")
@@ -664,6 +634,7 @@ client.createUser(
     User
         .builder()
         .id("id")
+        .email("string")
         .password("password")
         .profile(
             UserProfile
@@ -672,6 +643,7 @@ client.createUser(
                 .verification(
                     UserProfileVerification
                         .builder()
+                        .verified("string")
                         .build()
                 )
                 .ssn("ssn")

--- a/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -421,11 +421,14 @@ export class DynamicTypeLiteralMapper {
                 if (inUndiscriminatedUnion === true) {
                     throw new Error(`Required property "${param.name.wireValue}" is missing from value`);
                 }
-                properties.push({
-                    name: param.name,
-                    typeReference: param.typeReference,
-                    value: this.getDefaultValueForTypeReference(param.typeReference)
-                });
+                const defaultValue = this.getDefaultValueForTypeReference(param.typeReference);
+                if (defaultValue !== undefined) {
+                    properties.push({
+                        name: param.name,
+                        typeReference: param.typeReference,
+                        value: defaultValue
+                    });
+                }
             }
         }
         // Re-sort all properties (including newly added defaults) to match schema declaration order.
@@ -491,11 +494,26 @@ export class DynamicTypeLiteralMapper {
                 return {};
             case "named": {
                 const named = this.context.resolveNamedType({ typeId: typeReference.value });
-                if (named != null && named.type === "enum" && named.values.length > 0) {
-                    const firstValue = named.values[0];
-                    return firstValue != null ? firstValue.wireValue : undefined;
+                if (named == null) {
+                    return {};
                 }
-                return {};
+                switch (named.type) {
+                    case "enum":
+                        if (named.values.length > 0) {
+                            const firstValue = named.values[0];
+                            return firstValue != null ? firstValue.wireValue : undefined;
+                        }
+                        return undefined;
+                    case "object":
+                    case "alias":
+                        return {};
+                    case "discriminatedUnion":
+                    case "undiscriminatedUnion":
+                        // Cannot synthesize valid defaults for union types
+                        return undefined;
+                    default:
+                        return {};
+                }
             }
             case "literal":
                 return typeReference.value.value;

--- a/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -453,8 +453,12 @@ export class DynamicTypeLiteralMapper {
                 });
                 // If a required property converts to nop (e.g., invalid enum value for the wrong
                 // union variant), throw to reject this variant during undiscriminated union matching.
+                // Outside of union matching, just skip the nop value to produce best-effort output.
                 if (java.TypeLiteral.isNop(convertedValue) && !this.context.isOptional(property.typeReference)) {
-                    throw new Error(`Required property "${property.name.wireValue}" could not be converted`);
+                    if (inUndiscriminatedUnion === true) {
+                        throw new Error(`Required property "${property.name.wireValue}" could not be converted`);
+                    }
+                    continue;
                 }
                 builderParameters.push({
                     name: this.context.getMethodName(property.name.name),

--- a/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -25,17 +25,12 @@ export class DynamicTypeLiteralMapper {
         this.context = context;
     }
 
-    private isNopTypeLiteral(value: java.TypeLiteral): boolean {
-        const valueWithInternal = value as unknown as { internalType?: { type?: string } };
-        return valueWithInternal.internalType?.type === "nop";
-    }
-
     private usesOptionalNullable(): boolean {
         return this.context.customConfig?.["collapse-optional-nullable"] === true;
     }
 
     private wrapInOptionalIfNotNop(value: java.TypeLiteral, useOf: boolean = false): java.TypeLiteral {
-        if (this.isNopTypeLiteral(value)) {
+        if (java.TypeLiteral.isNop(value)) {
             return value;
         }
         if (this.usesOptionalNullable()) {
@@ -316,7 +311,7 @@ export class DynamicTypeLiteralMapper {
             case "enum":
                 return this.convertEnum({ enum_: named, value });
             case "object":
-                return this.convertObject({ object_: named, value, as });
+                return this.convertObject({ object_: named, value, as, inUndiscriminatedUnion });
             case "undiscriminatedUnion":
                 // Don't pass inUndiscriminatedUnion here - we're AT the undiscriminated union level,
                 // not within it. The flag should only apply to the variants within the union.
@@ -401,36 +396,145 @@ export class DynamicTypeLiteralMapper {
     private convertObject({
         object_,
         value,
-        as
+        as,
+        inUndiscriminatedUnion
     }: {
         object_: FernIr.dynamic.ObjectType;
         value: unknown;
         as?: DynamicTypeLiteralMapper.ConvertedAs;
+        inUndiscriminatedUnion?: boolean;
     }): java.TypeLiteral {
         const properties = this.context.associateByWireValue({
             parameters: object_.properties,
             values: this.context.getRecord(value) ?? {}
         });
+        // Add missing required properties with default values to ensure valid staged builder code.
+        // Java uses type-state staged builders where required fields must be set before build() can
+        // be called. Without this, an empty value like {} would generate .builder().build() which
+        // fails to compile when the builder has required stages.
+        //
+        // When inside undiscriminated union matching, throw on missing required properties instead
+        // of adding defaults. This allows the matching to reject incorrect variants and try others.
+        const existingWireValues = new Set(properties.map((p) => p.name.wireValue));
+        for (const param of object_.properties) {
+            if (!existingWireValues.has(param.name.wireValue) && !this.context.isOptional(param.typeReference)) {
+                if (inUndiscriminatedUnion === true) {
+                    throw new Error(`Required property "${param.name.wireValue}" is missing from value`);
+                }
+                properties.push({
+                    name: param.name,
+                    typeReference: param.typeReference,
+                    value: this.getDefaultValueForTypeReference(param.typeReference)
+                });
+            }
+        }
+        // Re-sort all properties (including newly added defaults) to match schema declaration order.
+        // Java staged builders require method calls in the exact order defined by the schema.
+        const paramOrderMap = new Map<string, number>();
+        object_.properties.forEach((param, index) => {
+            paramOrderMap.set(param.name.wireValue, index);
+        });
+        properties.sort(
+            (a, b) => (paramOrderMap.get(a.name.wireValue) ?? 0) - (paramOrderMap.get(b.name.wireValue) ?? 0)
+        );
         const filteredProperties =
             as === "request"
                 ? properties.filter((property) => !this.context.isDirectLiteral(property.typeReference))
                 : properties;
+        const builderParameters: java.BuilderParameter[] = [];
+        for (const property of filteredProperties) {
+            this.context.errors.scope(property.name.wireValue);
+            try {
+                const convertedValue = this.convert({
+                    typeReference: property.typeReference,
+                    value: property.value,
+                    as,
+                    inUndiscriminatedUnion
+                });
+                // If a required property converts to nop (e.g., invalid enum value for the wrong
+                // union variant), throw to reject this variant during undiscriminated union matching.
+                if (java.TypeLiteral.isNop(convertedValue) && !this.context.isOptional(property.typeReference)) {
+                    throw new Error(`Required property "${property.name.wireValue}" could not be converted`);
+                }
+                builderParameters.push({
+                    name: this.context.getMethodName(property.name.name),
+                    value: convertedValue
+                });
+            } finally {
+                this.context.errors.unscope();
+            }
+        }
         return java.TypeLiteral.builder({
             classReference: this.context.getJavaClassReferenceFromDeclaration({
                 declaration: object_.declaration
             }),
-            parameters: filteredProperties.map((property) => {
-                this.context.errors.scope(property.name.wireValue);
-                try {
-                    return {
-                        name: this.context.getMethodName(property.name.name),
-                        value: this.convert({ typeReference: property.typeReference, value: property.value, as })
-                    };
-                } finally {
-                    this.context.errors.unscope();
-                }
-            })
+            parameters: builderParameters
         });
+    }
+
+    private getDefaultValueForTypeReference(typeReference: FernIr.dynamic.TypeReference): unknown {
+        switch (typeReference.type) {
+            case "primitive":
+                return this.getDefaultPrimitiveValue(typeReference.value);
+            case "nullable":
+                return null;
+            case "optional":
+                return undefined;
+            case "list":
+            case "set":
+                return [];
+            case "map":
+                return {};
+            case "named": {
+                const named = this.context.resolveNamedType({ typeId: typeReference.value });
+                if (named != null && named.type === "enum" && named.values.length > 0) {
+                    const firstValue = named.values[0];
+                    return firstValue != null ? firstValue.wireValue : undefined;
+                }
+                return {};
+            }
+            case "literal":
+                return typeReference.value.value;
+            case "unknown":
+                return {};
+            default:
+                assertNever(typeReference);
+        }
+    }
+
+    private getDefaultPrimitiveValue(primitive: FernIr.dynamic.PrimitiveTypeV1): unknown {
+        switch (primitive) {
+            case "STRING":
+                return "string";
+            case "INTEGER":
+            case "UINT":
+                return 1;
+            case "LONG":
+            case "UINT_64":
+                return 1000000;
+            case "FLOAT":
+            case "DOUBLE":
+                return 1.1;
+            case "BOOLEAN":
+                return true;
+            case "DATE":
+                return "2024-01-15";
+            case "DATE_TIME":
+                return "2024-01-15T09:30:00Z";
+            case "UUID":
+                return "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32";
+            case "BASE_64":
+                return "SGVsbG8gd29ybGQh";
+            case "BIG_INTEGER":
+                return "123456789";
+            default: {
+                const primitiveStr: string = primitive;
+                if (primitiveStr === "DATE_TIME_RFC_2822") {
+                    return "Tue, 15 Jan 2024 09:30:00 +0000";
+                }
+                return "string";
+            }
+        }
     }
 
     private convertEnum({ enum_, value }: { enum_: FernIr.dynamic.EnumType; value: unknown }): java.TypeLiteral {

--- a/generators/java-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/java-v2/sdk/src/SdkGeneratorContext.ts
@@ -242,6 +242,12 @@ export class SdkGeneratorContext extends AbstractJavaGeneratorContext<SdkCustomC
         return this.customConfig?.["base-api-exception-class-name"] ?? `${this.getBaseNamePrefix()}ApiException`;
     }
 
+    public getHttpResponseClassName(): string {
+        return this.customConfig?.["client-class-name"]
+            ? `${this.customConfig["client-class-name"]}HttpResponse`
+            : `${this.getBaseNamePrefix()}HttpResponse`;
+    }
+
     public getEnvironmentClassReference(): java.ClassReference {
         return java.classReference({
             name: this.getEnvironmentClassName(),

--- a/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -29,6 +29,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     private readonly defaultEndpointId: FernIr.EndpointId;
     private readonly rootPackageClientName: string;
     private readonly isPaginationEnabled: boolean;
+    private cachedEnvironmentUrlVariables?: FernIr.ServerVariable[];
 
     constructor({
         context,
@@ -153,7 +154,7 @@ For PATCH requests, the SDK uses \`OptionalNullable<T>\` to handle three-state n
 - **PRESENT**: Field has a non-null value
 
 \`\`\`java
-import com.seed.api.core.OptionalNullable;
+import ${this.context.getCorePackageName()}.OptionalNullable;
 
 UpdateRequest request = UpdateRequest.builder()
     .fieldName(OptionalNullable.absent())    // Skip field
@@ -211,9 +212,15 @@ ${clientClassName} client = ${clientClassName}.builder()
         predicate: (endpoint: EndpointWithFilepath) => boolean = () => true,
         backupRenderer: (endpoint: EndpointWithFilepath) => string
     ): string[] {
+        // For Usage snippets, always use the backup renderer when environment URL variables
+        // exist, since prerendered snippets from the dynamic generator don't include them.
+        const hasUrlVariables = this.getEnvironmentUrlVariables().length > 0;
         return this.getEndpointsForFeature(featureId)
             .filter(predicate)
             .map((endpoint) => {
+                if (hasUrlVariables && featureId === FernGeneratorCli.StructuredFeatureId.Usage) {
+                    return backupRenderer(endpoint);
+                }
                 const prerendered = this.prerenderedSnippetsByEndpointId[endpoint.endpoint.id];
                 return prerendered ?? backupRenderer(endpoint);
             });
@@ -232,15 +239,7 @@ ${clientClassName} client = ${clientClassName}.builder()
         const endpointMethodInvocation = this.getMethodCall(endpoint, [ReadmeSnippetBuilder.ELLIPSES]);
 
         const builderParameters: Array<{ name: string; value: java.TypeLiteral }> = [];
-        if (this.context.ir.variables != null && this.context.ir.variables.length > 0) {
-            for (const variable of this.context.ir.variables) {
-                const variableName = variable.name.camelCase.unsafeName;
-                builderParameters.push({
-                    name: variableName,
-                    value: java.TypeLiteral.string(`YOUR_${variable.name.screamingSnakeCase.unsafeName}`)
-                });
-            }
-        }
+        this.addClientBuilderParameters(builderParameters);
 
         const clientBuilder = java.TypeLiteral.builder({
             classReference: clientClassReference,
@@ -515,9 +514,8 @@ ${clientClassName} client = ${clientClassName}.builder()
             arguments_: [ReadmeSnippetBuilder.ELLIPSES]
         });
 
-        // Get the endpoint name for the response type
-        const endpointMethodName = this.getEndpointMethodName(endpoint.endpoint);
-        const responseTypeName = this.capitalizeFirstLetter(endpointMethodName) + "HttpResponse";
+        // Get the HttpResponse class name (matches v1's naming: {BaseNamePrefix}HttpResponse)
+        const responseTypeName = this.context.getHttpResponseClassName();
 
         const snippet = java.codeblock((writer) => {
             writer.write(responseTypeName);
@@ -894,6 +892,105 @@ ${clientClassName} client = ${clientClassName}.builder()
         return str.charAt(0).toUpperCase() + str.slice(1);
     }
 
+    /**
+     * Adds all common client builder parameters: auth, IR variables, path parameters, and URL variables.
+     */
+    private addClientBuilderParameters(builderParameters: Array<{ name: string; value: java.TypeLiteral }>): void {
+        // Auth parameters
+        if (this.context.ir.auth.schemes.length > 0) {
+            const authScheme = this.context.ir.auth.schemes[0];
+            if (authScheme?.type === "bearer") {
+                const tokenName = authScheme.token?.camelCase?.unsafeName ?? "token";
+                builderParameters.push({
+                    name: tokenName,
+                    value: java.TypeLiteral.string("<token>")
+                });
+            } else if (authScheme?.type === "basic") {
+                builderParameters.push({
+                    name: "username",
+                    value: java.TypeLiteral.string("<username>")
+                });
+                builderParameters.push({
+                    name: "password",
+                    value: java.TypeLiteral.string("<password>")
+                });
+            } else if (authScheme?.type === "header") {
+                const headerName = authScheme.name.name?.camelCase?.unsafeName ?? "apiKey";
+                builderParameters.push({
+                    name: headerName,
+                    value: java.TypeLiteral.string("<api-key>")
+                });
+            }
+        }
+        // IR variables
+        if (this.context.ir.variables != null && this.context.ir.variables.length > 0) {
+            for (const variable of this.context.ir.variables) {
+                builderParameters.push({
+                    name: variable.name.camelCase.unsafeName,
+                    value: java.TypeLiteral.string(`YOUR_${variable.name.screamingSnakeCase.unsafeName}`)
+                });
+            }
+        }
+        // Path parameters
+        if (this.context.ir.pathParameters != null && this.context.ir.pathParameters.length > 0) {
+            for (const param of this.context.ir.pathParameters.filter((p) => p.variable == null)) {
+                builderParameters.push({
+                    name: param.name.camelCase.unsafeName,
+                    value: java.TypeLiteral.string(`YOUR_${param.name.screamingSnakeCase.unsafeName}`)
+                });
+            }
+        }
+        // Environment URL variables (e.g., tenantDomain)
+        for (const urlVariable of this.getEnvironmentUrlVariables()) {
+            builderParameters.push({
+                name: urlVariable.name.camelCase.unsafeName,
+                value: java.TypeLiteral.string(`YOUR_${urlVariable.name.screamingSnakeCase.unsafeName}`)
+            });
+        }
+    }
+
+    /**
+     * Extracts URL variables from the first environment definition (e.g., tenantDomain from
+     * server URL templates like "https://{tenantDomain}/my-org").
+     */
+    private getEnvironmentUrlVariables(): FernIr.ServerVariable[] {
+        if (this.cachedEnvironmentUrlVariables != null) {
+            return this.cachedEnvironmentUrlVariables;
+        }
+        const result = this.computeEnvironmentUrlVariables();
+        this.cachedEnvironmentUrlVariables = result;
+        return result;
+    }
+
+    private computeEnvironmentUrlVariables(): FernIr.ServerVariable[] {
+        const environments = this.context.ir.environments;
+        if (environments == null) {
+            return [];
+        }
+        const envType = environments.environments;
+        if (envType.type === "singleBaseUrl") {
+            const firstEnv = envType.environments[0];
+            return firstEnv?.urlVariables ?? [];
+        }
+        if (envType.type === "multipleBaseUrls") {
+            const firstEnv = envType.environments[0];
+            if (firstEnv?.urlVariables != null) {
+                const seenIds = new Set<string>();
+                const variables: FernIr.ServerVariable[] = [];
+                for (const vars of Object.values(firstEnv.urlVariables)) {
+                    for (const v of vars) {
+                        if (!seenIds.has(v.id)) {
+                            seenIds.add(v.id);
+                            variables.push(v);
+                        }
+                    }
+                }
+                return variables;
+            }
+        }
+        return [];
+    }
+
     private hasWebSocketChannels(): boolean {
         return this.context.ir.websocketChannels != null && Object.keys(this.context.ir.websocketChannels).length > 0;
     }
@@ -943,44 +1040,7 @@ ${clientClassName} client = ${clientClassName}.builder()
         // Build client initialization with auth if needed
         const clientClassReference = this.context.getRootClientClassReference();
         const builderParameters: Array<{ name: string; value: java.TypeLiteral }> = [];
-
-        // Add auth parameters if auth is configured
-        if (this.context.ir.auth.schemes.length > 0) {
-            const authScheme = this.context.ir.auth.schemes[0];
-            if (authScheme?.type === "bearer") {
-                const tokenName = authScheme.token?.camelCase?.unsafeName ?? "token";
-                builderParameters.push({
-                    name: tokenName,
-                    value: java.TypeLiteral.string("<token>")
-                });
-            } else if (authScheme?.type === "basic") {
-                builderParameters.push({
-                    name: "username",
-                    value: java.TypeLiteral.string("<username>")
-                });
-                builderParameters.push({
-                    name: "password",
-                    value: java.TypeLiteral.string("<password>")
-                });
-            } else if (authScheme?.type === "header") {
-                const headerName = authScheme.name.name?.camelCase?.unsafeName ?? "apiKey";
-                builderParameters.push({
-                    name: headerName,
-                    value: java.TypeLiteral.string("<api-key>")
-                });
-            }
-        }
-
-        // Add environment variables if any
-        if (this.context.ir.variables != null && this.context.ir.variables.length > 0) {
-            for (const variable of this.context.ir.variables) {
-                const variableName = variable.name.camelCase.unsafeName;
-                builderParameters.push({
-                    name: variableName,
-                    value: java.TypeLiteral.string(`YOUR_${variable.name.screamingSnakeCase.unsafeName}`)
-                });
-            }
-        }
+        this.addClientBuilderParameters(builderParameters);
 
         const clientBuilder = java.TypeLiteral.builder({
             classReference: clientClassReference,

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,44 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.44.4
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippet compilation errors for objects with required fields
+        in staged builders. When an endpoint example omits a required property,
+        the snippet generator now fills in a type-appropriate default value
+        instead of producing an invalid `.builder().build()` call that skips
+        mandatory builder stages.
+      type: fix
+    - summary: |
+        Fix dynamic snippet builder ordering when default values are added for
+        missing required properties. Properties are now re-sorted to match schema
+        declaration order after defaults are injected, ensuring Java staged
+        builder method calls follow the correct sequence.
+      type: fix
+    - summary: |
+        Fix undiscriminated union variant matching selecting incorrect variants
+        when example data doesn't match. Required properties and their nested
+        types are now validated during matching, so variants with mismatched
+        enum values or missing required fields are correctly rejected.
+      type: fix
+    - summary: |
+        Fix hardcoded `com.seed.api.core.OptionalNullable` import in generated
+        README OptionalNullable documentation. The import now uses the correct
+        dynamic package name for the SDK being generated.
+      type: fix
+    - summary: |
+        Fix incorrect raw response type name in generated README. The "Access
+        Raw Response Data" section now uses the correct `{BaseNamePrefix}HttpResponse`
+        class name (e.g., `Auth0ApiHttpResponse`) instead of the endpoint-derived
+        name (e.g., `CreateHttpResponse`).
+      type: fix
+    - summary: |
+        Fix missing environment URL variables in generated README Usage example.
+        Builder parameters like `tenantDomain` from OpenAPI server URL templates
+        are now included in the Usage snippet alongside auth parameters.
+      type: fix
+  createdAt: "2026-03-18"
+  irVersion: 65
+
 - version: 3.44.3
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/exhaustive/custom-client-class-name/README.md
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+BestHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/custom-dependency/README.md
+++ b/seed/java-sdk/exhaustive/custom-dependency/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/custom-error-names/README.md
+++ b/seed/java-sdk/exhaustive/custom-error-names/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/custom-interceptors/README.md
+++ b/seed/java-sdk/exhaustive/custom-interceptors/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/custom-license/README.md
+++ b/seed/java-sdk/exhaustive/custom-license/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/custom-plugins/README.md
+++ b/seed/java-sdk/exhaustive/custom-plugins/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/README.md
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/flat-package-layout/README.md
+++ b/seed/java-sdk/exhaustive/flat-package-layout/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/README.md
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/README.md
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/local-files/README.md
+++ b/seed/java-sdk/exhaustive/local-files/README.md
@@ -173,7 +173,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/no-custom-config/README.md
+++ b/seed/java-sdk/exhaustive/no-custom-config/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/publish-to/README.md
+++ b/seed/java-sdk/exhaustive/publish-to/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/exhaustive/signed_publish/README.md
+++ b/seed/java-sdk/exhaustive/signed_publish/README.md
@@ -199,7 +199,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-GetAndReturnListOfPrimitivesHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
+SeedExhaustiveHttpResponse response = client.endpoints().container().withRawResponse().getAndReturnListOfPrimitives(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/java-optional-nullable-query-params/default/README.md
+++ b/seed/java-sdk/java-optional-nullable-query-params/default/README.md
@@ -104,7 +104,7 @@ For PATCH requests, the SDK uses `OptionalNullable<T>` to handle three-state nul
 - **PRESENT**: Field has a non-null value
 
 ```java
-import com.seed.api.core.OptionalNullable;
+import com.seed.javaOptionalNullableQueryParams.core.OptionalNullable;
 
 UpdateRequest request = UpdateRequest.builder()
     .fieldName(OptionalNullable.absent())    // Skip field
@@ -245,7 +245,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-SearchHttpResponse response = client.withRawResponse().search(...);
+SeedJavaOptionalNullableQueryParamsHttpResponse response = client.withRawResponse().search(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/nullable-optional/collapse-optional-nullable/README.md
+++ b/seed/java-sdk/nullable-optional/collapse-optional-nullable/README.md
@@ -114,7 +114,7 @@ For PATCH requests, the SDK uses `OptionalNullable<T>` to handle three-state nul
 - **PRESENT**: Field has a non-null value
 
 ```java
-import com.seed.api.core.OptionalNullable;
+import com.seed.nullableOptional.core.OptionalNullable;
 
 UpdateRequest request = UpdateRequest.builder()
     .fieldName(OptionalNullable.absent())    // Skip field
@@ -255,7 +255,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-CreateUserHttpResponse response = client.nullableOptional().withRawResponse().createUser(...);
+SeedNullableOptionalHttpResponse response = client.nullableOptional().withRawResponse().createUser(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/nullable-optional/legacy/README.md
+++ b/seed/java-sdk/nullable-optional/legacy/README.md
@@ -216,7 +216,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-CreateUserHttpResponse response = client.nullableOptional().withRawResponse().createUser(...);
+SeedNullableOptionalHttpResponse response = client.nullableOptional().withRawResponse().createUser(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/README.md
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/README.md
@@ -216,7 +216,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-CreateUserHttpResponse response = client.nullableOptional().withRawResponse().createUser(...);
+SeedNullableOptionalHttpResponse response = client.nullableOptional().withRawResponse().createUser(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));

--- a/seed/java-sdk/variables/README.md
+++ b/seed/java-sdk/variables/README.md
@@ -196,7 +196,7 @@ The `withRawResponse()` method returns a raw client that wraps all responses wit
 (A normal client's `response` is identical to a raw client's `response.body()`.)
 
 ```java
-PostHttpResponse response = client.service().withRawResponse().post(...);
+SeedVariablesHttpResponse response = client.service().withRawResponse().post(...);
 
 System.out.println(response.body());
 System.out.println(response.headers().get("X-My-Header"));


### PR DESCRIPTION
## Description
Several fixes for the `java-v2` generator:
```
    - summary: |
        Fix dynamic snippet compilation errors for objects with required fields
        in staged builders. When an endpoint example omits a required property,
        the snippet generator now fills in a type-appropriate default value
        instead of producing an invalid `.builder().build()` call that skips
        mandatory builder stages.
      type: fix
    - summary: |
        Fix dynamic snippet builder ordering when default values are added for
        missing required properties. Properties are now re-sorted to match schema
        declaration order after defaults are injected, ensuring Java staged
        builder method calls follow the correct sequence.
      type: fix
    - summary: |
        Fix undiscriminated union variant matching selecting incorrect variants
        when example data doesn't match. Required properties and their nested
        types are now validated during matching, so variants with mismatched
        enum values or missing required fields are correctly rejected.
      type: fix
    - summary: |
        Fix hardcoded `com.seed.api.core.OptionalNullable` import in generated
        README OptionalNullable documentation. The import now uses the correct
        dynamic package name for the SDK being generated.
      type: fix
    - summary: |
        Fix incorrect raw response type name in generated README. The "Access
        Raw Response Data" section now uses the correct `{BaseNamePrefix}HttpResponse`
        class name (e.g., `Auth0ApiHttpResponse`) instead of the endpoint-derived
        name (e.g., `CreateHttpResponse`).
      type: fix
    - summary: |
        Fix missing environment URL variables in generated README Usage example.
        Builder parameters like `tenantDomain` from OpenAPI server URL templates
        are now included in the Usage snippet alongside auth parameters.
      type: fix
```

These are important to avoid `.build()` invalidly showing up in dynamic snippets and wire tests.

## Changes Made
To `java-v2`'s dynamic snippets generator and README generator.

## Testing
Seed fixtures reflect changes; allows Auth0's MyOrg SDK to generate without failure.
- [X] Unit tests added/updated
- [X] Manual testing completed
