### PR TITLE
feat(csharp): add per-message deflate compression support for WebSocket connections

### DIFF
--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -26,6 +26,13 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     }
 
     /// <summary>
+    /// Optional per-message deflate compression options.
+    /// When set, enables WebSocket compression (RFC 7692).
+    /// Warning: Do not use compression when sending data containing secrets (CRIME/BREACH vulnerability).
+    /// </summary>
+    public WebSocketDeflateOptions? DeflateOptions { get; set; }
+
+    /// <summary>
     /// Gets the current connection status of the WebSocket.
     /// </summary>
     public ConnectionStatus Status
@@ -182,6 +189,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         _webSocket = new WebSocketConnection(_uri, () => new ClientWebSocket())
         {
+            DeflateOptions = DeflateOptions,
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -25,12 +25,14 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
         _onTextMessage = onTextMessage;
     }
 
+#if NET6_0_OR_GREATER
     /// <summary>
     /// Optional per-message deflate compression options.
     /// When set, enables WebSocket compression (RFC 7692).
     /// Warning: Do not use compression when sending data containing secrets (CRIME/BREACH vulnerability).
     /// </summary>
     public WebSocketDeflateOptions? DeflateOptions { get; set; }
+#endif
 
     /// <summary>
     /// Gets the current connection status of the WebSocket.
@@ -187,9 +189,11 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         Status = ConnectionStatus.Connecting;
 
-        _webSocket = new WebSocketConnection(_uri, () => new ClientWebSocket())
+        _webSocket = new WebSocketConnection(_uri, (Func<ClientWebSocket>?)null)
         {
+#if NET6_0_OR_GREATER
             DeflateOptions = DeflateOptions,
+#endif
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -25,6 +25,24 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
         _onTextMessage = onTextMessage;
     }
 
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Optional per-message deflate compression options (RFC 7692).
+    /// When set, enables WebSocket compression via
+    /// <see cref="ClientWebSocketOptions.DangerousDeflateOptions" />.
+    /// Compression is negotiated during the WebSocket handshake; if the server does not
+    /// support it, the connection proceeds without compression.
+    /// <para>
+    /// <b>Security warning:</b> Do not enable compression when transmitting data that
+    /// contains secrets. Compressed encrypted payloads are vulnerable to CRIME/BREACH
+    /// side-channel attacks.
+    /// See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">
+    /// ClientWebSocketOptions.DangerousDeflateOptions</see> for details.
+    /// </para>
+    /// </summary>
+    public WebSocketDeflateOptions? DeflateOptions { get; set; }
+#endif
+
     /// <summary>
     /// Gets the current connection status of the WebSocket.
     /// </summary>
@@ -182,6 +200,9 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         _webSocket = new WebSocketConnection(_uri)
         {
+#if NET6_0_OR_GREATER
+            DeflateOptions = DeflateOptions,
+#endif
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -27,9 +27,18 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
 #if NET6_0_OR_GREATER
     /// <summary>
-    /// Optional per-message deflate compression options.
-    /// When set, enables WebSocket compression (RFC 7692).
-    /// Warning: Do not use compression when sending data containing secrets (CRIME/BREACH vulnerability).
+    /// Optional per-message deflate compression options (RFC 7692).
+    /// When set, enables WebSocket compression via
+    /// <see cref="ClientWebSocketOptions.DangerousDeflateOptions" />.
+    /// Compression is negotiated during the WebSocket handshake; if the server does not
+    /// support it, the connection proceeds without compression.
+    /// <para>
+    /// <b>Security warning:</b> Do not enable compression when transmitting data that
+    /// contains secrets. Compressed encrypted payloads are vulnerable to CRIME/BREACH
+    /// side-channel attacks.
+    /// See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">
+    /// ClientWebSocketOptions.DangerousDeflateOptions</see> for details.
+    /// </para>
     /// </summary>
     public WebSocketDeflateOptions? DeflateOptions { get; set; }
 #endif

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -97,9 +97,18 @@ internal partial class WebSocketConnection
 
 #if NET6_0_OR_GREATER
     /// <summary>
-    /// Optional per-message deflate compression options.
-    /// When set, enables WebSocket compression (RFC 7692).
-    /// Warning: Do not use compression when sending data containing secrets (CRIME/BREACH vulnerability).
+    /// Optional per-message deflate compression options (RFC 7692).
+    /// When set, the <see cref="ClientWebSocket" /> created by the default connection factory
+    /// assigns this value to <see cref="ClientWebSocketOptions.DangerousDeflateOptions" />.
+    /// Compression is negotiated during the WebSocket handshake; if the server does not
+    /// support it, the connection proceeds without compression.
+    /// <para>
+    /// <b>Security warning:</b> Do not enable compression when transmitting data that
+    /// contains secrets. Compressed encrypted payloads are vulnerable to CRIME/BREACH
+    /// side-channel attacks.
+    /// See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">
+    /// ClientWebSocketOptions.DangerousDeflateOptions</see> for details.
+    /// </para>
     /// </summary>
     public WebSocketDeflateOptions? DeflateOptions { get; set; }
 #endif

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -81,6 +81,10 @@ internal partial class WebSocketConnection
                     //    Options = { KeepAliveInterval = new TimeSpan(0, 0, 5, 0) }
                     //};
                     var client = new ClientWebSocket();
+                    if (DeflateOptions != null)
+                    {
+                        client.Options.DangerousDeflateOptions = DeflateOptions;
+                    }
                     await client.ConnectAsync(uri, token).ConfigureAwait(false);
                     return client;
                 }
