### PR TITLE
fix(ruby): pagination code mixes string- and symbol-keys; URI-encode path params

### DIFF
--- a/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -104,6 +104,8 @@ export class HttpEndpointGenerator {
         const splatOptionDocs = this.generateSplatOptionDocs({ endpoint });
         const requestOptionsDocs = this.generateRequestOptionsDocs();
 
+        // Pagination blocks use string keys for query_params to match initialization
+        // in WrappedEndpointRequest (e.g. query_params["page"], not query_params[:page])
         if (endpoint.pagination) {
             switch (endpoint.pagination.type) {
                 case "custom": {
@@ -159,7 +161,6 @@ export class HttpEndpointGenerator {
                                 }),
                                 ruby.keywordArgument({
                                     name: "initial_cursor",
-                                    // Use string key to match how query_params are initialized in WrappedEndpointRequest
                                     value: ruby.codeblock(
                                         `${QUERY_PARAMETER_BAG_NAME}["${endpoint.pagination.page.property.name.wireValue}"]`
                                     )
@@ -169,7 +170,6 @@ export class HttpEndpointGenerator {
                                 ["next_cursor"],
                                 [
                                     ruby.codeblock(
-                                        // Use string key to match how query_params are initialized in WrappedEndpointRequest
                                         `${QUERY_PARAMETER_BAG_NAME}["${endpoint.pagination.page.property.name.wireValue}"] = next_cursor`
                                     ),
                                     ...requestStatements
@@ -190,7 +190,6 @@ export class HttpEndpointGenerator {
                             keywordArguments: [
                                 ruby.keywordArgument({
                                     name: "initial_page",
-                                    // Use string key to match how query_params are initialized in WrappedEndpointRequest
                                     value: ruby.codeblock(
                                         `${QUERY_PARAMETER_BAG_NAME}["${endpoint.pagination.page.property.name.wireValue}"]`
                                     )
@@ -220,7 +219,6 @@ export class HttpEndpointGenerator {
                                 ["next_page"],
                                 [
                                     ruby.codeblock(
-                                        // Use string key to match how query_params are initialized in WrappedEndpointRequest
                                         `${QUERY_PARAMETER_BAG_NAME}["${endpoint.pagination.page.property.name.wireValue}"] = next_page`
                                     ),
                                     ...requestStatements

--- a/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -159,9 +159,9 @@ export class HttpEndpointGenerator {
                                 }),
                                 ruby.keywordArgument({
                                     name: "initial_cursor",
-                                    // Keep wireValue for query params (sent over HTTP)
+                                    // Use string key to match how query_params are initialized in WrappedEndpointRequest
                                     value: ruby.codeblock(
-                                        `${QUERY_PARAMETER_BAG_NAME}[:${endpoint.pagination.page.property.name.wireValue}]`
+                                        `${QUERY_PARAMETER_BAG_NAME}["${endpoint.pagination.page.property.name.wireValue}"]`
                                     )
                                 })
                             ],
@@ -169,8 +169,8 @@ export class HttpEndpointGenerator {
                                 ["next_cursor"],
                                 [
                                     ruby.codeblock(
-                                        // Keep wireValue for query params (sent over HTTP)
-                                        `${QUERY_PARAMETER_BAG_NAME}[:${endpoint.pagination.page.property.name.wireValue}] = next_cursor`
+                                        // Use string key to match how query_params are initialized in WrappedEndpointRequest
+                                        `${QUERY_PARAMETER_BAG_NAME}["${endpoint.pagination.page.property.name.wireValue}"] = next_cursor`
                                     ),
                                     ...requestStatements
                                 ]
@@ -190,9 +190,9 @@ export class HttpEndpointGenerator {
                             keywordArguments: [
                                 ruby.keywordArgument({
                                     name: "initial_page",
-                                    // Keep wireValue for query params (sent over HTTP)
+                                    // Use string key to match how query_params are initialized in WrappedEndpointRequest
                                     value: ruby.codeblock(
-                                        `${QUERY_PARAMETER_BAG_NAME}[:${endpoint.pagination.page.property.name.wireValue}]`
+                                        `${QUERY_PARAMETER_BAG_NAME}["${endpoint.pagination.page.property.name.wireValue}"]`
                                     )
                                 }),
                                 ruby.keywordArgument({
@@ -220,8 +220,8 @@ export class HttpEndpointGenerator {
                                 ["next_page"],
                                 [
                                     ruby.codeblock(
-                                        // Keep wireValue for query params (sent over HTTP)
-                                        `${QUERY_PARAMETER_BAG_NAME}[:${endpoint.pagination.page.property.name.wireValue}] = next_page`
+                                        // Use string key to match how query_params are initialized in WrappedEndpointRequest
+                                        `${QUERY_PARAMETER_BAG_NAME}["${endpoint.pagination.page.property.name.wireValue}"] = next_page`
                                     ),
                                     ...requestStatements
                                 ]

--- a/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
@@ -144,8 +144,9 @@ export class RawClient {
                 if (reference == null) {
                     rubyPath += `#{${part.tail}}`;
                 } else {
-                    // Insert Ruby interpolation for the path parameter
-                    rubyPath += `#{${reference}}${part.tail}`;
+                    // Insert Ruby interpolation for the path parameter, URI-encoding to handle
+                    // special characters (e.g. auth0|abc123 in Auth0 user IDs)
+                    rubyPath += `#{URI.encode_uri_component(${reference}.to_s)}${part.tail}`;
                 }
             } else {
                 rubyPath += part.tail;

--- a/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
@@ -144,8 +144,7 @@ export class RawClient {
                 if (reference == null) {
                     rubyPath += `#{${part.tail}}`;
                 } else {
-                    // Insert Ruby interpolation for the path parameter, URI-encoding to handle
-                    // special characters (e.g. auth0|abc123 in Auth0 user IDs)
+                    // URI-encode path parameters to handle reserved characters (e.g. pipes, spaces)
                     rubyPath += `#{URI.encode_uri_component(${reference}.to_s)}${part.tail}`;
                 }
             } else {

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,20 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.1.2
+  changelogEntry:
+    - summary: |
+        Fix pagination query parameter key mismatch. Query parameters were initialized
+        with string keys but pagination iterator blocks used symbol keys, causing duplicate
+        parameters to be sent (e.g., `page=0&page=0`) which resulted in 400 errors.
+      type: fix
+    - summary: |
+        URI-encode path parameters before interpolation into URL paths. Resource IDs
+        containing special characters (e.g., `auth0|abc123`) now work correctly instead
+        of raising `URI::InvalidURIError`.
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 61
+
 - version: 1.1.1
   changelogEntry:
     - summary: |

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -9,8 +9,8 @@
       type: fix
     - summary: |
         URI-encode path parameters before interpolation into URL paths. Resource IDs
-        containing special characters (e.g., `auth0|abc123`) now work correctly instead
-        of raising `URI::InvalidURIError`.
+        containing reserved URI characters (e.g., pipes, spaces) now work correctly
+        instead of raising `URI::InvalidURIError`.
       type: fix
   createdAt: "2026-03-19"
   irVersion: 61

--- a/seed/ruby-sdk-v2/alias-extends/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/alias-extends/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/alias-extends/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/alias-extends/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/alias/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/alias/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/alias/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/alias/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/any-auth/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/any-auth/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/any-auth/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/any-auth/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/service/client.rb
@@ -28,7 +28,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/test/#{params[:path_param]}/#{params[:service_param]}/#{params[:endpoint_param]}/#{params[:resource_param]}",
+          path: "/test/#{URI.encode_uri_component(params[:path_param].to_s)}/#{URI.encode_uri_component(params[:service_param].to_s)}/#{URI.encode_uri_component(params[:endpoint_param].to_s)}/#{URI.encode_uri_component(params[:resource_param].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/api-wide-base-path/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/api-wide-base-path/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/basic-auth/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/basic-auth/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/basic-auth/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/basic-auth/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/bytes-download/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/bytes-download/lib/seed/service/client.rb
@@ -54,7 +54,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "download-content/#{params[:id]}",
+          path: "download-content/#{URI.encode_uri_component(params[:id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/bytes-download/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/bytes-download/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/bytes-download/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/bytes-download/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/bytes-upload/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/bytes-upload/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/client-side-params/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/client-side-params/lib/seed/service/client.rb
@@ -85,7 +85,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/api/resources/#{params[:resource_id]}",
+          path: "/api/resources/#{URI.encode_uri_component(params[:resource_id].to_s)}",
           query: query_params,
           request_options: request_options
         )
@@ -229,7 +229,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/api/users/#{params[:user_id]}",
+          path: "/api/users/#{URI.encode_uri_component(params[:user_id].to_s)}",
           query: query_params,
           request_options: request_options
         )
@@ -298,7 +298,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "PATCH",
-          path: "/api/users/#{params[:user_id]}",
+          path: "/api/users/#{URI.encode_uri_component(params[:user_id].to_s)}",
           body: Seed::Types::Types::UpdateUserRequest.new(params).to_h,
           request_options: request_options
         )
@@ -333,7 +333,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "DELETE",
-          path: "/api/users/#{params[:user_id]}",
+          path: "/api/users/#{URI.encode_uri_component(params[:user_id].to_s)}",
           request_options: request_options
         )
         begin
@@ -413,7 +413,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/api/connections/#{params[:connection_id]}",
+          path: "/api/connections/#{URI.encode_uri_component(params[:connection_id].to_s)}",
           query: query_params,
           request_options: request_options
         )
@@ -510,7 +510,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/api/clients/#{params[:client_id]}",
+          path: "/api/clients/#{URI.encode_uri_component(params[:client_id].to_s)}",
           query: query_params,
           request_options: request_options
         )

--- a/seed/ruby-sdk-v2/client-side-params/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/client-side-params/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/client-side-params/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/client-side-params/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/content-type/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/content-type/lib/seed/service/client.rb
@@ -64,7 +64,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "PATCH",
-          path: "complex/#{params[:id]}",
+          path: "complex/#{URI.encode_uri_component(params[:id].to_s)}",
           body: body,
           request_options: request_options
         )
@@ -102,7 +102,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "PATCH",
-          path: "named-mixed/#{params[:id]}",
+          path: "named-mixed/#{URI.encode_uri_component(params[:id].to_s)}",
           body: body,
           request_options: request_options
         )
@@ -174,7 +174,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "PATCH",
-          path: "regular/#{params[:id]}",
+          path: "regular/#{URI.encode_uri_component(params[:id].to_s)}",
           body: body,
           request_options: request_options
         )

--- a/seed/ruby-sdk-v2/enum/lib/seed/path_param/client.rb
+++ b/seed/ruby-sdk-v2/enum/lib/seed/path_param/client.rb
@@ -26,7 +26,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "path/#{params[:operand]}/#{params[:operand_or_color]}",
+          path: "path/#{URI.encode_uri_component(params[:operand].to_s)}/#{URI.encode_uri_component(params[:operand_or_color].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/file/notification/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/file/notification/service/client.rb
@@ -27,7 +27,7 @@ module Seed
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
-              path: "/file/notification/#{params[:notification_id]}",
+              path: "/file/notification/#{URI.encode_uri_component(params[:notification_id].to_s)}",
               request_options: request_options
             )
             begin

--- a/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/file/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/file/service/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/file/#{params[:filename]}",
+            path: "/file/#{URI.encode_uri_component(params[:filename].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/health/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/health/service/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/check/#{params[:id]}",
+            path: "/check/#{URI.encode_uri_component(params[:id].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/service/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/movie/#{params[:movie_id]}",
+          path: "/movie/#{URI.encode_uri_component(params[:movie_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/file/notification/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/file/notification/service/client.rb
@@ -27,7 +27,7 @@ module Seed
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
-              path: "/file/notification/#{params[:notification_id]}",
+              path: "/file/notification/#{URI.encode_uri_component(params[:notification_id].to_s)}",
               request_options: request_options
             )
             begin

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/file/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/file/service/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/file/#{params[:filename]}",
+            path: "/file/#{URI.encode_uri_component(params[:filename].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/health/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/health/service/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/check/#{params[:id]}",
+            path: "/check/#{URI.encode_uri_component(params[:id].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/service/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/movie/#{params[:movie_id]}",
+          path: "/movie/#{URI.encode_uri_component(params[:movie_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/examples/readme-config/lib/seed/file/notification/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/lib/seed/file/notification/service/client.rb
@@ -27,7 +27,7 @@ module Seed
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
-              path: "/file/notification/#{params[:notification_id]}",
+              path: "/file/notification/#{URI.encode_uri_component(params[:notification_id].to_s)}",
               request_options: request_options
             )
             begin

--- a/seed/ruby-sdk-v2/examples/readme-config/lib/seed/file/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/lib/seed/file/service/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/file/#{params[:filename]}",
+            path: "/file/#{URI.encode_uri_component(params[:filename].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/examples/readme-config/lib/seed/health/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/lib/seed/health/service/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/check/#{params[:id]}",
+            path: "/check/#{URI.encode_uri_component(params[:id].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/examples/readme-config/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/lib/seed/service/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/movie/#{params[:movie_id]}",
+          path: "/movie/#{URI.encode_uri_component(params[:movie_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/examples/require-paths/lib/seed/file/notification/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/lib/seed/file/notification/service/client.rb
@@ -27,7 +27,7 @@ module Seed
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
-              path: "/file/notification/#{params[:notification_id]}",
+              path: "/file/notification/#{URI.encode_uri_component(params[:notification_id].to_s)}",
               request_options: request_options
             )
             begin

--- a/seed/ruby-sdk-v2/examples/require-paths/lib/seed/file/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/lib/seed/file/service/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/file/#{params[:filename]}",
+            path: "/file/#{URI.encode_uri_component(params[:filename].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/examples/require-paths/lib/seed/health/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/lib/seed/health/service/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/check/#{params[:id]}",
+            path: "/check/#{URI.encode_uri_component(params[:id].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/examples/require-paths/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/lib/seed/service/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/movie/#{params[:movie_id]}",
+          path: "/movie/#{URI.encode_uri_component(params[:movie_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/file/notification/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/file/notification/service/client.rb
@@ -27,7 +27,7 @@ module Seed
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
-              path: "/file/notification/#{params[:notification_id]}",
+              path: "/file/notification/#{URI.encode_uri_component(params[:notification_id].to_s)}",
               request_options: request_options
             )
             begin

--- a/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/file/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/file/service/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/file/#{params[:filename]}",
+            path: "/file/#{URI.encode_uri_component(params[:filename].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/health/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/health/service/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/check/#{params[:id]}",
+            path: "/check/#{URI.encode_uri_component(params[:id].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/service/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/movie/#{params[:movie_id]}",
+          path: "/movie/#{URI.encode_uri_component(params[:movie_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/http_methods/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/http_methods/client.rb
@@ -26,7 +26,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/http-methods/#{params[:id]}",
+            path: "/http-methods/#{URI.encode_uri_component(params[:id].to_s)}",
             request_options: request_options
           )
           begin
@@ -88,7 +88,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "PUT",
-            path: "/http-methods/#{params[:id]}",
+            path: "/http-methods/#{URI.encode_uri_component(params[:id].to_s)}",
             body: Seed::Types::Object_::Types::ObjectWithRequiredField.new(params).to_h,
             request_options: request_options
           )
@@ -121,7 +121,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "PATCH",
-            path: "/http-methods/#{params[:id]}",
+            path: "/http-methods/#{URI.encode_uri_component(params[:id].to_s)}",
             body: Seed::Types::Object_::Types::ObjectWithOptionalField.new(params).to_h,
             request_options: request_options
           )
@@ -154,7 +154,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "DELETE",
-            path: "/http-methods/#{params[:id]}",
+            path: "/http-methods/#{URI.encode_uri_component(params[:id].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/object/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/object/client.rb
@@ -154,7 +154,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "POST",
-            path: "/object/get-and-return-nested-with-required-field/#{params[:string]}",
+            path: "/object/get-and-return-nested-with-required-field/#{URI.encode_uri_component(params[:string].to_s)}",
             body: Seed::Types::Object_::Types::NestedObjectWithRequiredField.new(params).to_h,
             request_options: request_options
           )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/pagination/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/pagination/client.rb
@@ -35,9 +35,9 @@ module Seed
           Seed::Internal::CursorItemIterator.new(
             cursor_field: :next_,
             item_field: :items,
-            initial_cursor: query_params[:cursor]
+            initial_cursor: query_params["cursor"]
           ) do |next_cursor|
-            query_params[:cursor] = next_cursor
+            query_params["cursor"] = next_cursor
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/params/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/params/client.rb
@@ -28,7 +28,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/params/path/#{params[:param]}",
+            path: "/params/path/#{URI.encode_uri_component(params[:param].to_s)}",
             request_options: request_options
           )
           begin
