### PR TITLE
fix(rust): derive meaningful variant names for container types in undiscriminated unions

### DIFF
--- a/generators/rust/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/rust/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -808,30 +808,85 @@ export class DynamicTypeLiteralMapper {
     }
 
     private getUndiscriminatedUnionVariantName(typeReference: FernIr.dynamic.TypeReference): string {
+        const name = this.getInnerTypeVariantName(typeReference);
+        if (name) {
+            return name;
+        }
+
+        // Handle container types with inner type information
+        switch (typeReference.type) {
+            case "list": {
+                const innerName = this.getInnerTypeVariantName(typeReference.value);
+                return innerName ? `${innerName}List` : "List";
+            }
+            case "set": {
+                const innerName = this.getInnerTypeVariantName(typeReference.value);
+                return innerName ? `${innerName}Set` : "Set";
+            }
+            case "map": {
+                const keyName = this.getInnerTypeVariantName(typeReference.key);
+                const valueName = this.getInnerTypeVariantName(typeReference.value);
+                if (keyName && valueName) {
+                    return `${keyName}To${valueName}Map`;
+                }
+                return "Map";
+            }
+            case "optional": {
+                const innerName = this.getInnerTypeVariantName(typeReference.value);
+                return innerName ? `Optional${innerName}` : "Optional";
+            }
+            case "nullable": {
+                const innerName = this.getInnerTypeVariantName(typeReference.value);
+                return innerName ? `Nullable${innerName}` : "Nullable";
+            }
+            default:
+                return "Unknown";
+        }
+    }
+
+    /**
+     * Gets a meaningful variant name for a named or primitive type reference.
+     * Returns undefined for container or unknown types.
+     */
+    private getInnerTypeVariantName(typeReference: FernIr.dynamic.TypeReference): string | undefined {
         switch (typeReference.type) {
             case "named": {
                 const namedType = this.context.ir.types[typeReference.value];
-                if (namedType) {
-                    return namedType.declaration.name.pascalCase.safeName;
-                }
-                return "Unknown";
+                return namedType?.declaration.name.pascalCase.safeName;
             }
             case "primitive":
-                // Map primitive types to Rust variant names
                 switch (typeReference.value) {
                     case "STRING":
                         return "String";
-                    case "INTEGER":
-                        return "Integer";
                     case "BOOLEAN":
                         return "Boolean";
+                    case "INTEGER":
+                        return "Integer";
+                    case "LONG":
+                        return "Long";
                     case "DOUBLE":
                         return "Double";
+                    case "FLOAT":
+                        return "Float";
+                    case "DATE_TIME":
+                        return "DateTime";
+                    case "DATE":
+                        return "Date";
+                    case "UUID":
+                        return "Uuid";
+                    case "BASE_64":
+                        return "Base64";
+                    case "BIG_INTEGER":
+                        return "BigInteger";
+                    case "UINT":
+                        return "Uint";
+                    case "UINT_64":
+                        return "Uint64";
                     default:
-                        return "Unknown";
+                        return undefined;
                 }
             default:
-                return "Unknown";
+                return undefined;
         }
     }
 

