### PR TITLE
fix(rust): Prevent double Option types

### DIFF
--- a/generators/rust/codegen/src/ast/Type.ts
+++ b/generators/rust/codegen/src/ast/Type.ts
@@ -13,6 +13,9 @@ export abstract class Type extends AstNode {
     }
 
     public static option(inner: Type): Type {
+        if (this.isAlreadyOptional(inner)) {
+            return inner;
+        }
         return new OptionType(inner);
     }
 
@@ -74,6 +77,10 @@ export abstract class Type extends AstNode {
 
     public static never(): Type {
         return new NeverType();
+    }
+
+    private static isAlreadyOptional(value: Type): boolean {
+        return value instanceof OptionType;
     }
 }
 

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.19.8
+  changelogEntry:
+    - summary: |
+        Fixes an issue where redundant, duplicative `Option<T>` type references were generated.
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 62
+
 - version: 0.19.7
   changelogEntry:
     - summary: |

--- a/seed/rust-model/circular-references/src/ast_json_like_with_null_and_undefined.rs
+++ b/seed/rust-model/circular-references/src/ast_json_like_with_null_and_undefined.rs
@@ -3,15 +3,15 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum JsonLikeWithNullAndUndefined {
-        List0(Vec<Option<Option<JsonLikeWithNullAndUndefined>>>),
+        List0(Vec<Option<JsonLikeWithNullAndUndefined>>),
 
-        Map1(HashMap<String, Option<Option<JsonLikeWithNullAndUndefined>>>),
+        Map1(HashMap<String, Option<JsonLikeWithNullAndUndefined>>),
 
-        Optional2(Option<Option<String>>),
+        Optional2(Option<String>),
 
-        Optional3(Option<Option<i64>>),
+        Optional3(Option<i64>),
 
-        Optional4(Option<Option<bool>>),
+        Optional4(Option<bool>),
 }
 
 impl JsonLikeWithNullAndUndefined {
@@ -36,70 +36,70 @@ impl JsonLikeWithNullAndUndefined {
     }
 
 
-    pub fn as_list0(&self) -> Option<&Vec<Option<Option<JsonLikeWithNullAndUndefined>>>> {
+    pub fn as_list0(&self) -> Option<&Vec<Option<JsonLikeWithNullAndUndefined>>> {
         match self {
                     Self::List0(value) => Some(value),
                     _ => None,
                 }
     }
 
-    pub fn into_list0(self) -> Option<Vec<Option<Option<JsonLikeWithNullAndUndefined>>>> {
+    pub fn into_list0(self) -> Option<Vec<Option<JsonLikeWithNullAndUndefined>>> {
         match self {
                     Self::List0(value) => Some(value),
                     _ => None,
                 }
     }
 
-    pub fn as_map1(&self) -> Option<&HashMap<String, Option<Option<JsonLikeWithNullAndUndefined>>>> {
+    pub fn as_map1(&self) -> Option<&HashMap<String, Option<JsonLikeWithNullAndUndefined>>> {
         match self {
                     Self::Map1(value) => Some(value),
                     _ => None,
                 }
     }
 
-    pub fn into_map1(self) -> Option<HashMap<String, Option<Option<JsonLikeWithNullAndUndefined>>>> {
+    pub fn into_map1(self) -> Option<HashMap<String, Option<JsonLikeWithNullAndUndefined>>> {
         match self {
                     Self::Map1(value) => Some(value),
                     _ => None,
                 }
     }
 
-    pub fn as_optional2(&self) -> Option<&Option<Option<String>>> {
+    pub fn as_optional2(&self) -> Option<&Option<String>> {
         match self {
                     Self::Optional2(value) => Some(value),
                     _ => None,
                 }
     }
 
-    pub fn into_optional2(self) -> Option<Option<Option<String>>> {
+    pub fn into_optional2(self) -> Option<Option<String>> {
         match self {
                     Self::Optional2(value) => Some(value),
                     _ => None,
                 }
     }
 
-    pub fn as_optional3(&self) -> Option<&Option<Option<i64>>> {
+    pub fn as_optional3(&self) -> Option<&Option<i64>> {
         match self {
                     Self::Optional3(value) => Some(value),
                     _ => None,
                 }
     }
 
-    pub fn into_optional3(self) -> Option<Option<Option<i64>>> {
+    pub fn into_optional3(self) -> Option<Option<i64>> {
         match self {
                     Self::Optional3(value) => Some(value),
                     _ => None,
                 }
     }
 
-    pub fn as_optional4(&self) -> Option<&Option<Option<bool>>> {
+    pub fn as_optional4(&self) -> Option<&Option<bool>> {
         match self {
                     Self::Optional4(value) => Some(value),
                     _ => None,
                 }
     }
 
-    pub fn into_optional4(self) -> Option<Option<Option<bool>>> {
+    pub fn into_optional4(self) -> Option<Option<bool>> {
         match self {
                     Self::Optional4(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/content-type/src/patch_complex_request.rs
+++ b/seed/rust-model/content-type/src/patch_complex_request.rs
@@ -14,14 +14,14 @@ pub struct PatchComplexRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<Option<String>>,
+    pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nickname: Option<Option<String>>,
+    pub nickname: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bio: Option<Option<String>>,
+    pub bio: Option<String>,
     #[serde(rename = "profileImageUrl")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub profile_image_url: Option<Option<String>>,
+    pub profile_image_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub settings: Option<Option<HashMap<String, serde_json::Value>>>,
+    pub settings: Option<HashMap<String, serde_json::Value>>,
 }

--- a/seed/rust-model/nullable-optional/src/filter_by_role_query_request.rs
+++ b/seed/rust-model/nullable-optional/src/filter_by_role_query_request.rs
@@ -11,5 +11,5 @@ pub struct FilterByRoleQueryRequest {
     pub status: Option<UserStatus>,
     #[serde(rename = "secondaryRole")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub secondary_role: Option<Option<UserRole>>,
+    pub secondary_role: Option<UserRole>,
 }

--- a/seed/rust-model/nullable-optional/src/list_users_query_request.rs
+++ b/seed/rust-model/nullable-optional/src/list_users_query_request.rs
@@ -14,5 +14,5 @@ pub struct ListUsersQueryRequest {
     pub include_deleted: Option<bool>,
     #[serde(rename = "sortBy")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_by: Option<Option<String>>,
+    pub sort_by: Option<String>,
 }

--- a/seed/rust-model/nullable-optional/src/nullable_optional_address.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_address.rs
@@ -13,7 +13,7 @@ pub struct Address {
     #[serde(default)]
     pub zip_code: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<Option<String>>,
+    pub country: Option<String>,
     #[serde(rename = "buildingId")]
     #[serde(default)]
     pub building_id: NullableUserId,

--- a/seed/rust-model/nullable-optional/src/nullable_optional_complex_profile.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_complex_profile.rs
@@ -13,7 +13,7 @@ pub struct ComplexProfile {
     pub optional_role: Option<UserRole>,
     #[serde(rename = "optionalNullableRole")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_role: Option<Option<UserRole>>,
+    pub optional_nullable_role: Option<UserRole>,
     #[serde(rename = "nullableStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_status: Option<UserStatus>,
@@ -22,7 +22,7 @@ pub struct ComplexProfile {
     pub optional_status: Option<UserStatus>,
     #[serde(rename = "optionalNullableStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_status: Option<Option<UserStatus>>,
+    pub optional_nullable_status: Option<UserStatus>,
     #[serde(rename = "nullableNotification")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_notification: Option<NotificationMethod>,
@@ -31,7 +31,7 @@ pub struct ComplexProfile {
     pub optional_notification: Option<NotificationMethod>,
     #[serde(rename = "optionalNullableNotification")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_notification: Option<Option<NotificationMethod>>,
+    pub optional_nullable_notification: Option<NotificationMethod>,
     #[serde(rename = "nullableSearchResult")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_search_result: Option<SearchResult>,
@@ -46,7 +46,7 @@ pub struct ComplexProfile {
     pub optional_array: Option<Vec<String>>,
     #[serde(rename = "optionalNullableArray")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_array: Option<Option<Vec<String>>>,
+    pub optional_nullable_array: Option<Vec<String>>,
     #[serde(rename = "nullableListOfNullables")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_list_of_nullables: Option<Vec<Option<String>>>,

--- a/seed/rust-model/nullable-optional/src/nullable_optional_create_user_request.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_create_user_request.rs
@@ -9,5 +9,5 @@ pub struct CreateUserRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<Option<Address>>,
+    pub address: Option<Address>,
 }

--- a/seed/rust-model/nullable-optional/src/nullable_optional_deserialization_test_request.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_deserialization_test_request.rs
@@ -14,7 +14,7 @@ pub struct DeserializationTestRequest {
     pub optional_string: Option<String>,
     #[serde(rename = "optionalNullableString")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_string: Option<Option<String>>,
+    pub optional_nullable_string: Option<String>,
     #[serde(rename = "nullableEnum")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_enum: Option<UserRole>,

--- a/seed/rust-model/nullable-optional/src/nullable_optional_update_user_request.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_update_user_request.rs
@@ -6,9 +6,9 @@ pub struct UpdateUserRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<Option<String>>,
+    pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<Option<Address>>,
+    pub address: Option<Address>,
 }

--- a/seed/rust-model/nullable-optional/src/nullable_optional_user_profile.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_user_profile.rs
@@ -55,8 +55,8 @@ pub struct UserProfile {
     pub optional_map: Option<HashMap<String, String>>,
     #[serde(rename = "optionalNullableString")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_string: Option<Option<String>>,
+    pub optional_nullable_string: Option<String>,
     #[serde(rename = "optionalNullableObject")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_object: Option<Option<Address>>,
+    pub optional_nullable_object: Option<Address>,
 }

--- a/seed/rust-model/nullable-optional/src/search_users_query_request.rs
+++ b/seed/rust-model/nullable-optional/src/search_users_query_request.rs
@@ -13,5 +13,5 @@ pub struct SearchUsersQueryRequest {
     pub role: Option<String>,
     #[serde(rename = "isActive")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub is_active: Option<Option<bool>>,
+    pub is_active: Option<bool>,
 }

--- a/seed/rust-model/nullable-optional/src/update_complex_profile_request.rs
+++ b/seed/rust-model/nullable-optional/src/update_complex_profile_request.rs
@@ -5,17 +5,17 @@ pub use crate::prelude::*;
 pub struct UpdateComplexProfileRequest {
     #[serde(rename = "nullableRole")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_role: Option<Option<UserRole>>,
+    pub nullable_role: Option<UserRole>,
     #[serde(rename = "nullableStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_status: Option<Option<UserStatus>>,
+    pub nullable_status: Option<UserStatus>,
     #[serde(rename = "nullableNotification")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_notification: Option<Option<NotificationMethod>>,
+    pub nullable_notification: Option<NotificationMethod>,
     #[serde(rename = "nullableSearchResult")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_search_result: Option<Option<SearchResult>>,
+    pub nullable_search_result: Option<SearchResult>,
     #[serde(rename = "nullableArray")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_array: Option<Option<Vec<String>>>,
+    pub nullable_array: Option<Vec<String>>,
 }

--- a/seed/rust-model/nullable-optional/src/update_tags_request.rs
+++ b/seed/rust-model/nullable-optional/src/update_tags_request.rs
@@ -8,5 +8,5 @@ pub struct UpdateTagsRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub categories: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub labels: Option<Option<Vec<String>>>,
+    pub labels: Option<Vec<String>>,
 }

--- a/seed/rust-model/nullable-request-body/src/test_method_name_request.rs
+++ b/seed/rust-model/nullable-request-body/src/test_method_name_request.rs
@@ -6,9 +6,9 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct TestMethodNameRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub query_param_object: Option<Option<PlainObject>>,
+    pub query_param_object: Option<PlainObject>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub query_param_integer: Option<Option<i64>>,
+    pub query_param_integer: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<PlainObject>,
 }

--- a/seed/rust-model/nullable/src/create_user_request.rs
+++ b/seed/rust-model/nullable/src/create_user_request.rs
@@ -10,5 +10,5 @@ pub struct CreateUserRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub avatar: Option<Option<String>>,
+    pub avatar: Option<String>,
 }

--- a/seed/rust-model/nullable/src/delete_user_request.rs
+++ b/seed/rust-model/nullable/src/delete_user_request.rs
@@ -5,5 +5,5 @@ pub use crate::prelude::*;
 pub struct DeleteUserRequest {
     /// The user to delete.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub username: Option<Option<String>>,
+    pub username: Option<String>,
 }

--- a/seed/rust-model/nullable/src/get_users_query_request.rs
+++ b/seed/rust-model/nullable/src/get_users_query_request.rs
@@ -12,7 +12,7 @@ pub struct GetUsersQueryRequest {
     #[serde(default)]
     pub activated: Vec<Option<bool>>,
     #[serde(default)]
-    pub tags: Vec<Option<Option<String>>>,
+    pub tags: Vec<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extra: Option<Option<bool>>,
+    pub extra: Option<bool>,
 }

--- a/seed/rust-model/nullable/src/nullable_metadata.rs
+++ b/seed/rust-model/nullable/src/nullable_metadata.rs
@@ -13,8 +13,8 @@ pub struct Metadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub activated: Option<Option<bool>>,
+    pub activated: Option<bool>,
     pub status: Status,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub values: Option<HashMap<String, Option<Option<String>>>>,
+    pub values: Option<HashMap<String, Option<String>>>,
 }

--- a/seed/rust-model/nullable/src/nullable_user.rs
+++ b/seed/rust-model/nullable/src/nullable_user.rs
@@ -9,13 +9,13 @@ pub struct User {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<Option<Metadata>>,
+    pub metadata: Option<Metadata>,
     #[serde(default)]
     pub email: Email,
     #[serde(rename = "favorite-number")]
     pub favorite_number: WeirdNumber,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub numbers: Option<Option<Vec<i64>>>,
+    pub numbers: Option<Vec<i64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub strings: Option<Option<HashMap<String, serde_json::Value>>>,
+    pub strings: Option<HashMap<String, serde_json::Value>>,
 }

--- a/seed/rust-model/nullable/src/nullable_weird_number.rs
+++ b/seed/rust-model/nullable/src/nullable_weird_number.rs
@@ -7,7 +7,7 @@ pub enum WeirdNumber {
 
         Nullable1(Option<f64>),
 
-        Optional2(Option<Option<String>>),
+        Optional2(Option<String>),
 
         Double(f64),
 }
@@ -58,14 +58,14 @@ impl WeirdNumber {
                 }
     }
 
-    pub fn as_optional2(&self) -> Option<&Option<Option<String>>> {
+    pub fn as_optional2(&self) -> Option<&Option<String>> {
         match self {
                     Self::Optional2(value) => Some(value),
                     _ => None,
                 }
     }
 
-    pub fn into_optional2(self) -> Option<Option<Option<String>>> {
+    pub fn into_optional2(self) -> Option<Option<String>> {
         match self {
                     Self::Optional2(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/required-nullable/src/foo.rs
+++ b/seed/rust-model/required-nullable/src/foo.rs
@@ -5,7 +5,7 @@ pub struct Foo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_bar: Option<Option<String>>,
+    pub nullable_bar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_required_bar: Option<String>,
     #[serde(default)]

--- a/seed/rust-model/required-nullable/src/get_foo_query_request.rs
+++ b/seed/rust-model/required-nullable/src/get_foo_query_request.rs
@@ -10,7 +10,7 @@ pub struct GetFooQueryRequest {
     pub optional_baz: Option<String>,
     /// An optional baz
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_baz: Option<Option<String>>,
+    pub optional_nullable_baz: Option<String>,
     /// A required baz
     #[serde(default)]
     pub required_baz: String,

--- a/seed/rust-model/required-nullable/src/update_foo_request.rs
+++ b/seed/rust-model/required-nullable/src/update_foo_request.rs
@@ -5,10 +5,10 @@ pub use crate::prelude::*;
 pub struct UpdateFooRequest {
     /// Can be explicitly set to null to clear the value
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_text: Option<Option<String>>,
+    pub nullable_text: Option<String>,
     /// Can be explicitly set to null to clear the value
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_number: Option<Option<f64>>,
+    pub nullable_number: Option<f64>,
     /// Regular non-nullable field
     #[serde(skip_serializing_if = "Option::is_none")]
     pub non_nullable_text: Option<String>,

--- a/seed/rust-sdk/circular-references/src/api/types/ast_json_like_with_null_and_undefined.rs
+++ b/seed/rust-sdk/circular-references/src/api/types/ast_json_like_with_null_and_undefined.rs
@@ -3,15 +3,15 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum JsonLikeWithNullAndUndefined {
-    List0(Vec<Option<Option<JsonLikeWithNullAndUndefined>>>),
+    List0(Vec<Option<JsonLikeWithNullAndUndefined>>),
 
-    Map1(HashMap<String, Option<Option<JsonLikeWithNullAndUndefined>>>),
+    Map1(HashMap<String, Option<JsonLikeWithNullAndUndefined>>),
 
-    Optional2(Option<Option<String>>),
+    Optional2(Option<String>),
 
-    Optional3(Option<Option<i64>>),
+    Optional3(Option<i64>),
 
-    Optional4(Option<Option<bool>>),
+    Optional4(Option<bool>),
 }
 
 impl JsonLikeWithNullAndUndefined {
@@ -35,74 +35,70 @@ impl JsonLikeWithNullAndUndefined {
         matches!(self, Self::Optional4(_))
     }
 
-    pub fn as_list0(&self) -> Option<&Vec<Option<Option<JsonLikeWithNullAndUndefined>>>> {
+    pub fn as_list0(&self) -> Option<&Vec<Option<JsonLikeWithNullAndUndefined>>> {
         match self {
             Self::List0(value) => Some(value),
             _ => None,
         }
     }
 
-    pub fn into_list0(self) -> Option<Vec<Option<Option<JsonLikeWithNullAndUndefined>>>> {
+    pub fn into_list0(self) -> Option<Vec<Option<JsonLikeWithNullAndUndefined>>> {
         match self {
             Self::List0(value) => Some(value),
             _ => None,
         }
     }
 
-    pub fn as_map1(
-        &self,
-    ) -> Option<&HashMap<String, Option<Option<JsonLikeWithNullAndUndefined>>>> {
+    pub fn as_map1(&self) -> Option<&HashMap<String, Option<JsonLikeWithNullAndUndefined>>> {
         match self {
             Self::Map1(value) => Some(value),
             _ => None,
         }
     }
 
-    pub fn into_map1(
-        self,
-    ) -> Option<HashMap<String, Option<Option<JsonLikeWithNullAndUndefined>>>> {
+    pub fn into_map1(self) -> Option<HashMap<String, Option<JsonLikeWithNullAndUndefined>>> {
         match self {
             Self::Map1(value) => Some(value),
             _ => None,
         }
     }
 
-    pub fn as_optional2(&self) -> Option<&Option<Option<String>>> {
+    pub fn as_optional2(&self) -> Option<&Option<String>> {
         match self {
             Self::Optional2(value) => Some(value),
             _ => None,
         }
     }
 
-    pub fn into_optional2(self) -> Option<Option<Option<String>>> {
+    pub fn into_optional2(self) -> Option<Option<String>> {
         match self {
             Self::Optional2(value) => Some(value),
             _ => None,
         }
     }
 
-    pub fn as_optional3(&self) -> Option<&Option<Option<i64>>> {
+    pub fn as_optional3(&self) -> Option<&Option<i64>> {
         match self {
             Self::Optional3(value) => Some(value),
             _ => None,
         }
     }
 
-    pub fn into_optional3(self) -> Option<Option<Option<i64>>> {
+    pub fn into_optional3(self) -> Option<Option<i64>> {
         match self {
             Self::Optional3(value) => Some(value),
             _ => None,
         }
     }
 
-    pub fn as_optional4(&self) -> Option<&Option<Option<bool>>> {
+    pub fn as_optional4(&self) -> Option<&Option<bool>> {
         match self {
             Self::Optional4(value) => Some(value),
             _ => None,
         }
     }
 
-    pub fn into_optional4(self) -> Option<Option<Option<bool>>> {
+    pub fn into_optional4(self) -> Option<Option<bool>> {
         match self {
             Self::Optional4(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/content-type/src/api/types/patch_complex_request.rs
+++ b/seed/rust-sdk/content-type/src/api/types/patch_complex_request.rs
@@ -14,14 +14,14 @@ pub struct PatchComplexRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<Option<String>>,
+    pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nickname: Option<Option<String>>,
+    pub nickname: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bio: Option<Option<String>>,
+    pub bio: Option<String>,
     #[serde(rename = "profileImageUrl")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub profile_image_url: Option<Option<String>>,
+    pub profile_image_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub settings: Option<Option<HashMap<String, serde_json::Value>>>,
+    pub settings: Option<HashMap<String, serde_json::Value>>,
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/filter_by_role_query_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/filter_by_role_query_request.rs
@@ -11,5 +11,5 @@ pub struct FilterByRoleQueryRequest {
     pub status: Option<UserStatus>,
     #[serde(rename = "secondaryRole")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub secondary_role: Option<Option<UserRole>>,
+    pub secondary_role: Option<UserRole>,
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/list_users_query_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/list_users_query_request.rs
@@ -14,5 +14,5 @@ pub struct ListUsersQueryRequest {
     pub include_deleted: Option<bool>,
     #[serde(rename = "sortBy")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_by: Option<Option<String>>,
+    pub sort_by: Option<String>,
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_address.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_address.rs
@@ -13,7 +13,7 @@ pub struct Address {
     #[serde(default)]
     pub zip_code: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<Option<String>>,
+    pub country: Option<String>,
     #[serde(rename = "buildingId")]
     #[serde(default)]
     pub building_id: NullableUserId,

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_complex_profile.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_complex_profile.rs
@@ -13,7 +13,7 @@ pub struct ComplexProfile {
     pub optional_role: Option<UserRole>,
     #[serde(rename = "optionalNullableRole")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_role: Option<Option<UserRole>>,
+    pub optional_nullable_role: Option<UserRole>,
     #[serde(rename = "nullableStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_status: Option<UserStatus>,
@@ -22,7 +22,7 @@ pub struct ComplexProfile {
     pub optional_status: Option<UserStatus>,
     #[serde(rename = "optionalNullableStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_status: Option<Option<UserStatus>>,
+    pub optional_nullable_status: Option<UserStatus>,
     #[serde(rename = "nullableNotification")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_notification: Option<NotificationMethod>,
@@ -31,7 +31,7 @@ pub struct ComplexProfile {
     pub optional_notification: Option<NotificationMethod>,
     #[serde(rename = "optionalNullableNotification")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_notification: Option<Option<NotificationMethod>>,
+    pub optional_nullable_notification: Option<NotificationMethod>,
     #[serde(rename = "nullableSearchResult")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_search_result: Option<SearchResult>,
@@ -46,7 +46,7 @@ pub struct ComplexProfile {
     pub optional_array: Option<Vec<String>>,
     #[serde(rename = "optionalNullableArray")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_array: Option<Option<Vec<String>>>,
+    pub optional_nullable_array: Option<Vec<String>>,
     #[serde(rename = "nullableListOfNullables")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_list_of_nullables: Option<Vec<Option<String>>>,

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_create_user_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_create_user_request.rs
@@ -9,5 +9,5 @@ pub struct CreateUserRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<Option<Address>>,
+    pub address: Option<Address>,
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_deserialization_test_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_deserialization_test_request.rs
@@ -14,7 +14,7 @@ pub struct DeserializationTestRequest {
     pub optional_string: Option<String>,
     #[serde(rename = "optionalNullableString")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_string: Option<Option<String>>,
+    pub optional_nullable_string: Option<String>,
     #[serde(rename = "nullableEnum")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_enum: Option<UserRole>,

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_update_user_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_update_user_request.rs
@@ -6,9 +6,9 @@ pub struct UpdateUserRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<Option<String>>,
+    pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<Option<Address>>,
+    pub address: Option<Address>,
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_user_profile.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_user_profile.rs
@@ -55,8 +55,8 @@ pub struct UserProfile {
     pub optional_map: Option<HashMap<String, String>>,
     #[serde(rename = "optionalNullableString")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_string: Option<Option<String>>,
+    pub optional_nullable_string: Option<String>,
     #[serde(rename = "optionalNullableObject")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_object: Option<Option<Address>>,
+    pub optional_nullable_object: Option<Address>,
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/search_users_query_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/search_users_query_request.rs
@@ -13,5 +13,5 @@ pub struct SearchUsersQueryRequest {
     pub role: Option<String>,
     #[serde(rename = "isActive")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub is_active: Option<Option<bool>>,
+    pub is_active: Option<bool>,
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/update_complex_profile_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/update_complex_profile_request.rs
@@ -5,17 +5,17 @@ pub use crate::prelude::*;
 pub struct UpdateComplexProfileRequest {
     #[serde(rename = "nullableRole")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_role: Option<Option<UserRole>>,
+    pub nullable_role: Option<UserRole>,
     #[serde(rename = "nullableStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_status: Option<Option<UserStatus>>,
+    pub nullable_status: Option<UserStatus>,
     #[serde(rename = "nullableNotification")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_notification: Option<Option<NotificationMethod>>,
+    pub nullable_notification: Option<NotificationMethod>,
     #[serde(rename = "nullableSearchResult")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_search_result: Option<Option<SearchResult>>,
+    pub nullable_search_result: Option<SearchResult>,
     #[serde(rename = "nullableArray")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_array: Option<Option<Vec<String>>>,
+    pub nullable_array: Option<Vec<String>>,
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/update_tags_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/update_tags_request.rs
@@ -8,5 +8,5 @@ pub struct UpdateTagsRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub categories: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub labels: Option<Option<Vec<String>>>,
+    pub labels: Option<Vec<String>>,
 }

--- a/seed/rust-sdk/nullable-request-body/src/api/types/test_method_name_request.rs
+++ b/seed/rust-sdk/nullable-request-body/src/api/types/test_method_name_request.rs
@@ -6,9 +6,9 @@ pub use crate::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct TestMethodNameRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub query_param_object: Option<Option<PlainObject>>,
+    pub query_param_object: Option<PlainObject>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub query_param_integer: Option<Option<i64>>,
+    pub query_param_integer: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<PlainObject>,
 }

--- a/seed/rust-sdk/nullable/src/api/types/create_user_request.rs
+++ b/seed/rust-sdk/nullable/src/api/types/create_user_request.rs
@@ -10,5 +10,5 @@ pub struct CreateUserRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub avatar: Option<Option<String>>,
+    pub avatar: Option<String>,
 }

--- a/seed/rust-sdk/nullable/src/api/types/delete_user_request.rs
+++ b/seed/rust-sdk/nullable/src/api/types/delete_user_request.rs
@@ -5,5 +5,5 @@ pub use crate::prelude::*;
 pub struct DeleteUserRequest {
     /// The user to delete.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub username: Option<Option<String>>,
+    pub username: Option<String>,
 }

--- a/seed/rust-sdk/nullable/src/api/types/get_users_query_request.rs
+++ b/seed/rust-sdk/nullable/src/api/types/get_users_query_request.rs
@@ -12,7 +12,7 @@ pub struct GetUsersQueryRequest {
     #[serde(default)]
     pub activated: Vec<Option<bool>>,
     #[serde(default)]
-    pub tags: Vec<Option<Option<String>>>,
+    pub tags: Vec<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extra: Option<Option<bool>>,
+    pub extra: Option<bool>,
 }

--- a/seed/rust-sdk/nullable/src/api/types/nullable_metadata.rs
+++ b/seed/rust-sdk/nullable/src/api/types/nullable_metadata.rs
@@ -13,8 +13,8 @@ pub struct Metadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub activated: Option<Option<bool>>,
+    pub activated: Option<bool>,
     pub status: Status,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub values: Option<HashMap<String, Option<Option<String>>>>,
+    pub values: Option<HashMap<String, Option<String>>>,
 }

--- a/seed/rust-sdk/nullable/src/api/types/nullable_user.rs
+++ b/seed/rust-sdk/nullable/src/api/types/nullable_user.rs
@@ -9,13 +9,13 @@ pub struct User {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<Option<Metadata>>,
+    pub metadata: Option<Metadata>,
     #[serde(default)]
     pub email: Email,
     #[serde(rename = "favorite-number")]
     pub favorite_number: WeirdNumber,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub numbers: Option<Option<Vec<i64>>>,
+    pub numbers: Option<Vec<i64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub strings: Option<Option<HashMap<String, serde_json::Value>>>,
+    pub strings: Option<HashMap<String, serde_json::Value>>,
 }

--- a/seed/rust-sdk/nullable/src/api/types/nullable_weird_number.rs
+++ b/seed/rust-sdk/nullable/src/api/types/nullable_weird_number.rs
@@ -7,7 +7,7 @@ pub enum WeirdNumber {
 
     Nullable1(Option<f64>),
 
-    Optional2(Option<Option<String>>),
+    Optional2(Option<String>),
 
     Double(f64),
 }
@@ -57,14 +57,14 @@ impl WeirdNumber {
         }
     }
 
-    pub fn as_optional2(&self) -> Option<&Option<Option<String>>> {
+    pub fn as_optional2(&self) -> Option<&Option<String>> {
         match self {
             Self::Optional2(value) => Some(value),
             _ => None,
         }
     }
 
-    pub fn into_optional2(self) -> Option<Option<Option<String>>> {
+    pub fn into_optional2(self) -> Option<Option<String>> {
         match self {
             Self::Optional2(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/optional/src/api/resources/optional/optional.rs
+++ b/seed/rust-sdk/optional/src/api/resources/optional/optional.rs
@@ -60,7 +60,7 @@ impl OptionalClient {
         &self,
         action_id: &String,
         id: &String,
-        request: &Option<Option<DeployParams>>,
+        request: &Option<DeployParams>,
         options: Option<RequestOptions>,
     ) -> Result<DeployResponse, ApiError> {
         self.http_client

--- a/seed/rust-sdk/request-parameters/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/request-parameters/src/api/resources/user/user.rs
@@ -51,7 +51,7 @@ impl UserClient {
 
     pub async fn create_username_optional(
         &self,
-        request: &Option<Option<CreateUsernameBodyOptionalProperties>>,
+        request: &Option<CreateUsernameBodyOptionalProperties>,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client

--- a/seed/rust-sdk/required-nullable/src/api/types/foo.rs
+++ b/seed/rust-sdk/required-nullable/src/api/types/foo.rs
@@ -5,7 +5,7 @@ pub struct Foo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_bar: Option<Option<String>>,
+    pub nullable_bar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_required_bar: Option<String>,
     #[serde(default)]

--- a/seed/rust-sdk/required-nullable/src/api/types/get_foo_query_request.rs
+++ b/seed/rust-sdk/required-nullable/src/api/types/get_foo_query_request.rs
@@ -10,7 +10,7 @@ pub struct GetFooQueryRequest {
     pub optional_baz: Option<String>,
     /// An optional baz
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_nullable_baz: Option<Option<String>>,
+    pub optional_nullable_baz: Option<String>,
     /// A required baz
     #[serde(default)]
     pub required_baz: String,

--- a/seed/rust-sdk/required-nullable/src/api/types/update_foo_request.rs
+++ b/seed/rust-sdk/required-nullable/src/api/types/update_foo_request.rs
@@ -5,10 +5,10 @@ pub use crate::prelude::*;
 pub struct UpdateFooRequest {
     /// Can be explicitly set to null to clear the value
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_text: Option<Option<String>>,
+    pub nullable_text: Option<String>,
     /// Can be explicitly set to null to clear the value
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_number: Option<Option<f64>>,
+    pub nullable_number: Option<f64>,
     /// Regular non-nullable field
     #[serde(skip_serializing_if = "Option::is_none")]
     pub non_nullable_text: Option<String>,


### PR DESCRIPTION
## Description

This fixes an issue where the Rust SDK would contain a duplicative `Option<T>` type. With this, we now only have a single generic wrapper (as expected).

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