@@ -60,7 +60,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/params/path/#{params[:param]}",
+            path: "/params/path/#{URI.encode_uri_component(params[:param].to_s)}",
             request_options: request_options
           )
           begin
@@ -178,7 +178,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/params/path-query/#{params[:param]}",
+            path: "/params/path-query/#{URI.encode_uri_component(params[:param].to_s)}",
             query: query_params,
             request_options: request_options
           )
@@ -217,7 +217,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/params/path-query/#{params[:param]}",
+            path: "/params/path-query/#{URI.encode_uri_component(params[:param].to_s)}",
             query: query_params,
             request_options: request_options
           )
@@ -250,7 +250,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "PUT",
-            path: "/params/path/#{params[:param]}",
+            path: "/params/path/#{URI.encode_uri_component(params[:param].to_s)}",
             body: params,
             request_options: request_options
           )
@@ -286,7 +286,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "PUT",
-            path: "/params/path/#{params[:param]}",
+            path: "/params/path/#{URI.encode_uri_component(params[:param].to_s)}",
             body: body_params,
             request_options: request_options
           )
@@ -319,7 +319,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "POST",
-            path: "/params/path/#{params[:param]}",
+            path: "/params/path/#{URI.encode_uri_component(params[:param].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/put/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/put/client.rb
@@ -26,7 +26,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "PUT",
-            path: params[:id].to_s,
+            path: URI.encode_uri_component(params[:id].to_s).to_s,
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/idempotency-headers/lib/seed/payment/client.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/lib/seed/payment/client.rb
@@ -55,7 +55,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "DELETE",
-          path: "/payment/#{params[:payment_id]}",
+          path: "/payment/#{URI.encode_uri_component(params[:payment_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/imdb/lib/seed/imdb/client.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/imdb/client.rb
@@ -59,7 +59,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/movies/#{params[:movie_id]}",
+          path: "/movies/#{URI.encode_uri_component(params[:movie_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/literal/lib/seed/path/client.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/path/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "path/#{params[:id]}",
+          path: "path/#{URI.encode_uri_component(params[:id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/mixed-case/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/mixed-case/lib/seed/service/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/resource/#{params[:resource_id]}",
+          path: "/resource/#{URI.encode_uri_component(params[:resource_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/multi-line-docs/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/multi-line-docs/lib/seed/user/client.rb
@@ -28,7 +28,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "users/#{params[:user_id]}",
+          path: "users/#{URI.encode_uri_component(params[:user_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/nullable-optional/lib/seed/nullable_optional/client.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/lib/seed/nullable_optional/client.rb
@@ -27,7 +27,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/api/users/#{params[:user_id]}",
+          path: "/api/users/#{URI.encode_uri_component(params[:user_id].to_s)}",
           request_options: request_options
         )
         begin
