### PR TITLE
chore(internal): replace inline error message extraction with extractErrorMessage utility

### DIFF
--- a/generators/base/src/AbstractGeneratorAgent.ts
+++ b/generators/base/src/AbstractGeneratorAgent.ts
@@ -1,10 +1,10 @@
 import { AbstractGeneratorContext, FernGeneratorExec } from "@fern-api/browser-compatible-base-generator";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { Logger } from "@fern-api/logger";
 import { FernGeneratorCli } from "@fern-fern/generator-cli-sdk";
 import { readFile } from "fs/promises";
 import yaml from "js-yaml";
 import path from "path";
-
 import { GeneratorAgentClient } from "./GeneratorAgentClient.js";
 import { ReferenceConfigBuilder } from "./reference/index.js";
 import { RawGithubConfig, resolveGitHubConfig } from "./utils/index.js";
@@ -84,7 +84,7 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
                 `AbstractGeneratorAgent.generateReadme: Remote config: ${remote ? JSON.stringify(remote) : "(none)"}`
             );
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             this.logger.debug(`AbstractGeneratorAgent.generateReadme: FAILED to get remote config: ${errorMessage}`);
             throw error;
         }
@@ -98,7 +98,7 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
                 `AbstractGeneratorAgent.generateReadme: Feature config loaded with ${featureConfig.features?.length ?? 0} features`
             );
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             this.logger.debug(`AbstractGeneratorAgent.generateReadme: FAILED to load feature config: ${errorMessage}`);
             throw error;
         }
@@ -122,7 +122,7 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
                     `apiReferenceLink: ${readmeConfig.apiReferenceLink ?? "(none)"}`
             );
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             const errorStack = error instanceof Error ? error.stack : undefined;
             this.logger.debug(`AbstractGeneratorAgent.generateReadme: FAILED to build README config: ${errorMessage}`);
             if (errorStack) {
@@ -138,7 +138,7 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
             this.logger.debug(`AbstractGeneratorAgent.generateReadme: CLI returned ${result.length} bytes`);
             return result;
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             this.logger.debug(`AbstractGeneratorAgent.generateReadme: CLI FAILED with error: ${errorMessage}`);
             throw error;
         }
@@ -170,7 +170,7 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
             language = this.getLanguage();
             this.logger.debug(`AbstractGeneratorAgent.generateReference: Language: ${language}`);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             this.logger.debug(`AbstractGeneratorAgent.generateReference: FAILED to get language: ${errorMessage}`);
             throw error;
         }
@@ -192,7 +192,7 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
                     `language: ${referenceConfig.language ?? "(none)"}`
             );
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             const errorStack = error instanceof Error ? error.stack : undefined;
             this.logger.debug(
                 `AbstractGeneratorAgent.generateReference: FAILED to build reference config: ${errorMessage}`
@@ -210,7 +210,7 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
             this.logger.debug(`AbstractGeneratorAgent.generateReference: CLI returned ${result.length} bytes`);
             return result;
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             this.logger.debug(`AbstractGeneratorAgent.generateReference: CLI FAILED with error: ${errorMessage}`);
             throw error;
         }
@@ -246,7 +246,7 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
             );
             return loaded;
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             this.logger.debug(
                 `AbstractGeneratorAgent.readFeatureConfig: Failed to read feature config: ${errorMessage}`
             );
@@ -309,7 +309,7 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
                 }
                 this.logger.debug(`AbstractGeneratorAgent.getFeaturesConfig: File at ${each} is empty, skipping`);
             } catch (error) {
-                const errorMessage = error instanceof Error ? error.message : String(error);
+                const errorMessage = extractErrorMessage(error);
                 this.logger.debug(
                     `AbstractGeneratorAgent.getFeaturesConfig: Path ${each} not accessible: ${errorMessage}`
                 );

--- a/generators/base/src/GeneratorAgentClient.ts
+++ b/generators/base/src/GeneratorAgentClient.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import {
     type GenerateReadmeParams,
     type GenerateReferenceParams,
@@ -8,7 +9,6 @@ import {
     githubPush
 } from "@fern-api/generator-cli";
 import { Logger } from "@fern-api/logger";
-
 export class GeneratorAgentClient {
     private logger: Logger;
 
@@ -23,7 +23,7 @@ export class GeneratorAgentClient {
             this.logger.debug(`Generated readme (${result.length} bytes)`);
             return result;
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             this.logger.debug(`Failed to generate readme: ${errorMessage}`);
             throw error;
         }
@@ -42,7 +42,7 @@ export class GeneratorAgentClient {
             }
             return "";
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             this.logger.debug(`Failed to push to GitHub: ${errorMessage}`);
             throw error;
         }
@@ -55,7 +55,7 @@ export class GeneratorAgentClient {
             this.logger.debug(`Generated reference (${result.length} bytes)`);
             return result;
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             this.logger.debug(`Failed to generate reference: ${errorMessage}`);
             throw error;
         }

--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -1,5 +1,5 @@
 import { AbstractProject, FernGeneratorExec, File } from "@fern-api/base-generator";
-import { assertNever } from "@fern-api/core-utils";
+import { assertNever, extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/fs-utils";
 import { BaseGoCustomConfigSchema, resolveRootImportPath, resolveRootModulePath } from "@fern-api/go-ast";
 import { loggingExeca } from "@fern-api/logging-execa";
@@ -91,7 +91,7 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
                 });
             } catch (error) {
                 this.context.logger.warn(
-                    `Failed to format Go files with 'go fmt': ${error instanceof Error ? error.message : String(error)}. ` +
+                    `Failed to format Go files with 'go fmt': ${extractErrorMessage(error)}. ` +
                         "The generated files have been written but may not be properly formatted."
                 );
             }
@@ -249,7 +249,7 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
             } else {
                 // Log other errors for debugging while maintaining backwards compatibility
                 this.context.logger.warn(
-                    `Failed to copy custom license file from ${dockerLicensePath} to ${destinationPath}: ${error instanceof Error ? error.message : String(error)}`
+                    `Failed to copy custom license file from ${dockerLicensePath} to ${destinationPath}: ${extractErrorMessage(error)}`
                 );
             }
         }

--- a/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -1,5 +1,5 @@
 import { Severity } from "@fern-api/browser-compatible-base-generator";
-import { assertNever } from "@fern-api/core-utils";
+import { assertNever, extractErrorMessage } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { java } from "@fern-api/java-ast";
 
@@ -659,9 +659,7 @@ export class DynamicTypeLiteralMapper {
                 return { valueTypeReference: typeReference, typeInstantiation };
             } catch (e) {
                 this.context.errors.truncate(errorsBefore);
-                variantErrors.push(
-                    `Type ${JSON.stringify(typeReference)}: ${e instanceof Error ? e.message : String(e)}`
-                );
+                variantErrors.push(`Type ${JSON.stringify(typeReference)}: ${extractErrorMessage(e)}`);
                 continue;
             }
         }

--- a/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
@@ -1,4 +1,5 @@
 import { File } from "@fern-api/base-generator";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { java } from "@fern-api/java-ast";
 import { DynamicSnippetsGenerator } from "@fern-api/java-dynamic-snippets";
@@ -11,7 +12,6 @@ import { TestMethodBuilder } from "./builders/TestMethodBuilder.js";
 import { SnippetExtractor } from "./extractors/SnippetExtractor.js";
 import { WireTestDataExtractor, WireTestExample } from "./extractors/TestDataExtractor.js";
 import { TestResourceWriter } from "./resources/TestResourceWriter.js";
-
 /**
  * Generates wire tests that validate SDK adherence to API specifications.
  */
