### PR TITLE
feat(csharp): add queued sending via Channel<T> to WebSocket connection

### DIFF
--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -101,6 +101,24 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     }
 
     /// <summary>
+    /// Queues a text message for sending on a background thread. Non-blocking.
+    /// </summary>
+    public bool Send(string message)
+    {
+        EnsureConnected();
+        return _webSocket!.Send(message);
+    }
+
+    /// <summary>
+    /// Queues a binary message for sending on a background thread. Non-blocking.
+    /// </summary>
+    public bool Send(byte[] message)
+    {
+        EnsureConnected();
+        return _webSocket!.Send(message);
+    }
+
+    /// <summary>
     /// Asynchronously disposes the WebSocketClient instance, closing any active connections and cleaning up resources.
     /// </summary>
     /// <returns>A ValueTask representing the asynchronous dispose operation.</returns>

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Sending.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Sending.Template.cs
@@ -209,9 +209,9 @@ internal partial class WebSocketConnection
                     {
                         await SendInternalSynchronized(new RequestTextMessage(message));
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
-                        // individual message send failed, continue draining
+                        await OnExceptionOccurred(e).ConfigureAwait(false);
                     }
                 }
             }
@@ -231,9 +231,9 @@ internal partial class WebSocketConnection
                     {
                         await SendInternalSynchronized(new ArraySegment<byte>(message));
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
-                        // individual message send failed, continue draining
+                        await OnExceptionOccurred(e).ConfigureAwait(false);
                     }
                 }
             }

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Sending.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Sending.Template.cs
@@ -2,11 +2,36 @@
 #pragma warning disable
 using global::System.Net.WebSockets;
 using global::System.Text;
+using global::System.Threading.Channels;
 
 namespace <%= namespace%>.WebSockets;
 
 internal partial class WebSocketConnection
 {
+    private readonly Channel<string> _textSendQueue = Channel.CreateUnbounded<string>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+
+    private readonly Channel<byte[]> _binarySendQueue = Channel.CreateUnbounded<byte[]>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+
+    /// <summary>
+    /// Queues a text message for sending. Actual send happens on a background thread.
+    /// </summary>
+    /// <returns>true if the message was written to the queue</returns>
+    public bool Send(string message)
+    {
+        return _textSendQueue.Writer.TryWrite(message);
+    }
+
+    /// <summary>
+    /// Queues a binary message for sending. Actual send happens on a background thread.
+    /// </summary>
+    /// <returns>true if the message was written to the queue</returns>
+    public bool Send(byte[] message)
+    {
+        return _binarySendQueue.Writer.TryWrite(message);
+    }
+
     /// <summary>
     /// Send text message to the websocket channel.
     /// It doesn't use a sending queue,
@@ -170,5 +195,49 @@ internal partial class WebSocketConnection
         return internalToken != CancellationToken.None
             ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, internalToken)
             : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+    }