@@ -95,7 +95,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "PATCH",
-          path: "/api/users/#{params[:user_id]}",
+          path: "/api/users/#{URI.encode_uri_component(params[:user_id].to_s)}",
           body: Seed::NullableOptional::Types::UpdateUserRequest.new(params).to_h,
           request_options: request_options
         )
@@ -252,7 +252,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/api/profiles/complex/#{params[:profile_id]}",
+          path: "/api/profiles/complex/#{URI.encode_uri_component(params[:profile_id].to_s)}",
           request_options: request_options
         )
         begin
@@ -290,7 +290,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "PATCH",
-          path: "/api/profiles/complex/#{params[:profile_id]}",
+          path: "/api/profiles/complex/#{URI.encode_uri_component(params[:profile_id].to_s)}",
           body: body,
           request_options: request_options
         )
@@ -401,7 +401,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/api/users/#{params[:user_id]}/notifications",
+          path: "/api/users/#{URI.encode_uri_component(params[:user_id].to_s)}/notifications",
           request_options: request_options
         )
         begin
@@ -437,7 +437,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "PUT",
-          path: "/api/users/#{params[:user_id]}/tags",
+          path: "/api/users/#{URI.encode_uri_component(params[:user_id].to_s)}/tags",
           body: body,
           request_options: request_options
         )

