### PR TITLE
fix(rust): gate WebSocket connector info behind enableWebsockets config

### DIFF
--- a/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
+++ b/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
@@ -26,6 +26,9 @@ export class WebSocketChannelGenerator {
         moduleName: string;
         channel: FernIr.WebSocketChannel;
     }> {
+        if (!this.context.hasWebSocketChannels()) {
+            return [];
+        }
         const websocketChannels = this.context.ir.websocketChannels;
         if (!websocketChannels) {
             return [];

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.19.5
+  changelogEntry:
+    - summary: |
+        Fix unresolved import error when WebSocket channels exist in the API spec but
+        `enableWebsockets` is not enabled. The root client no longer emits
+        `use crate::api::websocket::...` imports when WebSocket generation is disabled,
+        preventing compilation failures on generated SDKs.
+      type: fix
+  createdAt: "2026-03-18"
+  irVersion: 62
+
 - version: 0.19.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes unresolved import compilation errors in generated Rust SDKs (e.g., `fern-demo/xai-rust-internal`) when the API spec contains WebSocket channels but `enableWebsockets` is not set to `true`.

## Changes Made

- Added `hasWebSocketChannels()` guard to `WebSocketChannelGenerator.getConnectorInfo()` so it returns an empty list when WebSocket generation is disabled
- Bumped Rust SDK generator version to `0.19.5`

## Root Cause

`getConnectorInfo()` only checked whether `ir.websocketChannels` existed in the IR, but did **not** check the `enableWebsockets` config flag (which defaults to `false`). Meanwhile, all other WebSocket code paths (`generateApiModFile`, `generateWebSocketFiles`, `generateCoreModFile`) are gated behind `context.hasWebSocketChannels()`, which checks **both** the config flag and the IR.

This mismatch caused the `RootClientGenerator` to emit `use crate::api::websocket::{RealtimeConnector, TtsConnector}` and corresponding struct fields, even though the `websocket` module was never generated.

## Review Checklist

- [ ] Verify `hasWebSocketChannels()` is the correct predicate (checks `enableWebsockets && ir.websocketChannels != null && Object.keys(...).length > 0`)
- [ ] Consider whether `generateAll()` in the same class should also get this guard for defensive consistency (currently relies on the caller to gate)
- [ ] Confirm versions.yml entry is correct

## Testing

- [x] Verified `cargo check` on `fern-demo/xai-rust-internal` reproduces the `E0432: unresolved import crate::api::websocket` error
- [x] Lint passes (`pnpm run check`)
- [ ] No unit test added — this is a config-gating fix; behavior when `enableWebsockets: true` is unchanged

Link to Devin session: https://app.devin.ai/sessions/529ec8b51aac433bb0bcd957e5254984
Requested by: @iamnamananand996