@@ -88,6 +92,13 @@ internal partial class WebSocketConnection
     }
 
     public Uri Url { get; set; }
+
+    /// <summary>
+    /// Optional per-message deflate compression options.
+    /// When set, enables WebSocket compression (RFC 7692).
+    /// Warning: Do not use compression when sending data containing secrets (CRIME/BREACH vulnerability).
+    /// </summary>
+    public WebSocketDeflateOptions? DeflateOptions { get; set; }
 
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -81,10 +81,12 @@ internal partial class WebSocketConnection
                     //    Options = { KeepAliveInterval = new TimeSpan(0, 0, 5, 0) }
                     //};
                     var client = new ClientWebSocket();
+#if NET6_0_OR_GREATER
                     if (DeflateOptions != null)
                     {
                         client.Options.DangerousDeflateOptions = DeflateOptions;
                     }
+#endif
                     await client.ConnectAsync(uri, token).ConfigureAwait(false);
                     return client;
                 }
@@ -93,12 +95,14 @@ internal partial class WebSocketConnection
 
     public Uri Url { get; set; }
 
+#if NET6_0_OR_GREATER
     /// <summary>
     /// Optional per-message deflate compression options.
     /// When set, enables WebSocket compression (RFC 7692).
     /// Warning: Do not use compression when sending data containing secrets (CRIME/BREACH vulnerability).
     /// </summary>
     public WebSocketDeflateOptions? DeflateOptions { get; set; }
+#endif
 
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -78,6 +78,12 @@ internal partial class WebSocketConnection
                 {
                     var client = new ClientWebSocket();
                     client.Options.KeepAliveInterval = KeepAliveInterval;
+#if NET6_0_OR_GREATER
+                    if (DeflateOptions != null)
+                    {
+                        client.Options.DangerousDeflateOptions = DeflateOptions;
+                    }
+#endif
 #if NET9_0_OR_GREATER
                     client.Options.KeepAliveTimeout = KeepAliveTimeout;
 #endif
@@ -101,6 +107,24 @@ internal partial class WebSocketConnection
     /// Default: 20 seconds.
     /// </summary>
     public TimeSpan KeepAliveTimeout { get; set; } = TimeSpan.FromSeconds(20);
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Optional per-message deflate compression options (RFC 7692).
+    /// When set, the <see cref="ClientWebSocket" /> created by the default connection factory
+    /// assigns this value to <see cref="ClientWebSocketOptions.DangerousDeflateOptions" />.
+    /// Compression is negotiated during the WebSocket handshake; if the server does not
+    /// support it, the connection proceeds without compression.
+    /// <para>
+    /// <b>Security warning:</b> Do not enable compression when transmitting data that
+    /// contains secrets. Compressed encrypted payloads are vulnerable to CRIME/BREACH
+    /// side-channel attacks.
+    /// See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">
+    /// ClientWebSocketOptions.DangerousDeflateOptions</see> for details.
+    /// </para>
+    /// </summary>
+    public WebSocketDeflateOptions? DeflateOptions { get; set; }
+#endif
 
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -502,7 +502,16 @@ export class WebSocketClientGenerator extends WithGeneration {
             origin: optionsClass.explicit("EnableCompression"),
             access: ast.Access.Public,
             type: this.Primitive.boolean,
-            summary: "Enable per-message deflate compression (RFC 7692). Default: false.",
+            summary:
+                "Enable per-message deflate compression (RFC 7692). " +
+                "When true, the client sets <c>ClientWebSocketOptions.DangerousDeflateOptions</c> " +
+                "before connecting. Compression is negotiated during the handshake; if the server " +
+                "does not support it, the connection proceeds uncompressed. " +
+                "Default: <c>false</c>.\n" +
+                "<para><b>Security warning:</b> do not enable compression when transmitting data " +
+                "containing secrets — compressed encrypted payloads are vulnerable to CRIME/BREACH " +
+                'side-channel attacks. See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">' +
+                "ClientWebSocketOptions.DangerousDeflateOptions</see> for details.</para>",
             get: true,
             set: true,
             initializer: this.csharp.codeblock("false")

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -949,12 +949,14 @@ export class WebSocketClientGenerator extends WithGeneration {
                 summary: "Asynchronously establishes a WebSocket connection."
             }),
             body: this.csharp.codeblock((writer) => {
+                writer.writeLine("#if NET6_0_OR_GREATER");
                 writer.writeLine("if (_options.EnableCompression)");
                 writer.pushScope();
                 writer.writeTextStatement(
                     "_client.DeflateOptions = new System.Net.WebSockets.WebSocketDeflateOptions()"
                 );
                 writer.popScope();
+                writer.writeLine("#endif");
                 writer.writeTextStatement("await _client.ConnectAsync(cancellationToken).ConfigureAwait(false)");
             })
         });

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -416,6 +416,16 @@ export class WebSocketClientGenerator extends WithGeneration {
             });
         }
 