@@ -239,7 +239,7 @@ export class SdkWireTestGenerator {
                         const returnTypeInfo = this.testMethodBuilder.getEndpointReturnTypeWithImports(endpoint);
                         returnTypeInfo.imports.forEach((imp) => allImports.add(imp));
                     } catch (error) {
-                        const errorMessage = error instanceof Error ? error.message : String(error);
+                        const errorMessage = extractErrorMessage(error);
                         this.context.logger.debug(
                             `Skipping endpoint ${endpoint.id} (${endpoint.name.originalName}): Failed to generate snippet - ${errorMessage}`
                         );
@@ -287,7 +287,7 @@ export class SdkWireTestGenerator {
                         const returnTypeInfo = this.testMethodBuilder.getEndpointReturnTypeWithImports(endpoint);
                         returnTypeInfo.imports.forEach((imp) => allImports.add(imp));
                     } catch (error) {
-                        const errorMessage = error instanceof Error ? error.message : String(error);
+                        const errorMessage = extractErrorMessage(error);
                         this.context.logger.debug(
                             `Skipping endpoint ${endpoint.id} (${endpoint.name.originalName}): Failed to generate default snippet - ${errorMessage}`
                         );
@@ -464,7 +464,7 @@ export class SdkWireTestGenerator {
                 this.context.logger.debug(`Service correction succeeded for endpoint ${endpoint.id}`);
                 return snippet;
             } catch (error) {
-                const errorMessage = error instanceof Error ? error.message : String(error);
+                const errorMessage = extractErrorMessage(error);
                 throw new Error(
                     `Service mismatch (expected: '${expectedServiceName}', got: '${dynamicServiceName}'). ` +
                         `Correction attempt failed: ${errorMessage}. ` +

--- a/generators/python-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/python-v2/sdk/src/SdkGeneratorCli.ts
@@ -55,9 +55,7 @@ export class SdkGeneratorCli extends AbstractPythonGeneratorCli<SdkCustomConfigS
         try {
             endpointSnippets = this.generateSnippets({ context });
         } catch (error) {
-            context.logger.debug(
-                `Failed to generate snippets: ${error instanceof Error ? error.message : String(error)}`
-            );
+            context.logger.debug(`Failed to generate snippets: ${extractErrorMessage(error)}`);
         }
 
         // Generate README.md
@@ -135,7 +133,7 @@ export class SdkGeneratorCli extends AbstractPythonGeneratorCli<SdkCustomConfigS
                     });
                 } catch (error) {
                     context.logger.debug(
-                        `Failed to generate snippet for endpoint ${endpointId}: ${error instanceof Error ? error.message : String(error)}`
+                        `Failed to generate snippet for endpoint ${endpointId}: ${extractErrorMessage(error)}`
                     );
                 }
             }

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -132,7 +132,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
                 context.logger.warn(stderr);
             }
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             context.logger.debug(`Cargo publish failed with error: ${errorMessage}`);
             throw new Error(`Failed to publish crate: ${errorMessage}`);
         }

--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
+    "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/typescript-ast": "workspace:*",

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -1,4 +1,5 @@
 import { FernGeneratorExec } from "@fern-api/base-generator";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
 import { getNamespaceExport, resolveNaming } from "@fern-api/typescript-base";
@@ -15,10 +16,8 @@ import { GeneratorContext } from "@fern-typescript/contexts";
 import { SdkGenerator } from "@fern-typescript/sdk-generator";
 import { copyFile } from "fs/promises";
 import path from "path";
-
 import { SdkCustomConfig } from "./custom-config/SdkCustomConfig.js";
 import { SdkCustomConfigSchema } from "./custom-config/schema/SdkCustomConfigSchema.js";
-
 export declare namespace SdkGeneratorCli {
     export interface Init {
         configOverrides?: Partial<SdkCustomConfig>;
@@ -305,7 +304,7 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
             } catch (error) {
                 // If we can't read the license file, we'll skip writing it
                 // This maintains backwards compatibility
-                logger.warn(`Failed to write LICENSE file: ${error instanceof Error ? error.message : String(error)}`);
+                logger.warn(`Failed to write LICENSE file: ${extractErrorMessage(error)}`);
             }
         }
     }
@@ -317,9 +316,7 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
         try {
             await copyFile(dockerLicensePath, destinationPath);
         } catch (error) {
-            throw new Error(
-                `Could not copy license file from ${dockerLicensePath}: ${error instanceof Error ? error.message : String(error)}`
-            );
+            throw new Error(`Could not copy license file from ${dockerLicensePath}: ${extractErrorMessage(error)}`);
         }
     }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import {
     HeaderWithExample,
     PathParameterWithExample,
@@ -414,7 +415,7 @@ export function parseAsyncAPIV3({
                 }
             } catch (error) {
                 context.logger.warn(
-                    `Failed to build examples for channel ${channelPath}: ${error instanceof Error ? error.message : String(error)}`
+                    `Failed to build examples for channel ${channelPath}: ${extractErrorMessage(error)}`
                 );
             }
 
@@ -597,7 +598,7 @@ function convertMessageReferencesToWebsocketSchemas({
             }
         } catch (error) {
             context.logger.warn(
-                `Skipping message reference ${message.ref.$ref} in channel ${channelPath}: ${error instanceof Error ? error.message : String(error)}`
+                `Skipping message reference ${message.ref.$ref} in channel ${channelPath}: ${extractErrorMessage(error)}`
             );
         }
     });

--- a/packages/cli/api-importers/openrpc-to-ir/package.json
+++ b/packages/cli/api-importers/openrpc-to-ir/package.json
@@ -31,6 +31,7 @@
     "test:update": "vitest --run -u --passWithNoTests"
   },
   "dependencies": {
+    "@fern-api/core-utils": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/ir-utils": "workspace:*",
     "@fern-api/v3-importer-commons": "workspace:*",

--- a/packages/cli/api-importers/openrpc-to-ir/src/1.x/extensions/x-fern-parameters.ts
+++ b/packages/cli/api-importers/openrpc-to-ir/src/1.x/extensions/x-fern-parameters.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbstractExtension } from "@fern-api/v3-importer-commons";
 import { OpenAPIV3 } from "openapi-types";
 import { z } from "zod";