--- a/seed/ruby-sdk-v2/nullable-request-body/lib/seed/test_group/client.rb
+++ b/seed/ruby-sdk-v2/nullable-request-body/lib/seed/test_group/client.rb
@@ -38,7 +38,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "optional-request-body/#{params[:path_param]}",
+          path: "optional-request-body/#{URI.encode_uri_component(params[:path_param].to_s)}",
           query: query_params,
           body: body_params,
           request_options: request_options

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/service/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/service/#{params[:endpoint_param]}",
+          path: "/service/#{URI.encode_uri_component(params[:endpoint_param].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/optional/lib/seed/optional/client.rb
+++ b/seed/ruby-sdk-v2/optional/lib/seed/optional/client.rb
@@ -89,7 +89,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "deploy/#{params[:action_id]}/versions/#{params[:id]}",
+          path: "deploy/#{URI.encode_uri_component(params[:action_id].to_s)}/versions/#{URI.encode_uri_component(params[:id].to_s)}",
           body: params,
           request_options: request_options
         )

--- a/seed/ruby-sdk-v2/package-yml/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/package-yml/lib/seed/service/client.rb
@@ -26,7 +26,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:id]}//#{params[:nested_id]}",
+          path: "/#{URI.encode_uri_component(params[:id].to_s)}//#{URI.encode_uri_component(params[:nested_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/pagination/lib/seed/complex/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/complex/client.rb
@@ -25,13 +25,13 @@ module Seed
         Seed::Internal::CursorItemIterator.new(
           cursor_field: :starting_after,
           item_field: :conversations,
-          initial_cursor: query_params[:starting_after]
+          initial_cursor: query_params["starting_after"]
         ) do |next_cursor|
-          query_params[:starting_after] = next_cursor
+          query_params["starting_after"] = next_cursor
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "POST",
-            path: "#{params[:index]}/conversations/search",
+            path: "#{URI.encode_uri_component(params[:index].to_s)}/conversations/search",
             body: Seed::Complex::Types::SearchRequest.new(params).to_h,
             request_options: request_options
           )

--- a/seed/ruby-sdk-v2/pagination/lib/seed/inline_users/inline_users/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/inline_users/inline_users/client.rb
@@ -37,9 +37,9 @@ module Seed
           Seed::Internal::CursorItemIterator.new(
             cursor_field: :starting_after,
             item_field: :users,
-            initial_cursor: query_params[:starting_after]
+            initial_cursor: query_params["starting_after"]
           ) do |next_cursor|
-            query_params[:starting_after] = next_cursor
+            query_params["starting_after"] = next_cursor
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
@@ -82,9 +82,9 @@ module Seed
           Seed::Internal::CursorItemIterator.new(
             cursor_field: :next_,
             item_field: :users,
-            initial_cursor: query_params[:cursor]
+            initial_cursor: query_params["cursor"]
           ) do |next_cursor|
-            query_params[:cursor] = next_cursor
+            query_params["cursor"] = next_cursor
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "POST",
@@ -121,9 +121,9 @@ module Seed
           Seed::Internal::CursorItemIterator.new(
             cursor_field: :starting_after,
             item_field: :users,
-            initial_cursor: query_params[:cursor]
+            initial_cursor: query_params["cursor"]
           ) do |next_cursor|
