### PR TITLE
feat(csharp): add InjectTestMessage for WebSocket unit testing

### DIFF
--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -1181,6 +1181,23 @@ export class WebSocketClientGenerator extends WithGeneration {
      * @param typeReference - The type reference to check
      * @returns True if the type is a named/object type, false for primitives and containers
      */
+    private isComplexType(typeReference: TypeReference): boolean {
+        return typeReference._visit({
+            container: (container) => {
+                // For optional types, check the inner type
+                if (container.type === "optional") {
+                    return this.isComplexType(container.optional);
+                }
+                // Lists, maps, sets are not deep objects
+                return false;
+            },
+            named: () => true,
+            primitive: () => false,
+            unknown: () => false,
+            _other: () => false
+        });
+    }
+
     /**
      * Creates an internal method for injecting fake text messages during unit testing.
      *
@@ -1212,23 +1229,6 @@ export class WebSocketClientGenerator extends WithGeneration {
                 writer.writeLine(`    System.Text.Encoding.UTF8.GetBytes(rawJson));`);
                 writer.writeTextStatement(`await OnTextMessage(stream).ConfigureAwait(false)`);
             })
-        });
-    }
-
-    private isComplexType(typeReference: TypeReference): boolean {
-        return typeReference._visit({
-            container: (container) => {
-                // For optional types, check the inner type
-                if (container.type === "optional") {
-                    return this.isComplexType(container.optional);
-                }
-                // Lists, maps, sets are not deep objects
-                return false;
-            },
-            named: () => true,
-            primitive: () => false,
-            unknown: () => false,
-            _other: () => false
         });
     }
 

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -1164,6 +1164,7 @@ export class WebSocketClientGenerator extends WithGeneration {
         this.createOnTextMessageMethod(cls);
 
         this.createSendMessageMethods(cls);
+        this.createInjectTestMessageMethod(cls);
         this.createEventFields(cls);
         const environmentsClass = this.createEnvironmentsClass();
         if (environmentsClass != null) {
@@ -1180,6 +1181,40 @@ export class WebSocketClientGenerator extends WithGeneration {
      * @param typeReference - The type reference to check
      * @returns True if the type is a named/object type, false for primitives and containers
      */
+    /**
+     * Creates an internal method for injecting fake text messages during unit testing.
+     *
+     * The method converts a raw JSON string into a MemoryStream and dispatches it
+     * through the normal OnTextMessage handler, allowing tests to simulate incoming
+     * WebSocket messages without a real connection.
+     *
+     * Marked as `internal` so it is only accessible via [InternalsVisibleTo] in test projects.
+     *
+     * @param cls - The class to add the method to
+     */
+    private createInjectTestMessageMethod(cls: ast.Class): void {
+        cls.addMethod({
+            access: ast.Access.Internal,
+            isAsync: true,
+            name: "InjectTestMessage",
+            doc: this.csharp.xmlDocBlockOf({
+                summary:
+                    "Injects a fake text message for testing. Dispatches through the normal message handling pipeline."
+            }),
+            parameters: [
+                this.csharp.parameter({
+                    name: "rawJson",
+                    type: this.Primitive.string
+                })
+            ],
+            body: this.csharp.codeblock((writer) => {
+                writer.writeLine(`using var stream = new System.IO.MemoryStream(`);
+                writer.writeLine(`    System.Text.Encoding.UTF8.GetBytes(rawJson));`);
+                writer.writeTextStatement(`await OnTextMessage(stream).ConfigureAwait(false)`);
+            })
+        });
+    }
+
     private isComplexType(typeReference: TypeReference): boolean {
         return typeReference._visit({
             container: (container) => {

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.39.0
+  changelogEntry:
+    - summary: |
+        Add `InjectTestMessage` internal method to generated WebSocket client classes.
+        This allows unit tests to simulate incoming WebSocket messages by injecting raw
+        JSON strings through the normal `OnTextMessage` pipeline without requiring a real
+        WebSocket connection. The method is marked `internal` so it is only accessible
+        via `[InternalsVisibleTo]` in test projects, keeping the public API surface clean.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.38.1
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -88,6 +88,15 @@ public partial class EmptyRealtimeApi : IAsyncDisposable, IDisposable, INotifyPr
     }
 
     /// <summary>
+    /// Injects a fake text message for testing. Dispatches through the normal message handling pipeline.
+    /// </summary>
+    internal async Task InjectTestMessage(string rawJson)
+    {
+        using var stream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(rawJson));
+        await OnTextMessage(stream).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Asynchronously establishes a WebSocket connection.
     /// </summary>
     public async Task ConnectAsync(CancellationToken cancellationToken = default)

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -206,6 +206,15 @@ public partial class RealtimeApi : IAsyncDisposable, IDisposable, INotifyPropert
     }
 
     /// <summary>
+    /// Injects a fake text message for testing. Dispatches through the normal message handling pipeline.
+    /// </summary>
+    internal async Task InjectTestMessage(string rawJson)
+    {
+        using var stream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(rawJson));
+        await OnTextMessage(stream).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Asynchronously establishes a WebSocket connection.
     /// </summary>
     public async Task ConnectAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Description

Adds an `internal async Task InjectTestMessage(string rawJson)` method to generated WebSocket client classes, enabling unit tests to simulate incoming server messages without a real WebSocket connection.

### Usage (with `[InternalsVisibleTo]` in test project)
```csharp
var api = new StreamApi(new StreamApi.Options { BaseUrl = "wss://fake" });
api.StreamConfigStatusMessage.Subscribe(msg =>
{
    Assert.Equal("CONFIG_ACCEPTED", msg.Type);
});
await api.InjectTestMessage("{\"type\": \"CONFIG_ACCEPTED\", ...}");
```

## Changes Made

- Added `createInjectTestMessageMethod` to `WebSocketClientGenerator` that generates an `internal` method on the WebSocket client class
- The generated method converts a raw JSON string to a `MemoryStream` and dispatches it through `OnTextMessage`, reusing the normal deserialization/event-dispatch pipeline
- Called after `createSendMessageMethods` in `createWebsocketClass`
- Added version 2.42.0 entry in `versions.yml`
- Updated seed snapshots for the `websocket` fixture (`with-websockets` config): `RealtimeApi.cs` and `EmptyRealtimeApi.cs`

## Testing

- [x] Lint/typecheck passes (`pnpm run check`)
- [x] Seed tests pass for `websocket`, `websocket-bearer-auth`, and `websocket-inferred-auth` fixtures
- [x] Verified generated `InjectTestMessage` in `RealtimeApi.cs` and `EmptyRealtimeApi.cs`
- [x] All CI checks pass (63/63)

## ⚠️ Reviewer Checklist

- [ ] Confirm `internal` access is the right visibility (vs. `public` or `protected internal`)
- [ ] No JSON validation is performed on `rawJson` before dispatching — invalid JSON will surface as a deserialization error inside `OnTextMessage`, which is the same behavior as a malformed server message
- [ ] The method does not check connection state, so it can be called without `ConnectAsync` — this is intentional for unit testing but worth confirming is the desired behavior

Link to Devin session: https://app.devin.ai/sessions/be0a5ded87a94cda87701c5c6b0279c6
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