+
+    private async global::System.Threading.Tasks.Task DrainTextQueue(CancellationToken token)
+    {
+        try
+        {
+            while (await _textSendQueue.Reader.WaitToReadAsync(token))
+            {
+                while (_textSendQueue.Reader.TryRead(out var message))
+                {
+                    try
+                    {
+                        await SendInternalSynchronized(new RequestTextMessage(message));
+                    }
+                    catch (Exception)
+                    {
+                        // individual message send failed, continue draining
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private async global::System.Threading.Tasks.Task DrainBinaryQueue(CancellationToken token)
+    {
+        try
+        {
+            while (await _binarySendQueue.Reader.WaitToReadAsync(token))
+            {
+                while (_binarySendQueue.Reader.TryRead(out var message))
+                {
+                    try
+                    {
+                        await SendInternalSynchronized(new ArraySegment<byte>(message));
+                    }
+                    catch (Exception)
+                    {
+                        // individual message send failed, continue draining
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
     }
 }

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Sending.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Sending.Template.cs
@@ -209,6 +209,7 @@ internal partial class WebSocketConnection
                     {
                         await SendInternalSynchronized(new RequestTextMessage(message));
                     }
+                    catch (OperationCanceledException) { }
                     catch (Exception e)
                     {
                         await OnExceptionOccurred(e).ConfigureAwait(false);
@@ -231,6 +232,7 @@ internal partial class WebSocketConnection
                     {
                         await SendInternalSynchronized(new ArraySegment<byte>(message));
                     }
+                    catch (OperationCanceledException) { }
                     catch (Exception e)
                     {
                         await OnExceptionOccurred(e).ConfigureAwait(false);

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -151,6 +151,8 @@ internal partial class WebSocketConnection
         {
             _lastChanceTimer?.Dispose();
             _errorReconnectTimer?.Dispose();
+            _textSendQueue.Writer.TryComplete();
+            _binarySendQueue.Writer.TryComplete();
             _cancellation?.Cancel();
             _cancellationTotal?.Cancel();
             _client?.Abort();
@@ -259,6 +261,18 @@ internal partial class WebSocketConnection
         _cancellationTotal = new CancellationTokenSource();
 
         await StartClient(Url, _cancellation.Token).ConfigureAwait(false);
+
+        _ = global::System.Threading.Tasks.Task.Factory.StartNew(
+            () => DrainTextQueue(_cancellationTotal.Token),
+            _cancellationTotal.Token,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+
+        _ = global::System.Threading.Tasks.Task.Factory.StartNew(
+            () => DrainBinaryQueue(_cancellationTotal.Token),
+            _cancellationTotal.Token,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
     }
 
     private async global::System.Threading.Tasks.Task<bool> StopInternal(

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -154,8 +154,8 @@ internal partial class WebSocketConnection
             _textSendQueue.Writer.TryComplete();
             _binarySendQueue.Writer.TryComplete();
             _cancellation?.Cancel();
-            _cancellationTotal?.Cancel();
             _client?.Abort();
+            _cancellationTotal?.Cancel();
             _client?.Dispose();
             _cancellation?.Dispose();
             _cancellationTotal?.Dispose();

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -934,7 +934,8 @@ ${this.getAdditionalItemGroups().join(`\n${this.generation.constants.formatting.
         return this.context.hasWebSocketEndpoints
             ? [
                   '    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />',
-                  '    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />'
+                  '    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />',
+                  '    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />'
               ]
             : [];
     }

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.39.0
+  changelogEntry:
+    - summary: |
+        Add queued sending via `Channel<T>` to the WebSocket connection layer. Two
+        unbounded channels (text and binary) are drained by dedicated `LongRunning`
+        background tasks started alongside the connection. The non-blocking `Send(string)`
+        and `Send(byte[])` methods return `bool` indicating whether the message was
+        queued, while the existing `SendInstant` async-per-send path remains unchanged.
+        Queues are completed in `Dispose` before cancellation tokens are signalled.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.38.1
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -113,6 +113,24 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     }
 
     /// <summary>
+    /// Queues a text message for sending on a background thread. Non-blocking.
+    /// </summary>
+    public bool Send(string message)
+    {
+        EnsureConnected();
+        return _webSocket!.Send(message);
+    }
+
+    /// <summary>
+    /// Queues a binary message for sending on a background thread. Non-blocking.
+    /// </summary>
+    public bool Send(byte[] message)
+    {
+        EnsureConnected();
+        return _webSocket!.Send(message);
+    }
+
+    /// <summary>
     /// Asynchronously disposes the WebSocketClient instance, closing any active connections and cleaning up resources.
     /// </summary>
     /// <returns>A ValueTask representing the asynchronous dispose operation.</returns>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.Sending.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.Sending.cs
@@ -237,9 +237,9 @@ internal partial class WebSocketConnection
                     {
                         await SendInternalSynchronized(new RequestTextMessage(message));
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
-                        // individual message send failed, continue draining
+                        await OnExceptionOccurred(e).ConfigureAwait(false);
                     }
                 }
             }
@@ -259,9 +259,9 @@ internal partial class WebSocketConnection
                     {
                         await SendInternalSynchronized(new ArraySegment<byte>(message));
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
-                        // individual message send failed, continue draining
+                        await OnExceptionOccurred(e).ConfigureAwait(false);
                     }
                 }
             }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.Sending.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.Sending.cs
@@ -237,6 +237,7 @@ internal partial class WebSocketConnection
                     {
                         await SendInternalSynchronized(new RequestTextMessage(message));
                     }
+                    catch (OperationCanceledException) { }
                     catch (Exception e)
                     {
                         await OnExceptionOccurred(e).ConfigureAwait(false);
@@ -259,6 +260,7 @@ internal partial class WebSocketConnection
                     {
                         await SendInternalSynchronized(new ArraySegment<byte>(message));
                     }
+                    catch (OperationCanceledException) { }
                     catch (Exception e)
                     {
                         await OnExceptionOccurred(e).ConfigureAwait(false);

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.Sending.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.Sending.cs
@@ -2,11 +2,38 @@
 #pragma warning disable
 using global::System.Net.WebSockets;
 using global::System.Text;
+using global::System.Threading.Channels;
 
 namespace SeedWebsocket.Core.WebSockets;
 
 internal partial class WebSocketConnection
 {
+    private readonly Channel<string> _textSendQueue = Channel.CreateUnbounded<string>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false }
+    );
+
+    private readonly Channel<byte[]> _binarySendQueue = Channel.CreateUnbounded<byte[]>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false }
+    );
+
+    /// <summary>
+    /// Queues a text message for sending. Actual send happens on a background thread.
+    /// </summary>
+    /// <returns>true if the message was written to the queue</returns>
+    public bool Send(string message)
+    {
+        return _textSendQueue.Writer.TryWrite(message);
+    }
+
+    /// <summary>
+    /// Queues a binary message for sending. Actual send happens on a background thread.
+    /// </summary>
+    /// <returns>true if the message was written to the queue</returns>
+    public bool Send(byte[] message)
+    {
+        return _binarySendQueue.Writer.TryWrite(message);
+    }
+
     /// <summary>
     /// Send text message to the websocket channel.
     /// It doesn't use a sending queue,
@@ -196,5 +223,49 @@ internal partial class WebSocketConnection
         return internalToken != CancellationToken.None
             ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, internalToken)
             : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+    }
+
+    private async global::System.Threading.Tasks.Task DrainTextQueue(CancellationToken token)
+    {
+        try
+        {
+            while (await _textSendQueue.Reader.WaitToReadAsync(token))
+            {
+                while (_textSendQueue.Reader.TryRead(out var message))
+                {
+                    try
+                    {
+                        await SendInternalSynchronized(new RequestTextMessage(message));
+                    }
+                    catch (Exception)
+                    {
+                        // individual message send failed, continue draining
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private async global::System.Threading.Tasks.Task DrainBinaryQueue(CancellationToken token)
+    {
+        try
+        {
+            while (await _binarySendQueue.Reader.WaitToReadAsync(token))
+            {
+                while (_binarySendQueue.Reader.TryRead(out var message))
+                {
+                    try
+                    {
+                        await SendInternalSynchronized(new ArraySegment<byte>(message));
+                    }
+                    catch (Exception)
+                    {
+                        // individual message send failed, continue draining
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
     }
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -166,6 +166,8 @@ internal partial class WebSocketConnection
         {
             _lastChanceTimer?.Dispose();
             _errorReconnectTimer?.Dispose();
+            _textSendQueue.Writer.TryComplete();
+            _binarySendQueue.Writer.TryComplete();
             _cancellation?.Cancel();
             _cancellationTotal?.Cancel();
             _client?.Abort();
@@ -296,6 +298,20 @@ internal partial class WebSocketConnection
         _cancellationTotal = new CancellationTokenSource();
 
         await StartClient(Url, _cancellation.Token).ConfigureAwait(false);
+
+        _ = global::System.Threading.Tasks.Task.Factory.StartNew(
+            () => DrainTextQueue(_cancellationTotal.Token),
+            _cancellationTotal.Token,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default
+        );
+
+        _ = global::System.Threading.Tasks.Task.Factory.StartNew(
+            () => DrainBinaryQueue(_cancellationTotal.Token),
+            _cancellationTotal.Token,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default
+        );
     }
 
     private async global::System.Threading.Tasks.Task<bool> StopInternal(

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -169,8 +169,8 @@ internal partial class WebSocketConnection
             _textSendQueue.Writer.TryComplete();
             _binarySendQueue.Writer.TryComplete();
             _cancellation?.Cancel();
-            _cancellationTotal?.Cancel();
             _client?.Abort();
+            _cancellationTotal?.Cancel();
             _client?.Dispose();
             _cancellation?.Dispose();
             _cancellationTotal?.Dispose();

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/SeedWebsocket.csproj
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/SeedWebsocket.csproj
@@ -45,6 +45,7 @@
 
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Adds non-blocking queued sending to the C# WebSocket connection layer using `System.Threading.Channels.Channel<T>`. This complements the existing `SendInstant` (await-per-send) path with a queue-based approach suited for high-throughput scenarios like audio streaming.

## Changes Made

- **`WebSocketConnection.Sending.Template.cs`**: Added two unbounded `Channel<T>` queues (text + binary) with `SingleReader = true`, non-blocking `Send(string)` / `Send(byte[])` methods returning `bool`, and `DrainTextQueue` / `DrainBinaryQueue` background drain loops that route through `SendInternalSynchronized`. Drain loop errors are surfaced via `OnExceptionOccurred`; `OperationCanceledException` is caught separately to avoid spurious error events during shutdown.
- **`WebSocketConnection.Template.cs`**: Start drain loops via `Task.Run` in `StartInternal` after connection; complete queue writers in `Dispose` before cancelling tokens. Dispose ordering: `TryComplete` → `_cancellationConnection.Cancel` → `_cancellation.Cancel` → `_client.Abort` → `_cancellationTotal.Cancel` (drain loop safety net).
- **`WebSocketClient.Template.cs`**: Expose `Send(string)` and `Send(byte[])` alongside existing `SendInstant` overloads
- **`CsharpProject.ts`**: Added `System.Threading.Channels` 8.0.0 NuGet package to `getWebSocketAsyncDependencies()` — required for `netstandard2.0` and `net462` targets where the namespace is not built-in
- **No changes to `WebsocketClientGenerator.ts`**: Generated `Send` methods continue using `SendInstant`. The queued path is available as an advanced option through the underlying client
- Updated `versions.yml` with 2.44.0 entry

## Updates Since Initial Revision

- **Fixed `Task<Task>` bug**: Replaced `Task.Factory.StartNew` (with `LongRunning`) with `Task.Run`, which correctly unwraps async lambdas. The `LongRunning` hint was wasted since the dedicated thread was released at the first `await`.
- **Fixed exception swallowing**: Drain loop catch blocks now call `await OnExceptionOccurred(e).ConfigureAwait(false)` instead of silently discarding errors, consistent with how `Listen` handles exceptions.
- **Fixed spurious `OperationCanceledException` during Dispose**: Added inner `catch (OperationCanceledException) { }` before the general `catch (Exception e)` in both drain loops. During `Dispose()`, `_cancellation` is cancelled before `_cancellationTotal`, so in-flight `SendAsync` calls (which use `_cancellation.Token`) throw `OperationCanceledException`. Without this fix, those expected cancellations were routed to `OnExceptionOccurred` as spurious error events.
- **Improved Dispose ordering**: Moved `_cancellationTotal.Cancel()` after `_client.Abort()` so drain loops have maximum time between `TryComplete` and cancellation to read remaining items. After `Abort()`, sends fail fast (caught), then `Cancel` is the safety-net exit.
- **Added `System.Threading.Channels` NuGet dependency**: `System.Threading.Channels` is not built-in on `netstandard2.0` or `net462`; added as an explicit package reference to fix CI build failures.

## Review Checklist for Humans

- [ ] **Dispose race**: `Dispose` is synchronous and does not await drain loop completion. After `TryComplete()` + `Abort()`, remaining queued items are read but sends fail immediately (`IsClientConnected()` returns false). Items in flight during hard dispose are lost — verify this is acceptable (matches Marfusios reference behavior).
- [ ] **Unobserved handler exceptions**: If the `ExceptionOccurred` event handler itself throws inside the drain loop's `catch (Exception e)`, that exception is unobserved. Confirm this is acceptable.
- [ ] **Unbounded channels**: No backpressure cap. `TryWrite` always returns `true` unless the channel is completed, so the `bool` return from `Send()` is only meaningful for detecting post-dispose writes.
- [ ] **Integration with recent features**: This PR was merged across multiple main updates (ConnectTimeout v2.41.0, HTTP/2 v2.42.0, deflate compression v2.43.0). Verify the Dispose ordering and StartInternal flow still compose correctly with those features.

## Testing

- [x] All 3 C# websocket seed fixtures pass (`websocket`, `websocket-bearer-auth`, `websocket-inferred-auth`)
- [x] Generated seed output verified to contain Channel queues, `Send` methods, `DrainTextQueue`/`DrainBinaryQueue`, drain thread startup in `StartInternal`, and queue completion in `Dispose`
- [x] Generated `.csproj` includes `System.Threading.Channels` 8.0.0 NuGet reference
- [x] All 63 CI checks pass

Link to Devin session: https://app.devin.ai/sessions/a512116fa76c4c95be153ef09073f23c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
