### PR TITLE
fix(cli): populate apiNameToId in local docs preview for Schema component

### DIFF
--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -256,6 +256,7 @@ export async function getPreviewDocsDefinition({
     const apiCollectorV2 = new ReferencedAPICollectorV2(context);
 
     const filesV2: Record<string, DocsV1Read.File_> = {};
+    const apiNameToIdMap: Record<string, string> = {};
 
     const resolver = new DocsDefinitionResolver({
         domain,
@@ -277,7 +278,13 @@ export async function getPreviewDocsDefinition({
                     fileId
                 };
             }),
-        registerApi: async (opts) => apiCollector.addReferencedAPI(opts),
+        registerApi: async (opts) => {
+            const id = apiCollector.addReferencedAPI(opts);
+            if (opts.apiName != null) {
+                apiNameToIdMap[opts.apiName] = id;
+            }
+            return id;
+        },
         targetAudiences: undefined
     });
 
@@ -313,7 +320,7 @@ export async function getPreviewDocsDefinition({
         filesV2,
         pages: dbDocsDefinition.pages,
         jsFiles: dbDocsDefinition.jsFiles,
-        apiNameToId: {},
+        apiNameToId: apiNameToIdMap,
         id: undefined
     };
 

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -256,7 +256,7 @@ export async function getPreviewDocsDefinition({
     const apiCollectorV2 = new ReferencedAPICollectorV2(context);
 
     const filesV2: Record<string, DocsV1Read.File_> = {};
-    const apiNameToIdMap: Record<string, string> = {};
+    const apiNameToIdMap: Record<string, FdrAPI.ApiDefinitionId> = {};
 
     const resolver = new DocsDefinitionResolver({
         domain,
@@ -281,7 +281,7 @@ export async function getPreviewDocsDefinition({
         registerApi: async (opts) => {
             const id = apiCollector.addReferencedAPI(opts);
             if (opts.apiName != null) {
-                apiNameToIdMap[opts.apiName] = id;
+                apiNameToIdMap[opts.apiName] = FdrAPI.ApiDefinitionId(id);
             }
             return id;
         },


### PR DESCRIPTION
## Description

Fixes the Schema component showing referenced types as `any` when running `fern docs dev` locally. The `apiNameToId` field in the local preview docs definition was always set to `{}`, so `getTypes()` could never resolve types via the `apiNameToId` lookup path.

Companion to [fern-platform#8767](https://github.com/fern-api/fern-platform/pull/8767), which simplifies `getTypes()` to use `apiNameToId` exclusively.

## Changes Made

- Capture the `apiName` → definition ID mapping (as branded `FdrAPI.ApiDefinitionId`) from each `registerApi` call during docs resolution
- Pass the populated `apiNameToIdMap` into the docs definition instead of an empty `{}`

## Testing

- [ ] Manual testing with `fern docs dev` on a project using `<Schema api="..." type="..." />` with nested `$ref` types
- No unit tests added — this is a local preview code path

## Review Checklist

- [ ] **Deployment ordering**: the fern-platform companion PR (#8767) removes the `apis` (v1) inline fallback in `getTypes()` and relies solely on `apiNameToId`. If that PR merges before this one ships in a CLI release, local preview will have no type resolution at all until users update their CLI. Confirm acceptable rollout order.
- [ ] Verify `opts.apiName` is reliably passed by `DocsDefinitionResolver` (it derives from `item.apiName ?? workspace.workspaceName`). If all three sources are `undefined`, the mapping won't be populated for that API.
- [ ] The incremental reload path (markdown-only edits reusing `previousDocsDefinition`) returns early and doesn't re-run `registerApi`, so `apiNameToId` from the initial full load is preserved — confirm this is correct.

Link to Devin session: https://app.devin.ai/sessions/4aae30fdee504a1a8d54a86fc3c6c336
Requested by: @alecharmon
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
