### PR TITLE
fix(changelog): handle triple-backtick code fences in sanitizeChangelogEntry

### DIFF
--- a/packages/commons/core-utils/src/__tests__/sanitizeChangelogEntry.test.ts
+++ b/packages/commons/core-utils/src/__tests__/sanitizeChangelogEntry.test.ts
@@ -74,4 +74,23 @@ describe("sanitizeChangelogEntry", () => {
         const expected = "Added `Optional<String>` support.\nAlso changed `Map<String, Object>` handling.";
         expect(sanitizeChangelogEntry(input)).toBe(expected);
     });
+
+    it("preserves inline code spans after triple-backtick code fences", () => {
+        const input =
+            "Example:\n\n```java\nList<String> items = new ArrayList<>();\n```\n\n**Generic `onMessage(Consumer<String>)` handler** — fires.";
+        const expected =
+            "Example:\n\n```java\nList<String> items = new ArrayList<>();\n```\n\n**Generic `onMessage(Consumer<String>)` handler** — fires.";
+        expect(sanitizeChangelogEntry(input)).toBe(expected);
+    });
+
+    it("wraps bare angle-bracket types after triple-backtick code fences", () => {
+        const input = "Example:\n\n```java\nfoo();\n```\n\nReturns Optional<String> now.";
+        const expected = "Example:\n\n```java\nfoo();\n```\n\nReturns `Optional<String>` now.";
+        expect(sanitizeChangelogEntry(input)).toBe(expected);
+    });
+
+    it("handles triple-backtick code fences without angle brackets", () => {
+        const input = "Example:\n\n```java\nSystem.out.println();\n```\n\nDone.";
+        expect(sanitizeChangelogEntry(input)).toBe(input);
+    });
 });

--- a/packages/commons/core-utils/src/sanitizeChangelogEntry.ts
+++ b/packages/commons/core-utils/src/sanitizeChangelogEntry.ts
@@ -10,11 +10,14 @@
  */
 export function sanitizeChangelogEntry(entry: string): string {
     // Split the text into alternating segments: plain text and backtick-delimited code spans.
-    // Odd-indexed segments are inside backticks and must be preserved as-is.
-    const parts = entry.split(/(`[^`]+`)/g);
+    // Match triple-backtick fenced code blocks first (```...```), then single-backtick
+    // inline code spans (`...`). This prevents triple backticks from being partially
+    // consumed by the single-backtick pattern, which would leave stray backticks that
+    // corrupt subsequent inline code span detection.
+    const parts = entry.split(/(```[\s\S]*?```|`[^`]+`)/g);
     return parts
         .map((part) => {
-            // If this part is a code span, leave it as-is
+            // If this part is a code span or fenced code block, leave it as-is
             if (part.startsWith("`") && part.endsWith("`")) {
                 return part;
             }


### PR DESCRIPTION
## Description

Refs: https://github.com/fern-api/docs/actions/runs/23297468010/job/67748709958

Fixes a bug where `sanitizeChangelogEntry` corrupted inline code spans (stripping their backticks) when the changelog summary also contained triple-backtick fenced code blocks. This caused the generated MDX in `fern-api/docs` to expose bare `<String>` as an HTML/JSX tag, breaking the docs build.

## Changes Made

- Updated the split regex in `sanitizeChangelogEntry` from `` /(`[^`]+`)/g `` to `` /(```[\s\S]*?```|`[^`]+`)/g `` so that triple-backtick code fences are matched as a single unit before falling back to single-backtick inline code spans
- Added 3 test cases covering code fences followed by inline code spans, bare generics after code fences, and code fences without angle brackets

### Root cause

The old regex only recognized single-backtick code spans. When a changelog summary contained a fenced code block like ` ```java...``` `, the regex consumed one backtick from the opening ` ``` `, leaving two stray backticks as plain text. These strays then paired with subsequent legitimate inline backticks, cascading through the rest of the text and stripping the backticks from spans like `` `onMessage(Consumer<String>)` ``. With the backticks gone, the MDX compiler parsed `<String>` as an unclosed HTML tag.

## Testing

- [x] Unit tests added (3 new cases in `sanitizeChangelogEntry.test.ts`)
- [x] All 97 existing tests in `@fern-api/core-utils` continue to pass

## Review checklist for humans
- [ ] Verify that `[\s\S]*?` (lazy match) correctly handles entries with **multiple** fenced code blocks
- [ ] Confirm the fix will cause the `write-changelogs-to-docs` workflow to regenerate correct MDX on the next run (no manual docs repo fix needed beyond this)

Link to Devin session: https://app.devin.ai/sessions/cfc4d746f9814cd9944225c7ede073da
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
