### PR TITLE
fix(rust): handle empty HTTP responses, normalize WS URLs, and add serde transparent for undiscriminated unions

### DIFF
--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -433,7 +433,17 @@ impl HttpClient {
     where
         T: DeserializeOwned,
     {
+        let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
+
+        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
+        if text.is_empty() {
+            return Err(ApiError::Http {
+                status,
+                message: String::new(),
+            });
+        }
+
         serde_json::from_str(&text).map_err(ApiError::Serialization)
     }
 

--- a/generators/rust/base/src/asIs/websocket.rs
+++ b/generators/rust/base/src/asIs/websocket.rs
@@ -150,9 +150,22 @@ impl WebSocketClient {
         Ok(read)
     }
 
+    /// Convert HTTP(S) URLs to WS(S) URLs for WebSocket connections.
+    /// tokio-tungstenite requires ws:// or wss:// scheme.
+    fn to_ws_url(url: &str) -> String {
+        if url.starts_with("https://") {
+            format!("wss://{}", &url[8..])
+        } else if url.starts_with("http://") {
+            format!("ws://{}", &url[7..])
+        } else {
+            url.to_string()
+        }
+    }
+
     fn build_url(&self) -> String {
+        let base = Self::to_ws_url(&self.url);
         if self.options.query_params.is_empty() {
-            return self.url.clone();
+            return base;
         }
         let query: String = self
             .options
@@ -161,7 +174,7 @@ impl WebSocketClient {
             .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
             .collect::<Vec<_>>()
             .join("&");
-        format!("{}?{}", self.url, query)
+        format!("{}?{}", base, query)
     }
 
     pub async fn send_json<T: Serialize>(&self, message: &T) -> Result<(), ApiError> {
@@ -331,8 +344,9 @@ impl WebSocketClient {
         options: &WebSocketOptions,
         sink: &Arc<Mutex<Option<WsSink>>>,
     ) -> Result<WsSource, ApiError> {
+        let base = Self::to_ws_url(url);
         let full_url = if options.query_params.is_empty() {
-            url.to_string()
+            base
         } else {
             let query: String = options
                 .query_params
@@ -340,7 +354,7 @@ impl WebSocketClient {
                 .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
                 .collect::<Vec<_>>()
                 .join("&");
-            format!("{}?{}", url, query)
+            format!("{}?{}", base, query)
         };
 
         let uri: Uri = full_url

--- a/generators/rust/codegen/src/ast/Attribute.ts
+++ b/generators/rust/codegen/src/ast/Attribute.ts
@@ -124,6 +124,12 @@ export class Attribute extends AstNode {
             new Attribute({
                 name: "serde",
                 args: [`tag = ${JSON.stringify(tag)}`, `content = ${JSON.stringify(content)}`]
+            }),
+
+        transparent: (): Attribute =>
+            new Attribute({
+                name: "serde",
+                args: ["transparent"]
             })
     };
 }

--- a/generators/rust/model/src/ModelGeneratorContext.ts
+++ b/generators/rust/model/src/ModelGeneratorContext.ts
@@ -11,6 +11,13 @@ export class ModelGeneratorContext extends AbstractRustGeneratorContext<ModelCus
      */
     public websocketServerMessageTypeIds: Set<string> = new Set();
 
+    /**
+     * Set of type IDs that are referenced as members of undiscriminated unions.
+     * Single-property structs in this set need #[serde(transparent)] so they
+     * serialize/deserialize as the inner value for untagged enum matching.
+     */
+    public undiscriminatedUnionMemberTypeIds: Set<string> = new Set();
+
     public getCoreAsIsFiles(): AsIsFileDefinition[] {
         // Model generator doesn't need the client templates, return empty array
         return [];

--- a/generators/rust/model/src/__test__/snapshots/alias-types/types_user_profile.rs
+++ b/generators/rust/model/src/__test__/snapshots/alias-types/types_user_profile.rs
@@ -1,10 +1,13 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct UserProfile {
+    #[serde(default)]
     pub user_id: UserID,
+    #[serde(default)]
     pub email: UserEmail,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub age: Option<UserAge>,
+    #[serde(default)]
     pub tags: UserTags,
 }

--- a/generators/rust/model/src/__test__/snapshots/basic-object/types_user.rs
+++ b/generators/rust/model/src/__test__/snapshots/basic-object/types_user.rs
@@ -1,13 +1,19 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct User {
+    #[serde(default)]
     pub id: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub email: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub age: Option<i64>,
+    #[serde(default)]
     pub is_active: bool,
+    #[serde(default)]
     pub balance: f64,
+    #[serde(default)]
     pub tags: Vec<String>,
 }

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_category.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_category.rs
@@ -1,9 +1,12 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct Category {
+    #[serde(default)]
     pub id: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_error_response.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_error_response.rs
@@ -1,8 +1,10 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ErrorResponse {
+    #[serde(default)]
     pub error: String,
+    #[serde(default)]
     pub code: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<Vec<String>>,

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_product.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_product.rs
@@ -1,9 +1,13 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct Product {
+    #[serde(default)]
     pub id: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub price: f64,
+    #[serde(default)]
     pub in_stock: bool,
 }

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_success_response.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_success_response.rs
@@ -1,7 +1,9 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct SuccessResponse {
+    #[serde(default)]
     pub data: String,
+    #[serde(default)]
     pub status: i64,
 }

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_user.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_user.rs
@@ -1,8 +1,11 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct User {
+    #[serde(default)]
     pub id: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub email: String,
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_bank_transfer.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_bank_transfer.rs
@@ -1,7 +1,9 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct BankTransfer {
+    #[serde(default)]
     pub account_number: String,
+    #[serde(default)]
     pub routing_number: String,
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_bird.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_bird.rs
@@ -1,8 +1,10 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct Bird {
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub can_fly: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wing_span: Option<f64>,

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_car.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_car.rs
@@ -1,7 +1,9 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct Car {
+    #[serde(default)]
     pub doors: i64,
+    #[serde(default)]
     pub fuel_type: String,
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_cat.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_cat.rs
@@ -1,8 +1,11 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct Cat {
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub is_indoor: bool,
+    #[serde(default)]
     pub lives_remaining: i64,
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_credit_card.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_credit_card.rs
@@ -1,7 +1,9 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct CreditCard {
+    #[serde(default)]
     pub card_number: String,
+    #[serde(default)]
     pub expiry_date: String,
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_dog.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_dog.rs
@@ -1,8 +1,11 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct Dog {
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub breed: String,
+    #[serde(default)]
     pub age: i64,
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_motorcycle.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_motorcycle.rs
@@ -1,7 +1,9 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct Motorcycle {
+    #[serde(default)]
     pub engine_size: f64,
+    #[serde(default)]
     pub has_sidecar: bool,
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_rectangle.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_rectangle.rs
@@ -1,7 +1,9 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct Rectangle {
+    #[serde(default)]
     pub width: f64,
+    #[serde(default)]
     pub height: f64,
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_truck.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_truck.rs
@@ -1,7 +1,9 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct Truck {
+    #[serde(default)]
     pub payload_capacity: f64,
+    #[serde(default)]
     pub axles: i64,
 }

--- a/generators/rust/model/src/generateModels.ts
+++ b/generators/rust/model/src/generateModels.ts
@@ -12,6 +12,19 @@ import { UndiscriminatedUnionGenerator, UnionGenerator } from "./union/index.js"
 export function generateModels({ context }: { context: ModelGeneratorContext }): RustFile[] {
     const files: RustFile[] = [];
 
+    // Pre-compute which type IDs are members of undiscriminated unions.
+    // Single-property structs in undiscriminated unions need #[serde(transparent)]
+    // so they serialize as the inner value for untagged enum matching.
+    for (const [_typeId, typeDeclaration] of Object.entries(context.ir.types)) {
+        if (typeDeclaration.shape.type === "undiscriminatedUnion") {
+            for (const member of typeDeclaration.shape.members) {
+                if (member.type.type === "named") {
+                    context.undiscriminatedUnionMemberTypeIds.add(member.type.typeId);
+                }
+            }
+        }
+    }
+
     for (const [_typeId, typeDeclaration] of Object.entries(context.ir.types)) {
         const file = typeDeclaration.shape._visit<RustFile | undefined>({
             alias: (aliasTypeDeclaration) => {

--- a/generators/rust/model/src/object/StructGenerator.ts
+++ b/generators/rust/model/src/object/StructGenerator.ts
@@ -114,6 +114,13 @@ export class StructGenerator {
 
         attributes.push(Attribute.derive(derives));
 
+        // Add #[serde(transparent)] for single-property structs used in undiscriminated unions.
+        // This makes the struct serialize/deserialize as the inner value directly,
+        // which is required for untagged enum variant matching.
+        if (this.isSinglePropertyUndiscriminatedUnionMember()) {
+            attributes.push(Attribute.serde.transparent());
+        }
+
         return attributes;
     }
 
@@ -126,7 +133,10 @@ export class StructGenerator {
 
         // Generate the field type, wrapping in Box<T> if recursive
         const fieldType = generateFieldType(property, this.context, isRecursive);
-        const fieldAttributes = generateFieldAttributes(property, this.context);
+        const isTransparent = this.isSinglePropertyUndiscriminatedUnionMember();
+        // When struct is transparent, skip field-level serde attributes (rename, default, etc.)
+        // as they are incompatible with #[serde(transparent)]
+        const fieldAttributes = isTransparent ? [] : generateFieldAttributes(property, this.context);
         const fieldName = this.context.escapeRustKeyword(property.name.name.snakeCase.unsafeName);
 
         return rust.field({
@@ -201,6 +211,21 @@ export class StructGenerator {
             );
         });
         return isTypeSupportsHashAndEq && isNamedTypeSupportsHashAndEq;
+    }
+
+    /**
+     * Check if this struct is a single-property wrapper used in an undiscriminated union.
+     * Such structs need #[serde(transparent)] so they serialize/deserialize as the
+     * inner value directly, enabling correct untagged enum variant matching.
+     */
+    private isSinglePropertyUndiscriminatedUnionMember(): boolean {
+        // Must have exactly one property and no extends (inheritance)
+        if (this.objectTypeDeclaration.properties.length !== 1 || this.objectTypeDeclaration.extends.length > 0) {
+            return false;
+        }
+        // Check if this type is referenced by any undiscriminated union
+        const typeId = Object.entries(this.context.ir.types).find(([_, type]) => type === this.typeDeclaration)?.[0];
+        return typeId != null && this.context.undiscriminatedUnionMemberTypeIds.has(typeId);
     }
 
     private canDeriveDefault(): boolean {

--- a/generators/rust/model/src/object/StructGenerator.ts
+++ b/generators/rust/model/src/object/StructGenerator.ts
@@ -97,6 +97,11 @@ export class StructGenerator {
         // Build derives conditionally based on actual needs
         const derives: string[] = ["Debug", "Clone", "Serialize", "Deserialize"];
 
+        // Default - add if all fields support Default
+        if (this.canDeriveDefault()) {
+            derives.push("Default");
+        }
+
         // PartialEq - for equality comparisons
         if (this.needsPartialEq()) {
             derives.push("PartialEq");
@@ -196,5 +201,66 @@ export class StructGenerator {
             );
         });
         return isTypeSupportsHashAndEq && isNamedTypeSupportsHashAndEq;
+    }
+
+    private canDeriveDefault(): boolean {
+        // Check if all properties support Default
+        const propertiesSupport = this.objectTypeDeclaration.properties.every((property) => {
+            return this.typeSupportsDefault(property.valueType, new Set());
+        });
+        // Check if all inherited types support Default
+        const extendsSupport = this.objectTypeDeclaration.extends.every((parentType) => {
+            return this.namedTypeSupportsDefault(parentType.typeId, new Set());
+        });
+        return propertiesSupport && extendsSupport;
+    }
+
+    private typeSupportsDefault(typeRef: FernIr.TypeReference, visited: Set<string>): boolean {
+        if (typeRef.type === "primitive") {
+            return true; // All Rust primitives implement Default
+        }
+        if (typeRef.type === "container") {
+            return typeRef.container._visit({
+                list: () => true,
+                map: () => true,
+                set: () => true,
+                optional: () => true,
+                nullable: () => true,
+                literal: () => false,
+                _other: () => false
+            });
+        }
+        if (typeRef.type === "named") {
+            return this.namedTypeSupportsDefault(typeRef.typeId, visited);
+        }
+        if (typeRef.type === "unknown") {
+            return true; // serde_json::Value implements Default
+        }
+        return false;
+    }
+
+    private namedTypeSupportsDefault(typeId: string, visited: Set<string>): boolean {
+        if (visited.has(typeId)) {
+            return false; // Prevent infinite recursion, be conservative
+        }
+        visited.add(typeId);
+        const typeDecl = this.context.ir.types[typeId];
+        if (!typeDecl) {
+            return false;
+        }
+        if (typeDecl.shape.type === "object") {
+            // Object supports Default if all its fields support Default
+            return typeDecl.shape.properties.every((prop) =>
+                this.typeSupportsDefault(prop.valueType, visited)
+            );
+        }
+        if (typeDecl.shape.type === "enum") {
+            return false; // Enums don't derive Default (no #[default] variant)
+        }
+        if (typeDecl.shape.type === "alias") {
+            return this.typeSupportsDefault(typeDecl.shape.aliasOf, visited);
+        }
+        // Unions don't derive Default
+        return false;
     }
 }

--- a/generators/rust/model/src/union/UnionGenerator.ts
+++ b/generators/rust/model/src/union/UnionGenerator.ts
@@ -237,6 +237,7 @@ export class UnionGenerator {
 
         // Generate variant attributes
         const variantAttributes = this.generateVariantAttributes(unionType, variantName);
+
         variantAttributes.forEach((attr) => {
             writer.write("    ");
             attr.write(writer);

--- a/generators/rust/model/src/utils/primitiveTypeUtils.ts
+++ b/generators/rust/model/src/utils/primitiveTypeUtils.ts
@@ -185,6 +185,57 @@ export function isUnknownType(typeRef: FernIr.TypeReference): boolean {
     return typeRef.type === "unknown";
 }
 
+/**
+ * Check if a type has a natural Default implementation in Rust.
+ * Primitives (String, bool, i64, f64, etc.) and containers (Vec, HashMap, HashSet)
+ * all implement Default. Named types (enums, structs) may not.
+ * Used to add #[serde(default)] so missing fields get zero-values during deserialization.
+ */
+export function hasDefaultImpl(typeRef: FernIr.TypeReference, context?: ModelGeneratorContext): boolean {
+    if (typeRef.type === "primitive") {
+        return true;
+    }
+    if (typeRef.type === "container") {
+        return typeRef.container._visit({
+            list: () => true,
+            map: () => true,
+            set: () => true,
+            optional: () => true,
+            nullable: () => true,
+            literal: () => false,
+            _other: () => false
+        });
+    }
+    if (typeRef.type === "named" && context) {
+        return namedTypeSupportsDefault(typeRef.typeId, context, new Set());
+    }
+    return false;
+}
+
+/**
+ * Check if a named type (object) supports Default by checking if all its fields
+ * have types that implement Default. Enums and unions don't derive Default.
+ */
+function namedTypeSupportsDefault(typeId: string, context: ModelGeneratorContext, visited: Set<string>): boolean {
+    if (visited.has(typeId)) {
+        return false;
+    }
+    visited.add(typeId);
+    const typeDecl = context.ir.types[typeId];
+    if (!typeDecl) {
+        return false;
+    }
+    if (typeDecl.shape.type === "object") {
+        return typeDecl.shape.properties.every((prop) =>
+            hasDefaultImpl(prop.valueType, context)
+        );
+    }
+    if (typeDecl.shape.type === "alias") {
+        return hasDefaultImpl(typeDecl.shape.aliasOf, context);
+    }
+    return false;
+}
+
 export function isOptionalType(typeReference: FernIr.TypeReference): boolean {
     return typeReference._visit<boolean>({
         container: (container) => {

--- a/generators/rust/model/src/utils/structUtils.ts
+++ b/generators/rust/model/src/utils/structUtils.ts
@@ -5,6 +5,7 @@ import { ModelGeneratorContext } from "../ModelGeneratorContext.js";
 import {
     extractNamedTypesFromTypeReference,
     getInnerTypeFromOptional,
+    hasDefaultImpl,
     isBase64Type,
     isBigIntType,
     isCollectionType,
@@ -230,6 +231,13 @@ export function generateFieldAttributes(
     const isOptional = isOptionalType(property.valueType);
     if (isOptional) {
         attributes.push(Attribute.serde.skipSerializingIf('"Option::is_none"'));
+    }
+
+    // For non-optional fields with types that implement Default (primitives, containers),
+    // add #[serde(default)] so deserialization succeeds when the field is missing from JSON.
+    // This handles cases like deferred responses that return partial objects.
+    if (!isOptional && hasDefaultImpl(property.valueType, context)) {
+        attributes.push(Attribute.serde.default());
     }
 
     // Add flexible datetime serde attribute - both "offset" (default) and "utc" use flexible parsing

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -433,7 +433,17 @@ impl HttpClient {
     where
         T: DeserializeOwned,
     {
+        let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
+
+        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
+        if text.is_empty() {
+            return Err(ApiError::Http {
+                status,
+                message: String::new(),
+            });
+        }
+
         serde_json::from_str(&text).map_err(ApiError::Serialization)
     }
 

--- a/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
+++ b/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
@@ -192,12 +192,7 @@ export class WebSocketChannelGenerator {
 
         const rawDeclarations: string[] = [];
 
-        // The IR message type IDs always use the full channel-derived prefix
-        // (e.g. "ListenV2Connected"), even when collision resolution shortens the
-        // Rust enum prefix (e.g. "V2"). Derive wirePrefix from the channel ID
-        // so we can strip it correctly.
-        const wirePrefix = this.deriveNameFromChannelId(channelId).pascalCase;
-        const serverEnum = this.generateServerMessageEnum(enumPrefix, jsonServerMessages, wirePrefix);
+        const serverEnum = this.generateServerMessageEnum(enumPrefix, jsonServerMessages);
         if (serverEnum) {
             rawDeclarations.push(serverEnum);
         }
@@ -261,8 +256,7 @@ export class WebSocketChannelGenerator {
      */
     private generateServerMessageEnum(
         enumPrefix: string,
-        jsonServerMessages: FernIr.WebSocketMessage[],
-        wirePrefix: string
+        jsonServerMessages: FernIr.WebSocketMessage[]
     ): string | undefined {
         if (jsonServerMessages.length === 0) {
             return undefined;
@@ -273,28 +267,16 @@ export class WebSocketChannelGenerator {
         const variants = jsonServerMessages
             .map((msg) => {
                 const variantName = this.getMessageVariantName(msg);
-                // The IR msg.type (from AsyncAPI operationId) includes the channel name
-                // as a prefix (e.g. "ListenV2Connected"), but the actual API sends just
-                // the short discriminant (e.g. "Connected"). Strip the wire prefix.
-                // wirePrefix comes from channel.displayName (the original channel name),
-                // which may differ from enumPrefix when collision resolution renames it.
-                let wireValue = msg.type;
-                if (wireValue.startsWith(wirePrefix)) {
-                    wireValue = wireValue.slice(wirePrefix.length);
-                } else if (wireValue.startsWith(enumPrefix)) {
-                    wireValue = wireValue.slice(enumPrefix.length);
-                }
                 const bodyType = this.getMessageBodyType(msg);
-                const renameAttr = `    #[serde(rename = "${wireValue}")]\n`;
                 if (bodyType) {
-                    return `${renameAttr}    ${variantName}(${bodyType}),`;
+                    return `    ${variantName}(${bodyType}),`;
                 }
-                return `${renameAttr}    ${variantName},`;
+                return `    ${variantName},`;
             })
             .join("\n");
 
         return `#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
+#[serde(untagged)]
 pub enum ${enumName} {
 ${variants}
 }`;


### PR DESCRIPTION
## Description

Multiple fixes for the Rust SDK generator targeting HTTP response handling, WebSocket URL schemes, and serde serialization for undiscriminated unions.

## Changes Made

### HTTP client: handle empty response bodies (`http_client.rs`)
- When `response.text()` returns an empty string, return an `ApiError::Http` instead of attempting JSON deserialization (which would produce a confusing serde error). Targets cases like `202 Accepted` with no body.

### WebSocket: normalize HTTP(S) → WS(S) URLs (`websocket.rs`)
- Added `to_ws_url()` helper that converts `http://`/`https://` schemes to `ws://`/`wss://`, since `tokio-tungstenite` requires WebSocket schemes.
- Applied in both `build_url()` and the static `connect` path.

### Model codegen: `#[serde(transparent)]` for undiscriminated union members (`StructGenerator.ts`, `generateModels.ts`, `ModelGeneratorContext.ts`, `Attribute.ts`)
- Pre-computes which type IDs appear as members of undiscriminated unions.
- Single-property structs in that set now get `#[serde(transparent)]`, making them serialize/deserialize as their inner value so `#[serde(untagged)]` enum matching works correctly.
- Field-level serde attributes (rename, default, etc.) are skipped when the struct is transparent, as they're incompatible.

### Model codegen: derive `Default` for eligible structs (`StructGenerator.ts`)
- Structs where all fields (including inherited) have types that implement `Default` now derive `Default`.

### Model codegen: `#[serde(default)]` on non-optional fields (`structUtils.ts`, `primitiveTypeUtils.ts`)
- Non-optional fields whose types implement `Default` (primitives, `Vec`, `HashMap`, `Option`, etc.) now get `#[serde(default)]`, so missing fields in JSON deserialize to zero-values instead of erroring.

### WebSocket server message enum: switch to untagged (`WebSocketChannelGenerator.ts`)
- Changed from `#[serde(tag = "type")]` (internally tagged) to `#[serde(untagged)]`.
- Removed `#[serde(rename = "...")]` on variants and the wire-prefix stripping logic.

- [x] Updated seed / snapshot tests

## Testing
- [x] Snapshot tests updated (http-client, rust-model: basic-object, alias-types, union-types, undiscriminated-union-types)
- [ ] Manual testing completed
- [x] Seed tests passing in CI

## Human Review Checklist
> These are the areas with the highest risk or ambiguity — please pay extra attention.

1. **Empty HTTP response → `ApiError::Http`**: Is returning an error the right behavior for empty 2xx responses (e.g. `202 Accepted`)? Callers will see this as an error, not a success. Should empty bodies be handled upstream (before calling `deserialize_response`) or return a sentinel value instead?

2. **Broad `#[serde(default)]` on all non-optional Default-capable fields**: This silently zero-fills any missing field in a JSON payload rather than failing deserialization. This could mask real API contract violations. Is this the intended behavior, or should it be opt-in per field/type?

3. **`#[serde(untagged)]` for WS server messages**: Untagged enums try each variant in declaration order and pick the first match. This is slower than tagged dispatch and can produce surprising results when variant shapes overlap. Was the previous `#[serde(tag = "type")]` actually incorrect for the wire format, or is this papering over a different issue?

4. **Duplicated `namedTypeSupportsDefault` logic**: Nearly identical implementations exist in both `StructGenerator.ts` and `primitiveTypeUtils.ts`. These could drift — consider consolidating.

Link to Devin session: https://app.devin.ai/sessions/4b21b05f4e4849ee99888577fdd345c9
Requested by: @iamnamananand996