+        optionsClass.addField({
+            origin: optionsClass.explicit("EnableCompression"),
+            access: ast.Access.Public,
+            type: this.Primitive.boolean,
+            summary: "Enable per-message deflate compression (RFC 7692). Default: false.",
+            get: true,
+            set: true,
+            initializer: this.csharp.codeblock("false")
+        });
+
         for (const queryParameter of this.websocketChannel.queryParameters) {
             // add to the options class
             const type = this.context.csharpTypeMapper.convert({
@@ -939,6 +949,12 @@ export class WebSocketClientGenerator extends WithGeneration {
                 summary: "Asynchronously establishes a WebSocket connection."
             }),
             body: this.csharp.codeblock((writer) => {
+                writer.writeLine("if (_options.EnableCompression)");
+                writer.pushScope();
+                writer.writeTextStatement(
+                    "_client.DeflateOptions = new System.Net.WebSockets.WebSocketDeflateOptions()"
+                );
+                writer.popScope();
                 writer.writeTextStatement("await _client.ConnectAsync(cancellationToken).ConfigureAwait(false)");
             })
         });

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.39.0
+  changelogEntry:
+    - summary: |
+        Add per-message deflate compression support (RFC 7692) for WebSocket connections.
+        A new `EnableCompression` option on the generated WebSocket Options class enables
+        `WebSocketDeflateOptions` via `ClientWebSocketOptions.DangerousDeflateOptions`.
+        This can significantly reduce bandwidth for text-heavy (JSON) WebSocket APIs.
+        Warning: Do not use compression when sending data containing secrets
+        (CRIME/BREACH vulnerability).
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.38.1
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,19 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.41.0
+  changelogEntry:
+    - summary: |
+        Add per-message deflate compression support (RFC 7692) for WebSocket connections.
+        A new `EnableCompression` option on the generated WebSocket Options class enables
+        `WebSocketDeflateOptions` via `ClientWebSocketOptions.DangerousDeflateOptions`.
+        This can significantly reduce bandwidth for text-heavy (JSON) WebSocket APIs.
+        Warning: Do not use compression when sending data containing secrets
+        (CRIME/BREACH vulnerability).
+        See https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions
+        for details.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.40.0
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -25,6 +25,15 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
         _onTextMessage = onTextMessage;
     }
 
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Optional per-message deflate compression options.
+    /// When set, enables WebSocket compression (RFC 7692).
+    /// Warning: Do not use compression when sending data containing secrets (CRIME/BREACH vulnerability).
+    /// </summary>
+    public WebSocketDeflateOptions? DeflateOptions { get; set; }
+#endif
+
     /// <summary>
     /// Gets the current connection status of the WebSocket.
     /// </summary>
