### PR TITLE
fix(java): more websocket fixes; discrimination over message types uses wire vals

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AbstractWebSocketChannelWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AbstractWebSocketChannelWriter.java
@@ -18,9 +18,17 @@ package com.fern.java.client.generators.websocket;
 
 import com.fern.ir.model.http.PathParameter;
 import com.fern.ir.model.ir.Subpackage;
+import com.fern.ir.model.types.ContainerType;
+import com.fern.ir.model.types.EnumValue;
+import com.fern.ir.model.types.Literal;
+import com.fern.ir.model.types.ObjectProperty;
+import com.fern.ir.model.types.ObjectTypeDeclaration;
 import com.fern.ir.model.types.PrimitiveType;
+import com.fern.ir.model.types.Type;
+import com.fern.ir.model.types.TypeDeclaration;
 import com.fern.ir.model.types.TypeReference;
 import com.fern.ir.model.websocket.InlinedWebSocketMessageBody;
+import com.fern.ir.model.websocket.InlinedWebSocketMessageBodyProperty;
 import com.fern.ir.model.websocket.WebSocketChannel;
 import com.fern.ir.model.websocket.WebSocketMessage;
 import com.fern.ir.model.websocket.WebSocketMessageBody;
@@ -89,6 +97,8 @@ public abstract class AbstractWebSocketChannelWriter {
     // produces the same method name, Java type-erasure makes the two
     // overloads ambiguous. We append "Message" to disambiguate.
     private static final Set<String> RESERVED_CONSUMER_METHOD_NAMES = Set.of("onError", "onDisconnected");
+
+    private static final String DISCRIMINANT_FIELD = "type";
 
     // Connect options class name (present when channel has query parameters)
     protected final Optional<ClassName> connectOptionsClassName;
@@ -431,17 +441,25 @@ public abstract class AbstractWebSocketChannelWriter {
                 .beginControlFlow("if (typeNode == null || typeNode.isNull())")
                 .addStatement("throw new $T($S)", IllegalArgumentException.class, "Message missing 'type' field")
                 .endControlFlow()
-                .addStatement("String type = typeNode.asText()")
-                .beginControlFlow("switch (type)");
+                .addStatement("String type = typeNode.asText()");
 
-        // Add cases for each non-binary server message (binary messages are handled by onBinaryMessage)
+        // Iterate over each non-binary server message type, trying to match the discriminant value.
+        // This matches Python's approach of iterating over all possible message types to find the
+        // correct one, using the wire discriminant value from the body's literal type property.
+        boolean first = true;
         for (WebSocketMessage message : websocketChannel.getMessages()) {
             if (message.getOrigin() == WebSocketMessageOrigin.SERVER && !isMessageBodyBinary(message)) {
                 TypeName messageType = getMessageBodyType(message);
                 String handlerFieldName = getHandlerFieldName(message);
+                String wireDiscriminantValue = getWireDiscriminantValue(message);
 
-                builder.addCode("case $S:\n", message.getType().get())
-                        .beginControlFlow("if ($L != null)", handlerFieldName)
+                if (first) {
+                    builder.beginControlFlow("if ($S.equals(type))", wireDiscriminantValue);
+                    first = false;
+                } else {
+                    builder.nextControlFlow("else if ($S.equals(type))", wireDiscriminantValue);
+                }
+                builder.beginControlFlow("if ($L != null)", handlerFieldName)
                         .addStatement(
                                 "$T event = $N.treeToValue(node, $T.class)",
                                 messageType,
@@ -450,24 +468,19 @@ public abstract class AbstractWebSocketChannelWriter {
                         .beginControlFlow("if (event != null)")
                         .addStatement("$L.accept(event)", handlerFieldName)
                         .endControlFlow()
-                        .endControlFlow()
-                        .addStatement("break");
+                        .endControlFlow();
             }
         }
 
-        builder.addCode("default:\n")
-                .beginControlFlow("if ($N != null)", onErrorHandlerField)
-                .addStatement(
-                        "$N.accept(new $T($S + type + $S))",
-                        onErrorHandlerField,
-                        RuntimeException.class,
-                        "Unknown WebSocket message type: '",
-                        "'. Update your SDK version to support new message types.")
-                .endControlFlow()
-                .addStatement("break");
+        if (!first) {
+            builder.nextControlFlow("else");
+        }
+        addUnknownTypeErrorHandler(builder);
+        if (!first) {
+            builder.endControlFlow(); // end if-else chain
+        }
 
-        builder.endControlFlow() // end switch
-                .endControlFlow() // end try
+        builder.endControlFlow() // end try
                 .beginControlFlow("catch ($T e)", IllegalArgumentException.class)
                 .beginControlFlow("if ($N != null)", onErrorHandlerField)
                 .addStatement("$N.accept(e)", onErrorHandlerField)
@@ -480,6 +493,135 @@ public abstract class AbstractWebSocketChannelWriter {
                 .endControlFlow(); // end catch
 
         return builder.build();
+    }
+
+    private void addUnknownTypeErrorHandler(MethodSpec.Builder builder) {
+        builder.beginControlFlow("if ($N != null)", onErrorHandlerField)
+                .addStatement(
+                        "$N.accept(new $T($S + type + $S))",
+                        onErrorHandlerField,
+                        RuntimeException.class,
+                        "Unknown WebSocket message type: '",
+                        "'. Update your SDK version to support new message types.")
+                .endControlFlow();
+    }
+
+    /**
+     * Extracts the wire discriminant value for a WebSocket message by examining the body's
+     * literal "type" property. Falls back to the message ID if no literal type is found.
+     *
+     * For inlined bodies, looks for a property with wire name "type" that has a literal value.
+     * For reference bodies, resolves the type declaration and checks its object properties.
+     */
+    protected String getWireDiscriminantValue(WebSocketMessage message) {
+        String messageId = message.getType().get();
+        return message.getBody().visit(new WebSocketMessageBody.Visitor<String>() {
+            @Override
+            public String visitInlinedBody(InlinedWebSocketMessageBody inlinedBody) {
+                for (InlinedWebSocketMessageBodyProperty property : inlinedBody.getProperties()) {
+                    if (DISCRIMINANT_FIELD.equals(property.getName().getWireValue())) {
+                        Optional<String> value = extractDiscriminantFromTypeProperty(
+                                property.getValueType(), messageId);
+                        if (value.isPresent()) {
+                            return value.get();
+                        }
+                    }
+                }
+                return messageId;
+            }
+
+            @Override
+            public String visitReference(WebSocketMessageBodyReference reference) {
+                Optional<String> value = extractTypeLiteralFromReference(reference.getBodyType(), messageId);
+                if (value.isPresent()) {
+                    return value.get();
+                }
+                return messageId;
+            }
+
+            @Override
+            public String _visitUnknown(Object unknown) {
+                return messageId;
+            }
+        });
+    }
+
+    /**
+     * Extracts the wire discriminant string from a TypeReference for the "type" property.
+     * First checks for a literal container, then for an enum type where one value matches
+     * the message ID suffix.
+     */
+    private Optional<String> extractDiscriminantFromTypeProperty(TypeReference typeReference, String messageId) {
+        // Check for literal container (e.g., literal<"Welcome">)
+        Optional<String> literal = typeReference
+                .getContainer()
+                .flatMap(ContainerType::getLiteral)
+                .flatMap(Literal::getString);
+        if (literal.isPresent()) {
+            return literal;
+        }
+        // Check for enum type where a value matches the message ID suffix
+        return extractMatchingEnumValue(typeReference, messageId);
+    }
+
+    /**
+     * For an enum-typed property, finds the enum value whose wire value matches the
+     * message ID. Tries exact match first, then suffix match (e.g., message ID
+     * "SpeakV1Flushed" with enum values ["Flushed", "Cleared"] → returns "Flushed").
+     */
+    private Optional<String> extractMatchingEnumValue(TypeReference typeReference, String messageId) {
+        if (!typeReference.isNamed()) {
+            return Optional.empty();
+        }
+        try {
+            TypeDeclaration typeDeclaration =
+                    clientGeneratorContext.getTypeDeclaration(typeReference.getNamed().get().getTypeId());
+            if (!typeDeclaration.getShape().isEnum()) {
+                return Optional.empty();
+            }
+            // Prefer exact match over suffix match to avoid ambiguity
+            Optional<String> suffixMatch = Optional.empty();
+            for (EnumValue enumValue : typeDeclaration.getShape().getEnum().get().getValues()) {
+                String wireValue = enumValue.getName().getWireValue();
+                if (messageId.equals(wireValue)) {
+                    return Optional.of(wireValue);
+                }
+                if (suffixMatch.isEmpty() && messageId.endsWith(wireValue)) {
+                    suffixMatch = Optional.of(wireValue);
+                }
+            }
+            return suffixMatch;
+        } catch (IllegalArgumentException e) {
+            // Type not found in IR declarations, fall back to message ID
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * For a reference body type, resolves the type declaration and looks for a literal or
+     * enum-based "type" property in the object's properties.
+     */
+    private Optional<String> extractTypeLiteralFromReference(TypeReference bodyType, String messageId) {
+        if (!bodyType.isNamed()) {
+            return Optional.empty();
+        }
+        try {
+            TypeDeclaration typeDeclaration =
+                    clientGeneratorContext.getTypeDeclaration(bodyType.getNamed().get().getTypeId());
+            Type shape = typeDeclaration.getShape();
+            if (!shape.isObject()) {
+                return Optional.empty();
+            }
+            ObjectTypeDeclaration objectType = shape.getObject().get();
+            for (ObjectProperty property : objectType.getProperties()) {
+                if (DISCRIMINANT_FIELD.equals(property.getName().getWireValue())) {
+                    return extractDiscriminantFromTypeProperty(property.getValueType(), messageId);
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            // Type not found in declarations, fall back
+        }
+        return Optional.empty();
     }
 
     protected FieldSpec generatePathParameterField(PathParameter pathParam) {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AbstractWebSocketChannelWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AbstractWebSocketChannelWriter.java
@@ -507,11 +507,11 @@ public abstract class AbstractWebSocketChannelWriter {
     }
 
     /**
-     * Extracts the wire discriminant value for a WebSocket message by examining the body's
-     * literal "type" property. Falls back to the message ID if no literal type is found.
+     * Extracts the wire discriminant value for a WebSocket message by examining the body's literal "type" property.
+     * Falls back to the message ID if no literal type is found.
      *
-     * For inlined bodies, looks for a property with wire name "type" that has a literal value.
-     * For reference bodies, resolves the type declaration and checks its object properties.
+     * <p>For inlined bodies, looks for a property with wire name "type" that has a literal value. For reference bodies,
+     * resolves the type declaration and checks its object properties.
      */
     protected String getWireDiscriminantValue(WebSocketMessage message) {
         String messageId = message.getType().get();
@@ -520,8 +520,8 @@ public abstract class AbstractWebSocketChannelWriter {
             public String visitInlinedBody(InlinedWebSocketMessageBody inlinedBody) {
                 for (InlinedWebSocketMessageBodyProperty property : inlinedBody.getProperties()) {
                     if (DISCRIMINANT_FIELD.equals(property.getName().getWireValue())) {
-                        Optional<String> value = extractDiscriminantFromTypeProperty(
-                                property.getValueType(), messageId);
+                        Optional<String> value =
+                                extractDiscriminantFromTypeProperty(property.getValueType(), messageId);
                         if (value.isPresent()) {
                             return value.get();
                         }
@@ -547,16 +547,13 @@ public abstract class AbstractWebSocketChannelWriter {
     }
 
     /**
-     * Extracts the wire discriminant string from a TypeReference for the "type" property.
-     * First checks for a literal container, then for an enum type where one value matches
-     * the message ID suffix.
+     * Extracts the wire discriminant string from a TypeReference for the "type" property. First checks for a literal
+     * container, then for an enum type where one value matches the message ID suffix.
      */
     private Optional<String> extractDiscriminantFromTypeProperty(TypeReference typeReference, String messageId) {
         // Check for literal container (e.g., literal<"Welcome">)
-        Optional<String> literal = typeReference
-                .getContainer()
-                .flatMap(ContainerType::getLiteral)
-                .flatMap(Literal::getString);
+        Optional<String> literal =
+                typeReference.getContainer().flatMap(ContainerType::getLiteral).flatMap(Literal::getString);
         if (literal.isPresent()) {
             return literal;
         }
@@ -565,23 +562,24 @@ public abstract class AbstractWebSocketChannelWriter {
     }
 
     /**
-     * For an enum-typed property, finds the enum value whose wire value matches the
-     * message ID. Tries exact match first, then suffix match (e.g., message ID
-     * "SpeakV1Flushed" with enum values ["Flushed", "Cleared"] → returns "Flushed").
+     * For an enum-typed property, finds the enum value whose wire value matches the message ID. Tries exact match
+     * first, then suffix match (e.g., message ID "SpeakV1Flushed" with enum values ["Flushed", "Cleared"] → returns
+     * "Flushed").
      */
     private Optional<String> extractMatchingEnumValue(TypeReference typeReference, String messageId) {
         if (!typeReference.isNamed()) {
             return Optional.empty();
         }
         try {
-            TypeDeclaration typeDeclaration =
-                    clientGeneratorContext.getTypeDeclaration(typeReference.getNamed().get().getTypeId());
+            TypeDeclaration typeDeclaration = clientGeneratorContext.getTypeDeclaration(
+                    typeReference.getNamed().get().getTypeId());
             if (!typeDeclaration.getShape().isEnum()) {
                 return Optional.empty();
             }
             // Prefer exact match over suffix match to avoid ambiguity
             Optional<String> suffixMatch = Optional.empty();
-            for (EnumValue enumValue : typeDeclaration.getShape().getEnum().get().getValues()) {
+            for (EnumValue enumValue :
+                    typeDeclaration.getShape().getEnum().get().getValues()) {
                 String wireValue = enumValue.getName().getWireValue();
                 if (messageId.equals(wireValue)) {
                     return Optional.of(wireValue);
@@ -598,16 +596,16 @@ public abstract class AbstractWebSocketChannelWriter {
     }
 
     /**
-     * For a reference body type, resolves the type declaration and looks for a literal or
-     * enum-based "type" property in the object's properties.
+     * For a reference body type, resolves the type declaration and looks for a literal or enum-based "type" property in
+     * the object's properties.
      */
     private Optional<String> extractTypeLiteralFromReference(TypeReference bodyType, String messageId) {
         if (!bodyType.isNamed()) {
             return Optional.empty();
         }
         try {
-            TypeDeclaration typeDeclaration =
-                    clientGeneratorContext.getTypeDeclaration(bodyType.getNamed().get().getTypeId());
+            TypeDeclaration typeDeclaration = clientGeneratorContext.getTypeDeclaration(
+                    bodyType.getNamed().get().getTypeId());
             Type shape = typeDeclaration.getShape();
             if (!shape.isObject()) {
                 return Optional.empty();

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AbstractWebSocketChannelWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AbstractWebSocketChannelWriter.java
@@ -16,6 +16,8 @@
 
 package com.fern.java.client.generators.websocket;
 
+import com.fern.ir.model.http.HttpPath;
+import com.fern.ir.model.http.HttpPathPart;
 import com.fern.ir.model.http.PathParameter;
 import com.fern.ir.model.ir.Subpackage;
 import com.fern.ir.model.types.ContainerType;
@@ -318,7 +320,7 @@ public abstract class AbstractWebSocketChannelWriter {
                         .build())
                 .addJavadoc(
                         "Registers a handler for $L messages from the server.\n",
-                        message.getType().get())
+                        message.getDisplayName().orElse(message.getType().get()))
                 .addJavadoc("@param handler the handler to invoke when a message is received\n")
                 .addStatement("this.$L = handler", handlerFieldName)
                 .build();
@@ -443,23 +445,18 @@ public abstract class AbstractWebSocketChannelWriter {
                 .endControlFlow()
                 .addStatement("String type = typeNode.asText()");
 
-        // Iterate over each non-binary server message type, trying to match the discriminant value.
-        // This matches Python's approach of iterating over all possible message types to find the
-        // correct one, using the wire discriminant value from the body's literal type property.
-        boolean first = true;
+        // Switch on wire discriminant values extracted from each message body's literal/enum
+        // "type" property, rather than the Fern-internal message ID.
+        builder.beginControlFlow("switch (type)");
+
         for (WebSocketMessage message : websocketChannel.getMessages()) {
             if (message.getOrigin() == WebSocketMessageOrigin.SERVER && !isMessageBodyBinary(message)) {
                 TypeName messageType = getMessageBodyType(message);
                 String handlerFieldName = getHandlerFieldName(message);
                 String wireDiscriminantValue = getWireDiscriminantValue(message);
 
-                if (first) {
-                    builder.beginControlFlow("if ($S.equals(type))", wireDiscriminantValue);
-                    first = false;
-                } else {
-                    builder.nextControlFlow("else if ($S.equals(type))", wireDiscriminantValue);
-                }
-                builder.beginControlFlow("if ($L != null)", handlerFieldName)
+                builder.addCode("case $S:\n", wireDiscriminantValue)
+                        .beginControlFlow("if ($L != null)", handlerFieldName)
                         .addStatement(
                                 "$T event = $N.treeToValue(node, $T.class)",
                                 messageType,
@@ -468,24 +465,17 @@ public abstract class AbstractWebSocketChannelWriter {
                         .beginControlFlow("if (event != null)")
                         .addStatement("$L.accept(event)", handlerFieldName)
                         .endControlFlow()
-                        .endControlFlow();
+                        .endControlFlow()
+                        .addStatement("break");
             }
         }
 
-        if (!first) {
-            builder.nextControlFlow("else");
-        }
+        builder.addCode("default:\n");
         addUnknownTypeErrorHandler(builder);
-        if (!first) {
-            builder.endControlFlow(); // end if-else chain
-        }
+        builder.addStatement("break");
 
-        builder.endControlFlow() // end try
-                .beginControlFlow("catch ($T e)", IllegalArgumentException.class)
-                .beginControlFlow("if ($N != null)", onErrorHandlerField)
-                .addStatement("$N.accept(e)", onErrorHandlerField)
-                .endControlFlow()
-                .endControlFlow() // end catch
+        builder.endControlFlow() // end switch
+                .endControlFlow() // end try
                 .beginControlFlow("catch ($T e)", Exception.class)
                 .beginControlFlow("if ($N != null)", onErrorHandlerField)
                 .addStatement("$N.accept(e)", onErrorHandlerField)
@@ -630,6 +620,34 @@ public abstract class AbstractWebSocketChannelWriter {
                 .build();
     }
 
+    /**
+     * Appends path-building code to the method builder. For static paths (no path parameters), emits a simple string
+     * literal. For dynamic paths, uses a StringBuilder to concatenate the head, path parameters, and tails.
+     */
+    protected void appendPathBuildingCode(MethodSpec.Builder builder) {
+        HttpPath path = websocketChannel.getPath();
+        if (path.getParts().isEmpty()) {
+            builder.addStatement("String fullPath = $S", path.getHead());
+        } else {
+            builder.addStatement("$T pathBuilder = new $T()", StringBuilder.class, StringBuilder.class);
+            builder.addStatement("pathBuilder.append($S)", path.getHead());
+            for (HttpPathPart part : path.getParts()) {
+                String pathParamId = part.getPathParameter();
+                if (pathParamId != null && !pathParamId.isEmpty()) {
+                    PathParameter matchingParam = websocketChannel.getPathParameters().stream()
+                            .filter(p -> p.getName().getOriginalName().equals(pathParamId))
+                            .findFirst()
+                            .orElseThrow();
+                    String paramFieldName =
+                            matchingParam.getName().getCamelCase().getSafeName();
+                    builder.addStatement("pathBuilder.append($L)", paramFieldName);
+                }
+                builder.addStatement("pathBuilder.append($S)", part.getTail());
+            }
+            builder.addStatement("String fullPath = pathBuilder.toString()");
+        }
+    }
+
     protected TypeName getMessageBodyType(WebSocketMessage message) {
         if (isMessageBodyBinary(message)) {
             return ClassName.get("okio", "ByteString");
@@ -769,30 +787,15 @@ public abstract class AbstractWebSocketChannelWriter {
     }
 
     protected String getHandlerFieldName(WebSocketMessage message) {
-        // Use custom methodName if available, otherwise fall back to message type
+        // Use custom methodName if available, otherwise fall back to wire discriminant value
         String baseName;
         if (message.getMethodName().isPresent()) {
             // methodName is already the desired name (e.g., "sendSettings", "onFunctionCallResponse")
             baseName = toCamelCase(message.getMethodName().get());
         } else {
-            // Fall back to converting message type from snake_case to camelCase
-            String messageType = message.getType().get();
-            String[] parts = messageType.split("_");
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < parts.length; i++) {
-                String part = parts[i];
-                if (!part.isEmpty()) {
-                    if (i == 0) {
-                        sb.append(part.toLowerCase());
-                    } else {
-                        sb.append(Character.toUpperCase(part.charAt(0)));
-                        if (part.length() > 1) {
-                            sb.append(part.substring(1).toLowerCase());
-                        }
-                    }
-                }
-            }
-            baseName = sb.toString();
+            // Use the wire discriminant value (e.g., "Welcome" → "welcome", not "AgentV1Welcome")
+            String wireValue = getWireDiscriminantValue(message);
+            baseName = decapitalize(toCamelCase(wireValue));
         }
         return baseName + "Handler";
     }
@@ -814,6 +817,21 @@ public abstract class AbstractWebSocketChannelWriter {
             }
         }
         return result.toString();
+    }
+
+    protected String decapitalize(String str) {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+        return Character.toLowerCase(str.charAt(0)) + str.substring(1);
+    }
+
+    /** Returns "an X" or "a X" depending on whether X starts with a vowel sound. */
+    protected String articleFor(String name) {
+        if (name != null && !name.isEmpty() && "AEIOUaeiou".indexOf(name.charAt(0)) >= 0) {
+            return "an " + name;
+        }
+        return "a " + name;
     }
 
     protected String toPascalCase(String str) {
@@ -869,7 +887,8 @@ public abstract class AbstractWebSocketChannelWriter {
         if (message.getMethodName().isPresent()) {
             baseName = toCamelCase(message.getMethodName().get());
         } else {
-            baseName = "on" + toPascalCase(message.getType().get());
+            // Use the wire discriminant value (e.g., "Welcome" instead of "AgentV1Welcome")
+            baseName = "on" + toPascalCase(getWireDiscriminantValue(message));
         }
         if (RESERVED_CONSUMER_METHOD_NAMES.contains(baseName)) {
             return baseName + "Message";

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AsyncWebSocketChannelWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/AsyncWebSocketChannelWriter.java
@@ -16,8 +16,6 @@
 
 package com.fern.java.client.generators.websocket;
 
-import com.fern.ir.model.http.HttpPath;
-import com.fern.ir.model.http.HttpPathPart;
 import com.fern.ir.model.http.PathParameter;
 import com.fern.ir.model.http.QueryParameter;
 import com.fern.ir.model.ir.Subpackage;
@@ -148,27 +146,7 @@ public class AsyncWebSocketChannelWriter extends AbstractWebSocketChannelWriter 
                 "String baseUrl = $N.environment().$L()", clientOptionsField, getEnvironmentUrlMethodName());
 
         // Build path with parameters
-        builder.addStatement("$T pathBuilder = new $T()", StringBuilder.class, StringBuilder.class);
-
-        HttpPath path = websocketChannel.getPath();
-        builder.addStatement("pathBuilder.append($S)", path.getHead());
-
-        for (HttpPathPart part : path.getParts()) {
-            String pathParamId = part.getPathParameter();
-            if (pathParamId != null && !pathParamId.isEmpty()) {
-                // Find the matching path parameter
-                PathParameter matchingParam = websocketChannel.getPathParameters().stream()
-                        .filter(p -> p.getName().getOriginalName().equals(pathParamId))
-                        .findFirst()
-                        .orElseThrow();
-                String paramFieldName = matchingParam.getName().getCamelCase().getSafeName();
-                builder.addStatement("pathBuilder.append($L)", paramFieldName);
-            }
-            builder.addStatement("pathBuilder.append($S)", part.getTail());
-        }
-
-        // Build HttpUrl with query parameters
-        builder.addStatement("String fullPath = pathBuilder.toString()");
+        appendPathBuildingCode(builder);
         builder.beginControlFlow("if (baseUrl.endsWith(\"/\") && fullPath.startsWith(\"/\"))");
         builder.addStatement("fullPath = fullPath.substring(1)");
         builder.endControlFlow();
@@ -374,8 +352,8 @@ public class AsyncWebSocketChannelWriter extends AbstractWebSocketChannelWriter 
                 .returns(ParameterizedTypeName.get(ClassName.get(CompletableFuture.class), TypeName.VOID.box()))
                 .addParameter(messageType, "message")
                 .addJavadoc(
-                        "Sends a $L message to the server asynchronously.\n",
-                        message.getType().get())
+                        "Sends $L message to the server asynchronously.\n",
+                        articleFor(message.getType().get()))
                 .addJavadoc("@param message the message to send\n")
                 .addJavadoc("@return a CompletableFuture that completes when the message is sent\n");
 
@@ -420,14 +398,8 @@ public class AsyncWebSocketChannelWriter extends AbstractWebSocketChannelWriter 
                 .addStatement("assertSocketIsOpen()")
                 .addStatement("String json = $N.writeValueAsString(body)", objectMapperField)
                 .addComment("Use reconnecting listener's send method which handles queuing")
-                .addStatement("boolean sent = $N.send(json)", reconnectingListenerField)
-                .beginControlFlow("if (sent)")
+                .addStatement("$N.send(json)", reconnectingListenerField)
                 .addStatement("future.complete(null)")
-                .endControlFlow()
-                .beginControlFlow("else")
-                .addComment("Message was queued for later delivery when reconnected")
-                .addStatement("future.complete(null)")
-                .endControlFlow()
                 .endControlFlow()
                 .beginControlFlow("catch ($T e)", IllegalStateException.class)
                 .addStatement("future.completeExceptionally(e)")

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/SyncWebSocketChannelWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/websocket/SyncWebSocketChannelWriter.java
@@ -16,8 +16,6 @@
 
 package com.fern.java.client.generators.websocket;
 
-import com.fern.ir.model.http.HttpPath;
-import com.fern.ir.model.http.HttpPathPart;
 import com.fern.ir.model.http.PathParameter;
 import com.fern.ir.model.http.QueryParameter;
 import com.fern.ir.model.ir.Subpackage;
@@ -144,27 +142,7 @@ public class SyncWebSocketChannelWriter extends AbstractWebSocketChannelWriter {
                 "String baseUrl = $N.environment().$L()", clientOptionsField, getEnvironmentUrlMethodName());
 
         // Build path with parameters
-        builder.addStatement("$T pathBuilder = new $T()", StringBuilder.class, StringBuilder.class);
-
-        HttpPath path = websocketChannel.getPath();
-        builder.addStatement("pathBuilder.append($S)", path.getHead());
-
-        for (HttpPathPart part : path.getParts()) {
-            String pathParamId = part.getPathParameter();
-            if (pathParamId != null && !pathParamId.isEmpty()) {
-                // Find the matching path parameter
-                PathParameter matchingParam = websocketChannel.getPathParameters().stream()
-                        .filter(p -> p.getName().getOriginalName().equals(pathParamId))
-                        .findFirst()
-                        .orElseThrow();
-                String paramFieldName = matchingParam.getName().getCamelCase().getSafeName();
-                builder.addStatement("pathBuilder.append($L)", paramFieldName);
-            }
-            builder.addStatement("pathBuilder.append($S)", part.getTail());
-        }
-
-        // Build HttpUrl with query parameters
-        builder.addStatement("String fullPath = pathBuilder.toString()");
+        appendPathBuildingCode(builder);
         builder.beginControlFlow("if (baseUrl.endsWith(\"/\") && fullPath.startsWith(\"/\"))");
         builder.addStatement("fullPath = fullPath.substring(1)");
         builder.endControlFlow();
@@ -379,7 +357,8 @@ public class SyncWebSocketChannelWriter extends AbstractWebSocketChannelWriter {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(messageType, "message")
                 .addJavadoc(
-                        "Sends a $L message to the server.\n", message.getType().get())
+                        "Sends $L message to the server.\n",
+                        articleFor(message.getType().get()))
                 .addJavadoc("@param message the message to send\n")
                 .addJavadoc("@throws RuntimeException if send fails\n");
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -9,11 +9,25 @@
 
         The generator now extracts wire discriminant values from each message body's
         `type` property — resolving literal values (e.g. `literal<"Welcome">`) and
-        enum values (e.g. `enum[Flushed, Cleared]`) — and matches incoming messages
-        via an if-else chain over those values. This aligns with the approach used by
-        the Python generator.
+        enum values (e.g. `enum[Flushed, Cleared]`) — and dispatches via a `switch`
+        statement on those values. This aligns with the approach used by the Python
+        generator.
       type: fix
-  createdAt: "2026-03-19"
+    - summary: |
+        WebSocket handler registration methods and field names now use
+        wire discriminant values instead of Fern-internal prefixed names. For example,
+        `onAgentV1Welcome(handler)` is now `onWelcome(handler)`, and
+        `onAgentV1PromptUpdated(handler)` is now `onPromptUpdated(handler)`. Methods
+        that were already backed by a custom `x-fern-sdk-method-name` (e.g.
+        `onFunctionCallResponse`) are unchanged.
+      type: fix
+    - summary: |
+        Improve generated WebSocket client code quality: use a string literal for
+        static URL paths instead of `StringBuilder`, remove dead if/else branches in
+        async `sendMessage()`, consolidate redundant catch blocks in message dispatch,
+        and correct Javadoc articles ("a" vs "an") for type names starting with vowels.
+      type: chore
+  createdAt: "2026-03-20"
   irVersion: 65
 
 - version: 4.0.2

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,21 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.0.3
+  changelogEntry:
+    - summary: |
+        Fix WebSocket `handleIncomingMessage()` using Fern-internal message IDs
+        (e.g. `AgentV1Welcome`, `ListenV1Results`) instead of the wire discriminant
+        values from the spec (e.g. `Welcome`, `Results`). This caused all incoming
+        message handlers to never fire, falling through to the unknown type handler.
+
+        The generator now extracts wire discriminant values from each message body's
+        `type` property — resolving literal values (e.g. `literal<"Welcome">`) and
+        enum values (e.g. `enum[Flushed, Cleared]`) — and matches incoming messages
+        via an if-else chain over those values. This aligns with the approach used by
+        the Python generator.
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 65
+
 - version: 4.0.2
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/resources/realtime/websocket/RealtimeWebSocketClient.java
+++ b/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/resources/realtime/websocket/RealtimeWebSocketClient.java
@@ -355,45 +355,39 @@ public class RealtimeWebSocketClient implements AutoCloseable {
                 throw new IllegalArgumentException("Message missing 'type' field");
             }
             String type = typeNode.asText();
-            switch (type) {
-                case "receive":
-                    if (receiveHandler != null) {
-                        ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
-                        if (event != null) {
-                            receiveHandler.accept(event);
-                        }
+            if ("receive".equals(type)) {
+                if (receiveHandler != null) {
+                    ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
+                    if (event != null) {
+                        receiveHandler.accept(event);
                     }
-                    break;
-                case "receive_snake_case":
-                    if (receiveSnakeCaseHandler != null) {
-                        ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
-                        if (event != null) {
-                            receiveSnakeCaseHandler.accept(event);
-                        }
+                }
+            } else if ("receive_snake_case".equals(type)) {
+                if (receiveSnakeCaseHandler != null) {
+                    ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
+                    if (event != null) {
+                        receiveSnakeCaseHandler.accept(event);
                     }
-                    break;
-                case "receive2":
-                    if (receive2Handler != null) {
-                        ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
-                        if (event != null) {
-                            receive2Handler.accept(event);
-                        }
+                }
+            } else if ("receive2".equals(type)) {
+                if (receive2Handler != null) {
+                    ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
+                    if (event != null) {
+                        receive2Handler.accept(event);
                     }
-                    break;
-                case "receive3":
-                    if (receive3Handler != null) {
-                        ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
-                        if (event != null) {
-                            receive3Handler.accept(event);
-                        }
+                }
+            } else if ("receive3".equals(type)) {
+                if (receive3Handler != null) {
+                    ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
+                    if (event != null) {
+                        receive3Handler.accept(event);
                     }
-                    break;
-                default:
-                    if (onErrorHandler != null) {
-                        onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
-                                + "'. Update your SDK version to support new message types."));
-                    }
-                    break;
+                }
+            } else {
+                if (onErrorHandler != null) {
+                    onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
+                            + "'. Update your SDK version to support new message types."));
+                }
             }
         } catch (IllegalArgumentException e) {
             if (onErrorHandler != null) {

--- a/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/resources/realtime/websocket/RealtimeWebSocketClient.java
+++ b/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/resources/realtime/websocket/RealtimeWebSocketClient.java
@@ -225,7 +225,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive messages from the server.
+     * Registers a handler for Receive messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceive(Consumer<ReceiveEvent> handler) {
@@ -233,7 +233,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive_snake_case messages from the server.
+     * Registers a handler for Receive messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceiveSnakeCase(Consumer<ReceiveSnakeCase> handler) {
@@ -241,7 +241,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive2 messages from the server.
+     * Registers a handler for Receive2 messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceive2(Consumer<ReceiveEvent2> handler) {
@@ -249,7 +249,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive3 messages from the server.
+     * Registers a handler for Receive3 messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceive3(Consumer<ReceiveEvent3> handler) {
@@ -326,13 +326,8 @@ public class RealtimeWebSocketClient implements AutoCloseable {
             assertSocketIsOpen();
             String json = objectMapper.writeValueAsString(body);
             // Use reconnecting listener's send method which handles queuing
-            boolean sent = reconnectingListener.send(json);
-            if (sent) {
-                future.complete(null);
-            } else {
-                // Message was queued for later delivery when reconnected
-                future.complete(null);
-            }
+            reconnectingListener.send(json);
+            future.complete(null);
         } catch (IllegalStateException e) {
             future.completeExceptionally(e);
         } catch (Exception e) {
@@ -355,43 +350,45 @@ public class RealtimeWebSocketClient implements AutoCloseable {
                 throw new IllegalArgumentException("Message missing 'type' field");
             }
             String type = typeNode.asText();
-            if ("receive".equals(type)) {
-                if (receiveHandler != null) {
-                    ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
-                    if (event != null) {
-                        receiveHandler.accept(event);
+            switch (type) {
+                case "receive":
+                    if (receiveHandler != null) {
+                        ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
+                        if (event != null) {
+                            receiveHandler.accept(event);
+                        }
                     }
-                }
-            } else if ("receive_snake_case".equals(type)) {
-                if (receiveSnakeCaseHandler != null) {
-                    ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
-                    if (event != null) {
-                        receiveSnakeCaseHandler.accept(event);
+                    break;
+                case "receive_snake_case":
+                    if (receiveSnakeCaseHandler != null) {
+                        ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
+                        if (event != null) {
+                            receiveSnakeCaseHandler.accept(event);
+                        }
                     }
-                }
-            } else if ("receive2".equals(type)) {
-                if (receive2Handler != null) {
-                    ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
-                    if (event != null) {
-                        receive2Handler.accept(event);
+                    break;
+                case "receive2":
+                    if (receive2Handler != null) {
+                        ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
+                        if (event != null) {
+                            receive2Handler.accept(event);
+                        }
                     }
-                }
-            } else if ("receive3".equals(type)) {
-                if (receive3Handler != null) {
-                    ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
-                    if (event != null) {
-                        receive3Handler.accept(event);
+                    break;
+                case "receive3":
+                    if (receive3Handler != null) {
+                        ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
+                        if (event != null) {
+                            receive3Handler.accept(event);
+                        }
                     }
-                }
-            } else {
-                if (onErrorHandler != null) {
-                    onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
-                            + "'. Update your SDK version to support new message types."));
-                }
-            }
-        } catch (IllegalArgumentException e) {
-            if (onErrorHandler != null) {
-                onErrorHandler.accept(e);
+                    break;
+                default:
+                    if (onErrorHandler != null) {
+                        onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
+                                + "'. Update your SDK version to support new message types."));
+                    }
+                    break;
             }
         } catch (Exception e) {
             if (onErrorHandler != null) {

--- a/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/resources/realtimenoauth/websocket/RealtimeNoAuthWebSocketClient.java
+++ b/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/resources/realtimenoauth/websocket/RealtimeNoAuthWebSocketClient.java
@@ -192,7 +192,7 @@ public class RealtimeNoAuthWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive messages from the server.
+     * Registers a handler for Receive messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceive(Consumer<NoAuthReceiveEvent> handler) {
@@ -269,13 +269,8 @@ public class RealtimeNoAuthWebSocketClient implements AutoCloseable {
             assertSocketIsOpen();
             String json = objectMapper.writeValueAsString(body);
             // Use reconnecting listener's send method which handles queuing
-            boolean sent = reconnectingListener.send(json);
-            if (sent) {
-                future.complete(null);
-            } else {
-                // Message was queued for later delivery when reconnected
-                future.complete(null);
-            }
+            reconnectingListener.send(json);
+            future.complete(null);
         } catch (IllegalStateException e) {
             future.completeExceptionally(e);
         } catch (Exception e) {
@@ -298,22 +293,21 @@ public class RealtimeNoAuthWebSocketClient implements AutoCloseable {
                 throw new IllegalArgumentException("Message missing 'type' field");
             }
             String type = typeNode.asText();
-            if ("receive".equals(type)) {
-                if (receiveHandler != null) {
-                    NoAuthReceiveEvent event = objectMapper.treeToValue(node, NoAuthReceiveEvent.class);
-                    if (event != null) {
-                        receiveHandler.accept(event);
+            switch (type) {
+                case "receive":
+                    if (receiveHandler != null) {
+                        NoAuthReceiveEvent event = objectMapper.treeToValue(node, NoAuthReceiveEvent.class);
+                        if (event != null) {
+                            receiveHandler.accept(event);
+                        }
                     }
-                }
-            } else {
-                if (onErrorHandler != null) {
-                    onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
-                            + "'. Update your SDK version to support new message types."));
-                }
-            }
-        } catch (IllegalArgumentException e) {
-            if (onErrorHandler != null) {
-                onErrorHandler.accept(e);
+                    break;
+                default:
+                    if (onErrorHandler != null) {
+                        onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
+                                + "'. Update your SDK version to support new message types."));
+                    }
+                    break;
             }
         } catch (Exception e) {
             if (onErrorHandler != null) {

--- a/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/resources/realtimenoauth/websocket/RealtimeNoAuthWebSocketClient.java
+++ b/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/resources/realtimenoauth/websocket/RealtimeNoAuthWebSocketClient.java
@@ -298,21 +298,18 @@ public class RealtimeNoAuthWebSocketClient implements AutoCloseable {
                 throw new IllegalArgumentException("Message missing 'type' field");
             }
             String type = typeNode.asText();
-            switch (type) {
-                case "receive":
-                    if (receiveHandler != null) {
-                        NoAuthReceiveEvent event = objectMapper.treeToValue(node, NoAuthReceiveEvent.class);
-                        if (event != null) {
-                            receiveHandler.accept(event);
-                        }
+            if ("receive".equals(type)) {
+                if (receiveHandler != null) {
+                    NoAuthReceiveEvent event = objectMapper.treeToValue(node, NoAuthReceiveEvent.class);
+                    if (event != null) {
+                        receiveHandler.accept(event);
                     }
-                    break;
-                default:
-                    if (onErrorHandler != null) {
-                        onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
-                                + "'. Update your SDK version to support new message types."));
-                    }
-                    break;
+                }
+            } else {
+                if (onErrorHandler != null) {
+                    onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
+                            + "'. Update your SDK version to support new message types."));
+                }
             }
         } catch (IllegalArgumentException e) {
             if (onErrorHandler != null) {

--- a/seed/java-sdk/websocket-inferred-auth/src/main/java/com/seed/websocketAuth/resources/realtime/websocket/RealtimeWebSocketClient.java
+++ b/seed/java-sdk/websocket-inferred-auth/src/main/java/com/seed/websocketAuth/resources/realtime/websocket/RealtimeWebSocketClient.java
@@ -355,45 +355,39 @@ public class RealtimeWebSocketClient implements AutoCloseable {
                 throw new IllegalArgumentException("Message missing 'type' field");
             }
             String type = typeNode.asText();
-            switch (type) {
-                case "receive":
-                    if (receiveHandler != null) {
-                        ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
-                        if (event != null) {
-                            receiveHandler.accept(event);
-                        }
+            if ("receive".equals(type)) {
+                if (receiveHandler != null) {
+                    ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
+                    if (event != null) {
+                        receiveHandler.accept(event);
                     }
-                    break;
-                case "receive_snake_case":
-                    if (receiveSnakeCaseHandler != null) {
-                        ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
-                        if (event != null) {
-                            receiveSnakeCaseHandler.accept(event);
-                        }
+                }
+            } else if ("receive_snake_case".equals(type)) {
+                if (receiveSnakeCaseHandler != null) {
+                    ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
+                    if (event != null) {
+                        receiveSnakeCaseHandler.accept(event);
                     }
-                    break;
-                case "receive2":
-                    if (receive2Handler != null) {
-                        ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
-                        if (event != null) {
-                            receive2Handler.accept(event);
-                        }
+                }
+            } else if ("receive2".equals(type)) {
+                if (receive2Handler != null) {
+                    ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
+                    if (event != null) {
+                        receive2Handler.accept(event);
                     }
-                    break;
-                case "receive3":
-                    if (receive3Handler != null) {
-                        ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
-                        if (event != null) {
-                            receive3Handler.accept(event);
-                        }
+                }
+            } else if ("receive3".equals(type)) {
+                if (receive3Handler != null) {
+                    ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
+                    if (event != null) {
+                        receive3Handler.accept(event);
                     }
-                    break;
-                default:
-                    if (onErrorHandler != null) {
-                        onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
-                                + "'. Update your SDK version to support new message types."));
-                    }
-                    break;
+                }
+            } else {
+                if (onErrorHandler != null) {
+                    onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
+                            + "'. Update your SDK version to support new message types."));
+                }
             }
         } catch (IllegalArgumentException e) {
             if (onErrorHandler != null) {

--- a/seed/java-sdk/websocket-inferred-auth/src/main/java/com/seed/websocketAuth/resources/realtime/websocket/RealtimeWebSocketClient.java
+++ b/seed/java-sdk/websocket-inferred-auth/src/main/java/com/seed/websocketAuth/resources/realtime/websocket/RealtimeWebSocketClient.java
@@ -225,7 +225,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive messages from the server.
+     * Registers a handler for Receive messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceive(Consumer<ReceiveEvent> handler) {
@@ -233,7 +233,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive_snake_case messages from the server.
+     * Registers a handler for Receive messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceiveSnakeCase(Consumer<ReceiveSnakeCase> handler) {
@@ -241,7 +241,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive2 messages from the server.
+     * Registers a handler for Receive2 messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceive2(Consumer<ReceiveEvent2> handler) {
@@ -249,7 +249,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive3 messages from the server.
+     * Registers a handler for Receive3 messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceive3(Consumer<ReceiveEvent3> handler) {
@@ -326,13 +326,8 @@ public class RealtimeWebSocketClient implements AutoCloseable {
             assertSocketIsOpen();
             String json = objectMapper.writeValueAsString(body);
             // Use reconnecting listener's send method which handles queuing
-            boolean sent = reconnectingListener.send(json);
-            if (sent) {
-                future.complete(null);
-            } else {
-                // Message was queued for later delivery when reconnected
-                future.complete(null);
-            }
+            reconnectingListener.send(json);
+            future.complete(null);
         } catch (IllegalStateException e) {
             future.completeExceptionally(e);
         } catch (Exception e) {
@@ -355,43 +350,45 @@ public class RealtimeWebSocketClient implements AutoCloseable {
                 throw new IllegalArgumentException("Message missing 'type' field");
             }
             String type = typeNode.asText();
-            if ("receive".equals(type)) {
-                if (receiveHandler != null) {
-                    ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
-                    if (event != null) {
-                        receiveHandler.accept(event);
+            switch (type) {
+                case "receive":
+                    if (receiveHandler != null) {
+                        ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
+                        if (event != null) {
+                            receiveHandler.accept(event);
+                        }
                     }
-                }
-            } else if ("receive_snake_case".equals(type)) {
-                if (receiveSnakeCaseHandler != null) {
-                    ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
-                    if (event != null) {
-                        receiveSnakeCaseHandler.accept(event);
+                    break;
+                case "receive_snake_case":
+                    if (receiveSnakeCaseHandler != null) {
+                        ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
+                        if (event != null) {
+                            receiveSnakeCaseHandler.accept(event);
+                        }
                     }
-                }
-            } else if ("receive2".equals(type)) {
-                if (receive2Handler != null) {
-                    ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
-                    if (event != null) {
-                        receive2Handler.accept(event);
+                    break;
+                case "receive2":
+                    if (receive2Handler != null) {
+                        ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
+                        if (event != null) {
+                            receive2Handler.accept(event);
+                        }
                     }
-                }
-            } else if ("receive3".equals(type)) {
-                if (receive3Handler != null) {
-                    ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
-                    if (event != null) {
-                        receive3Handler.accept(event);
+                    break;
+                case "receive3":
+                    if (receive3Handler != null) {
+                        ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
+                        if (event != null) {
+                            receive3Handler.accept(event);
+                        }
                     }
-                }
-            } else {
-                if (onErrorHandler != null) {
-                    onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
-                            + "'. Update your SDK version to support new message types."));
-                }
-            }
-        } catch (IllegalArgumentException e) {
-            if (onErrorHandler != null) {
-                onErrorHandler.accept(e);
+                    break;
+                default:
+                    if (onErrorHandler != null) {
+                        onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
+                                + "'. Update your SDK version to support new message types."));
+                    }
+                    break;
             }
         } catch (Exception e) {
             if (onErrorHandler != null) {

--- a/seed/java-sdk/websocket/src/main/java/com/seed/websocket/resources/empty/emptyrealtime/websocket/EmptyRealtimeWebSocketClient.java
+++ b/seed/java-sdk/websocket/src/main/java/com/seed/websocket/resources/empty/emptyrealtime/websocket/EmptyRealtimeWebSocketClient.java
@@ -258,13 +258,9 @@ public class EmptyRealtimeWebSocketClient implements AutoCloseable {
                 throw new IllegalArgumentException("Message missing 'type' field");
             }
             String type = typeNode.asText();
-            switch (type) {
-                default:
-                    if (onErrorHandler != null) {
-                        onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
-                                + "'. Update your SDK version to support new message types."));
-                    }
-                    break;
+            if (onErrorHandler != null) {
+                onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
+                        + "'. Update your SDK version to support new message types."));
             }
         } catch (IllegalArgumentException e) {
             if (onErrorHandler != null) {

--- a/seed/java-sdk/websocket/src/main/java/com/seed/websocket/resources/empty/emptyrealtime/websocket/EmptyRealtimeWebSocketClient.java
+++ b/seed/java-sdk/websocket/src/main/java/com/seed/websocket/resources/empty/emptyrealtime/websocket/EmptyRealtimeWebSocketClient.java
@@ -65,9 +65,7 @@ public class EmptyRealtimeWebSocketClient implements AutoCloseable {
     public CompletableFuture<Void> connect() {
         connectionFuture = new CompletableFuture<>();
         String baseUrl = clientOptions.environment().getUrl();
-        StringBuilder pathBuilder = new StringBuilder();
-        pathBuilder.append("/empty/realtime/");
-        String fullPath = pathBuilder.toString();
+        String fullPath = "/empty/realtime/";
         if (baseUrl.endsWith("/") && fullPath.startsWith("/")) {
             fullPath = fullPath.substring(1);
         } else if (!baseUrl.endsWith("/") && !fullPath.startsWith("/")) {
@@ -229,13 +227,8 @@ public class EmptyRealtimeWebSocketClient implements AutoCloseable {
             assertSocketIsOpen();
             String json = objectMapper.writeValueAsString(body);
             // Use reconnecting listener's send method which handles queuing
-            boolean sent = reconnectingListener.send(json);
-            if (sent) {
-                future.complete(null);
-            } else {
-                // Message was queued for later delivery when reconnected
-                future.complete(null);
-            }
+            reconnectingListener.send(json);
+            future.complete(null);
         } catch (IllegalStateException e) {
             future.completeExceptionally(e);
         } catch (Exception e) {
@@ -258,13 +251,13 @@ public class EmptyRealtimeWebSocketClient implements AutoCloseable {
                 throw new IllegalArgumentException("Message missing 'type' field");
             }
             String type = typeNode.asText();
-            if (onErrorHandler != null) {
-                onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
-                        + "'. Update your SDK version to support new message types."));
-            }
-        } catch (IllegalArgumentException e) {
-            if (onErrorHandler != null) {
-                onErrorHandler.accept(e);
+            switch (type) {
+                default:
+                    if (onErrorHandler != null) {
+                        onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
+                                + "'. Update your SDK version to support new message types."));
+                    }
+                    break;
             }
         } catch (Exception e) {
             if (onErrorHandler != null) {

--- a/seed/java-sdk/websocket/src/main/java/com/seed/websocket/resources/realtime/websocket/RealtimeWebSocketClient.java
+++ b/seed/java-sdk/websocket/src/main/java/com/seed/websocket/resources/realtime/websocket/RealtimeWebSocketClient.java
@@ -392,69 +392,60 @@ public class RealtimeWebSocketClient implements AutoCloseable {
                 throw new IllegalArgumentException("Message missing 'type' field");
             }
             String type = typeNode.asText();
-            switch (type) {
-                case "receive":
-                    if (receiveHandler != null) {
-                        ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
-                        if (event != null) {
-                            receiveHandler.accept(event);
-                        }
+            if ("receive".equals(type)) {
+                if (receiveHandler != null) {
+                    ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
+                    if (event != null) {
+                        receiveHandler.accept(event);
                     }
-                    break;
-                case "receive_snake_case":
-                    if (receiveSnakeCaseHandler != null) {
-                        ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
-                        if (event != null) {
-                            receiveSnakeCaseHandler.accept(event);
-                        }
+                }
+            } else if ("receive_snake_case".equals(type)) {
+                if (receiveSnakeCaseHandler != null) {
+                    ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
+                    if (event != null) {
+                        receiveSnakeCaseHandler.accept(event);
                     }
-                    break;
-                case "receive2":
-                    if (receive2Handler != null) {
-                        ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
-                        if (event != null) {
-                            receive2Handler.accept(event);
-                        }
+                }
+            } else if ("receive2".equals(type)) {
+                if (receive2Handler != null) {
+                    ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
+                    if (event != null) {
+                        receive2Handler.accept(event);
                     }
-                    break;
-                case "receive3":
-                    if (receive3Handler != null) {
-                        ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
-                        if (event != null) {
-                            receive3Handler.accept(event);
-                        }
+                }
+            } else if ("receive3".equals(type)) {
+                if (receive3Handler != null) {
+                    ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
+                    if (event != null) {
+                        receive3Handler.accept(event);
                     }
-                    break;
-                case "receive_transcript":
-                    if (receiveTranscriptHandler != null) {
-                        TranscriptEvent event = objectMapper.treeToValue(node, TranscriptEvent.class);
-                        if (event != null) {
-                            receiveTranscriptHandler.accept(event);
-                        }
+                }
+            } else if ("transcript".equals(type)) {
+                if (receiveTranscriptHandler != null) {
+                    TranscriptEvent event = objectMapper.treeToValue(node, TranscriptEvent.class);
+                    if (event != null) {
+                        receiveTranscriptHandler.accept(event);
                     }
-                    break;
-                case "receive_flushed":
-                    if (receiveFlushedHandler != null) {
-                        FlushedEvent event = objectMapper.treeToValue(node, FlushedEvent.class);
-                        if (event != null) {
-                            receiveFlushedHandler.accept(event);
-                        }
+                }
+            } else if ("flushed".equals(type)) {
+                if (receiveFlushedHandler != null) {
+                    FlushedEvent event = objectMapper.treeToValue(node, FlushedEvent.class);
+                    if (event != null) {
+                        receiveFlushedHandler.accept(event);
                     }
-                    break;
-                case "error":
-                    if (errorHandler != null) {
-                        ErrorEvent event = objectMapper.treeToValue(node, ErrorEvent.class);
-                        if (event != null) {
-                            errorHandler.accept(event);
-                        }
+                }
+            } else if ("error".equals(type)) {
+                if (errorHandler != null) {
+                    ErrorEvent event = objectMapper.treeToValue(node, ErrorEvent.class);
+                    if (event != null) {
+                        errorHandler.accept(event);
                     }
-                    break;
-                default:
-                    if (onErrorHandler != null) {
-                        onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
-                                + "'. Update your SDK version to support new message types."));
-                    }
-                    break;
+                }
+            } else {
+                if (onErrorHandler != null) {
+                    onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
+                            + "'. Update your SDK version to support new message types."));
+                }
             }
         } catch (IllegalArgumentException e) {
             if (onErrorHandler != null) {

--- a/seed/java-sdk/websocket/src/main/java/com/seed/websocket/resources/realtime/websocket/RealtimeWebSocketClient.java
+++ b/seed/java-sdk/websocket/src/main/java/com/seed/websocket/resources/realtime/websocket/RealtimeWebSocketClient.java
@@ -69,9 +69,9 @@ public class RealtimeWebSocketClient implements AutoCloseable {
 
     private volatile Consumer<ReceiveEvent3> receive3Handler;
 
-    private volatile Consumer<TranscriptEvent> receiveTranscriptHandler;
+    private volatile Consumer<TranscriptEvent> transcriptHandler;
 
-    private volatile Consumer<FlushedEvent> receiveFlushedHandler;
+    private volatile Consumer<FlushedEvent> flushedHandler;
 
     private volatile Consumer<ErrorEvent> errorHandler;
 
@@ -238,7 +238,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive messages from the server.
+     * Registers a handler for Receive messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceive(Consumer<ReceiveEvent> handler) {
@@ -246,7 +246,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive_snake_case messages from the server.
+     * Registers a handler for Receive messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceiveSnakeCase(Consumer<ReceiveSnakeCase> handler) {
@@ -254,7 +254,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive2 messages from the server.
+     * Registers a handler for Receive2 messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceive2(Consumer<ReceiveEvent2> handler) {
@@ -262,7 +262,7 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive3 messages from the server.
+     * Registers a handler for Receive3 messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onReceive3(Consumer<ReceiveEvent3> handler) {
@@ -270,23 +270,23 @@ public class RealtimeWebSocketClient implements AutoCloseable {
     }
 
     /**
-     * Registers a handler for receive_transcript messages from the server.
+     * Registers a handler for ReceiveTranscript messages from the server.
      * @param handler the handler to invoke when a message is received
      */
-    public void onReceiveTranscript(Consumer<TranscriptEvent> handler) {
-        this.receiveTranscriptHandler = handler;
+    public void onTranscript(Consumer<TranscriptEvent> handler) {
+        this.transcriptHandler = handler;
     }
 
     /**
-     * Registers a handler for receive_flushed messages from the server.
+     * Registers a handler for ReceiveFlushed messages from the server.
      * @param handler the handler to invoke when a message is received
      */
-    public void onReceiveFlushed(Consumer<FlushedEvent> handler) {
-        this.receiveFlushedHandler = handler;
+    public void onFlushed(Consumer<FlushedEvent> handler) {
+        this.flushedHandler = handler;
     }
 
     /**
-     * Registers a handler for error messages from the server.
+     * Registers a handler for Error messages from the server.
      * @param handler the handler to invoke when a message is received
      */
     public void onErrorMessage(Consumer<ErrorEvent> handler) {
@@ -363,13 +363,8 @@ public class RealtimeWebSocketClient implements AutoCloseable {
             assertSocketIsOpen();
             String json = objectMapper.writeValueAsString(body);
             // Use reconnecting listener's send method which handles queuing
-            boolean sent = reconnectingListener.send(json);
-            if (sent) {
-                future.complete(null);
-            } else {
-                // Message was queued for later delivery when reconnected
-                future.complete(null);
-            }
+            reconnectingListener.send(json);
+            future.complete(null);
         } catch (IllegalStateException e) {
             future.completeExceptionally(e);
         } catch (Exception e) {
@@ -392,64 +387,69 @@ public class RealtimeWebSocketClient implements AutoCloseable {
                 throw new IllegalArgumentException("Message missing 'type' field");
             }
             String type = typeNode.asText();
-            if ("receive".equals(type)) {
-                if (receiveHandler != null) {
-                    ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
-                    if (event != null) {
-                        receiveHandler.accept(event);
+            switch (type) {
+                case "receive":
+                    if (receiveHandler != null) {
+                        ReceiveEvent event = objectMapper.treeToValue(node, ReceiveEvent.class);
+                        if (event != null) {
+                            receiveHandler.accept(event);
+                        }
                     }
-                }
-            } else if ("receive_snake_case".equals(type)) {
-                if (receiveSnakeCaseHandler != null) {
-                    ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
-                    if (event != null) {
-                        receiveSnakeCaseHandler.accept(event);
+                    break;
+                case "receive_snake_case":
+                    if (receiveSnakeCaseHandler != null) {
+                        ReceiveSnakeCase event = objectMapper.treeToValue(node, ReceiveSnakeCase.class);
+                        if (event != null) {
+                            receiveSnakeCaseHandler.accept(event);
+                        }
                     }
-                }
-            } else if ("receive2".equals(type)) {
-                if (receive2Handler != null) {
-                    ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
-                    if (event != null) {
-                        receive2Handler.accept(event);
+                    break;
+                case "receive2":
+                    if (receive2Handler != null) {
+                        ReceiveEvent2 event = objectMapper.treeToValue(node, ReceiveEvent2.class);
+                        if (event != null) {
+                            receive2Handler.accept(event);
+                        }
                     }
-                }
-            } else if ("receive3".equals(type)) {
-                if (receive3Handler != null) {
-                    ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
-                    if (event != null) {
-                        receive3Handler.accept(event);
+                    break;
+                case "receive3":
+                    if (receive3Handler != null) {
+                        ReceiveEvent3 event = objectMapper.treeToValue(node, ReceiveEvent3.class);
+                        if (event != null) {
+                            receive3Handler.accept(event);
+                        }
                     }
-                }
-            } else if ("transcript".equals(type)) {
-                if (receiveTranscriptHandler != null) {
-                    TranscriptEvent event = objectMapper.treeToValue(node, TranscriptEvent.class);
-                    if (event != null) {
-                        receiveTranscriptHandler.accept(event);
+                    break;
+                case "transcript":
+                    if (transcriptHandler != null) {
+                        TranscriptEvent event = objectMapper.treeToValue(node, TranscriptEvent.class);
+                        if (event != null) {
+                            transcriptHandler.accept(event);
+                        }
                     }
-                }
-            } else if ("flushed".equals(type)) {
-                if (receiveFlushedHandler != null) {
-                    FlushedEvent event = objectMapper.treeToValue(node, FlushedEvent.class);
-                    if (event != null) {
-                        receiveFlushedHandler.accept(event);
+                    break;
+                case "flushed":
+                    if (flushedHandler != null) {
+                        FlushedEvent event = objectMapper.treeToValue(node, FlushedEvent.class);
+                        if (event != null) {
+                            flushedHandler.accept(event);
+                        }
                     }
-                }
-            } else if ("error".equals(type)) {
-                if (errorHandler != null) {
-                    ErrorEvent event = objectMapper.treeToValue(node, ErrorEvent.class);
-                    if (event != null) {
-                        errorHandler.accept(event);
+                    break;
+                case "error":
+                    if (errorHandler != null) {
+                        ErrorEvent event = objectMapper.treeToValue(node, ErrorEvent.class);
+                        if (event != null) {
+                            errorHandler.accept(event);
+                        }
                     }
-                }
-            } else {
-                if (onErrorHandler != null) {
-                    onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
-                            + "'. Update your SDK version to support new message types."));
-                }
-            }
-        } catch (IllegalArgumentException e) {
-            if (onErrorHandler != null) {
-                onErrorHandler.accept(e);
+                    break;
+                default:
+                    if (onErrorHandler != null) {
+                        onErrorHandler.accept(new RuntimeException("Unknown WebSocket message type: '" + type
+                                + "'. Update your SDK version to support new message types."));
+                    }
+                    break;
             }
         } catch (Exception e) {
             if (onErrorHandler != null) {


### PR DESCRIPTION
## Description
More websocket fixes. `handleIncomingMessage()` was switching on Fern-internal message IDs (e.g. stuff like `AgentV1Welcome`) instead of the wire values from the spec (`Welcome`). This caused all incoming message handlers to silently never fire, falling through to the unknown type handler. The generator now extracts wire discriminant values from each message body's literal or enum type property and switches over them, matching the approach used by the Python generator.

In addition, public handler registration methods like `onAgentV1Welcome()` are now `onWelcome()` - using the wire discriminant value instead of the Fern-prefixed message ID. Methods backed by a custom x-fern-sdk-method-name (e.g. onFunctionCallResponse) are unchanged.

Also other improvements to generated WebSocket client idiomaticity:
    - Use string literal for static URL paths instead of unnecessary StringBuilder
    - Remove dead if/else branches in async sendMessage() (both branches did future.complete(null))
    - Consolidate redundant catch (IllegalArgumentException) + catch (Exception) into single catch (Exception) in message dispatch
    - Correct Javadoc grammar — "Sends a AgentV1Settings" → "Sends an AgentV1Settings"
    - Use displayName for handler Javadoc when available
  - Refactor: Extract duplicated path-building logic from AsyncWebSocketChannelWriter and SyncWebSocketChannelWriter into shared appendPathBuildingCode() in the abstract base class.

## Testing
The websocket fixtures; the Deepgram SDK.
- [X] Unit tests added/updated
- [X] Manual testing completed