--- a/generators/rust/model/src/union/UndiscriminatedUnionGenerator.ts
+++ b/generators/rust/model/src/union/UndiscriminatedUnionGenerator.ts
@@ -135,60 +135,100 @@ export class UndiscriminatedUnionGenerator {
         if (memberType.type === "named") {
             return memberType.name.pascalCase.unsafeName;
         } else if (memberType.type === "primitive") {
-            // Handle primitive types
-            const primitiveType = memberType.primitive.v1;
-            switch (primitiveType) {
-                case "STRING":
-                    return "String";
-                case "BOOLEAN":
-                    return "Boolean";
-                case "INTEGER":
-                    return "Integer";
-                case "LONG":
-                    return "Long";
-                case "DOUBLE":
-                    return "Double";
-                case "DATE_TIME":
-                    return "DateTime";
-                case "DATE":
-                    return "Date";
-                case "UUID":
-                    return "Uuid";
-                case "BASE_64":
-                    return "Base64";
-                default:
-                    return `Variant${index}`;
-            }
+            return this.getPrimitiveVariantName(memberType.primitive.v1) ?? `Variant${index}`;
         } else if (memberType.type === "container") {
-            // Handle container types - include inner type information to avoid conflicts
-            const containerType = memberType.container.type;
-            switch (containerType) {
-                case "list": {
-                    // Try to get the inner type name to make it unique
-                    const listInnerType = memberType.container.list;
-                    if (listInnerType.type === "named") {
-                        return `${listInnerType.name.pascalCase.unsafeName}List`;
-                    }
-                    return `List${index}`;
-                }
-                case "map":
-                    return `Map${index}`;
-                case "set":
-                    return `Set${index}`;
-                case "optional":
-                    return `Optional${index}`;
-                case "nullable":
-                    return `Nullable${index}`;
-                case "literal":
-                    return `Literal${index}`;
-                default:
-                    return `Container${index}`;
-            }
+            return this.getContainerVariantName(memberType.container, index);
         } else if (memberType.type === "unknown") {
             return "Unknown";
         } else {
             // Fallback to indexed variant name
             return `Variant${index}`;
+        }
+    }
+
+    /**
+     * Maps a primitive type to a meaningful variant name.
+     */
+    private getPrimitiveVariantName(primitiveType: string): string | undefined {
+        switch (primitiveType) {
+            case "STRING":
+                return "String";
+            case "BOOLEAN":
+                return "Boolean";
+            case "INTEGER":
+                return "Integer";
+            case "LONG":
+                return "Long";
+            case "DOUBLE":
+                return "Double";
+            case "FLOAT":
+                return "Float";
+            case "DATE_TIME":
+                return "DateTime";
+            case "DATE":
+                return "Date";
+            case "UUID":
+                return "Uuid";
+            case "BASE_64":
+                return "Base64";
+            case "BIG_INTEGER":
+                return "BigInteger";
+            case "UINT":
+                return "Uint";
+            case "UINT_64":
+                return "Uint64";
+            default:
+                return undefined;
+        }
+    }
+
+    /**
+     * Derives a meaningful variant name from any type reference.
+     * Returns undefined if no meaningful name can be determined.
+     */
+    private getInnerTypeName(typeRef: FernIr.TypeReference): string | undefined {
+        if (typeRef.type === "named") {
+            return typeRef.name.pascalCase.unsafeName;
+        } else if (typeRef.type === "primitive") {
+            return this.getPrimitiveVariantName(typeRef.primitive.v1);
+        }
+        return undefined;
+    }
+
+    /**
+     * Generates a variant name for container types, using inner type information
+     * to produce meaningful names (e.g. "DoubleList" instead of "List1").
+     */
+    private getContainerVariantName(container: FernIr.ContainerType, index: number): string {
+        switch (container.type) {
+            case "list": {
+                const innerName = this.getInnerTypeName(container.list);
+                return innerName ? `${innerName}List` : `List${index}`;
+            }
+            case "set": {
+                const innerName = this.getInnerTypeName(container.set);
+                return innerName ? `${innerName}Set` : `Set${index}`;
+            }
+            case "map": {
+                const keyName = this.getInnerTypeName(container.keyType);
+                const valueName = this.getInnerTypeName(container.valueType);
+                if (keyName && valueName) {
+                    return `${keyName}To${valueName}Map`;
+                }
+                return `Map${index}`;
+            }
+            case "optional": {
+                const innerName = this.getInnerTypeName(container.optional);
+                return innerName ? `Optional${innerName}` : `Optional${index}`;
+            }
+            case "nullable": {
+                const innerName = this.getInnerTypeName(container.nullable);
+                return innerName ? `Nullable${innerName}` : `Nullable${index}`;
+            }
+            case "literal":
+                return `Literal${index}`;
+            default:
+                return `Container${index}`;
         }
     }
 

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.19.9
+  changelogEntry:
+    - summary: |
+        Fix undiscriminated union variant naming for container types with primitive inner types.
+        Previously, variants like `Vec<f64>` produced index-based names (e.g. `List1`). Now they
+        derive meaningful names from the inner type (e.g. `DoubleList`). Also applies to set, map,
+        optional, and nullable containers.
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 62
+
 - version: 0.19.8
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Linear ticket: Closes FER-9132

Undiscriminated union variants for container types with primitive inner types (e.g. `Vec<f64>`) were producing index-based names like `List1` instead of meaningful names like `DoubleList`. This happened because `getVariantNameForMember` only extracted inner type info for `named` types, falling back to `${ContainerType}${index}` for primitives.

## Changes Made

- **Model generator** (`UndiscriminatedUnionGenerator.ts`): Refactored variant naming into three helpers:
  - `getPrimitiveVariantName` — maps all primitive types (added missing `FLOAT`, `BIG_INTEGER`, `UINT`, `UINT_64`)
  - `getInnerTypeName` — resolves a meaningful name from named or primitive type references
  - `getContainerVariantName` — generates `{InnerType}{Container}` names for list, set, map, optional, nullable (e.g. `DoubleList`, `StringToIntegerMap`, `OptionalUuid`)
- **Dynamic snippets** (`DynamicTypeLiteralMapper.ts`): Mirrored the same fix with `getInnerTypeVariantName` to keep variant names in sync
- Added `versions.yml` entry (0.19.9)

### Naming examples after fix
| Type | Before | After |
|------|--------|-------|
| `Vec<f64>` (index 1) | `List1` | `DoubleList` |
| `HashSet<String>` (index 2) | `Set2` | `StringSet` |
| `HashMap<String, i64>` (index 0) | `Map0` | `StringToLongMap` |
| `Option<Uuid>` (index 3) | `Optional3` | `OptionalUuid` |

## ⚠️ Key Review Items

1. **Breaking rename**: This changes generated variant names for existing SDKs. Consumers referencing old names like `List1` will need to update. Acceptable as a bug fix?
2. **Fallback inconsistency**: When inner type can't be resolved, the model generator falls back to `List${index}` (with index) while dynamic-snippets falls back to `"List"` (without index). This could cause snippet/model mismatch for edge cases like nested containers (`Vec<Vec<...>>`). Should the dynamic-snippets also use an index?

## Testing

- [x] Lint/biome check passes
- [ ] Seed test fixtures not yet updated — variant name changes will likely cause snapshot diffs in existing fixtures with undiscriminated unions containing primitive containers

Link to Devin session: https://app.devin.ai/sessions/b5e6f78a38604f3e9bcd871682e496d5
Requested by: @iamnamananand996