-            query_params[:cursor] = next_cursor
+            query_params["cursor"] = next_cursor
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "POST",
@@ -170,12 +170,12 @@ module Seed
           params.except(*query_param_names)
 
           Seed::Internal::OffsetItemIterator.new(
-            initial_page: query_params[:page],
+            initial_page: query_params["page"],
             item_field: :users,
             has_next_field: nil,
             step: false
           ) do |next_page|
-            query_params[:page] = next_page
+            query_params["page"] = next_page
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
@@ -222,12 +222,12 @@ module Seed
           params.except(*query_param_names)
 
           Seed::Internal::OffsetItemIterator.new(
-            initial_page: query_params[:page],
+            initial_page: query_params["page"],
             item_field: :users,
             has_next_field: nil,
             step: false
           ) do |next_page|
-            query_params[:page] = next_page
+            query_params["page"] = next_page
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
@@ -262,12 +262,12 @@ module Seed
         def list_with_body_offset_pagination(request_options: {}, **params)
           params = Seed::Internal::Types::Utils.normalize_keys(params)
           Seed::Internal::OffsetItemIterator.new(
-            initial_page: query_params[:page],
+            initial_page: query_params["page"],
             item_field: :users,
             has_next_field: nil,
             step: false
           ) do |next_page|
-            query_params[:page] = next_page
+            query_params["page"] = next_page
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "POST",
@@ -312,12 +312,12 @@ module Seed
           params.except(*query_param_names)
 
           Seed::Internal::OffsetItemIterator.new(
-            initial_page: query_params[:page],
+            initial_page: query_params["page"],
             item_field: :users,
             has_next_field: nil,
             step: true
           ) do |next_page|
-            query_params[:page] = next_page
+            query_params["page"] = next_page
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
@@ -362,12 +362,12 @@ module Seed
           params.except(*query_param_names)
 
           Seed::Internal::OffsetItemIterator.new(
-            initial_page: query_params[:page],
+            initial_page: query_params["page"],
             item_field: :users,
             has_next_field: :has_next_page,
             step: true
           ) do |next_page|
-            query_params[:page] = next_page
+            query_params["page"] = next_page
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
@@ -410,9 +410,9 @@ module Seed
           Seed::Internal::CursorItemIterator.new(
             cursor_field: :next_,
             item_field: :users,
-            initial_cursor: query_params[:cursor]
+            initial_cursor: query_params["cursor"]
           ) do |next_cursor|
-            query_params[:cursor] = next_cursor
+            query_params["cursor"] = next_cursor
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
@@ -455,9 +455,9 @@ module Seed
           Seed::Internal::CursorItemIterator.new(
             cursor_field: :next_,
             item_field: :users,
-            initial_cursor: query_params[:cursor]
+            initial_cursor: query_params["cursor"]
           ) do |next_cursor|
-            query_params[:cursor] = next_cursor
+            query_params["cursor"] = next_cursor
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
@@ -500,9 +500,9 @@ module Seed
           Seed::Internal::CursorItemIterator.new(
             cursor_field: :after,
             item_field: :data,
-            initial_cursor: query_params[:starting_after]
+            initial_cursor: query_params["starting_after"]
           ) do |next_cursor|
-            query_params[:starting_after] = next_cursor
+            query_params["starting_after"] = next_cursor
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
@@ -543,12 +543,12 @@ module Seed
           params.except(*query_param_names)
 
           Seed::Internal::OffsetItemIterator.new(
-            initial_page: query_params[:offset],
+            initial_page: query_params["offset"],
             item_field: :results,
             has_next_field: nil,
             step: false
           ) do |next_page|
-            query_params[:offset] = next_page
+            query_params["offset"] = next_page
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",

--- a/seed/ruby-sdk-v2/pagination/lib/seed/users/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/users/client.rb
@@ -36,9 +36,9 @@ module Seed
         Seed::Internal::CursorItemIterator.new(
           cursor_field: :starting_after,
           item_field: :data,
-          initial_cursor: query_params[:starting_after]
+          initial_cursor: query_params["starting_after"]
         ) do |next_cursor|
-          query_params[:starting_after] = next_cursor
+          query_params["starting_after"] = next_cursor
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
@@ -81,9 +81,9 @@ module Seed
         Seed::Internal::CursorItemIterator.new(
           cursor_field: :next_,
           item_field: :data,
-          initial_cursor: query_params[:cursor]
+          initial_cursor: query_params["cursor"]
         ) do |next_cursor|
-          query_params[:cursor] = next_cursor
+          query_params["cursor"] = next_cursor
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "POST",
@@ -120,9 +120,9 @@ module Seed
         Seed::Internal::CursorItemIterator.new(
           cursor_field: :starting_after,
           item_field: :data,
-          initial_cursor: query_params[:cursor]
+          initial_cursor: query_params["cursor"]
         ) do |next_cursor|
-          query_params[:cursor] = next_cursor
+          query_params["cursor"] = next_cursor
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "POST",
@@ -163,9 +163,9 @@ module Seed
         Seed::Internal::CursorItemIterator.new(
           cursor_field: :next_cursor,
           item_field: :data,
-          initial_cursor: query_params[:cursor]
+          initial_cursor: query_params["cursor"]
         ) do |next_cursor|
-          query_params[:cursor] = next_cursor
+          query_params["cursor"] = next_cursor
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "POST",
@@ -212,12 +212,12 @@ module Seed
         params.except(*query_param_names)
 
         Seed::Internal::OffsetItemIterator.new(
-          initial_page: query_params[:page],
+          initial_page: query_params["page"],
           item_field: :data,
           has_next_field: nil,
           step: false
         ) do |next_page|
-          query_params[:page] = next_page
+          query_params["page"] = next_page
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
@@ -264,12 +264,12 @@ module Seed
         params.except(*query_param_names)
 
         Seed::Internal::OffsetItemIterator.new(
-          initial_page: query_params[:page],
+          initial_page: query_params["page"],
           item_field: :data,
           has_next_field: nil,
           step: false
         ) do |next_page|
