### PR TITLE
fix(ci): enable auto-merge and approval on updated changelog PRs

### DIFF
--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -88,7 +88,7 @@ jobs:
           path: docs
 
       - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
+        if: steps.cpr.outputs.pull-request-number
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
@@ -97,7 +97,7 @@ jobs:
           merge-method: squash
 
       - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
+        if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.PR_BOT_GH_PAT }}
         run: gh pr review ${{ steps.cpr.outputs.pull-request-number }} --repo fern-api/docs --approve


### PR DESCRIPTION
## Description

Fixes the "Write Changelogs to Docs" workflow so that changelog PRs in `fern-api/docs` don't get stuck open when they are updated by subsequent workflow runs.

Currently, [fern-api/docs#4355](https://github.com/fern-api/docs/pull/4355) is stuck open with the correct changelog content (CLI versions 4.35.0–4.37.1) because auto-merge and approval were never re-applied after the PR was updated.

## Changes Made

- Changed the condition for the "Enable Pull Request Automerge" and "Approve PR" steps from `steps.cpr.outputs.pull-request-operation == 'created'` to `steps.cpr.outputs.pull-request-number`

**Root cause:** The `peter-evans/create-pull-request` action sets `pull-request-operation` to `'updated'` when pushing to an existing branch/PR. The old condition only matched `'created'`, so if a PR didn't merge before the next workflow run, auto-merge and approval were never re-applied — leaving the PR permanently stuck.

**Why this fix is safe:** `pull-request-number` is truthy for both `created` and `updated` operations, and empty when no changes are detected (so the steps still skip when there's nothing to do). Both auto-merge enablement and PR approval are idempotent.

## Testing

- [ ] Manual testing completed — this is a CI workflow change that can only be fully validated by a push to `main` triggering the workflow

### Human review checklist
- [x] Confirm that re-approving an already-approved PR via `gh pr review --approve` is acceptable (it is idempotent, but worth confirming with repo settings)
- [x] After merging, verify the next workflow run unblocks [fern-api/docs#4355](https://github.com/fern-api/docs/pull/4355)

Link to Devin session: https://app.devin.ai/sessions/2f9a2b57f249498da208b219be2324f0
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
