### PR TITLE
fix(cli): move async lock changelog entry to its own version

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+
+- version: 4.37.10
+  changelogEntry:
+    - summary: |
+        Guard concurrent `npm install -g fern-api` invocations with an async lock to prevent race conditions during protobuf toolchain setup
+      type: fix
+  createdAt: "2026-03-19"
+  irVersion: 65
+
 - version: 4.37.9
   changelogEntry:
     - summary: |
@@ -68,9 +77,6 @@
         `go install protoc-gen-openapi`, removing the Go toolchain dependency
         from CI.
       type: chore
-    - summary: |
-        Guard concurrent `npm install -g fern-api` invocations with an async lock to prevent race conditions during protobuf toolchain setup
-      type: fix
   createdAt: "2026-03-19"
   irVersion: 65
 


### PR DESCRIPTION
## Description
Fixes the CLI version history by moving the async lock changelog entry to its own version (4.37.10). The entry for guarding concurrent `npm install -g fern-api` invocations was incorrectly placed under version 4.37.9 instead of having its own version bump.

## Changes Made
- **versions.yml**: Created new version 4.37.10 with the async lock fix changelog entry, removing it from version 4.37.9

## Testing
- [x] Verified versions.yml structure is correct with proper ordering
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