-          query_params[:page] = next_page
+          query_params["page"] = next_page
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
@@ -304,12 +304,12 @@ module Seed
       def list_with_body_offset_pagination(request_options: {}, **params)
         params = Seed::Internal::Types::Utils.normalize_keys(params)
         Seed::Internal::OffsetItemIterator.new(
-          initial_page: query_params[:page],
+          initial_page: query_params["page"],
           item_field: :data,
           has_next_field: nil,
           step: false
         ) do |next_page|
-          query_params[:page] = next_page
+          query_params["page"] = next_page
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "POST",
@@ -354,12 +354,12 @@ module Seed
         params.except(*query_param_names)
 
         Seed::Internal::OffsetItemIterator.new(
-          initial_page: query_params[:page],
+          initial_page: query_params["page"],
           item_field: :data,
           has_next_field: nil,
           step: true
         ) do |next_page|
-          query_params[:page] = next_page
+          query_params["page"] = next_page
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
@@ -404,12 +404,12 @@ module Seed
         params.except(*query_param_names)
 
         Seed::Internal::OffsetItemIterator.new(
-          initial_page: query_params[:page],
+          initial_page: query_params["page"],
           item_field: :data,
           has_next_field: :has_next_page,
           step: true
         ) do |next_page|
-          query_params[:page] = next_page
+          query_params["page"] = next_page
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
@@ -452,9 +452,9 @@ module Seed
         Seed::Internal::CursorItemIterator.new(
           cursor_field: :next_,
           item_field: :users,
-          initial_cursor: query_params[:cursor]
+          initial_cursor: query_params["cursor"]
         ) do |next_cursor|
-          query_params[:cursor] = next_cursor
+          query_params["cursor"] = next_cursor
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
@@ -497,9 +497,9 @@ module Seed
         Seed::Internal::CursorItemIterator.new(
           cursor_field: :next_,
           item_field: :users,
-          initial_cursor: query_params[:cursor]
+          initial_cursor: query_params["cursor"]
         ) do |next_cursor|
-          query_params[:cursor] = next_cursor
+          query_params["cursor"] = next_cursor
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
@@ -542,9 +542,9 @@ module Seed
         Seed::Internal::CursorItemIterator.new(
           cursor_field: :after,
           item_field: :data,
-          initial_cursor: query_params[:starting_after]
+          initial_cursor: query_params["starting_after"]
         ) do |next_cursor|
-          query_params[:starting_after] = next_cursor
+          query_params["starting_after"] = next_cursor
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
@@ -587,9 +587,9 @@ module Seed
         Seed::Internal::CursorItemIterator.new(
           cursor_field: :after,
           item_field: :data,
-          initial_cursor: query_params[:starting_after]
+          initial_cursor: query_params["starting_after"]
         ) do |next_cursor|
-          query_params[:starting_after] = next_cursor
+          query_params["starting_after"] = next_cursor
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
@@ -628,12 +628,12 @@ module Seed
         params.except(*query_param_names)
 
         Seed::Internal::OffsetItemIterator.new(
-          initial_page: query_params[:offset],
+          initial_page: query_params["offset"],
           item_field: :results,
           has_next_field: nil,
           step: false
         ) do |next_page|
-          query_params[:offset] = next_page
+          query_params["offset"] = next_page
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
@@ -674,12 +674,12 @@ module Seed
         params.except(*query_param_names)
 
         Seed::Internal::OffsetItemIterator.new(
-          initial_page: query_params[:page],
+          initial_page: query_params["page"],
           item_field: :data,
           has_next_field: nil,
           step: false
         ) do |next_page|
-          query_params[:page] = next_page
+          query_params["page"] = next_page
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",

--- a/seed/ruby-sdk-v2/path-parameters/lib/seed/organizations/client.rb
+++ b/seed/ruby-sdk-v2/path-parameters/lib/seed/organizations/client.rb
@@ -26,7 +26,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:tenant_id]}/organizations/#{params[:organization_id]}/",
+          path: "/#{URI.encode_uri_component(params[:tenant_id].to_s)}/organizations/#{URI.encode_uri_component(params[:organization_id].to_s)}/",
           request_options: request_options
         )
         begin
@@ -60,7 +60,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:tenant_id]}/organizations/#{params[:organization_id]}/users/#{params[:user_id]}",
+          path: "/#{URI.encode_uri_component(params[:tenant_id].to_s)}/organizations/#{URI.encode_uri_component(params[:organization_id].to_s)}/users/#{URI.encode_uri_component(params[:user_id].to_s)}",
           request_options: request_options
         )
         begin
@@ -99,7 +99,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:tenant_id]}/organizations/#{params[:organization_id]}/search",
+          path: "/#{URI.encode_uri_component(params[:tenant_id].to_s)}/organizations/#{URI.encode_uri_component(params[:organization_id].to_s)}/search",
           query: query_params,
           request_options: request_options
         )

--- a/seed/ruby-sdk-v2/path-parameters/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/path-parameters/lib/seed/user/client.rb
@@ -26,7 +26,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:tenant_id]}/user/#{params[:user_id]}",
+          path: "/#{URI.encode_uri_component(params[:tenant_id].to_s)}/user/#{URI.encode_uri_component(params[:user_id].to_s)}",
           request_options: request_options
         )
         begin
@@ -58,7 +58,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/#{params[:tenant_id]}/user/",
+          path: "/#{URI.encode_uri_component(params[:tenant_id].to_s)}/user/",
           body: Seed::User::Types::User.new(params).to_h,
           request_options: request_options
         )
@@ -95,7 +95,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "PATCH",
-          path: "/#{params[:tenant_id]}/user/#{params[:user_id]}",
+          path: "/#{URI.encode_uri_component(params[:tenant_id].to_s)}/user/#{URI.encode_uri_component(params[:user_id].to_s)}",
           body: Seed::User::Types::User.new(body_params).to_h,
           request_options: request_options
         )
@@ -135,7 +135,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:tenant_id]}/user/#{params[:user_id]}/search",
+          path: "/#{URI.encode_uri_component(params[:tenant_id].to_s)}/user/#{URI.encode_uri_component(params[:user_id].to_s)}/search",
           query: query_params,
           request_options: request_options
         )
