### PR TITLE
fix(parser): read asyncapi v3 query params and headers from `channel.bindings.ws`

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
@@ -369,6 +369,125 @@ export function parseAsyncAPIV3({
             }
         }
 
+        // Also read query parameters from channel.bindings.ws.query (the standard
+        // WebSocket binding location per the AsyncAPI WebSocket bindings spec).
+        // Skip any parameters already added from channel.parameters to avoid duplicates.
+        if (channel.bindings?.ws?.query != null) {
+            const queryParamNames = new Set(queryParameters.map((qp) => qp.name));
+            const required = channel.bindings.ws.query.required ?? [];
+            for (const [name, schema] of Object.entries(channel.bindings.ws.query.properties ?? {})) {
+                if (queryParamNames.has(name)) {
+                    continue;
+                }
+                if (isReferenceObject(schema)) {
+                    const resolvedSchema = context.resolveSchemaReference(schema);
+                    const isRequired = required.includes(name);
+                    const [isOptional, isNullable] = context.options.coerceOptionalSchemasToNullable
+                        ? [false, !isRequired]
+                        : [!isRequired, false];
+                    queryParameters.push({
+                        name,
+                        schema: convertReferenceObject(
+                            schema,
+                            isOptional,
+                            isNullable,
+                            context,
+                            [channelPath, name],
+                            undefined,
+                            source,
+                            context.namespace
+                        ),
+                        description: resolvedSchema.description,
+                        parameterNameOverride: undefined,
+                        availability: convertAvailability(resolvedSchema),
+                        source,
+                        explode: undefined
+                    });
+                    continue;
+                }
+                const isRequired = required.includes(name);
+                const [isOptional, isNullable] = context.options.coerceOptionalSchemasToNullable
+                    ? [false, !isRequired]
+                    : [!isRequired, false];
+                queryParameters.push({
+                    name,
+                    schema: convertSchema(
+                        schema,
+                        isOptional,
+                        isNullable,
+                        context,
+                        [channelPath, name],
+                        source,
+                        context.namespace
+                    ),
+                    description: schema.description,
+                    parameterNameOverride: undefined,
+                    availability: convertAvailability(schema),
+                    source,
+                    explode: undefined
+                });
+            }
+        }
+
+        // Also read headers from channel.bindings.ws.headers (standard WebSocket binding location).
+        // Skip any headers already added from channel.parameters to avoid duplicates.
+        if (channel.bindings?.ws?.headers != null) {
+            const headerNames = new Set(headers.map((h) => h.name));
+            const required = channel.bindings.ws.headers.required ?? [];
+            for (const [name, schema] of Object.entries(channel.bindings.ws.headers.properties ?? {})) {
+                if (headerNames.has(name)) {
+                    continue;
+                }
+                if (isReferenceObject(schema)) {
+                    const resolvedSchema = context.resolveSchemaReference(schema);
+                    const isRequired = required.includes(name);
+                    const [isOptional, isNullable] = context.options.coerceOptionalSchemasToNullable
+                        ? [false, !isRequired]
+                        : [!isRequired, false];
+                    headers.push({
+                        name,
+                        schema: convertReferenceObject(
+                            schema,
+                            isOptional,
+                            isNullable,
+                            context,
+                            [channelPath, name],
+                            undefined,
+                            source,
+                            context.namespace
+                        ),
+                        description: resolvedSchema.description,
+                        parameterNameOverride: undefined,
+                        env: undefined,
+                        availability: convertAvailability(resolvedSchema),
+                        source
+                    });
+                    continue;
+                }
+                const isRequired = required.includes(name);
+                const [isOptional, isNullable] = context.options.coerceOptionalSchemasToNullable
+                    ? [false, !isRequired]
+                    : [!isRequired, false];
+                headers.push({
+                    name,
+                    schema: convertSchema(
+                        schema,
+                        isOptional,
+                        isNullable,
+                        context,
+                        [channelPath, name],
+                        source,
+                        context.namespace
+                    ),
+                    description: schema.description,
+                    parameterNameOverride: undefined,
+                    env: undefined,
+                    availability: convertAvailability(schema),
+                    source
+                });
+            }
+        }
+
         if (
             headers.length > 0 ||
             queryParameters.length > 0 ||

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
@@ -374,14 +374,14 @@ export function parseAsyncAPIV3({
         // Skip any parameters already added from channel.parameters to avoid duplicates.
         if (channel.bindings?.ws?.query != null) {
             const queryParamNames = new Set(queryParameters.map((qp) => qp.name));
-            const required = channel.bindings.ws.query.required ?? [];
+            const requiredSet = new Set(channel.bindings.ws.query.required ?? []);
             for (const [name, schema] of Object.entries(channel.bindings.ws.query.properties ?? {})) {
                 if (queryParamNames.has(name)) {
                     continue;
                 }
                 if (isReferenceObject(schema)) {
                     const resolvedSchema = context.resolveSchemaReference(schema);
-                    const isRequired = required.includes(name);
+                    const isRequired = requiredSet.has(name);
                     const [isOptional, isNullable] = context.options.coerceOptionalSchemasToNullable
                         ? [false, !isRequired]
                         : [!isRequired, false];
@@ -405,7 +405,7 @@ export function parseAsyncAPIV3({
                     });
                     continue;
                 }
-                const isRequired = required.includes(name);
+                const isRequired = requiredSet.has(name);
                 const [isOptional, isNullable] = context.options.coerceOptionalSchemasToNullable
                     ? [false, !isRequired]
                     : [!isRequired, false];
@@ -433,14 +433,14 @@ export function parseAsyncAPIV3({
         // Skip any headers already added from channel.parameters to avoid duplicates.
         if (channel.bindings?.ws?.headers != null) {
             const headerNames = new Set(headers.map((h) => h.name));
-            const required = channel.bindings.ws.headers.required ?? [];
+            const requiredSet = new Set(channel.bindings.ws.headers.required ?? []);
             for (const [name, schema] of Object.entries(channel.bindings.ws.headers.properties ?? {})) {
                 if (headerNames.has(name)) {
                     continue;
                 }
                 if (isReferenceObject(schema)) {
                     const resolvedSchema = context.resolveSchemaReference(schema);
-                    const isRequired = required.includes(name);
+                    const isRequired = requiredSet.has(name);
                     const [isOptional, isNullable] = context.options.coerceOptionalSchemasToNullable
                         ? [false, !isRequired]
                         : [!isRequired, false];
@@ -464,7 +464,7 @@ export function parseAsyncAPIV3({
                     });
                     continue;
                 }
-                const isRequired = required.includes(name);
+                const isRequired = requiredSet.has(name);
                 const [isOptional, isNullable] = context.options.coerceOptionalSchemasToNullable
                     ? [false, !isRequired]
                     : [!isRequired, false];

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/asyncapi-v3-bindings-query.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/asyncapi-v3-bindings-query.json
@@ -1,0 +1,329 @@
+{
+  "servers": [],
+  "websocketServers": [
+    {
+      "name": "production",
+      "url": "wss://api.example.com"
+    }
+  ],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [],
+  "webhooks": [],
+  "channels": {
+    "listen": {
+      "audiences": [],
+      "handshake": {
+        "headers": [
+          {
+            "name": "Authorization",
+            "schema": {
+              "generatedName": "ListenAuthorization",
+              "description": "Bearer token for authentication",
+              "value": {
+                "description": "Bearer token for authentication",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "ListenAuthorization",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "description": "Bearer token for authentication",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            }
+          }
+        ],
+        "queryParameters": [
+          {
+            "name": "model",
+            "schema": {
+              "generatedName": "ListenModel",
+              "schema": "Model",
+              "source": {
+                "file": "../asyncapi.yml",
+                "type": "openapi"
+              },
+              "type": "reference"
+            },
+            "description": "The AI model to use for transcription",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            }
+          },
+          {
+            "name": "encoding",
+            "schema": {
+              "generatedName": "ListenEncoding",
+              "value": {
+                "generatedName": "ListenEncoding",
+                "schema": "Encoding",
+                "source": {
+                  "file": "../asyncapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "description": "Encoding of the audio",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            }
+          },
+          {
+            "name": "sample_rate",
+            "schema": {
+              "generatedName": "ListenSampleRate",
+              "description": "Sample rate of the audio in Hz",
+              "value": {
+                "description": "Sample rate of the audio in Hz",
+                "schema": {
+                  "type": "int"
+                },
+                "generatedName": "ListenSampleRate",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "description": "Sample rate of the audio in Hz",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            }
+          }
+        ],
+        "pathParameters": []
+      },
+      "groupName": [
+        "listen"
+      ],
+      "messages": [
+        {
+          "origin": "server",
+          "name": "Transcript",
+          "body": {
+            "generatedName": "Transcript",
+            "schema": "TranscriptPayload",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          }
+        },
+        {
+          "origin": "client",
+          "name": "AudioData",
+          "body": {
+            "generatedName": "AudioData",
+            "schema": "AudioPayload",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          }
+        }
+      ],
+      "servers": [
+        {
+          "name": "production",
+          "url": "wss://api.example.com"
+        }
+      ],
+      "path": "/v1/listen",
+      "description": "Channel with query parameters defined via bindings.ws.query",
+      "examples": [
+        {
+          "queryParameters": [],
+          "headers": [],
+          "messages": [
+            {
+              "messageType": "AudioData",
+              "payload": {
+                "properties": {},
+                "type": "object"
+              }
+            },
+            {
+              "messageType": "Transcript",
+              "payload": {
+                "properties": {},
+                "type": "object"
+              }
+            }
+          ]
+        }
+      ],
+      "source": {
+        "file": "../asyncapi.yml",
+        "type": "openapi"
+      }
+    }
+  },
+  "groupedSchemas": {
+    "rootSchemas": {
+      "Model": {
+        "generatedName": "Model",
+        "values": [
+          {
+            "generatedName": "Nova2",
+            "value": "nova-2",
+            "casing": {}
+          },
+          {
+            "generatedName": "Nova3",
+            "value": "nova-3",
+            "casing": {}
+          },
+          {
+            "generatedName": "whisper",
+            "value": "whisper",
+            "casing": {}
+          }
+        ],
+        "description": "The AI model to use for transcription",
+        "groupName": [],
+        "source": {
+          "file": "../asyncapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "Encoding": {
+        "generatedName": "Encoding",
+        "values": [
+          {
+            "generatedName": "linear16",
+            "value": "linear16",
+            "casing": {}
+          },
+          {
+            "generatedName": "flac",
+            "value": "flac",
+            "casing": {}
+          },
+          {
+            "generatedName": "opus",
+            "value": "opus",
+            "casing": {}
+          }
+        ],
+        "description": "Encoding of the audio",
+        "groupName": [],
+        "source": {
+          "file": "../asyncapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "AudioPayload": {
+        "properties": [
+          {
+            "key": "data",
+            "schema": {
+              "generatedName": "AudioPayloadData",
+              "value": {
+                "generatedName": "AudioPayloadData",
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                },
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": [],
+            "conflict": {},
+            "generatedName": "audioPayloadData"
+          }
+        ],
+        "generatedName": "AudioPayload",
+        "allOf": [],
+        "allOfPropertyConflicts": [],
+        "groupName": [],
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../asyncapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "TranscriptPayload": {
+        "properties": [
+          {
+            "key": "transcript",
+            "schema": {
+              "generatedName": "TranscriptPayloadTranscript",
+              "value": {
+                "generatedName": "TranscriptPayloadTranscript",
+                "schema": {
+                  "type": "string"
+                },
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": [],
+            "conflict": {},
+            "generatedName": "transcriptPayloadTranscript"
+          },
+          {
+            "key": "confidence",
+            "schema": {
+              "generatedName": "TranscriptPayloadConfidence",
+              "value": {
+                "generatedName": "TranscriptPayloadConfidence",
+                "schema": {
+                  "type": "double"
+                },
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": [],
+            "conflict": {},
+            "generatedName": "transcriptPayloadConfidence"
+          }
+        ],
+        "generatedName": "TranscriptPayload",
+        "allOf": [],
+        "allOfPropertyConflicts": [],
+        "groupName": [],
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../asyncapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v3-bindings-query.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v3-bindings-query.json
@@ -1,0 +1,223 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "types": {
+          "AudioPayload": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "data": {
+                "type": "optional<string>",
+                "validation": {
+                  "format": "binary",
+                  "maxLength": undefined,
+                  "minLength": undefined,
+                  "pattern": undefined,
+                },
+              },
+            },
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+          "Encoding": {
+            "docs": "Encoding of the audio",
+            "enum": [
+              "linear16",
+              "flac",
+              "opus",
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+          "Model": {
+            "docs": "The AI model to use for transcription",
+            "enum": [
+              {
+                "name": "Nova2",
+                "value": "nova-2",
+              },
+              {
+                "name": "Nova3",
+                "value": "nova-3",
+              },
+              "whisper",
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+          "TranscriptPayload": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "confidence": "optional<double>",
+              "transcript": "optional<string>",
+            },
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  Model:
+    enum:
+      - value: nova-2
+        name: Nova2
+      - value: nova-3
+        name: Nova3
+      - whisper
+    docs: The AI model to use for transcription
+    source:
+      openapi: ../asyncapi.yml
+  Encoding:
+    enum:
+      - linear16
+      - flac
+      - opus
+    docs: Encoding of the audio
+    source:
+      openapi: ../asyncapi.yml
+  AudioPayload:
+    properties:
+      data:
+        type: optional<string>
+        validation:
+          format: binary
+    source:
+      openapi: ../asyncapi.yml
+  TranscriptPayload:
+    properties:
+      transcript: optional<string>
+      confidence: optional<double>
+    source:
+      openapi: ../asyncapi.yml
+",
+    },
+    "listen.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "channel": {
+          "auth": false,
+          "docs": "Channel with query parameters defined via bindings.ws.query",
+          "examples": [
+            {
+              "messages": [
+                {
+                  "body": {},
+                  "type": "AudioData",
+                },
+                {
+                  "body": {},
+                  "type": "Transcript",
+                },
+              ],
+            },
+          ],
+          "headers": {
+            "Authorization": {
+              "docs": "Bearer token for authentication",
+              "name": "authorization",
+              "type": "optional<string>",
+            },
+          },
+          "messages": {
+            "AudioData": {
+              "body": "root.AudioPayload",
+              "origin": "client",
+            },
+            "Transcript": {
+              "body": "root.TranscriptPayload",
+              "origin": "server",
+            },
+          },
+          "path": "/v1/listen",
+          "query-parameters": {
+            "encoding": {
+              "docs": "Encoding of the audio",
+              "type": "optional<root.Encoding>",
+            },
+            "model": {
+              "docs": "The AI model to use for transcription",
+              "type": "root.Model",
+            },
+            "sample_rate": {
+              "docs": "Sample rate of the audio in Hz",
+              "type": "optional<integer>",
+            },
+          },
+          "url": undefined,
+        },
+        "imports": {
+          "root": "__package__.yml",
+        },
+      },
+      "rawContents": "imports:
+  root: __package__.yml
+channel:
+  path: /v1/listen
+  auth: false
+  docs: Channel with query parameters defined via bindings.ws.query
+  query-parameters:
+    model:
+      type: root.Model
+      docs: The AI model to use for transcription
+    encoding:
+      type: optional<root.Encoding>
+      docs: Encoding of the audio
+    sample_rate:
+      type: optional<integer>
+      docs: Sample rate of the audio in Hz
+  headers:
+    Authorization:
+      type: optional<string>
+      name: authorization
+      docs: Bearer token for authentication
+  messages:
+    Transcript:
+      origin: server
+      body: root.TranscriptPayload
+    AudioData:
+      origin: client
+      body: root.AudioPayload
+  examples:
+    - messages:
+        - type: AudioData
+          body: {}
+        - type: Transcript
+          body: {}
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "default-environment": "production",
+      "default-url": "Base",
+      "environments": {
+        "production": "wss://api.example.com",
+      },
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": "Base",
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+environments:
+  production: wss://api.example.com
+default-environment: production
+default-url: Base
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-bindings-query/asyncapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-bindings-query/asyncapi.yml
@@ -1,0 +1,102 @@
+asyncapi: 3.0.0
+
+info:
+  title: WebSocket Bindings Query Test API
+  version: 1.0.0
+  description: Tests that query parameters from channel.bindings.ws.query are parsed correctly
+
+servers:
+  production:
+    host: api.example.com
+    protocol: wss
+
+channels:
+  listen:
+    address: /v1/listen
+    description: Channel with query parameters defined via bindings.ws.query
+    bindings:
+      ws:
+        query:
+          type: object
+          properties:
+            model:
+              $ref: "#/components/schemas/Model"
+            encoding:
+              $ref: "#/components/schemas/Encoding"
+            sample_rate:
+              type: integer
+              description: Sample rate of the audio in Hz
+          required:
+            - model
+        headers:
+          type: object
+          properties:
+            Authorization:
+              type: string
+              description: Bearer token for authentication
+    messages:
+      AudioData:
+        $ref: "#/components/messages/AudioData"
+      Transcript:
+        $ref: "#/components/messages/Transcript"
+
+operations:
+  sendAudio:
+    action: send
+    channel:
+      $ref: "#/channels/listen"
+    messages:
+      - $ref: "#/channels/listen/messages/AudioData"
+
+  receiveTranscript:
+    action: receive
+    channel:
+      $ref: "#/channels/listen"
+    messages:
+      - $ref: "#/channels/listen/messages/Transcript"
+
+components:
+  messages:
+    AudioData:
+      name: AudioData
+      contentType: application/octet-stream
+      payload:
+        $ref: "#/components/schemas/AudioPayload"
+
+    Transcript:
+      name: Transcript
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/TranscriptPayload"
+
+  schemas:
+    Model:
+      type: string
+      description: The AI model to use for transcription
+      enum:
+        - nova-2
+        - nova-3
+        - whisper
+
+    Encoding:
+      type: string
+      description: Encoding of the audio
+      enum:
+        - linear16
+        - flac
+        - opus
+
+    AudioPayload:
+      type: object
+      properties:
+        data:
+          type: string
+          format: binary
+
+    TranscriptPayload:
+      type: object
+      properties:
+        transcript:
+          type: string
+        confidence:
+          type: number

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-bindings-query/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-bindings-query/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - asyncapi: ../asyncapi.yml

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.37.9
+  changelogEntry:
+    - summary: |
+        Fix AsyncAPI v3 parser to read WebSocket query parameters and headers
+        from `channel.bindings.ws.query` and `channel.bindings.ws.headers`, which
+        is the standard location per the AsyncAPI WebSocket bindings spec.
+        Previously the v3 parser only read from `channel.parameters`, which the
+        AsyncAPI spec reserves for path parameters. This caused WebSocket connect
+        options classes (e.g. `ConnectOptions`) to be missing from generated SDKs
+        when specs used the standard bindings location.
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 65
+
 - version: 4.37.8
   changelogEntry:
     - summary: |
@@ -20,6 +34,7 @@
       type: fix
   createdAt: "2026-03-19"
   irVersion: 65
+
 - version: 4.37.6
   changelogEntry:
     - summary: |

--- a/packages/cli/ete-tests/src/tests/write-definition/__snapshots__/writeDefinition.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/write-definition/__snapshots__/writeDefinition.test.ts.snap
@@ -744,12 +744,40 @@ channel:
       origin: client
   path: /v1/marketdata/{symbol}
   query-parameters:
+    auctions:
+      default: true
+      docs: Include auction events
+      type: optional<boolean>
+    bids:
+      default: true
+      docs: Include bids in change events
+      type: optional<boolean>
+    heartbeat:
+      default: false
+      docs: >-
+        Optionally add this parameter and set to true to receive a heartbeat
+        every 5 seconds
+      type: optional<boolean>
+    offers:
+      default: true
+      docs: Include asks in change events
+      type: optional<boolean>
     symbol:
       docs: >
         Symbols are formatted as CCY1CCY2 where prices are in CCY2 and
         quantities are in CCY1. To read more click
         [here](https://docs.sandbox.gemini.com/websocket-api/#symbols-and-minimums).
       type: Symbol
+    top_of_book:
+      default: false
+      docs: >-
+        If absent or false, receive full order book depth; if present and true,
+        receive top of book only. Only applies to bids and offers.
+      type: optional<boolean>
+    trades:
+      default: true
+      docs: Include trade events
+      type: optional<boolean>
   url: public
 ",
         "name": "marketDataV1.yml",

--- a/packages/cli/ete-tests/src/tests/write-definition/fixtures/namespaced/fern/.definition/stream/marketDataV1.yml
+++ b/packages/cli/ete-tests/src/tests/write-definition/fixtures/namespaced/fern/.definition/stream/marketDataV1.yml
@@ -87,10 +87,38 @@ channel:
       origin: client
   path: /v1/marketdata/{symbol}
   query-parameters:
+    auctions:
+      default: true
+      docs: Include auction events
+      type: optional<boolean>
+    bids:
+      default: true
+      docs: Include bids in change events
+      type: optional<boolean>
+    heartbeat:
+      default: false
+      docs: >-
+        Optionally add this parameter and set to true to receive a heartbeat
+        every 5 seconds
+      type: optional<boolean>
+    offers:
+      default: true
+      docs: Include asks in change events
+      type: optional<boolean>
     symbol:
       docs: >
         Symbols are formatted as CCY1CCY2 where prices are in CCY2 and
         quantities are in CCY1. To read more click
         [here](https://docs.sandbox.gemini.com/websocket-api/#symbols-and-minimums).
       type: Symbol
+    top_of_book:
+      default: false
+      docs: >-
+        If absent or false, receive full order book depth; if present and true,
+        receive top of book only. Only applies to bids and offers.
+      type: optional<boolean>
+    trades:
+      default: true
+      docs: Include trade events
+      type: optional<boolean>
   url: public


### PR DESCRIPTION
## Description
Like the AsyncAPI v2 parser, the AsyncAPI v3 parser now reads query parameters from `channel.bindings.ws.query` and headers from `channel.bindings.ws.headers`. These are deduplicated with anything defined in `channel.parameters`, with the stuff in `channel.parameters` taking precedence.

## Changes Made
The SDK AsyncAPI parser at `openapi/openapi-ir-parser/src/asyncapi/v3`.

## Testing
The new `asyncapi-v3-bindings-query` fixture, which tests that query params and headers flow through.
- [X] Unit tests added/updated
- [X] Manual testing completed