@@ -52,7 +53,7 @@ export class FernParametersExtension extends AbstractExtension<FernParametersExt
             return parsedValue as OpenAPIV3.ParameterObject[];
         } catch (error) {
             this.context.errorCollector.collect({
-                message: `Failed to parse x-fern-parameters extension: ${error instanceof Error ? error.message : String(error)}`,
+                message: `Failed to parse x-fern-parameters extension: ${extractErrorMessage(error)}`,
                 path: this.breadcrumbs
             });
             return undefined;

--- a/packages/cli/cli-v2/src/commands/api/split/command.ts
+++ b/packages/cli/cli-v2/src/commands/api/split/command.ts
@@ -1,4 +1,4 @@
-import { mergeWithOverrides } from "@fern-api/core-utils";
+import { extractErrorMessage, mergeWithOverrides } from "@fern-api/core-utils";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import chalk from "chalk";
 import { execFile } from "child_process";
@@ -238,7 +238,7 @@ export class SplitCommand {
             });
             return stdout;
         } catch (error: unknown) {
-            const detail = error instanceof Error ? error.message : String(error);
+            const detail = extractErrorMessage(error);
             throw new CliError({
                 message: `Failed to get file from git HEAD: ${absolutePath}. Is the file tracked by git and has at least one commit?\n  Cause: ${detail}`
             });

--- a/packages/cli/cli-v2/src/commands/docs/publish/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/publish/command.ts
@@ -1,4 +1,5 @@
 import type { FernToken } from "@fern-api/auth";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { filterOssWorkspaces } from "@fern-api/docs-resolver";
 import chalk from "chalk";
 import inquirer from "inquirer";
@@ -14,7 +15,6 @@ import { DocsTaskGroup } from "../../../docs/task/DocsTaskGroup.js";
 import { CliError } from "../../../errors/CliError.js";
 import { ValidationError } from "../../../errors/ValidationError.js";
 import { command } from "../../_internal/command.js";
-
 export declare namespace PublishCommand {
     export interface Args extends GlobalArgs {
         force: boolean;
@@ -116,7 +116,7 @@ export class PublishCommand {
                 throw new ValidationError(checkResult.violations);
             }
         } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
+            const message = extractErrorMessage(error);
             docsTask.stage.validation.fail(message);
         }
 

--- a/packages/cli/cli-v2/src/commands/sdk/update/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/update/command.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import chalk from "chalk";
 import inquirer from "inquirer";
 import type { Argv } from "yargs";
@@ -11,7 +12,6 @@ import { GeneratorMigrator } from "../../../sdk/updater/GeneratorMigrator.js";
 import { SdkUpdater } from "../../../sdk/updater/SdkUpdater.js";
 import { Icons } from "../../../ui/format.js";
 import { command } from "../../_internal/command.js";
-
 export declare namespace UpdateCommand {
     export interface Args extends GlobalArgs {
         /** The SDK target to update (e.g. typescript, python, go). */
@@ -105,7 +105,7 @@ export class UpdateCommand {
                         migrationInfo.set(update.name, result);
                     }
                 } catch (error) {
-                    const message = error instanceof Error ? error.message : String(error);
+                    const message = extractErrorMessage(error);
                     context.stderr.warn(chalk.yellow(`  Warning: migrations failed for ${target.name}: ${message}`));
                 }
             }

--- a/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
+++ b/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
@@ -1,4 +1,5 @@
 import type { FernToken } from "@fern-api/auth";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import type { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import type { Project } from "@fern-api/project-loader";
 import { runRemoteGenerationForDocsWorkspace } from "@fern-api/remote-workspace-runner";
@@ -7,7 +8,6 @@ import type { DocsWorkspace } from "@fern-api/workspace-loader";
 import { TaskContextAdapter } from "../../context/adapter/TaskContextAdapter.js";
 import type { Context } from "../../context/Context.js";
 import type { Task } from "../../ui/Task.js";
-
 export declare namespace LegacyDocsPublisher {
     export interface PublishResult {
         success: boolean;
@@ -87,7 +87,7 @@ export class LegacyDocsPublisher {
         } catch (error) {
             return {
                 success: false,
-                error: error instanceof Error ? error.message : String(error)
+                error: extractErrorMessage(error)
             };
         }
     }

--- a/packages/cli/cli-v2/src/init/Wizard.ts
+++ b/packages/cli/cli-v2/src/init/Wizard.ts
@@ -5,6 +5,7 @@ import {
     getOrganizationNameValidationError,
     verifyAndDecodeJwt
 } from "@fern-api/auth";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
 import { LogLevel } from "@fern-api/logger";
 import { getTokenFromAuth0 } from "@fern-api/login";
@@ -700,7 +701,7 @@ export class Wizard {
             try {
                 return await this.fetchApiFromUrl(url, specFormat);
             } catch (error) {
-                const message = error instanceof Error ? error.message : String(error);
+                const message = extractErrorMessage(error);
                 this.context.stderr.info(`  ${Icons.error} Could not fetch ${url}: ${message}\n`);
                 // Loop back to re-prompt.
             }

--- a/packages/cli/cli-v2/src/migrator/fern-config-json/FernConfigJsonMigrator.ts
+++ b/packages/cli/cli-v2/src/migrator/fern-config-json/FernConfigJsonMigrator.ts
@@ -1,8 +1,8 @@
 import { PROJECT_CONFIG_FILENAME } from "@fern-api/configuration";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { readFile } from "fs/promises";
 import type { DetectResult, MigratorWarning } from "../types/index.js";
-
 export declare namespace FernConfigJsonMigrator {
     export interface Config {
         cwd: AbsoluteFilePath;
@@ -76,7 +76,7 @@ export class FernConfigJsonMigrator {
                 absoluteFilePath
             };
         } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
+            const message = extractErrorMessage(error);
             return {
                 success: false,
                 warnings: [

--- a/packages/cli/cli-v2/src/migrator/generators-yml/GeneratorsYmlMigrator.ts
+++ b/packages/cli/cli-v2/src/migrator/generators-yml/GeneratorsYmlMigrator.ts
@@ -4,13 +4,13 @@ import {
     GENERATORS_CONFIGURATION_FILENAME_ALTERNATIVE,
     generatorsYml
 } from "@fern-api/configuration";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { readFile } from "fs/promises";
 import yaml from "js-yaml";
 import { convertApiSpecs } from "../converters/convertApiSpecs.js";
 import { convertSdkTargetsFromRaw } from "../converters/convertSdkTargets.js";
 import type { DetectResult, MigratorWarning } from "../types/index.js";
-
 export declare namespace GeneratorsYmlMigrator {
     export interface Config {
         cwd: AbsoluteFilePath;
@@ -116,7 +116,7 @@ export class GeneratorsYmlMigrator {
                 absoluteFilePath
             };
         } catch (error) {
-            let message = error instanceof Error ? error.message : String(error);
+            let message = extractErrorMessage(error);
 
             // When the YAML error reason indicates a "bad indentation" or anchor issue and
             // the offending line contains a value starting with @, it is almost certainly an

--- a/packages/cli/cli-v2/src/sdk/generator/GeneratorPipeline.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/GeneratorPipeline.ts
@@ -2,6 +2,7 @@ import type { FernToken } from "@fern-api/auth";
 import { schemas } from "@fern-api/config";
 import type { Audiences } from "@fern-api/configuration";
 import type { ContainerRunner } from "@fern-api/core-utils";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { AiConfig } from "../../ai/config/AiConfig.js";
 import type { ApiDefinition } from "../../api/config/ApiDefinition.js";
@@ -11,7 +12,6 @@ import type { Task } from "../../ui/Task.js";
 import type { Target } from "../config/Target.js";
 import { LegacyLocalGenerationRunner } from "./LegacyLocalGenerationRunner.js";
 import { LegacyRemoteGenerationRunner } from "./LegacyRemoteGenerationRunner.js";
-
 /**
  * Orchestrates SDK generation for a single target.
  *
@@ -113,7 +113,7 @@ export class GeneratorPipeline {
             }
             return await this.runRemoteGeneration(args);
         } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
+            const message = extractErrorMessage(error);
             return {
                 success: false,
                 target: args.target,

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyLocalGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyLocalGenerationRunner.ts
@@ -4,6 +4,7 @@ import { schemas } from "@fern-api/config";
 import type { Audiences } from "@fern-api/configuration";
 import { fernConfigJson, generatorsYml, SNIPPET_JSON_FILENAME } from "@fern-api/configuration";
 import type { ContainerRunner } from "@fern-api/core-utils";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
 import {
@@ -23,7 +24,6 @@ import type { Task } from "../../ui/Task.js";
 import { LegacyGeneratorInvocationAdapter } from "../adapter/LegacyGeneratorInvocationAdapter.js";
 import type { Target } from "../config/Target.js";
 import { resolveTargetOutput } from "./utils/resolveTargetOutput.js";
-
 /**
  * Runs generation using the legacy local-generation infrastructure.
  */
@@ -141,7 +141,7 @@ export class LegacyLocalGenerationRunner {
             }
             return {
                 success: false,
-                error: error instanceof Error ? error.message : String(error)
+                error: extractErrorMessage(error)
             };
         }
     }

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -1,6 +1,7 @@
 import type { FernToken } from "@fern-api/auth";
 import type { Audiences } from "@fern-api/configuration";
 import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, basename, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { LogLevel } from "@fern-api/logger";
 import { runRemoteGenerationForAPIWorkspace } from "@fern-api/remote-workspace-runner";
@@ -16,7 +17,6 @@ import type { Task } from "../../ui/Task.js";
 import { LegacyGeneratorInvocationAdapter } from "../adapter/LegacyGeneratorInvocationAdapter.js";
 import type { Target } from "../config/Target.js";
 import { resolveTargetOutput } from "./utils/resolveTargetOutput.js";
-
 /**
  * Runs remote generation using the legacy remote-generation infrastructure.
  */
@@ -171,7 +171,7 @@ export class LegacyRemoteGenerationRunner {
             }
             return {
                 success: false,
-                error: error instanceof Error ? error.message : String(error)
+                error: extractErrorMessage(error)
             };
         }
     }

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -1,4 +1,5 @@
 import type { generatorsYml } from "@fern-api/configuration";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
@@ -361,7 +362,7 @@ export class GeneratorMigrator {
 
             return module;
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
 
             if (errorMessage.includes("404") || errorMessage.includes("E404")) {
                 this.logger.debug(`No migration package found for ${generatorName}.`);
@@ -445,7 +446,7 @@ export class GeneratorMigrator {
                 });
                 appliedVersions.push(migration.version);
             } catch (error) {
-                const errorMessage = error instanceof Error ? error.message : String(error);
+                const errorMessage = extractErrorMessage(error);
                 throw new Error(
                     `Failed to apply migration for version ${migration.version}.\n\n` +
                         `Reason: ${errorMessage}\n\n` +

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -12,7 +12,13 @@ import {
     loadProjectConfig,
     PROJECT_CONFIG_FILENAME
 } from "@fern-api/configuration-loader";
-import { ContainerRunner, haveSameNullishness, undefinedIfNullish, undefinedIfSomeNullish } from "@fern-api/core-utils";
+import {
+    ContainerRunner,
+    extractErrorMessage,
+    haveSameNullishness,
+    undefinedIfNullish,
+    undefinedIfSomeNullish
+} from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, doesPathExist, isURL, resolve } from "@fern-api/fs-utils";
 import { formatBootstrapSummary, replayInit, replayResolve } from "@fern-api/generator-cli";
 import {
@@ -2237,9 +2243,7 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
                     cliContext.logger.info("\nDry run complete. No changes made.");
                 }
             } catch (error) {
-                cliContext.failAndThrow(
-                    `Failed to initialize Replay: ${error instanceof Error ? error.message : String(error)}`
-                );
+                cliContext.failAndThrow(`Failed to initialize Replay: ${extractErrorMessage(error)}`);
             }
         }
     );
@@ -2311,7 +2315,7 @@ function addReplayResolveCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCon
                         }
                 }
             } catch (error) {
-                cliContext.failAndThrow(`Failed to resolve: ${error instanceof Error ? error.message : String(error)}`);
+                cliContext.failAndThrow(`Failed to resolve: ${extractErrorMessage(error)}`);
             }
         }
     );

