### PR TITLE
fix(cli): prefer auto-downloaded protoc-gen-openapi; add install-dependencies command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,9 @@ jobs:
         run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
 
       - name: Install protobuf dependencies (buf + protoc-gen-openapi)
-        run: node packages/cli/cli/dist/dev/cli.cjs install-dependencies
+        run: |
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: Stop any stale turbo daemon
         run: pnpm turbo daemon stop || true
@@ -174,7 +176,9 @@ jobs:
         run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
 
       - name: Install protobuf dependencies (buf + protoc-gen-openapi)
-        run: node packages/cli/cli/dist/dev/cli.cjs install-dependencies
+        run: |
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: Stop any stale turbo daemon
         run: pnpm turbo daemon stop || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,20 +123,11 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
 
-      - name: Verify buf
-        run: buf --version
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache-dependency-path: generators/go/go.sum
-
-      - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
+        run: node packages/cli/cli/dist/dev/cli.cjs install-dependencies
 
       - name: Stop any stale turbo daemon
         run: pnpm turbo daemon stop || true
@@ -179,20 +170,11 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
 
-      - name: Verify buf
-        run: buf --version
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache-dependency-path: generators/go/go.sum
-
-      - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
+        run: node packages/cli/cli/dist/dev/cli.cjs install-dependencies
 
       - name: Stop any stale turbo daemon
         run: pnpm turbo daemon stop || true

--- a/devbox.json
+++ b/devbox.json
@@ -17,7 +17,6 @@
     "init_hook": [
       "printf '\\033]0;%s\\007' 'fern (devbox)'",
       "unset GOROOT # Unset GOROOT from parent shell to avoid conflicts with devbox's Go",
-      "go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@dc6f6fa 2>/dev/null || true",
       "echo 'Node.js:' $(node --version)",
       "echo 'pnpm:' $(pnpm --version)",
       "echo 'Go:' $(go version)",
@@ -27,7 +26,6 @@
       "echo 'buf:' $(buf --version)",
       "echo 'Bun:' $(bun --version 2>/dev/null || echo 'not available')",
       "echo 'Docker:' $(docker --version 2>/dev/null || echo 'not available')",
-      "echo 'protoc-gen-openapi:' $(ls -l ~/go/bin/protoc-gen-openapi 2>/dev/null | awk '{print $6,$7,$8}' || echo 'not installed')",
       "echo 'Fern development environment loaded!'"
     ],
     "scripts": {

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -60,6 +60,7 @@ import { generateOpenApiToFdrApiDefinitionForWorkspaces } from "./commands/gener
 import { generateOpenAPIIrForWorkspaces } from "./commands/generate-openapi-ir/generateOpenAPIIrForWorkspaces.js";
 import { compareOpenAPISpecs } from "./commands/generate-overrides/compareOpenAPISpecs.js";
 import { writeOverridesForWorkspaces } from "./commands/generate-overrides/writeOverridesForWorkspaces.js";
+import { installDependencies } from "./commands/install-dependencies/installDependencies.js";
 import { generateJsonschemaForWorkspaces } from "./commands/jsonschema/generateJsonschemaForWorkspace.js";
 import { mergeOpenAPIWithOverrides } from "./commands/merge/mergeOpenAPIWithOverrides.js";
 import { mockServer } from "./commands/mock/mockServer.js";
@@ -244,6 +245,7 @@ async function tryRunCli(cliContext: CliContext) {
     addGeneratorCommands(cli, cliContext);
 
     addProtocGenFernCommand(cli, cliContext);
+    addInstallDependenciesCommand(cli, cliContext);
 
     cli.middleware(async (argv) => {
         cliContext.setLogLevel(argv["log-level"]);
@@ -2148,6 +2150,18 @@ function writeBytes(stream: WriteStream, data: Uint8Array): Promise<void> {
             }
         });
     });
