### PR TITLE
chore(rust): add versions.yml entry for rust-sdk 0.19.6

### DIFF
--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.1.4
+  changelogEntry:
+    - summary: |
+        Add serde(transparent) for single-property structs used in undiscriminated unions.
+        Derive Default for structs where all fields support Default. Add serde(default)
+        on non-optional fields whose types implement Default to handle missing JSON fields
+        gracefully.
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 62
+
 - version: 0.1.3
   changelogEntry:
     - summary: |

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,15 +1,4 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 0.1.4
-  changelogEntry:
-    - summary: |
-        Add serde(transparent) for single-property structs used in undiscriminated unions.
-        Derive Default for structs where all fields support Default. Add serde(default)
-        on non-optional fields whose types implement Default to handle missing JSON fields
-        gracefully.
-      type: fix
-  createdAt: "2026-03-19"
-  irVersion: 62
-
 - version: 0.1.3
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.19.6
+  changelogEntry:
+    - summary: |
+        Handle empty HTTP response bodies by returning an ApiError::Http instead of
+        attempting JSON deserialization. Normalize HTTP(S) URLs to WS(S) schemes for
+        WebSocket connections. Switch WebSocket server message enums to untagged serde
+        representation.
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 62
+
 - version: 0.19.5
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/pull/13718

Adds the missing `versions.yml` changelog entry for the Rust SDK generator changes merged in #13718.

## Changes Made

- Added `rust-sdk` version `0.19.6` entry covering: empty HTTP response handling, WS URL normalization, untagged WS server message enums

## Updates since last revision

- Removed `rust-model` version `0.1.4` entry per reviewer feedback — only the SDK entry is needed.

## Human Review Checklist

1. **Changelog accuracy**: Verify the summary matches what was actually shipped in #13718 (empty response handling in `http_client.rs`, WS URL normalization in `websocket.rs`, untagged enums in `WebSocketChannelGenerator.ts`).
2. **Change type**: Entry is typed as `fix` — confirm this is the intended classification vs. `feat`.

## Testing

- [ ] N/A — changelog-only change; validated by `Validate versions.yml files` CI check

Link to Devin session: https://app.devin.ai/sessions/4b21b05f4e4849ee99888577fdd345c9
Requested by: @iamnamananand996