@@ -196,8 +205,11 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         Status = ConnectionStatus.Connecting;
 
-        _webSocket = new WebSocketConnection(_uri, () => new ClientWebSocket())
+        _webSocket = new WebSocketConnection(_uri, (Func<ClientWebSocket>?)null)
         {
+#if NET6_0_OR_GREATER
+            DeflateOptions = DeflateOptions,
+#endif
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -25,6 +25,24 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
         _onTextMessage = onTextMessage;
     }
 
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Optional per-message deflate compression options (RFC 7692).
+    /// When set, enables WebSocket compression via
+    /// <see cref="ClientWebSocketOptions.DangerousDeflateOptions" />.
+    /// Compression is negotiated during the WebSocket handshake; if the server does not
+    /// support it, the connection proceeds without compression.
+    /// <para>
+    /// <b>Security warning:</b> Do not enable compression when transmitting data that
+    /// contains secrets. Compressed encrypted payloads are vulnerable to CRIME/BREACH
+    /// side-channel attacks.
+    /// See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">
+    /// ClientWebSocketOptions.DangerousDeflateOptions</see> for details.
+    /// </para>
+    /// </summary>
+    public WebSocketDeflateOptions? DeflateOptions { get; set; }
+#endif
+
     /// <summary>
     /// Gets the current connection status of the WebSocket.
     /// </summary>
@@ -198,6 +216,9 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         _webSocket = new WebSocketConnection(_uri)
         {
+#if NET6_0_OR_GREATER
+            DeflateOptions = DeflateOptions,
+#endif
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -27,9 +27,18 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
 #if NET6_0_OR_GREATER
     /// <summary>
-    /// Optional per-message deflate compression options.
-    /// When set, enables WebSocket compression (RFC 7692).
-    /// Warning: Do not use compression when sending data containing secrets (CRIME/BREACH vulnerability).
+    /// Optional per-message deflate compression options (RFC 7692).
+    /// When set, enables WebSocket compression via
+    /// <see cref="ClientWebSocketOptions.DangerousDeflateOptions" />.
+    /// Compression is negotiated during the WebSocket handshake; if the server does not
+    /// support it, the connection proceeds without compression.
+    /// <para>
+    /// <b>Security warning:</b> Do not enable compression when transmitting data that
+    /// contains secrets. Compressed encrypted payloads are vulnerable to CRIME/BREACH
+    /// side-channel attacks.
+    /// See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">
+    /// ClientWebSocketOptions.DangerousDeflateOptions</see> for details.
+    /// </para>
     /// </summary>
     public WebSocketDeflateOptions? DeflateOptions { get; set; }
 #endif

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -82,6 +82,12 @@ internal partial class WebSocketConnection
                 {
                     var client = new ClientWebSocket();
                     client.Options.KeepAliveInterval = KeepAliveInterval;
+#if NET6_0_OR_GREATER
+                    if (DeflateOptions != null)
+                    {
+                        client.Options.DangerousDeflateOptions = DeflateOptions;
+                    }
+#endif
 #if NET9_0_OR_GREATER
                     client.Options.KeepAliveTimeout = KeepAliveTimeout;
 #endif
@@ -105,6 +111,24 @@ internal partial class WebSocketConnection
     /// Default: 20 seconds.
     /// </summary>
     public TimeSpan KeepAliveTimeout { get; set; } = TimeSpan.FromSeconds(20);
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Optional per-message deflate compression options (RFC 7692).
+    /// When set, the <see cref="ClientWebSocket" /> created by the default connection factory
+    /// assigns this value to <see cref="ClientWebSocketOptions.DangerousDeflateOptions" />.
+    /// Compression is negotiated during the WebSocket handshake; if the server does not
+    /// support it, the connection proceeds without compression.
+    /// <para>
+    /// <b>Security warning:</b> Do not enable compression when transmitting data that
+    /// contains secrets. Compressed encrypted payloads are vulnerable to CRIME/BREACH
+    /// side-channel attacks.
+    /// See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">
+    /// ClientWebSocketOptions.DangerousDeflateOptions</see> for details.
+    /// </para>
+    /// </summary>
+    public WebSocketDeflateOptions? DeflateOptions { get; set; }
+#endif
 
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -85,6 +85,12 @@ internal partial class WebSocketConnection
                     //    Options = { KeepAliveInterval = new TimeSpan(0, 0, 5, 0) }
                     //};
                     var client = new ClientWebSocket();
+#if NET6_0_OR_GREATER
+                    if (DeflateOptions != null)
+                    {
+                        client.Options.DangerousDeflateOptions = DeflateOptions;
+                    }
+#endif
                     await client.ConnectAsync(uri, token).ConfigureAwait(false);
                     return client;
                 }
@@ -92,6 +98,15 @@ internal partial class WebSocketConnection
     }
 
     public Uri Url { get; set; }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Optional per-message deflate compression options.
