### PR TITLE
chore(rust): add versions.yml entry for rust-model 0.1.4

### DIFF
--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.1.4
+  changelogEntry:
+    - summary: |
+        Add serde(transparent) for single-property structs used in undiscriminated unions.
+        Derive Default for structs where all fields support Default. Add serde(default)
+        on non-optional fields whose types implement Default to handle missing JSON fields
+        gracefully.
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 62
+
 - version: 0.1.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/pull/13718

Adds the missing `versions.yml` changelog entry for the Rust model generator changes merged in #13718. This is a companion to #13719 which added the rust-sdk version entry.

## Changes Made

- Added `rust-model` version `0.1.4` entry documenting: `serde(transparent)` for undiscriminated union member structs, `Default` derive for eligible structs, `serde(default)` on non-optional fields
- Bumped `irVersion` from 61 → 62

## Human Review Checklist

- [ ] Verify the changelog summary accurately reflects the model-generator-specific changes from #13718 (vs. SDK-only changes)
- [ ] Confirm `irVersion: 62` is correct for this release (previous model version used 61)
- [ ] Confirm `fix` is the intended change type (vs. `feat` for new Default/serde behavior)

## Testing

- [ ] N/A — changelog-only change; validated by `Validate versions.yml files` CI check

Link to Devin session: https://app.devin.ai/sessions/4b21b05f4e4849ee99888577fdd345c9
Requested by: @iamnamananand996