@@ -170,7 +170,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:tenant_id]}/user/#{params[:user_id]}/metadata/v#{params[:version]}",
+          path: "/#{URI.encode_uri_component(params[:tenant_id].to_s)}/user/#{URI.encode_uri_component(params[:user_id].to_s)}/metadata/v#{URI.encode_uri_component(params[:version].to_s)}",
           request_options: request_options
         )
         begin
@@ -207,7 +207,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:tenant_id]}/user/#{params[:user_id]}/specifics/#{params[:version]}/#{params[:thought]}",
+          path: "/#{URI.encode_uri_component(params[:tenant_id].to_s)}/user/#{URI.encode_uri_component(params[:user_id].to_s)}/specifics/#{URI.encode_uri_component(params[:version].to_s)}/#{URI.encode_uri_component(params[:thought].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/simple-api/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/simple-api/lib/seed/user/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/users/#{params[:id]}",
+          path: "/users/#{URI.encode_uri_component(params[:id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/trace/lib/seed/admin/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/admin/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/admin/store-test-submission-status/#{params[:submission_id]}",
+          path: "/admin/store-test-submission-status/#{URI.encode_uri_component(params[:submission_id].to_s)}",
           body: Seed::Submission::Types::TestSubmissionStatus.new(params).to_h,
           request_options: request_options
         )
@@ -56,7 +56,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/admin/store-test-submission-status-v2/#{params[:submission_id]}",
+          path: "/admin/store-test-submission-status-v2/#{URI.encode_uri_component(params[:submission_id].to_s)}",
           body: Seed::Submission::Types::TestSubmissionUpdate.new(params).to_h,
           request_options: request_options
         )
@@ -87,7 +87,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/admin/store-workspace-submission-status/#{params[:submission_id]}",
+          path: "/admin/store-workspace-submission-status/#{URI.encode_uri_component(params[:submission_id].to_s)}",
           body: Seed::Submission::Types::WorkspaceSubmissionStatus.new(params).to_h,
           request_options: request_options
         )
@@ -118,7 +118,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/admin/store-workspace-submission-status-v2/#{params[:submission_id]}",
+          path: "/admin/store-workspace-submission-status-v2/#{URI.encode_uri_component(params[:submission_id].to_s)}",
           body: Seed::Submission::Types::WorkspaceSubmissionUpdate.new(params).to_h,
           request_options: request_options
         )
@@ -154,7 +154,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/admin/store-test-trace/submission/#{params[:submission_id]}/testCase/#{params[:test_case_id]}",
+          path: "/admin/store-test-trace/submission/#{URI.encode_uri_component(params[:submission_id].to_s)}/testCase/#{URI.encode_uri_component(params[:test_case_id].to_s)}",
           body: body,
           request_options: request_options
         )
@@ -186,7 +186,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/admin/store-test-trace-v2/submission/#{params[:submission_id]}/testCase/#{params[:test_case_id]}",
+          path: "/admin/store-test-trace-v2/submission/#{URI.encode_uri_component(params[:submission_id].to_s)}/testCase/#{URI.encode_uri_component(params[:test_case_id].to_s)}",
           body: params,
           request_options: request_options
         )
@@ -221,7 +221,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/admin/store-workspace-trace/submission/#{params[:submission_id]}",
+          path: "/admin/store-workspace-trace/submission/#{URI.encode_uri_component(params[:submission_id].to_s)}",
           body: body,
           request_options: request_options
         )
@@ -252,7 +252,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/admin/store-workspace-trace-v2/submission/#{params[:submission_id]}",
+          path: "/admin/store-workspace-trace-v2/submission/#{URI.encode_uri_component(params[:submission_id].to_s)}",
           body: params,
           request_options: request_options
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/playlist/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/playlist/client.rb
@@ -38,7 +38,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/v2/playlist/#{params[:service_param]}/create",
+          path: "/v2/playlist/#{URI.encode_uri_component(params[:service_param].to_s)}/create",
           query: query_params,
           body: Seed::Playlist::Types::PlaylistCreateRequest.new(body_params).to_h,
           request_options: request_options
@@ -88,7 +88,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/v2/playlist/#{params[:service_param]}/all",
+          path: "/v2/playlist/#{URI.encode_uri_component(params[:service_param].to_s)}/all",
           query: query_params,
           request_options: request_options
         )
@@ -122,7 +122,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/v2/playlist/#{params[:service_param]}/#{params[:playlist_id]}",
+          path: "/v2/playlist/#{URI.encode_uri_component(params[:service_param].to_s)}/#{URI.encode_uri_component(params[:playlist_id].to_s)}",
           request_options: request_options
         )
         begin
@@ -157,7 +157,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "PUT",
-          path: "/v2/playlist/#{params[:service_param]}/#{params[:playlist_id]}",
+          path: "/v2/playlist/#{URI.encode_uri_component(params[:service_param].to_s)}/#{URI.encode_uri_component(params[:playlist_id].to_s)}",
           body: params,
           request_options: request_options
         )
@@ -191,7 +191,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "DELETE",
-          path: "/v2/playlist/#{params[:service_param]}/#{params[:playlist_id]}",
+          path: "/v2/playlist/#{URI.encode_uri_component(params[:service_param].to_s)}/#{URI.encode_uri_component(params[:playlist_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/trace/lib/seed/problem/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/problem/client.rb
@@ -61,7 +61,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/problem-crud/update/#{params[:problem_id]}",
+          path: "/problem-crud/update/#{URI.encode_uri_component(params[:problem_id].to_s)}",
           body: Seed::Problem::Types::CreateProblemRequest.new(params).to_h,
           request_options: request_options
         )
@@ -96,7 +96,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "DELETE",
-          path: "/problem-crud/delete/#{params[:problem_id]}",
+          path: "/problem-crud/delete/#{URI.encode_uri_component(params[:problem_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/trace/lib/seed/submission/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/submission/client.rb
@@ -27,7 +27,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/sessions/create-session/#{params[:language]}",
+          path: "/sessions/create-session/#{URI.encode_uri_component(params[:language].to_s)}",
           request_options: request_options
         )
         begin
