### PR TITLE
fix(cli): remove cli-progress from runtime dependencies

### DIFF
--- a/packages/cli/cli/build.prod.mjs
+++ b/packages/cli/cli/build.prod.mjs
@@ -20,7 +20,7 @@ buildCli({
         CLI_NAME: "fern",
         CLI_PACKAGE_NAME: "fern-api"
     },
-    runtimeDependencies: ["@boundaryml/baml", "cli-progress"],
+    runtimeDependencies: ["@boundaryml/baml"],
     packageJsonOverrides: {
         name: "fern-api",
         bin: { fern: "cli.cjs" }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.37.2
+  changelogEntry:
+    - summary: |
+        Remove `cli-progress` from the published `fern-api` package's runtime
+        dependencies. The package is a pure JS library that is already bundled
+        into the CLI output by tsup, so it does not need to be installed
+        separately at runtime.
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 65
+
 - version: 4.37.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Removes `cli-progress` from the published `fern-api` package's runtime dependencies. It's a pure JS package that tsup already bundles into `cli.cjs` — it doesn't need to be installed separately at runtime.

## Changes Made

- Removed `cli-progress` from `runtimeDependencies` in `build.prod.mjs`
- Added `versions.yml` entry (v4.37.2) for the changelog

Note: `@boundaryml/baml` remains as a runtime dependency because it has native bindings and is explicitly externalized from the bundle. The dev and local builds already don't list `cli-progress` as a runtime dependency, confirming it bundles correctly.

## Testing

- [x] Lint passes locally (`pnpm run check`)
- [x] Built prod CLI locally and verified:
  - Generated `package.json` only lists `@boundaryml/baml` as a dependency (no `cli-progress`)
  - `cli-progress` code (`SingleBar`, `barCompleteChar`, etc.) is confirmed present inside the bundled `cli.cjs`

## Human Review Checklist
- [ ] Confirm `cli-progress` is **not** in the tsup `external` list (it's not — see `FULL_EXTERNALS` and `MINIMAL_EXTERNALS` in `build-utils.mjs`), so it is bundled into the output
- [ ] Note that `build.dev.mjs` and `build.local.mjs` already omit `cli-progress` from `runtimeDependencies`, so this aligns prod with those builds
- [ ] Verify `versions.yml` entry version (4.37.2) and date are correct

Link to Devin session: https://app.devin.ai/sessions/1be2d6a0d9734e4ba4b2bd11e4107a07
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