+    /// When set, enables WebSocket compression (RFC 7692).
+    /// Warning: Do not use compression when sending data containing secrets (CRIME/BREACH vulnerability).
+    /// </summary>
+    public WebSocketDeflateOptions? DeflateOptions { get; set; }
+#endif
 
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -101,9 +101,18 @@ internal partial class WebSocketConnection
 
 #if NET6_0_OR_GREATER
     /// <summary>
-    /// Optional per-message deflate compression options.
-    /// When set, enables WebSocket compression (RFC 7692).
-    /// Warning: Do not use compression when sending data containing secrets (CRIME/BREACH vulnerability).
+    /// Optional per-message deflate compression options (RFC 7692).
+    /// When set, the <see cref="ClientWebSocket" /> created by the default connection factory
+    /// assigns this value to <see cref="ClientWebSocketOptions.DangerousDeflateOptions" />.
+    /// Compression is negotiated during the WebSocket handshake; if the server does not
+    /// support it, the connection proceeds without compression.
+    /// <para>
+    /// <b>Security warning:</b> Do not enable compression when transmitting data that
+    /// contains secrets. Compressed encrypted payloads are vulnerable to CRIME/BREACH
+    /// side-channel attacks.
+    /// See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">
+    /// ClientWebSocketOptions.DangerousDeflateOptions</see> for details.
+    /// </para>
     /// </summary>
     public WebSocketDeflateOptions? DeflateOptions { get; set; }
 #endif

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -144,7 +144,8 @@ public partial class EmptyRealtimeApi
         public string BaseUrl { get; set; } = "";
 
         /// <summary>
-        /// Enable per-message deflate compression (RFC 7692). Default: false.
+        /// Enable per-message deflate compression (RFC 7692). When true, the client sets <c>ClientWebSocketOptions.DangerousDeflateOptions</c> before connecting. Compression is negotiated during the handshake; if the server does not support it, the connection proceeds uncompressed. Default: <c>false</c>.
+        /// <para><b>Security warning:</b> do not enable compression when transmitting data containing secrets — compressed encrypted payloads are vulnerable to CRIME/BREACH side-channel attacks. See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">ClientWebSocketOptions.DangerousDeflateOptions</see> for details.</para>
         /// </summary>
         public bool EnableCompression { get; set; } = false;
     }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -92,6 +92,12 @@ public partial class EmptyRealtimeApi : IAsyncDisposable, IDisposable, INotifyPr
     /// </summary>
     public async Task ConnectAsync(CancellationToken cancellationToken = default)
     {
+#if NET6_0_OR_GREATER
+        if (_options.EnableCompression)
+        {
+            _client.DeflateOptions = new System.Net.WebSockets.WebSocketDeflateOptions();
+        }
+#endif
         await _client.ConnectAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -132,5 +138,10 @@ public partial class EmptyRealtimeApi : IAsyncDisposable, IDisposable, INotifyPr
         /// The Websocket URL for the API connection.
         /// </summary>
         public string BaseUrl { get; set; } = "";
+
+        /// <summary>
+        /// Enable per-message deflate compression (RFC 7692). Default: false.
+        /// </summary>
+        public bool EnableCompression { get; set; } = false;
     }
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -286,7 +286,8 @@ public partial class RealtimeApi
         public string BaseUrl { get; set; } = "";
 
         /// <summary>