@@ -61,7 +61,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/sessions/#{params[:session_id]}",
+          path: "/sessions/#{URI.encode_uri_component(params[:session_id].to_s)}",
           request_options: request_options
         )
         begin
@@ -93,7 +93,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "DELETE",
-          path: "/sessions/stop/#{params[:session_id]}",
+          path: "/sessions/stop/#{URI.encode_uri_component(params[:session_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/trace/lib/seed/sysprop/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/sysprop/client.rb
@@ -26,7 +26,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "PUT",
-          path: "/sysprop/num-warm-instances/#{params[:language]}/#{params[:num_warm_instances]}",
+          path: "/sysprop/num-warm-instances/#{URI.encode_uri_component(params[:language].to_s)}/#{URI.encode_uri_component(params[:num_warm_instances].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/trace/lib/seed/v_2/problem/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/v_2/problem/client.rb
@@ -90,7 +90,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/problems-v2/problem-info/#{params[:problem_id]}",
+            path: "/problems-v2/problem-info/#{URI.encode_uri_component(params[:problem_id].to_s)}",
             request_options: request_options
           )
           begin
@@ -125,7 +125,7 @@ module Seed
           request = Seed::Internal::JSON::Request.new(
             base_url: request_options[:base_url],
             method: "GET",
-            path: "/problems-v2/problem-info/#{params[:problem_id]}/version/#{params[:problem_version]}",
+            path: "/problems-v2/problem-info/#{URI.encode_uri_component(params[:problem_id].to_s)}/version/#{URI.encode_uri_component(params[:problem_version].to_s)}",
             request_options: request_options
           )
           begin

--- a/seed/ruby-sdk-v2/trace/lib/seed/v_2/v_3/problem/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/v_2/v_3/problem/client.rb
@@ -91,7 +91,7 @@ module Seed
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
-              path: "/problems-v2/problem-info/#{params[:problem_id]}",
+              path: "/problems-v2/problem-info/#{URI.encode_uri_component(params[:problem_id].to_s)}",
               request_options: request_options
             )
             begin
@@ -126,7 +126,7 @@ module Seed
             request = Seed::Internal::JSON::Request.new(
               base_url: request_options[:base_url],
               method: "GET",
-              path: "/problems-v2/problem-info/#{params[:problem_id]}/version/#{params[:problem_version]}",
+              path: "/problems-v2/problem-info/#{URI.encode_uri_component(params[:problem_id].to_s)}/version/#{URI.encode_uri_component(params[:problem_version].to_s)}",
               request_options: request_options
             )
             begin

--- a/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/bigunion/client.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/bigunion/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:id]}",
+          path: "/#{URI.encode_uri_component(params[:id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/types/client.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/types/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/time/#{params[:id]}",
+          path: "/time/#{URI.encode_uri_component(params[:id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/union/client.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/union/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:id]}",
+          path: "/#{URI.encode_uri_component(params[:id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/unions/lib/seed/bigunion/client.rb
+++ b/seed/ruby-sdk-v2/unions/lib/seed/bigunion/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:id]}",
+          path: "/#{URI.encode_uri_component(params[:id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/unions/lib/seed/union/client.rb
+++ b/seed/ruby-sdk-v2/unions/lib/seed/union/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/#{params[:id]}",
+          path: "/#{URI.encode_uri_component(params[:id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/variables/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/variables/lib/seed/service/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "POST",
-          path: "/#{params[:endpoint_param]}",
+          path: "/#{URI.encode_uri_component(params[:endpoint_param].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/version-no-default/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/version-no-default/lib/seed/user/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/users/#{params[:user_id]}",
+          path: "/users/#{URI.encode_uri_component(params[:user_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/version-no-default/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/version-no-default/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/version-no-default/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/version-no-default/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,

--- a/seed/ruby-sdk-v2/version/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/version/lib/seed/user/client.rb
@@ -25,7 +25,7 @@ module Seed
         request = Seed::Internal::JSON::Request.new(
           base_url: request_options[:base_url],
           method: "GET",
-          path: "/users/#{params[:user_id]}",
+          path: "/users/#{URI.encode_uri_component(params[:user_id].to_s)}",
           request_options: request_options
         )
         begin

--- a/seed/ruby-sdk-v2/version/test/unit/internal/iterators/test_cursor_item_iterator.rb
+++ b/seed/ruby-sdk-v2/version/test/unit/internal/iterators/test_cursor_item_iterator.rb
@@ -6,7 +6,7 @@ require "json"
 require "test_helper"
 
 NUMBERS = (1..65).to_a
-PageResponse = Struct.new(:cards, :next_cursor)
+PageResponse = Struct.new(:cards, :next_cursor, keyword_init: true)
 
 class CursorItemIteratorTest < Minitest::Test
   def make_iterator(initial_cursor:)

--- a/seed/ruby-sdk-v2/version/test/unit/internal/iterators/test_offset_item_iterator.rb
+++ b/seed/ruby-sdk-v2/version/test/unit/internal/iterators/test_offset_item_iterator.rb
@@ -5,7 +5,7 @@ require "stringio"
 require "json"
 require "test_helper"
 
-OffsetPageResponse = Struct.new(:items, :has_next)
+OffsetPageResponse = Struct.new(:items, :has_next, keyword_init: true)
 TestIteratorConfig = Struct.new(
   :step,
   :has_next_field,


### PR DESCRIPTION
## Description
(1) Pagination code would initialize `query_params` with string keys (`"page"`), but index it with symbol keys (`:page`), causing both to end up in the request, leading to a 400; now we just use string keys.
(2) Path parameters are now wrapped with `URI.encode_uri_component` to avoid special characters like `|` causing a `URI::InvalidURIError`.

## Changes Made
`ruby-v2` generator.

## Testing
All seed fixtures regenerated; the three pagination fixtures reflect fix (1), all fixtures reflect fix (2).
- [X] Unit tests added/updated
- [X] Manual testing completed