--- a/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
+++ b/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
@@ -1,5 +1,6 @@
 import { FernToken } from "@fern-api/auth";
 import { docsYml } from "@fern-api/configuration";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { FdrAPI } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath, resolve } from "@fern-api/fs-utils";
 import type { CppLibraryDocsIr } from "@fern-api/library-docs-generator";
@@ -9,9 +10,7 @@ import { Project } from "@fern-api/project-loader";
 import { InteractiveTaskContext, TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 import { readFile } from "fs/promises";
-
 import { CliContext } from "../../cli-context/CliContext.js";
-
 export interface GenerateLibraryDocsOptions {
     project: Project;
     cliContext: CliContext;
@@ -303,7 +302,7 @@ async function startGeneration(
         return result.jobId;
     } catch (error) {
         return context.failAndThrow(
-            `Failed to start generation for library '${opts.name}': ${error instanceof Error ? error.message : String(error)}`
+            `Failed to start generation for library '${opts.name}': ${extractErrorMessage(error)}`
         );
     }
 }
@@ -324,7 +323,7 @@ async function pollForCompletion(
             status = await client.getLibraryDocsGenerationStatus({ jobId });
         } catch (error) {
             return context.failAndThrow(
-                `Failed to check generation status for library '${libraryName}': ${error instanceof Error ? error.message : String(error)}`
+                `Failed to check generation status for library '${libraryName}': ${extractErrorMessage(error)}`
             );
         }
 
@@ -365,7 +364,7 @@ async function downloadIr(
         resultUrl = result.resultUrl;
     } catch (error) {
         return context.failAndThrow(
-            `Failed to fetch generation result for library '${libraryName}': ${error instanceof Error ? error.message : String(error)}`
+            `Failed to fetch generation result for library '${libraryName}': ${extractErrorMessage(error)}`
         );
     }
 

--- a/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
+++ b/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
@@ -9,6 +9,7 @@
 import { ClientRegistry } from "@boundaryml/baml";
 import { AnalyzeCommitDiffResponse, b as BamlClient, configureBamlClient, VersionBump } from "@fern-api/cli-ai";
 import { loadGeneratorsConfiguration } from "@fern-api/configuration-loader";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, doesPathExist, resolve } from "@fern-api/fs-utils";
 import {
     AutoVersioningService,
@@ -208,7 +209,7 @@ export async function sdkDiffCommand({
                 versionBumpReason = rollup.version_bump_reason?.trim() || "";
             } catch (rollupError) {
                 context.logger.warn(
-                    `Changelog consolidation failed, using raw entries: ${rollupError instanceof Error ? rollupError.message : String(rollupError)}`
+                    `Changelog consolidation failed, using raw entries: ${extractErrorMessage(rollupError)}`
                 );
                 changelogEntry = rawEntries;
             }
@@ -224,7 +225,7 @@ export async function sdkDiffCommand({
             version_bump_reason: versionBumpReason
         };
     } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorMessage = extractErrorMessage(error);
         context.failWithoutThrowing(
             `Failed to analyze SDK diff. ` +
                 `Diff stats: ${gitDiff.length.toLocaleString()} chars, ${diffSizeKB}KB, ${fileCount} files changed. ` +
@@ -272,8 +273,6 @@ async function generateDiff({
             return error.stdout;
         }
         // For other errors, throw
-        return context.failAndThrow(
-            `Failed to generate diff: ${error instanceof Error ? error.message : String(error)}`
-        );
+        return context.failAndThrow(`Failed to generate diff: ${extractErrorMessage(error)}`);
     }
 }

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -1,4 +1,5 @@
 import type { generatorsYml } from "@fern-api/configuration";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { readFileSync, unlinkSync } from "fs";
@@ -7,7 +8,6 @@ import { homedir } from "os";
 import { join } from "path";
 import semver from "semver";
 import { pathToFileURL } from "url";
-
 import { Migration, MigrationModule, MigratorResult } from "./types.js";
 
 /**
@@ -264,7 +264,7 @@ export async function loadMigrationModule(params: {
         return module;
     } catch (error) {
         // Migration package doesn't exist or failed to install
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorMessage = extractErrorMessage(error);
 
         // 404 errors mean the migration package doesn't exist yet - this is expected
         // for generators that don't have migrations
@@ -394,7 +394,7 @@ export function runMigrations(params: {
             currentConfig = migration.migrateGeneratorConfig({ config: currentConfig, context });
             appliedVersions.push(migration.version);
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             throw new Error(
                 `Failed to apply migration for version ${migration.version}.\n\n` +
                     `Reason: ${errorMessage}\n\n` +

--- a/packages/cli/cli/src/commands/write-translation/translation-service.ts
+++ b/packages/cli/cli/src/commands/write-translation/translation-service.ts
@@ -7,6 +7,7 @@ const DEFAULT_MAX_DELAY = 30000; // 30 seconds
 const DEFAULT_TIMEOUT = 30000; // 30 seconds
 
 import { getToken } from "@fern-api/auth";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { CliContext } from "../../cli-context/CliContext.js";
 
 // todo: replace with an SDK
@@ -218,14 +219,14 @@ export async function translateText({
 
             // Check if this is a retriable error
             if (error instanceof Error && !isRetriableError(error as NetworkError)) {
-                const errorMessage = error instanceof Error ? error.message : String(error);
+                const errorMessage = extractErrorMessage(error);
                 cliContext.logger.debug(`[TRANSLATE] Non-retriable error: ${errorMessage}`);
                 return text;
             }
 
             // If this is our final attempt, don't retry
             if (attempt > config.maxRetries) {
-                const errorMessage = error instanceof Error ? error.message : String(error);
+                const errorMessage = extractErrorMessage(error);
                 cliContext.logger.debug(
                     `[TRANSLATE] All ${config.maxRetries + 1} attempts failed. Final error: ${errorMessage}`
                 );
@@ -233,7 +234,7 @@ export async function translateText({
             }
 
             // Log retry attempt and wait before retrying
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             cliContext.logger.debug(`[TRANSLATE] Attempt ${attempt} failed: ${errorMessage}. Retrying...`);
             const delay = calculateDelay(attempt, config.baseDelay, config.maxDelay);
             await new Promise((resolve) => setTimeout(resolve, delay));

--- a/packages/cli/docs-importers/readme/src/ReadmeImporter.ts
+++ b/packages/cli/docs-importers/readme/src/ReadmeImporter.ts
@@ -1,11 +1,11 @@
 import { docsYml } from "@fern-api/configuration";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { DEFAULT_LAYOUT, DocsImporter, FernDocsBuilder } from "@fern-api/docs-importer-commons";
 import { AbsoluteFilePath, dirname, join as fsUtilsJoin, RelativeFilePath, relativize } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
 import { TaskContext } from "@fern-api/task-context";
 import { mkdir, writeFile } from "fs/promises";
 import type { Root as HastRoot } from "hast";
-
 import { getFavicon } from "./extract/favicon.js";
 import { getTitle } from "./extract/title.js";
 import { parsePage } from "./parse/parsePage.js";
@@ -17,7 +17,6 @@ import { getColors } from "./utils/colors.js";
 import { getLogos } from "./utils/files/logo.js";
 import { htmlToHast } from "./utils/hast.js";
 import { fetchPageHtml, startPuppeteer } from "./utils/network.js";
-
 export declare namespace ReadmeImporter {
     interface Args {
         context: TaskContext;
@@ -161,9 +160,7 @@ export class ReadmeImporter extends DocsImporter<object> {
 
             return navItems;
         } catch (error) {
-            this.logger.error(
-                `Failed to scrape tab ${name}: ${error instanceof Error ? error.message : String(error)}`
-            );
+            this.logger.error(`Failed to scrape tab ${name}: ${extractErrorMessage(error)}`);
             if (error instanceof Error && error.stack) {
                 this.logger.error(`Stack trace: ${error.stack}`);
             }

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { wrapWithHttps } from "@fern-api/docs-resolver";
 import { DocsV1Read, DocsV2Read, FernNavigation } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath, dirname, doesPathExist, listFiles, RelativeFilePath, resolve } from "@fern-api/fs-utils";
@@ -13,7 +14,6 @@ import path from "path";
 import { type Duplex } from "stream";
 import Watcher from "watcher";
 import { WebSocket, WebSocketServer } from "ws";
-
 import { type BunServer, createBunServer } from "./createBunServer.js";
 import { DebugLogger } from "./DebugLogger.js";
 import { downloadBundle, getPathToBundleFolder, getPathToPreviewFolder } from "./downloadLocalDocsBundle.js";
@@ -614,9 +614,7 @@ export async function runAppPreviewServer({
                 .catch((err) => {
                     const validationTime = Date.now() - validationStartTime;
                     void debugLogger.logCliValidation(validationTime, false);
-                    context.logger.error(
-                        `Validation failed (took ${validationTime}ms): ${err instanceof Error ? err.message : String(err)}`
-                    );
+                    context.logger.error(`Validation failed (took ${validationTime}ms): ${extractErrorMessage(err)}`);
                     // Still log validation errors to help developers
                     if (err instanceof Error && err.stack) {
                         context.logger.debug(`Validation error stack: ${err.stack}`);
@@ -655,7 +653,7 @@ export async function runAppPreviewServer({
             // Log CLI reload finish even on error
             void debugLogger.logCliReloadFinish(totalTime, {
                 error: true,
-                errorMessage: err instanceof Error ? err.message : String(err)
+                errorMessage: extractErrorMessage(err)
             });
             void debugLogger.logCliMemory();
 

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -1,7 +1,13 @@
 import { GraphQLSpec } from "@fern-api/api-workspace-commons";
 import { SourceResolverImpl } from "@fern-api/cli-source-resolver";
 import { docsYml, parseAudiences, parseDocsConfiguration, WithoutQuestionMarks } from "@fern-api/configuration-loader";
-import { assertNever, isNonNullish, replaceEnvVariables, visitDiscriminatedUnion } from "@fern-api/core-utils";
+import {
+    assertNever,
+    extractErrorMessage,
+    isNonNullish,
+    replaceEnvVariables,
+    visitDiscriminatedUnion
+} from "@fern-api/core-utils";
 import {
     isValidRelativeSlug,
     parseImagePaths,
@@ -411,9 +417,7 @@ export class DocsDefinitionResolver {
                     filesToUploadSet.add(filepath);
                 }
             } catch (error) {
-                this.taskContext.logger.error(
-                    `Failed to parse ${relativePath}: ${error instanceof Error ? error.message : String(error)}`
-                );
+                this.taskContext.logger.error(`Failed to parse ${relativePath}: ${extractErrorMessage(error)}`);
                 throw error;
             }
         }
@@ -1702,7 +1706,7 @@ export class DocsDefinitionResolver {
             return (jsYaml.load(yamlBody) as LibraryNavNode[] | null) ?? [];
         } catch (e) {
             this.taskContext.logger.warn(
-                `Failed to parse _navigation.yml for library '${libraryName}': ${e instanceof Error ? e.message : String(e)}`
+                `Failed to parse _navigation.yml for library '${libraryName}': ${extractErrorMessage(e)}`
             );
             return null;
         }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -1,6 +1,7 @@
 import { ClientRegistry } from "@boundaryml/baml";
 import { b as BamlClient, configureBamlClient, VersionBump } from "@fern-api/cli-ai";
 import { FERNIGNORE_FILENAME, generatorsYml, getFernIgnorePaths } from "@fern-api/configuration";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { TaskContext } from "@fern-api/task-context";
@@ -20,7 +21,6 @@ import {
 } from "./AutoVersioningService.js";
 import { sanitizeChangelogEntry } from "./sanitizeChangelogEntry.js";
 import { isAutoVersion, MAX_AI_DIFF_BYTES, MAX_CHUNKS, MAX_RAW_DIFF_BYTES, maxVersionBump } from "./VersionUtils.js";
-
 export declare namespace LocalTaskHandler {
     export interface Init {
         context: TaskContext;
@@ -355,7 +355,7 @@ export class LocalTaskHandler {
                                 versionBumpReason = rollup.version_bump_reason?.trim() || undefined;
                             } catch (rollupError) {
                                 this.context.logger.warn(
-                                    `Changelog consolidation failed, using raw entries: ${rollupError instanceof Error ? rollupError.message : String(rollupError)}`
+                                    `Changelog consolidation failed, using raw entries: ${extractErrorMessage(rollupError)}`
                                 );
                                 changelogEntry = rawEntries;
                             }
@@ -374,7 +374,7 @@ export class LocalTaskHandler {
                     }
                 }
             } catch (aiError) {
-                const errorMessage = aiError instanceof Error ? aiError.message : String(aiError);
+                const errorMessage = extractErrorMessage(aiError);
                 this.context.logger.warn(
                     `AI analysis failed, falling back to PATCH increment. ` +
                         `Diff stats: ${cleanedDiff.length.toLocaleString()} chars cleaned ` +

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -1,4 +1,4 @@
-import { ContainerRunner } from "@fern-api/core-utils";
+import { ContainerRunner, extractErrorMessage } from "@fern-api/core-utils";
 import {
     copyFromContainer,
     copyToContainer,
@@ -268,7 +268,7 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             }).catch((e: unknown) => {
                 // Swallow "not found" errors — generator didn't produce snippet.
                 // Propagate other errors (permissions, disk space, etc.).
-                const msg = e instanceof Error ? e.message : String(e);
+                const msg = extractErrorMessage(e);
                 if (msg.includes("No such container:path") || msg.includes("Could not find the file")) {
                     logger.debug(`Snippet file not found (expected): ${msg}`);
                 } else {
@@ -287,7 +287,7 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             }).catch((e: unknown) => {
                 // Swallow "not found" errors — generator didn't produce snippet template.
                 // Propagate other errors (permissions, disk space, etc.).
-                const msg = e instanceof Error ? e.message : String(e);
+                const msg = extractErrorMessage(e);
                 if (msg.includes("No such container:path") || msg.includes("Could not find the file")) {
                     logger.debug(`Snippet template file not found (expected): ${msg}`);
                 } else {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -9,7 +9,7 @@ import { FernToken, getAccessToken } from "@fern-api/auth";
 import { SourceResolverImpl } from "@fern-api/cli-source-resolver";
 import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
 import { createVenusService } from "@fern-api/core";
-import { ContainerRunner, replaceEnvVariables } from "@fern-api/core-utils";
+import { ContainerRunner, extractErrorMessage, replaceEnvVariables } from "@fern-api/core-utils";
 import { AbsoluteFilePath, dirname, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { logReplaySummary, type PipelineLogger, PostGenerationPipeline } from "@fern-api/generator-cli";
 import { cloneRepository, parseRepository } from "@fern-api/github";
@@ -277,7 +277,7 @@ export async function runLocalGenerationForWorkspace({
                         }
                     } catch (error) {
                         interactiveTaskContext.failAndThrow(
-                            `Failed to clone GitHub repository ${selfhostedGithubConfig.uri}: ${error instanceof Error ? error.message : String(error)}`
+                            `Failed to clone GitHub repository ${selfhostedGithubConfig.uri}: ${extractErrorMessage(error)}`
                         );
                     }
                 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -7,7 +7,7 @@ import { FernToken } from "@fern-api/auth";
 import { SourceResolverImpl } from "@fern-api/cli-source-resolver";
 import { Audiences, fernConfigJson, generatorsYml } from "@fern-api/configuration";
 import { createFdrService, createVenusService } from "@fern-api/core";
-import { replaceEnvVariables } from "@fern-api/core-utils";
+import { extractErrorMessage, replaceEnvVariables } from "@fern-api/core-utils";
 import { FdrAPI, FdrClient } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { convertIrToDynamicSnippetsIr, generateIntermediateRepresentation } from "@fern-api/ir-generator";
@@ -228,9 +228,7 @@ export async function runRemoteGenerationForGenerator({
                 context: interactiveTaskContext
             });
         } catch (error) {
-            interactiveTaskContext.failAndThrow(
-                `Failed to upload dynamic IR: ${error instanceof Error ? error.message : String(error)}`
-            );
+            interactiveTaskContext.failAndThrow(`Failed to upload dynamic IR: ${extractErrorMessage(error)}`);
         }
 
         // Return a minimal response since no SDK generation occurred
@@ -309,7 +307,7 @@ export async function runRemoteGenerationForGenerator({
             });
         } catch (error) {
             interactiveTaskContext.logger.warn(
-                `Failed to upload dynamic IR for SDK generation: ${error instanceof Error ? error.message : String(error)}`
+                `Failed to upload dynamic IR for SDK generation: ${extractErrorMessage(error)}`
             );
         }
     }

--- a/packages/cli/init/src/initializeDocs.ts
+++ b/packages/cli/init/src/initializeDocs.ts
@@ -1,5 +1,5 @@
 import { DOCS_CONFIGURATION_FILENAME, docsYml } from "@fern-api/configuration-loader";
-import { titleCase } from "@fern-api/core-utils";
+import { extractErrorMessage, titleCase } from "@fern-api/core-utils";
 import { doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
@@ -38,7 +38,7 @@ export async function initializeDocs({
                 taskContext.logger.info(chalk.green("Created docs configuration"));
                 return;
             } catch (writeError) {
-                const errorMessage = writeError instanceof Error ? writeError.message : String(writeError);
+                const errorMessage = extractErrorMessage(writeError);
                 taskContext.logger.debug(`Encountered an error while writing docs configuration: ${errorMessage}`);
                 taskContext.logger.error(chalk.red("Failed to write docs configuration"));
                 throw writeError;

--- a/packages/cli/register/src/ai-example-enhancer/lambdaClient.ts
+++ b/packages/cli/register/src/ai-example-enhancer/lambdaClient.ts
@@ -1,4 +1,5 @@
 import { FernToken } from "@fern-api/auth";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { isNetworkError } from "@fern-api/lazy-fern-workspace";
 import { TaskContext } from "@fern-api/task-context";
 import { AIExampleEnhancerConfig, ExampleEnhancementRequest, ExampleEnhancementResponse } from "./types.js";
@@ -73,7 +74,7 @@ export class LambdaExampleEnhancer {
             this.context.logger.debug("Venus connectivity check succeeded");
             return false;
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             if (isNetworkError(errorMessage)) {
                 this.venusAirGappedResult = true;
                 this.context.logger.debug(`Venus connectivity check failed - air-gapped mode: ${errorMessage}`);

--- a/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
@@ -13,7 +13,7 @@ import {
 import { AsyncAPIConverter, AsyncAPIConverterContext } from "@fern-api/asyncapi-to-ir";
 import { constructCasingsGenerator } from "@fern-api/casings-generator";
 import { Audiences, generatorsYml } from "@fern-api/configuration";
-import { isNonNullish } from "@fern-api/core-utils";
+import { extractErrorMessage, isNonNullish } from "@fern-api/core-utils";
 import { FdrAPI } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath, cwd, dirname, join, RelativeFilePath, relativize } from "@fern-api/fs-utils";
 import { IntermediateRepresentation, serialization } from "@fern-api/ir-sdk";
@@ -209,7 +209,7 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
             } catch (error) {
                 context.logger.error(
                     `Failed to process GraphQL spec ${spec.absoluteFilepath}:`,
-                    error instanceof Error ? error.message : String(error)
+                    extractErrorMessage(error)
                 );
             }
         }

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
@@ -1,9 +1,9 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
 import { runExeca } from "@fern-api/logging-execa";
 import { access, cp, rm } from "fs/promises";
 import tmp from "tmp-promise";
-
 /**
  * Check if an error message indicates a network error.
  * Used by both protobuf generation and AI example enhancement for air-gap detection.
@@ -58,7 +58,7 @@ async function performAirGapDetection(url: string, logger: Logger, timeoutMs: nu
         logger.debug("Network check succeeded - not in air-gapped mode");
         return false;
     } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorMessage = extractErrorMessage(error);
         if (isNetworkError(errorMessage)) {
             airGapDetectionResult = true;
             logger.debug(`Network check failed - entering air-gapped mode: ${errorMessage}`);
@@ -119,7 +119,7 @@ export async function detectAirGappedModeForProtobuf(
             logger.debug("Network check succeeded - not in air-gapped mode");
             return false;
         } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = extractErrorMessage(error);
             if (isNetworkError(errorMessage)) {
                 logger.debug(`Network check failed - entering air-gapped mode: ${errorMessage.substring(0, 100)}`);
                 return true;

--- a/packages/cli/workspace/loader/src/loadDocsWorkspace.ts
+++ b/packages/cli/workspace/loader/src/loadDocsWorkspace.ts
@@ -1,5 +1,5 @@
 import { DOCS_CONFIGURATION_FILENAME, docsYml } from "@fern-api/configuration-loader";
-import { sanitizeNullValues, validateAgainstJsonSchema } from "@fern-api/core-utils";
+import { extractErrorMessage, sanitizeNullValues, validateAgainstJsonSchema } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 import { readFile } from "fs/promises";
@@ -87,14 +87,10 @@ export async function loadRawDocsConfiguration({
             context.logger.debug(`Attempting to parse sanitized docs configuration`);
             return docsYml.RawSchemas.Serializer.DocsConfiguration.parseOrThrow(sanitizedJson);
         } catch (err) {
-            context.logger.error(
-                `Parsing failed even after sanitization: ${err instanceof Error ? err.message : String(err)}`
-            );
+            context.logger.error(`Parsing failed even after sanitization: ${extractErrorMessage(err)}`);
             // Log the JSON structure to debug
             context.logger.debug(`Sanitized JSON structure: ${JSON.stringify(sanitizedJson, null, 2)}`);
-            throw new Error(
-                `Failed to parse ${absolutePathOfConfiguration}: ${err instanceof Error ? err.message : String(err)}`
-            );
+            throw new Error(`Failed to parse ${absolutePathOfConfiguration}: ${extractErrorMessage(err)}`);
         }
     } else {
         throw new Error(`Failed to parse docs.yml:\n${result.error?.message ?? "Unknown error"}`);

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown/valid-markdown.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown/valid-markdown.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { getMarkdownFormat, parseImagePaths } from "@fern-api/docs-markdown-utils";
 import { AbsoluteFilePath, dirname } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
@@ -6,9 +7,7 @@ import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { z } from "zod";
-
 import { Rule } from "../../Rule.js";
-
 export const ValidMarkdownRule: Rule = {
     name: "valid-markdown",
     create: ({ logger, workspace }) => {
@@ -131,7 +130,7 @@ async function parseMarkdown({
             type: "success"
         };
     } catch (err) {
-        logger.trace(`Markdown parse failed with error: ${err instanceof Error ? err.message : String(err)}`);
+        logger.trace(`Markdown parse failed with error: ${extractErrorMessage(err)}`);
         return {
             type: "failure",
             message: err instanceof Error ? err.message : undefined

--- a/packages/cli/yaml/loader/package.json
+++ b/packages/cli/yaml/loader/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
+    "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/source": "workspace:*",

--- a/packages/cli/yaml/loader/src/YamlConfigLoader.ts
+++ b/packages/cli/yaml/loader/src/YamlConfigLoader.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, RelativeFilePath, relative } from "@fern-api/fs-utils";
 import { type Sourced, SourceLocation } from "@fern-api/source";
 import { z } from "zod";
@@ -7,7 +8,6 @@ import { ValidationIssue } from "./ValidationIssue.js";
 import type { YamlDocument } from "./YamlDocument.js";
 import { YamlParser } from "./YamlParser.js";
 import { YamlSourceResolver } from "./YamlSourceResolver.js";
-
 export namespace YamlConfigLoader {
     export type Result<T> = Success<T> | Failure;
 
@@ -122,9 +122,7 @@ export class YamlConfigLoader {
         try {
             return await this.parser.parseDocument({ absoluteFilePath, cwd: this.cwd });
         } catch (err) {
-            throw new Error(
-                `Failed to parse YAML file ${absoluteFilePath}: ${err instanceof Error ? err.message : String(err)}`
-            );
+            throw new Error(`Failed to parse YAML file ${absoluteFilePath}: ${extractErrorMessage(err)}`);
         }
     }
 

--- a/packages/commons/api-workspace-commons/src/checkVersionExists.ts
+++ b/packages/commons/api-workspace-commons/src/checkVersionExists.ts
@@ -1,6 +1,6 @@
 import type { generatorsYml } from "@fern-api/configuration";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { TaskContext } from "@fern-api/task-context";
-
 /**
  * Resolves the package name from the raw generator configuration.
  *
@@ -143,7 +143,7 @@ export async function checkVersionDoesNotAlreadyExist({
         // Best-effort check — if we can't reach the registry, don't block generation.
         // The error will surface later during the actual publish step.
         context.logger.debug(
-            `Could not verify version availability on ${getRegistryName(language)}: ${error instanceof Error ? error.message : String(error)}`
+            `Could not verify version availability on ${getRegistryName(language)}: ${extractErrorMessage(error)}`
         );
         return;
     }

--- a/packages/commons/core-utils/src/extractErrorMessage.ts
+++ b/packages/commons/core-utils/src/extractErrorMessage.ts
@@ -1,6 +1,6 @@
 export function extractErrorMessage(e: unknown): string {
     if (typeof e === "string") {
-        return e;
+        return e.length > 0 ? e : "Unknown error";
     }
     if (e instanceof Error) {
         return e.message;
@@ -8,5 +8,6 @@ export function extractErrorMessage(e: unknown): string {
     if (typeof e === "object" && e !== null && "message" in e && typeof e["message"] === "string") {
         return e["message"];
     }
-    return String(e);
+    const stringified = String(e);
+    return stringified.length > 0 ? stringified : "Unknown error";
 }

--- a/packages/commons/core-utils/src/extractErrorMessage.ts
+++ b/packages/commons/core-utils/src/extractErrorMessage.ts
@@ -3,10 +3,10 @@ export function extractErrorMessage(e: unknown): string {
         return e.length > 0 ? e : "Unknown error";
     }
     if (e instanceof Error) {
-        return e.message;
+        return e.message.length > 0 ? e.message : "Unknown error";
     }
     if (typeof e === "object" && e !== null && "message" in e && typeof e["message"] === "string") {
-        return e["message"];
+        return e["message"].length > 0 ? e["message"] : "Unknown error";
     }
     const stringified = String(e);
     return stringified.length > 0 ? stringified : "Unknown error";

--- a/packages/commons/core-utils/src/extractErrorMessage.ts
+++ b/packages/commons/core-utils/src/extractErrorMessage.ts
@@ -8,5 +8,5 @@ export function extractErrorMessage(e: unknown): string {
     if (typeof e === "object" && e !== null && "message" in e && typeof e["message"] === "string") {
         return e["message"];
     }
-    return "Unknown error";
+    return String(e);
 }

--- a/packages/commons/github/package.json
+++ b/packages/commons/github/package.json
@@ -35,6 +35,7 @@
     "test": "vitest --run --passWithNoTests --globals"
   },
   "dependencies": {
+    "@fern-api/core-utils": "workspace:*",
     "octokit": "^4.1.4",
     "simple-git": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/commons/github/src/cloneRepository.ts
+++ b/packages/commons/github/src/cloneRepository.ts
@@ -1,7 +1,7 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { execSync } from "child_process";
 import { simpleGit } from "simple-git";
 import tmp from "tmp-promise";
-
 import { ClonedRepository } from "./ClonedRepository.js";
 import { parseRepository } from "./parseRepository.js";
 
@@ -108,7 +108,7 @@ export async function cloneRepository({
         await git.clone(cloneUrl, ".");
     } catch (error) {
         const elapsed = Date.now() - startTime;
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorMessage = extractErrorMessage(error);
 
         // Git binary not found
         if (errorMessage.includes("ENOENT") || errorMessage.includes("spawn git")) {

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -23,6 +23,7 @@
   },
   "files": ["bin", "dist", "lib"],
   "dependencies": {
+    "@fern-api/core-utils": "workspace:*",
     "@fern-api/replay": "^0.7.0",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/src/cli.ts
+++ b/packages/generator-cli/src/cli.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { type AbsoluteFilePath, cwd, doesPathExist, resolve } from "@fern-api/fs-utils";
 import fs from "fs";
 import { mkdir, readFile } from "fs/promises";
@@ -205,7 +206,7 @@ void yargs(hideBin(process.argv))
                         try {
                             config = JSON.parse(configContent);
                         } catch (parseError) {
-                            const parseMessage = parseError instanceof Error ? parseError.message : String(parseError);
+                            const parseMessage = extractErrorMessage(parseError);
                             throw new Error(`Failed to parse pipeline config as JSON: ${parseMessage}`);
                         }
 
@@ -246,7 +247,7 @@ void yargs(hideBin(process.argv))
                         // Use process.exitCode instead of process.exit() to allow stdout to drain
                         process.exitCode = result.success ? 0 : 1;
                     } catch (error) {
-                        const errorMessage = error instanceof Error ? error.message : String(error);
+                        const errorMessage = extractErrorMessage(error);
                         process.stderr.write(`Pipeline failed: ${errorMessage}\n`);
                         process.exitCode = 1;
                     }
@@ -339,7 +340,7 @@ void yargs(hideBin(process.argv))
                             process.stdout.write(JSON.stringify(result, null, 2) + "\n");
                             process.exit(0);
                         } catch (error) {
-                            const errorMessage = error instanceof Error ? error.message : String(error);
+                            const errorMessage = extractErrorMessage(error);
                             process.stderr.write(`Replay init failed: ${errorMessage}\n`);
                             process.exit(1);
                         }
@@ -427,7 +428,7 @@ void yargs(hideBin(process.argv))
 
                             process.exit(0);
                         } catch (error) {
-                            const errorMessage = error instanceof Error ? error.message : String(error);
+                            const errorMessage = extractErrorMessage(error);
                             process.stderr.write(`Bootstrap failed: ${errorMessage}\n`);
                             process.exit(1);
                         }

--- a/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
+++ b/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { execFileSync } from "child_process";
 import { FERN_BOT_EMAIL, FERN_BOT_NAME } from "./github/constants";
 import { consolePipelineLogger, type PipelineLogger } from "./PipelineLogger";
@@ -94,7 +95,7 @@ export class PostGenerationPipeline {
             } catch (error) {
                 result.success = false;
                 result.errors = result.errors ?? [];
-                const errorMessage = error instanceof Error ? error.message : String(error);
+                const errorMessage = extractErrorMessage(error);
                 result.errors.push(`${step.name} step error: ${errorMessage}`);
             }
         }

--- a/packages/generator-cli/src/pipeline/github/findExistingUpdatablePR.ts
+++ b/packages/generator-cli/src/pipeline/github/findExistingUpdatablePR.ts
@@ -1,8 +1,7 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { Octokit } from "@octokit/rest";
-
 import type { PipelineLogger } from "../PipelineLogger";
 import { FERN_BOT_LOGIN } from "./constants";
-
 export interface ExistingPullRequest {
     number: number;
     headBranch: string;
@@ -66,7 +65,7 @@ export async function findExistingUpdatablePR(
 
         return undefined;
     } catch (error) {
-        logger.debug(`Error finding existing PRs: ${error instanceof Error ? error.message : String(error)}`);
+        logger.debug(`Error finding existing PRs: ${extractErrorMessage(error)}`);
         return undefined;
     }
 }
@@ -110,7 +109,7 @@ export async function checkPRHasOnlyGenerationCommits(
 
         return true;
     } catch (error) {
-        logger.debug(`Error checking PR commits: ${error instanceof Error ? error.message : String(error)}`);
+        logger.debug(`Error checking PR commits: ${extractErrorMessage(error)}`);
         return false;
     }
 }

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { ClonedRepository, parseRepository } from "@fern-api/github";
 import { Octokit } from "@octokit/rest";
 import { access, writeFile } from "fs/promises";
@@ -9,7 +10,6 @@ import type { PipelineLogger } from "../PipelineLogger";
 import { formatReplayPrBody } from "../replay-summary";
 import type { GithubStepConfig, GithubStepResult, PipelineContext, ReplayStepResult } from "../types";
 import { BaseStep } from "./BaseStep";
-
 export class GithubStep extends BaseStep {
     readonly name = "github";
 
@@ -168,9 +168,7 @@ export class GithubStep extends BaseStep {
                     this.logger.debug(`Pushed ${tagName} tag for generation tracking`);
                     result.generationBaseTagSha = generationBaseSha;
                 } catch (error) {
-                    this.logger.debug(
-                        `Could not push generation tag: ${error instanceof Error ? error.message : String(error)}`
-                    );
+                    this.logger.debug(`Could not push generation tag: ${extractErrorMessage(error)}`);
                 }
             }
         }
@@ -200,9 +198,7 @@ export class GithubStep extends BaseStep {
                 });
                 this.logger.debug(`Updated PR #${existingPR.number} title and body`);
             } catch (error) {
-                this.logger.debug(
-                    `Failed to update PR title/body: ${error instanceof Error ? error.message : String(error)}`
-                );
+                this.logger.debug(`Failed to update PR title/body: ${extractErrorMessage(error)}`);
             }
         } else {
             const head = `${owner}:${prBranch}`;
@@ -221,7 +217,7 @@ export class GithubStep extends BaseStep {
                 result.prUrl = pullRequest.html_url;
                 result.prNumber = pullRequest.number;
             } catch (error) {
-                const message = error instanceof Error ? error.message : String(error);
+                const message = extractErrorMessage(error);
                 if (message.includes("A pull request already exists for")) {
                     this.logger.warn(`A pull request already exists for ${head}`);
                 } else {

--- a/packages/seed/src/commands/test-remote-local/configuration.ts
+++ b/packages/seed/src/commands/test-remote-local/configuration.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import type { Logger } from "@fern-api/logger";
 import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
@@ -25,7 +26,6 @@ import {
     TS_SDK_PACKAGE_NAME
 } from "./constants.js";
 import type { RemoteLocalSeedConfig, RemoteVsLocalTestCase } from "./types.js";
-
 export async function writeGeneratorsYml(
     fernDirectory: string,
     localConfig: unknown,
@@ -99,7 +99,7 @@ export async function loadCustomConfig(
             logger.debug(`No seed.yml found at ${seedYmlPath}, using defaults`);
             return baseConfig;
         }
-        logger.warn(`Error loading seed.yml: ${error instanceof Error ? error.message : String(error)}`);
+        logger.warn(`Error loading seed.yml: ${extractErrorMessage(error)}`);
         return baseConfig;
     }
 }

--- a/packages/seed/src/commands/test-remote-local/dockerHubClient.ts
+++ b/packages/seed/src/commands/test-remote-local/dockerHubClient.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import type { Logger } from "@fern-api/logger";
 import {
     DOCKER_HUB_API_BASE_URL,
@@ -127,12 +128,8 @@ async function getLatestGeneratorVersion(generator: GeneratorName, logger: Logge
         logger.debug(`Found latest version: ${latestVersion} (from ${sortedVersions.length} total versions)`);
         return latestVersion;
     } catch (error) {
-        logger.error(
-            `Failed to fetch version from Docker Hub: ${error instanceof Error ? error.message : String(error)}`
-        );
-        throw new Error(
-            `${ERROR_FAILED_TO_FETCH_VERSION} ${generator} from Docker Hub: ${error instanceof Error ? error.message : String(error)}`
-        );
+        logger.error(`Failed to fetch version from Docker Hub: ${extractErrorMessage(error)}`);
+        throw new Error(`${ERROR_FAILED_TO_FETCH_VERSION} ${generator} from Docker Hub: ${extractErrorMessage(error)}`);
     }
 }
 

--- a/packages/seed/src/commands/test-remote-local/generation.ts
+++ b/packages/seed/src/commands/test-remote-local/generation.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { Logger, LogLevel } from "@fern-api/logger";
 import { runExeca } from "@fern-api/logging-execa";
 import path from "path";
@@ -180,8 +181,8 @@ export async function runGeneration(
     } catch (error) {
         const duration = Date.now() - startTime;
         logger.error(`✗ ${generationMode} generation failed after ${duration}ms`);
-        logger.error(`  Error: ${error instanceof Error ? error.message : String(error)}`);
-        return { success: false, error: error instanceof Error ? error.message : String(error) };
+        logger.error(`  Error: ${extractErrorMessage(error)}`);
+        return { success: false, error: extractErrorMessage(error) };
     }
 }
 

--- a/packages/seed/src/commands/test-remote-local/testExecution.ts
+++ b/packages/seed/src/commands/test-remote-local/testExecution.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { cp, mkdir, rm, stat, writeFile } from "fs/promises";
@@ -23,7 +24,6 @@ import {
 } from "./constants.js";
 import { runGeneration } from "./generation.js";
 import type { GenerationResult, GenerationResultSuccess, RemoteVsLocalTestCase, TestCaseResult } from "./types.js";
-
 export async function runTestCase(testCase: RemoteVsLocalTestCase): Promise<TestCaseResult> {
     const { generator, fixture, outputMode, localGeneratorVersions, remoteGeneratorVersions, context } = testCase;
     const { fernRepoDirectory, workingDirectory, logger } = context;
@@ -261,6 +261,6 @@ async function cleanupGitFolders(outputFolder: string, logger: Logger): Promise<
         }
     } catch (error) {
         // Non-fatal - log warning but don't fail the test
-        logger.warn(`Failed to clean up .git folders: ${error instanceof Error ? error.message : String(error)}`);
+        logger.warn(`Failed to clean up .git folders: ${extractErrorMessage(error)}`);
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3243,6 +3243,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../../packages/configs
+      '@fern-api/core-utils':
+        specifier: workspace:*
+        version: link:../../../../packages/commons/core-utils
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../../packages/commons/fs-utils
@@ -4461,6 +4464,9 @@ importers:
 
   packages/cli/api-importers/openrpc-to-ir:
     dependencies:
+      '@fern-api/core-utils':
+        specifier: workspace:*
+        version: link:../../../commons/core-utils
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../../ir-sdk
@@ -5257,12 +5263,6 @@ importers:
       yargs:
         specifier: ^17.4.1
         version: 17.7.2
-
-  packages/cli/cli/dist/prod-unminified:
-    dependencies:
-      '@boundaryml/baml':
-        specifier: 'catalog:'
-        version: 0.219.0
 
   packages/cli/config:
     devDependencies:
@@ -7627,6 +7627,9 @@ importers:
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../../configs
+      '@fern-api/core-utils':
+        specifier: workspace:*
+        version: link:../../../commons/core-utils
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -7862,6 +7865,9 @@ importers:
 
   packages/commons/github:
     dependencies:
+      '@fern-api/core-utils':
+        specifier: workspace:*
+        version: link:../core-utils
       octokit:
         specifier: ^4.1.4
         version: 4.1.4
@@ -8090,6 +8096,9 @@ importers:
 
   packages/generator-cli:
     dependencies:
+      '@fern-api/core-utils':
+        specifier: workspace:*
+        version: link:../commons/core-utils
       '@fern-api/replay':
         specifier: ^0.7.0
         version: 0.7.0


### PR DESCRIPTION
## Description

Replaces ~89 instances of the inline `error instanceof Error ? error.message : String(error)` pattern across the codebase with the existing `extractErrorMessage` utility from `@fern-api/core-utils`.

## Changes Made

- Replaced all inline `error instanceof Error ? error.message : String(error)` occurrences (50 files) with `extractErrorMessage(error)`
- Updated `extractErrorMessage` fallback: now uses `String(e)` instead of the previous hardcoded `"Unknown error"`, with a guard that falls back to `"Unknown error"` if `String(e)` produces an empty string
- Added empty-string guard for the `typeof e === "string"` branch as well (an empty string thrown as an error falls back to `"Unknown error"`)
- Added `@fern-api/core-utils` as a dependency to 5 packages that didn't already have it:
  - `@fern-typescript/sdk-generator-cli`
  - `@fern-api/openrpc-to-ir`
  - `@fern-api/yaml-loader`
  - `@fern-api/github`
  - `@fern-api/generator-cli`

## Human Review Checklist

- [x] **Fallback behavior in `extractErrorMessage`**: The fallback was changed from always returning `"Unknown error"` to `String(e) || "Unknown error"`. Any existing callers that relied on the exact `"Unknown error"` string for non-Error/non-string values will now get `String(e)` instead (e.g. `"42"` for a thrown number). Verify this is acceptable.
- [x] **Subtle semantic difference**: `extractErrorMessage` has a check for plain objects with a `message` string property (line 8–9). The old inline pattern would call `String(obj)` on such objects; the utility returns `obj.message` instead. This is arguably better behavior but is a minor change.
- [x] **Lockfile**: `pnpm install` removed a stale `packages/cli/cli/dist/prod-unminified` entry — unrelated to this PR.

## Testing
- [x] Lint/format check passes (`pnpm run check`)
- [x] CLI builds and runs (`--help` works)
- [x] Error paths produce correct human-readable messages (`fern check` on invalid workspace)
- [x] Verified zero remaining inline pattern instances in codebase
- [x] CI (293 checks passing)

Link to Devin session: https://app.devin.ai/sessions/e795b62f46644798a74b76d739a82b42
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