-        /// Enable per-message deflate compression (RFC 7692). Default: false.
+        /// Enable per-message deflate compression (RFC 7692). When true, the client sets <c>ClientWebSocketOptions.DangerousDeflateOptions</c> before connecting. Compression is negotiated during the handshake; if the server does not support it, the connection proceeds uncompressed. Default: <c>false</c>.
+        /// <para><b>Security warning:</b> do not enable compression when transmitting data containing secrets — compressed encrypted payloads are vulnerable to CRIME/BREACH side-channel attacks. See <see href="https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions">ClientWebSocketOptions.DangerousDeflateOptions</see> for details.</para>
         /// </summary>
         public bool EnableCompression { get; set; } = false;
 

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -210,6 +210,12 @@ public partial class RealtimeApi : IAsyncDisposable, IDisposable, INotifyPropert
     /// </summary>
     public async Task ConnectAsync(CancellationToken cancellationToken = default)
     {
+#if NET6_0_OR_GREATER
+        if (_options.EnableCompression)
+        {
+            _client.DeflateOptions = new System.Net.WebSockets.WebSocketDeflateOptions();
+        }
+#endif
         await _client.ConnectAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -274,6 +280,11 @@ public partial class RealtimeApi : IAsyncDisposable, IDisposable, INotifyPropert
         /// The Websocket URL for the API connection.
         /// </summary>
         public string BaseUrl { get; set; } = "";
+
+        /// <summary>
+        /// Enable per-message deflate compression (RFC 7692). Default: false.
+        /// </summary>
+        public bool EnableCompression { get; set; } = false;
 
         public string? Model { get; set; }
 


### PR DESCRIPTION
## Description

Adds opt-in per-message deflate compression (RFC 7692) for WebSocket connections in the C# SDK generator. When enabled, the generated client sets `ClientWebSocketOptions.DangerousDeflateOptions` to reduce bandwidth for text-heavy (JSON) WebSocket APIs.

Compression is negotiated during the WebSocket handshake — if the server doesn't support it, the extension is simply not activated and the connection proceeds uncompressed. Default: `false`.

See [ClientWebSocketOptions.DangerousDeflateOptions](https://learn.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions.dangerousdeflateoptions) for details on the underlying .NET API.

## Changes Made

- **`WebSocketConnection.Template.cs`**: Added `DeflateOptions` property (guarded with `#if NET6_0_OR_GREATER`); applied in the default connection factory lambda alongside the existing `KeepAliveInterval`/`KeepAliveTimeout`/`ConnectTimeout`/`HttpInvoker` settings
- **`WebSocketClient.Template.cs`**: Added `DeflateOptions` property (guarded with `#if NET6_0_OR_GREATER`); forwarded to `WebSocketConnection` in `ConnectAsync`
- **`WebsocketClientGenerator.ts`**: Added `EnableCompression` boolean field (default: `false`) to the generated `Options` class; `ConnectAsync` conditionally sets `_client.DeflateOptions = new WebSocketDeflateOptions()` when enabled, wrapped in `#if NET6_0_OR_GREATER`
- **`versions.yml`**: New version 2.43.0
- **Seed outputs**: Regenerated `with-websockets` fixture (`RealtimeApi.cs`, `EmptyRealtimeApi.cs`, `WebSocketClient.cs`, `WebSocketConnection.cs`) now include `EnableCompression` on Options and the conditional `DeflateOptions` assignment in `ConnectAsync`

## Items for Human Review

1. **Silent no-op on older frameworks**: `EnableCompression` is an unconditional `bool` on the generated Options class, but the code that acts on it is inside `#if NET6_0_OR_GREATER`. Setting `EnableCompression = true` on `net462`/`netstandard2.0` silently does nothing — confirm this is acceptable vs. omitting the property entirely on older TFMs.
2. **Custom factory bypass**: `DeflateOptions` is only applied in the default connection factory lambda. Users providing a custom `clientFactory` must handle compression themselves. This is intentional but worth confirming.
3. **Default deflate settings only**: The `EnableCompression` boolean creates a `new WebSocketDeflateOptions()` with .NET defaults (no custom window bits, etc.). Users needing fine-grained control would need to set `DeflateOptions` directly on the `WebSocketClient` instance. Confirm this level of abstraction is sufficient.
4. **XML doc correctness**: The `EnableCompression` summary includes `<see href>` linking to MS docs and CRIME/BREACH warnings — verify these render correctly in generated IntelliSense.
5. **Field ordering in generated Options class**: `EnableCompression` is emitted before `HttpInvoker`. Both are infrastructure options so this should be fine, but verify the ordering is acceptable.

## Testing

- [x] `pnpm seed test --generator csharp-sdk --fixture websocket` — 2/2 passed ✅
- [x] Multi-target build (`net462`, `net8.0`, `netstandard2.0`) verified via seed build scripts

Link to Devin session: https://app.devin.ai/sessions/d59c146fa05f42d6bf76562db3cf9ce9
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