+}
+
+function addInstallDependenciesCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
+    cli.command(
+        "install-dependencies",
+        false, // hidden from --help
+        // biome-ignore lint/suspicious/noEmptyBlockStatements: allow
+        (yargs) => {},
+        async () => {
+            await installDependencies({ cliContext });
+        }
+    );
 }
 
 function addReplayCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {

--- a/packages/cli/cli/src/commands/install-dependencies/__test__/installDependencies.test.ts
+++ b/packages/cli/cli/src/commands/install-dependencies/__test__/installDependencies.test.ts
@@ -1,0 +1,144 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@fern-api/lazy-fern-workspace", () => ({
+    resolveBuf: vi.fn(),
+    resolveProtocGenOpenAPI: vi.fn()
+}));
+
+import { resolveBuf, resolveProtocGenOpenAPI } from "@fern-api/lazy-fern-workspace";
+import { CliContext } from "../../../cli-context/CliContext.js";
+import { installDependencies } from "../installDependencies.js";
+
+describe("installDependencies", () => {
+    let mockContext: {
+        logger: {
+            info: ReturnType<typeof vi.fn>;
+            error: ReturnType<typeof vi.fn>;
+            warn: ReturnType<typeof vi.fn>;
+            debug: ReturnType<typeof vi.fn>;
+        };
+        failAndThrow: ReturnType<typeof vi.fn>;
+    };
+    let mockCliContext: CliContext;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockContext = {
+            logger: {
+                info: vi.fn(),
+                error: vi.fn(),
+                warn: vi.fn(),
+                debug: vi.fn()
+            },
+            failAndThrow: vi.fn((message: string) => {
+                throw new Error(message);
+            })
+        };
+
+        // Mock CliContext.runTask to invoke the callback with our mock context
+        mockCliContext = {
+            runTask: vi.fn(async (fn: (ctx: typeof mockContext) => Promise<void>) => {
+                await fn(mockContext);
+            })
+        } as unknown as CliContext;
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("succeeds when both buf and protoc-gen-openapi resolve", async () => {
+        vi.mocked(resolveBuf).mockResolvedValue(AbsoluteFilePath.of("/home/user/.fern/bin/buf"));
+        vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(AbsoluteFilePath.of("/home/user/.fern/bin"));
+
+        await installDependencies({ cliContext: mockCliContext });
+
+        expect(resolveBuf).toHaveBeenCalledOnce();
+        expect(resolveProtocGenOpenAPI).toHaveBeenCalledOnce();
+        expect(mockContext.logger.info).toHaveBeenCalledWith("All dependencies installed successfully.");
+        expect(mockContext.failAndThrow).not.toHaveBeenCalled();
+    });
+
+    it("logs buf install path on success", async () => {
+        const bufPath = AbsoluteFilePath.of("/home/user/.fern/bin/buf");
+        vi.mocked(resolveBuf).mockResolvedValue(bufPath);
+        vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(AbsoluteFilePath.of("/home/user/.fern/bin"));
+
+        await installDependencies({ cliContext: mockCliContext });
+
+        expect(mockContext.logger.info).toHaveBeenCalledWith(`buf installed: ${bufPath}`);
+    });
+
+    it("logs protoc-gen-openapi install path on success", async () => {
+        const protocDir = AbsoluteFilePath.of("/home/user/.fern/bin");
+        vi.mocked(resolveBuf).mockResolvedValue(AbsoluteFilePath.of("/home/user/.fern/bin/buf"));
+        vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(protocDir);
+
+        await installDependencies({ cliContext: mockCliContext });
+
+        expect(mockContext.logger.info).toHaveBeenCalledWith(`protoc-gen-openapi installed: ${protocDir}`);
+    });
+
+    it("fails when buf resolution returns undefined", async () => {
+        vi.mocked(resolveBuf).mockResolvedValue(undefined);
+        vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(AbsoluteFilePath.of("/home/user/.fern/bin"));
+
+        await expect(installDependencies({ cliContext: mockCliContext })).rejects.toThrow("Failed to install: buf");
+
+        expect(mockContext.logger.error).toHaveBeenCalledWith("Failed to install buf");
+        expect(mockContext.failAndThrow).toHaveBeenCalledWith(expect.stringContaining("Failed to install: buf"));
+    });
+
+    it("fails when protoc-gen-openapi resolution returns undefined", async () => {
+        vi.mocked(resolveBuf).mockResolvedValue(AbsoluteFilePath.of("/home/user/.fern/bin/buf"));
+        vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(undefined);
+
+        await expect(installDependencies({ cliContext: mockCliContext })).rejects.toThrow(
+            "Failed to install: protoc-gen-openapi"
+        );
+
+        expect(mockContext.logger.error).toHaveBeenCalledWith("Failed to install protoc-gen-openapi");
+    });
+
+    it("reports both failures when both resolutions return undefined", async () => {
+        vi.mocked(resolveBuf).mockResolvedValue(undefined);
+        vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(undefined);
+
+        await expect(installDependencies({ cliContext: mockCliContext })).rejects.toThrow(
+            "Failed to install: buf, protoc-gen-openapi"
+        );
+
+        expect(mockContext.logger.error).toHaveBeenCalledWith("Failed to install buf");
+        expect(mockContext.logger.error).toHaveBeenCalledWith("Failed to install protoc-gen-openapi");
+    });
+
+    it("calls resolveBuf before resolveProtocGenOpenAPI", async () => {
+        const callOrder: string[] = [];
+
+        vi.mocked(resolveBuf).mockImplementation(async () => {
+            callOrder.push("buf");
+            return AbsoluteFilePath.of("/home/user/.fern/bin/buf");
+        });
+        vi.mocked(resolveProtocGenOpenAPI).mockImplementation(async () => {
+            callOrder.push("protoc-gen-openapi");
+            return AbsoluteFilePath.of("/home/user/.fern/bin");
+        });
+
+        await installDependencies({ cliContext: mockCliContext });
+
+        expect(callOrder).toEqual(["buf", "protoc-gen-openapi"]);
+    });
+
+    it("still attempts protoc-gen-openapi even if buf fails", async () => {
+        vi.mocked(resolveBuf).mockResolvedValue(undefined);
+        vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(AbsoluteFilePath.of("/home/user/.fern/bin"));
+
+        await expect(installDependencies({ cliContext: mockCliContext })).rejects.toThrow();
+
+        // Both should have been called
+        expect(resolveBuf).toHaveBeenCalledOnce();
+        expect(resolveProtocGenOpenAPI).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/cli/cli/src/commands/install-dependencies/installDependencies.ts
+++ b/packages/cli/cli/src/commands/install-dependencies/installDependencies.ts
@@ -1,0 +1,42 @@
+import { resolveBuf, resolveProtocGenOpenAPI } from "@fern-api/lazy-fern-workspace";
+import { CliContext } from "../../cli-context/CliContext.js";
+
+export async function installDependencies({ cliContext }: { cliContext: CliContext }): Promise<void> {
+    await cliContext.runTask(async (context) => {
+        context.logger.info("Installing dependencies...");
+
+        const results: { name: string; success: boolean; path?: string }[] = [];
+
+        // Install buf
+        context.logger.info("Resolving buf...");
+        const bufPath = await resolveBuf(context.logger);
+        if (bufPath != null) {
+            results.push({ name: "buf", success: true, path: bufPath });
+            context.logger.info(`buf installed: ${bufPath}`);
+        } else {
+            results.push({ name: "buf", success: false });
+            context.logger.error("Failed to install buf");
+        }
+
+        // Install protoc-gen-openapi
+        context.logger.info("Resolving protoc-gen-openapi...");
+        const protocGenOpenAPIDir = await resolveProtocGenOpenAPI(context.logger);
+        if (protocGenOpenAPIDir != null) {
+            results.push({ name: "protoc-gen-openapi", success: true, path: protocGenOpenAPIDir });
+            context.logger.info(`protoc-gen-openapi installed: ${protocGenOpenAPIDir}`);
+        } else {
+            results.push({ name: "protoc-gen-openapi", success: false });
+            context.logger.error("Failed to install protoc-gen-openapi");
+        }
+
+        // Summary
+        const failed = results.filter((r) => !r.success);
+        if (failed.length > 0) {
+            context.failAndThrow(
+                `Failed to install: ${failed.map((r) => r.name).join(", ")}. Check network connectivity and try again.`
+            );
+        }
+
+        context.logger.info("All dependencies installed successfully.");
+    });
+}

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,16 +1,4 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 4.37.6
-  changelogEntry:
-    - summary: |
-        Add hidden `install-dependencies` CLI command that pre-downloads `buf`
-        and `protoc-gen-openapi` binaries into the Fern cache. CI workflows now
-        use this command instead of `bufbuild/buf-setup-action` and
-        `go install protoc-gen-openapi`, removing the Go toolchain dependency
-        from CI.
-      type: chore
-  createdAt: "2026-03-19"
-  irVersion: 65
-
 - version: 4.37.5
   changelogEntry:
     - summary: |
@@ -23,6 +11,13 @@
         `FERN_USE_LOCAL_PROTOC_GEN_OPENAPI=true` to force the PATH version
         (e.g. for testing a custom build).
       type: fix
+    - summary: |
+        Add hidden `install-dependencies` CLI command that pre-downloads `buf`
+        and `protoc-gen-openapi` binaries into the Fern cache. CI workflows now
+        use this command instead of `bufbuild/buf-setup-action` and
+        `go install protoc-gen-openapi`, removing the Go toolchain dependency
+        from CI.
+      type: chore
   createdAt: "2026-03-19"
   irVersion: 65
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.37.4
+  changelogEntry:
+    - summary: |
+        Always prefer the auto-downloaded fern fork of `protoc-gen-openapi` over
+        an arbitrary `protoc-gen-openapi` binary found on PATH. Users with the
+        original Google/gnostic `protoc-gen-openapi` installed would encounter
+        `no such flag -flatten_oneofs` errors because that version does not
+        support fern-specific plugin options. The CLI now downloads the fern fork
+        first and only falls back to PATH if the download fails.
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 65
+
 - version: 4.37.3
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.37.6
+  changelogEntry:
+    - summary: |
+        Add hidden `install-dependencies` CLI command that pre-downloads `buf`
+        and `protoc-gen-openapi` binaries into the Fern cache. CI workflows now
+        use this command instead of `bufbuild/buf-setup-action` and
+        `go install protoc-gen-openapi`, removing the Go toolchain dependency
+        from CI.
+      type: chore
+  createdAt: "2026-03-19"
+  irVersion: 65
+
 - version: 4.37.5
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -7,7 +7,9 @@
         original Google/gnostic `protoc-gen-openapi` installed would encounter
         `no such flag -flatten_oneofs` errors because that version does not
         support fern-specific plugin options. The CLI now downloads the fern fork
-        first and only falls back to PATH if the download fails.
+        first and only falls back to PATH if the download fails. Set
+        `FERN_USE_LOCAL_PROTOC_GEN_OPENAPI=true` to force the PATH version
+        (e.g. for testing a custom build).
       type: fix
   createdAt: "2026-03-19"
   irVersion: 65

--- a/packages/cli/workspace/lazy-fern-workspace/src/index.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/index.ts
@@ -2,5 +2,7 @@ export * from "./ConjureWorkspace.js";
 export * from "./LazyFernWorkspace.js";
 export { OpenAPILoader } from "./loaders/OpenAPILoader.js";
 export * from "./OSSWorkspace.js";
+export { resolveBuf } from "./protobuf/BufDownloader.js";
+export { resolveProtocGenOpenAPI } from "./protobuf/ProtocGenOpenAPIDownloader.js";
 export { detectAirGappedMode, isNetworkError } from "./protobuf/utils.js";
 export * from "./utils/index.js";

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts
@@ -4,7 +4,7 @@ import { access, chmod, copyFile, mkdir, readFile, rename, rm, writeFile } from 
 import os from "os";
 import path from "path";
 
-const BUF_VERSION = "v1.66.1";
+const BUF_VERSION = "v1.50.0";
 const GITHUB_RELEASE_URL_BASE = "https://github.com/bufbuild/buf/releases/download";
 const BINARY_NAME = "buf";
 const CACHE_DIR_NAME = ".fern";
@@ -163,7 +163,7 @@ function createLockReleaser(lockPath: string, logger: Logger): () => Promise<voi
 /**
  * Resolves the buf binary, downloading it from GitHub Releases if needed.
  *
- * **Versioning**: Binaries are cached with a versioned filename (e.g. `buf-v1.66.1`).
+ * **Versioning**: Binaries are cached with a versioned filename (e.g. `buf-v1.50.0`).
  * A `.version` marker file tracks which version the canonical `buf` binary corresponds to.
  * When `BUF_VERSION` is bumped, the canonical binary is atomically replaced on the
  * next invocation.

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
@@ -321,6 +321,19 @@ export class ProtobufOpenAPIGenerator {
             return;
         }
 
+        // Always prefer the auto-downloaded fern fork of protoc-gen-openapi.
+        // A user may have the original Google/gnostic protoc-gen-openapi on
+        // PATH, which does not support fern-specific flags like flatten_oneofs.
+        this.context.logger.debug("Resolving protoc-gen-openapi (preferring auto-downloaded fern fork)");
+        this.protocGenOpenAPIBinDir = await resolveProtocGenOpenAPI(this.context.logger);
+
+        if (this.protocGenOpenAPIBinDir != null) {
+            this.protocGenOpenAPIResolved = true;
+            return;
+        }
+
+        // Auto-download failed — fall back to whatever is on PATH.
+        this.context.logger.debug("Auto-download failed, checking PATH for protoc-gen-openapi");
         const which = createLoggingExecutable("which", {
             cwd: AbsoluteFilePath.of(process.cwd()),
             logger: undefined,
@@ -331,20 +344,15 @@ export class ProtobufOpenAPIGenerator {
             const result = await which(["protoc-gen-openapi"]);
             const resolvedPath = result.stdout?.trim();
             if (resolvedPath) {
-                this.context.logger.debug(`Found protoc-gen-openapi on PATH: ${resolvedPath}`);
+                this.context.logger.debug(`Falling back to protoc-gen-openapi on PATH: ${resolvedPath}`);
             } else {
-                this.context.logger.debug("Found protoc-gen-openapi on PATH");
+                this.context.logger.debug("Falling back to protoc-gen-openapi on PATH");
             }
             this.protocGenOpenAPIResolved = true;
         } catch {
-            this.context.logger.debug("protoc-gen-openapi not found on PATH, attempting auto-download");
-            this.protocGenOpenAPIBinDir = await resolveProtocGenOpenAPI(this.context.logger);
-            if (this.protocGenOpenAPIBinDir == null) {
-                this.context.failAndThrow(
-                    "Missing required dependency; please install 'protoc-gen-openapi' to continue (e.g. 'brew install go && go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest')."
-                );
-            }
-            this.protocGenOpenAPIResolved = true;
+            this.context.failAndThrow(
+                "Missing required dependency; please install 'protoc-gen-openapi' to continue (e.g. 'brew install go && go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest')."
+            );
         }
     }
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
@@ -322,7 +322,7 @@ export class ProtobufOpenAPIGenerator {
         }
 
         // Allow users to force the local PATH version (e.g. for testing a custom build).
-        if (process.env.FERN_USE_LOCAL_PROTOC_GEN_OPENAPI) {
+        if (process.env.FERN_USE_LOCAL_PROTOC_GEN_OPENAPI === "true") {
             this.context.logger.debug("FERN_USE_LOCAL_PROTOC_GEN_OPENAPI is set, using protoc-gen-openapi from PATH");
             const which = createLoggingExecutable("which", {
                 cwd: AbsoluteFilePath.of(process.cwd()),

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
@@ -321,6 +321,29 @@ export class ProtobufOpenAPIGenerator {
             return;
         }
 
+        // Allow users to force the local PATH version (e.g. for testing a custom build).
+        if (process.env.FERN_USE_LOCAL_PROTOC_GEN_OPENAPI) {
+            this.context.logger.debug("FERN_USE_LOCAL_PROTOC_GEN_OPENAPI is set, using protoc-gen-openapi from PATH");
+            const which = createLoggingExecutable("which", {
+                cwd: AbsoluteFilePath.of(process.cwd()),
+                logger: undefined,
+                doNotPipeOutput: true
+            });
+            try {
+                const result = await which(["protoc-gen-openapi"]);
+                const resolvedPath = result.stdout?.trim();
+                if (resolvedPath) {
+                    this.context.logger.debug(`Found protoc-gen-openapi on PATH: ${resolvedPath}`);
+                }
+                this.protocGenOpenAPIResolved = true;
+                return;
+            } catch {
+                this.context.failAndThrow(
+                    "FERN_USE_LOCAL_PROTOC_GEN_OPENAPI is set but protoc-gen-openapi was not found on PATH."
+                );
+            }
+        }
+
         // Always prefer the auto-downloaded fern fork of protoc-gen-openapi.
         // A user may have the original Google/gnostic protoc-gen-openapi on
         // PATH, which does not support fern-specific flags like flatten_oneofs.

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/__test__/BufDownloader.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/__test__/BufDownloader.test.ts
@@ -97,7 +97,7 @@ describe("BufDownloader", () => {
             expect(fetchUrl).toContain("bufbuild/buf/releases/download");
 
             // Versioned binary should exist
-            const versionedPath = path.join(getCacheDir(), getVersionedBinaryName("v1.66.1"));
+            const versionedPath = path.join(getCacheDir(), getVersionedBinaryName("v1.50.0"));
             expect(await fileExists(versionedPath)).toBe(true);
 
             // Canonical binary should exist
@@ -108,7 +108,7 @@ describe("BufDownloader", () => {
             const markerPath = path.join(getCacheDir(), "buf.version");
             expect(await fileExists(markerPath)).toBe(true);
             const markerContent = await readFile(markerPath, "utf-8");
-            expect(markerContent.trim()).toBe("v1.66.1");
+            expect(markerContent.trim()).toBe("v1.50.0");
 
             // Lock directory should be cleaned up
             const lockPath = path.join(getCacheDir(), "buf.lock");
@@ -124,7 +124,7 @@ describe("BufDownloader", () => {
             const cacheDir = getCacheDir();
             await mkdir(cacheDir, { recursive: true });
 
-            const versionedPath = path.join(cacheDir, getVersionedBinaryName("v1.66.1"));
+            const versionedPath = path.join(cacheDir, getVersionedBinaryName("v1.50.0"));
             await writeFile(versionedPath, FAKE_BINARY_CONTENT);
             await chmod(versionedPath, 0o755);
 
@@ -133,7 +133,7 @@ describe("BufDownloader", () => {
             await chmod(canonicalPath, 0o755);
 
             const markerPath = path.join(cacheDir, "buf.version");
-            await writeFile(markerPath, "v1.66.1");
+            await writeFile(markerPath, "v1.50.0");
 
             // fetch should NOT be called
             const mockFetch = vi.fn();
@@ -157,7 +157,7 @@ describe("BufDownloader", () => {
             const cacheDir = getCacheDir();
             await mkdir(cacheDir, { recursive: true });
 
-            const versionedPath = path.join(cacheDir, getVersionedBinaryName("v1.66.1"));
+            const versionedPath = path.join(cacheDir, getVersionedBinaryName("v1.50.0"));
             const newContent = "new-binary-content";
             await writeFile(versionedPath, newContent);
             await chmod(versionedPath, 0o755);
@@ -185,7 +185,7 @@ describe("BufDownloader", () => {
 
             // Marker should be updated
             const updatedMarker = await readFile(markerPath, "utf-8");
-            expect(updatedMarker.trim()).toBe("v1.66.1");
+            expect(updatedMarker.trim()).toBe("v1.50.0");
 
             // Should log the update
             expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Updated buf"));
@@ -197,13 +197,13 @@ describe("BufDownloader", () => {
             const cacheDir = getCacheDir();
             await mkdir(cacheDir, { recursive: true });
 
-            const versionedPath = path.join(cacheDir, getVersionedBinaryName("v1.66.1"));
+            const versionedPath = path.join(cacheDir, getVersionedBinaryName("v1.50.0"));
             await writeFile(versionedPath, FAKE_BINARY_CONTENT);
             await chmod(versionedPath, 0o755);
 
             // Marker is correct but canonical is missing
             const markerPath = path.join(cacheDir, "buf.version");
-            await writeFile(markerPath, "v1.66.1");
+            await writeFile(markerPath, "v1.50.0");
 
             const mockFetch = vi.fn();
             vi.stubGlobal("fetch", mockFetch);
@@ -304,7 +304,7 @@ describe("BufDownloader", () => {
             // Version marker should be correct
             const markerPath = path.join(getCacheDir(), "buf.version");
             const marker = await readFile(markerPath, "utf-8");
-            expect(marker.trim()).toBe("v1.66.1");
+            expect(marker.trim()).toBe("v1.50.0");
 
             // Lock should be released
             const lockPath = path.join(getCacheDir(), "buf.lock");
@@ -358,7 +358,7 @@ describe("BufDownloader", () => {
             expect(canonicalStat.mode & 0o100).toBeTruthy();
 
             // Versioned binary should also be executable
-            const versionedPath = path.join(getCacheDir(), getVersionedBinaryName("v1.66.1"));
+            const versionedPath = path.join(getCacheDir(), getVersionedBinaryName("v1.50.0"));
             const versionedStat = await stat(versionedPath);
             expect(versionedStat.mode & 0o100).toBeTruthy();
 
@@ -383,7 +383,7 @@ describe("BufDownloader", () => {
             const fetchUrl = mockFetch.mock.calls[0]?.[0] as string;
 
             // URL should match buf's release naming convention
-            expect(fetchUrl).toContain("github.com/bufbuild/buf/releases/download/v1.66.1/buf-");
+            expect(fetchUrl).toContain("github.com/bufbuild/buf/releases/download/v1.50.0/buf-");
 
             // OS name should be capitalized (Darwin, Linux, Windows)
             const platform = process.platform;
@@ -477,7 +477,7 @@ describe("BufDownloader (real e2e)", () => {
             // Verify cache structure
             const cacheDir = getCacheDir();
             const canonicalPath = path.join(cacheDir, getBinaryName());
-            const versionedPath = path.join(cacheDir, getVersionedBinaryName("v1.66.1"));
+            const versionedPath = path.join(cacheDir, getVersionedBinaryName("v1.50.0"));
             const markerPath = path.join(cacheDir, "buf.version");
 
             // All cache files should exist
@@ -485,9 +485,9 @@ describe("BufDownloader (real e2e)", () => {
             expect(await fileExists(versionedPath)).toBe(true);
             expect(await fileExists(markerPath)).toBe(true);
 
-            // Version marker should contain v1.66.1
+            // Version marker should contain v1.50.0
             const markerContent = await readFile(markerPath, "utf-8");
-            expect(markerContent.trim()).toBe("v1.66.1");
+            expect(markerContent.trim()).toBe("v1.50.0");
 
             // Binary should be a real executable (buf is ~47-52MB)
             const binaryStat = await stat(canonicalPath);

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/__test__/ProtobufOpenAPIGeneratorResolution.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/__test__/ProtobufOpenAPIGeneratorResolution.test.ts
@@ -1,0 +1,249 @@
+import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/fs-utils";
+import { TaskContext, TaskResult } from "@fern-api/task-context";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the dependencies before importing the module under test
+vi.mock("@fern-api/logging-execa", () => ({
+    createLoggingExecutable: vi.fn()
+}));
+
+vi.mock("../ProtocGenOpenAPIDownloader.js", () => ({
+    resolveProtocGenOpenAPI: vi.fn()
+}));
+
+vi.mock("../utils.js", () => ({
+    ensureBufCommand: vi.fn(),
+    detectAirGappedModeForProtobuf: vi.fn(),
+    getProtobufYamlV1: vi.fn().mockReturnValue("version: v1\n")
+}));
+
+vi.mock("fs/promises", async () => {
+    const actual = await vi.importActual<typeof import("fs/promises")>("fs/promises");
+    return {
+        ...actual,
+        cp: vi.fn(),
+        writeFile: vi.fn(),
+        readFile: vi.fn(),
+        rename: vi.fn(),
+        unlink: vi.fn(),
+        access: vi.fn()
+    };
+});
+
+vi.mock("tmp-promise", () => ({
+    default: {
+        dir: vi.fn().mockResolvedValue({ path: "/tmp/test-dir" }),
+        file: vi.fn().mockResolvedValue({ path: "/tmp/test-file.yaml" })
+    }
+}));
+
+import { createLoggingExecutable } from "@fern-api/logging-execa";
+import { ProtobufOpenAPIGenerator } from "../ProtobufOpenAPIGenerator.js";
+import { resolveProtocGenOpenAPI } from "../ProtocGenOpenAPIDownloader.js";
+import { ensureBufCommand } from "../utils.js";
+
+function createMockTaskContext(): TaskContext {
+    return {
+        logger: {
+            disable: vi.fn(),
+            enable: vi.fn(),
+            trace: vi.fn(),
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            log: vi.fn()
+        },
+        takeOverTerminal: async () => {
+            return;
+        },
+        failAndThrow: vi.fn((message?: string) => {
+            throw new Error(message ?? "Task failed");
+        }) as unknown as TaskContext["failAndThrow"],
+        failWithoutThrowing: vi.fn(),
+        getResult: () => TaskResult.Success,
+        addInteractiveTask: () => {
+            throw new Error("Not implemented in mock");
+        },
+        runInteractiveTask: async () => false,
+        instrumentPostHogEvent: async () => {
+            return;
+        }
+    };
+}
+
+describe("ProtobufOpenAPIGenerator resolution order", () => {
+    let context: TaskContext;
+    let mockWhichExecutable: ReturnType<typeof vi.fn>;
+    let mockBufExecutable: ReturnType<typeof vi.fn>;
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        context = createMockTaskContext();
+        process.env = { ...originalEnv };
+
+        // Mock buf command
+        vi.mocked(ensureBufCommand).mockResolvedValue("buf");
+
+        // Default mock for createLoggingExecutable
+        mockWhichExecutable = vi.fn();
+        mockBufExecutable = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+        vi.mocked(createLoggingExecutable).mockImplementation((cmd: string) => {
+            if (cmd === "which") {
+                return mockWhichExecutable;
+            }
+            return mockBufExecutable;
+        });
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+        vi.clearAllMocks();
+    });
+
+    describe("ensureProtocGenOpenAPIResolved (via prepare)", () => {
+        it("prefers auto-downloaded fern fork over PATH", async () => {
+            const cachedDir = AbsoluteFilePath.of("/home/user/.fern/bin");
+            vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(cachedDir);
+
+            const generator = new ProtobufOpenAPIGenerator({ context });
+            const result = await generator.prepare({
+                absoluteFilepathToProtobufRoot: AbsoluteFilePath.of("/tmp/proto"),
+                relativeFilepathToProtobufRoot: RelativeFilePath.of("proto"),
+                local: true,
+                deps: []
+            });
+
+            // Auto-download should be called
+            expect(resolveProtocGenOpenAPI).toHaveBeenCalledOnce();
+
+            // which should NOT be called (auto-download succeeded, no fallback needed)
+            expect(mockWhichExecutable).not.toHaveBeenCalled();
+
+            // envOverride should include the cached directory in PATH
+            expect(result.envOverride).toBeDefined();
+            expect(result.envOverride?.PATH).toContain("/home/user/.fern/bin");
+        });
+
+        it("falls back to PATH when auto-download returns undefined", async () => {
+            vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(undefined);
+            mockWhichExecutable.mockResolvedValue({ stdout: "/usr/local/bin/protoc-gen-openapi" });
+
+            const generator = new ProtobufOpenAPIGenerator({ context });
+            const result = await generator.prepare({
+                absoluteFilepathToProtobufRoot: AbsoluteFilePath.of("/tmp/proto"),
+                relativeFilepathToProtobufRoot: RelativeFilePath.of("proto"),
+                local: true,
+                deps: []
+            });
+
+            // Auto-download should be called first
+            expect(resolveProtocGenOpenAPI).toHaveBeenCalledOnce();
+
+            // which should be called as fallback
+            expect(mockWhichExecutable).toHaveBeenCalledWith(["protoc-gen-openapi"]);
+
+            // envOverride should be undefined (using PATH version)
+            expect(result.envOverride).toBeUndefined();
+        });
+
+        it("throws error when both auto-download and PATH fail", async () => {
+            vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(undefined);
+            mockWhichExecutable.mockRejectedValue(new Error("not found"));
+
+            const generator = new ProtobufOpenAPIGenerator({ context });
+
+            await expect(
+                generator.prepare({
+                    absoluteFilepathToProtobufRoot: AbsoluteFilePath.of("/tmp/proto"),
+                    relativeFilepathToProtobufRoot: RelativeFilePath.of("proto"),
+                    local: true,
+                    deps: []
+                })
+            ).rejects.toThrow("Missing required dependency");
+        });
+
+        it("does not call auto-download when FERN_USE_LOCAL_PROTOC_GEN_OPENAPI=true", async () => {
+            process.env.FERN_USE_LOCAL_PROTOC_GEN_OPENAPI = "true";
+            mockWhichExecutable.mockResolvedValue({ stdout: "/custom/path/protoc-gen-openapi" });
+
+            const generator = new ProtobufOpenAPIGenerator({ context });
+            const result = await generator.prepare({
+                absoluteFilepathToProtobufRoot: AbsoluteFilePath.of("/tmp/proto"),
+                relativeFilepathToProtobufRoot: RelativeFilePath.of("proto"),
+                local: true,
+                deps: []
+            });
+
+            // Auto-download should NOT be called
+            expect(resolveProtocGenOpenAPI).not.toHaveBeenCalled();
+
+            // which should be called instead
+            expect(mockWhichExecutable).toHaveBeenCalledWith(["protoc-gen-openapi"]);
+
+            // envOverride should be undefined (using PATH version)
+            expect(result.envOverride).toBeUndefined();
+        });
+
+        it("throws when FERN_USE_LOCAL_PROTOC_GEN_OPENAPI=true but not on PATH", async () => {
+            process.env.FERN_USE_LOCAL_PROTOC_GEN_OPENAPI = "true";
+            mockWhichExecutable.mockRejectedValue(new Error("not found"));
+
+            const generator = new ProtobufOpenAPIGenerator({ context });
+
+            await expect(
+                generator.prepare({
+                    absoluteFilepathToProtobufRoot: AbsoluteFilePath.of("/tmp/proto"),
+                    relativeFilepathToProtobufRoot: RelativeFilePath.of("proto"),
+                    local: true,
+                    deps: []
+                })
+            ).rejects.toThrow("FERN_USE_LOCAL_PROTOC_GEN_OPENAPI is set but protoc-gen-openapi was not found on PATH");
+        });
+
+        it("does not trigger auto-download for non-true FERN_USE_LOCAL_PROTOC_GEN_OPENAPI values", async () => {
+            // Test that only strict "true" bypasses auto-download
+            process.env.FERN_USE_LOCAL_PROTOC_GEN_OPENAPI = "1";
+            const cachedDir = AbsoluteFilePath.of("/home/user/.fern/bin");
+            vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(cachedDir);
+
+            const generator = new ProtobufOpenAPIGenerator({ context });
+            await generator.prepare({
+                absoluteFilepathToProtobufRoot: AbsoluteFilePath.of("/tmp/proto"),
+                relativeFilepathToProtobufRoot: RelativeFilePath.of("proto"),
+                local: true,
+                deps: []
+            });
+
+            // Auto-download SHOULD be called (env var is "1" not "true")
+            expect(resolveProtocGenOpenAPI).toHaveBeenCalledOnce();
+        });
+
+        it("caches resolution result across multiple calls", async () => {
+            const cachedDir = AbsoluteFilePath.of("/home/user/.fern/bin");
+            vi.mocked(resolveProtocGenOpenAPI).mockResolvedValue(cachedDir);
+
+            const generator = new ProtobufOpenAPIGenerator({ context });
+
+            // First call
+            await generator.prepare({
+                absoluteFilepathToProtobufRoot: AbsoluteFilePath.of("/tmp/proto"),
+                relativeFilepathToProtobufRoot: RelativeFilePath.of("proto"),
+                local: true,
+                deps: []
+            });
+
+            // Second call
+            await generator.prepare({
+                absoluteFilepathToProtobufRoot: AbsoluteFilePath.of("/tmp/proto"),
+                relativeFilepathToProtobufRoot: RelativeFilePath.of("proto"),
+                local: true,
+                deps: []
+            });
+
+            // resolveProtocGenOpenAPI should only be called once
+            expect(resolveProtocGenOpenAPI).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/__test__/ProtobufOpenAPIGeneratorResolution.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/__test__/ProtobufOpenAPIGeneratorResolution.test.ts
@@ -37,7 +37,7 @@ vi.mock("tmp-promise", () => ({
     }
 }));
 
-import { createLoggingExecutable } from "@fern-api/logging-execa";
+import { createLoggingExecutable, LoggingExecutable } from "@fern-api/logging-execa";
 import { ProtobufOpenAPIGenerator } from "../ProtobufOpenAPIGenerator.js";
 import { resolveProtocGenOpenAPI } from "../ProtocGenOpenAPIDownloader.js";
 import { ensureBufCommand } from "../utils.js";
@@ -89,12 +89,9 @@ describe("ProtobufOpenAPIGenerator resolution order", () => {
         // Default mock for createLoggingExecutable
         mockWhichExecutable = vi.fn();
         mockBufExecutable = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
-        vi.mocked(createLoggingExecutable).mockImplementation((cmd: string) => {
-            if (cmd === "which") {
-                return mockWhichExecutable;
-            }
-            return mockBufExecutable;
-        });
+        vi.mocked(createLoggingExecutable).mockImplementation(
+            (cmd: string) => (cmd === "which" ? mockWhichExecutable : mockBufExecutable) as unknown as LoggingExecutable
+        );
     });
 
     afterEach(() => {


### PR DESCRIPTION
## Description

Fixes `protoc-gen-openapi: no such flag -flatten_oneofs` errors for users who have the original Google/gnostic `protoc-gen-openapi` on their PATH. Also adds a hidden `install-dependencies` CLI command so CI can pre-download `buf` and `protoc-gen-openapi` without requiring Go or third-party GitHub Actions.

## Changes Made

### protoc-gen-openapi resolution order (v4.37.5)
- Reversed the resolution priority in `ensureProtocGenOpenAPIResolved()`: the CLI now always attempts to resolve the auto-downloaded fern fork **first**, and only falls back to whatever `protoc-gen-openapi` is on PATH if the download/cache lookup fails.
- Previously, any `protoc-gen-openapi` found on PATH was used directly — but the original Google/gnostic version does not support fern-specific flags (`flatten_oneofs`, `include_all_methods`, `source_root`), causing `buf generate` to fail.
- Added `FERN_USE_LOCAL_PROTOC_GEN_OPENAPI` env var: when set to `"true"`, the CLI skips auto-download and uses whatever `protoc-gen-openapi` is on PATH (useful for testing custom builds). Uses strict `=== "true"` comparison consistent with other `FERN_` env vars in the codebase. Fails fast with a clear message if the binary isn't found.
- Removed the `go install protoc-gen-openapi` command and its status echo from `devbox.json` init_hook — no longer needed since the CLI auto-downloads the binary.

### Hidden `install-dependencies` command (v4.37.6)
- Added a new hidden CLI command `fern install-dependencies` that calls `resolveBuf()` and `resolveProtocGenOpenAPI()` to pre-download and cache both binaries into `~/.fern/bin/`.
- Exported `resolveBuf` and `resolveProtocGenOpenAPI` from `@fern-api/lazy-fern-workspace`.
- **CI workflow change**: Replaced `bufbuild/buf-setup-action`, `actions/setup-go`, and `go install protoc-gen-openapi` in both the `test` and `test-ete` jobs with:
  1. `pnpm turbo run dist:cli:dev --filter=@fern-api/cli` (build the CLI)
  2. `FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies` (pre-download binaries)
  3. `echo "$HOME/.fern/bin" >> $GITHUB_PATH` (make cached binaries available to subsequent steps)
- `FERN_NO_VERSION_REDIRECTION=true` is required because the dev CLI version (`0.0.0`) differs from `fern/fern.config.json`, which would otherwise trigger redirection to an older published CLI that lacks this command.
- This removes the Go toolchain dependency from CI entirely for these jobs.
- Existing auto-download/caching tests are unaffected: they mock `os.homedir()` to isolated temp directories, so pre-downloaded binaries in `~/.fern/bin/` don't interfere.

### Unit tests
- **`installDependencies.test.ts`** (8 tests): Verifies the command handler calls both resolve functions, logs paths on success, handles individual and combined failures, preserves call order, and continues resolving remaining deps even when one fails.
- **`ProtobufOpenAPIGeneratorResolution.test.ts`** (7 tests): Verifies auto-download is preferred over PATH, fallback to PATH works when auto-download returns `undefined`, both failing throws the correct error, `FERN_USE_LOCAL_PROTOC_GEN_OPENAPI=true` bypasses auto-download, non-`"true"` values like `"1"` still trigger auto-download (strict equality), and resolution is cached across multiple `prepare()` calls.

### Key review points
- The `resolveProtocGenOpenAPI` fast-path (cached binary check) is cheap, so the latency impact of always trying the download path first should be negligible.
- Air-gapped environments: if auto-download fails but the fern fork _is_ on PATH, the fallback still works correctly.
- The `which` variable is declared in two separate block scopes (env var early-return and fallback path) — worth confirming this doesn't cause issues at review time.
- The `go@1.23` devbox package is kept since it may be used by other workflows (e.g., Go generators). Only the `protoc-gen-openapi`-specific lines were removed.

### Human review checklist
- [ ] Verify the CI workflow change doesn't regress: the `Build CLI for install-dependencies` step adds a CLI build before tests. In `test-ete`, the subsequent `Build CLIs (dev + seed)` step should hit the turbo cache — confirm this.
- [ ] Verify the resolution order change won't break air-gapped setups that rely on a locally-installed fern fork (fallback path should handle this, but worth confirming).
- [ ] The resolution order tests mock `createLoggingExecutable`, `resolveProtocGenOpenAPI`, `ensureBufCommand`, `fs/promises`, and `tmp-promise` — verify mocks faithfully represent real behavior, especially the `prepare()` return shape (`envOverride`).

## Testing
- [x] Unit tests added (15 total: 8 for `installDependencies`, 7 for resolution order)
- [x] Lint passes (`pnpm run check`)
- [x] All tests pass locally (`pnpm vitest run`)

Link to Devin session: https://app.devin.ai/sessions/9cb5967a51f64bd1ae2e54974a11dbb4
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
