### PR TITLE
feat(csharp): configure PING/PONG keep-alive on ClientWebSocket

### DIFF
--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -180,7 +180,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         Status = ConnectionStatus.Connecting;
 
-        _webSocket = new WebSocketConnection(_uri, () => new ClientWebSocket())
+        _webSocket = new WebSocketConnection(_uri)
         {
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -76,10 +76,6 @@ internal partial class WebSocketConnection
             ?? (
                 async (uri, token) =>
                 {
-                    //var client = new ClientWebSocket
-                    //{
-                    //    Options = { KeepAliveInterval = new TimeSpan(0, 0, 5, 0) }
-                    //};
                     var client = new ClientWebSocket();
                     client.Options.KeepAliveInterval = KeepAliveInterval;
 #if NET9_0_OR_GREATER

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -40,7 +40,7 @@ internal partial class WebSocketConnection
     /// A simple websocket client with built-in reconnection and error handling
     /// </summary>
     /// <param name="url">Target websocket url (wss://)</param>
-    /// <param name="clientFactory">Optional factory for native ClientWebSocket, use it whenever you need some custom features (proxy, settings, etc)</param>
+    /// <param name="clientFactory">Optional factory for native ClientWebSocket, use it whenever you need some custom features (proxy, settings, etc). Note: when providing a factory, you are responsible for configuring keep-alive on the returned ClientWebSocket instance.</param>
     public WebSocketConnection(Uri url, Func<ClientWebSocket>? clientFactory = null)
         : this(url, null, GetClientFactory(clientFactory)) { }
 
@@ -49,7 +49,7 @@ internal partial class WebSocketConnection
     /// </summary>
     /// <param name="url">Target websocket url (wss://)</param>
     /// <param name="logger">Logger instance, can be null</param>
-    /// <param name="clientFactory">Optional factory for native ClientWebSocket, use it whenever you need some custom features (proxy, settings, etc)</param>
+    /// <param name="clientFactory">Optional factory for native ClientWebSocket, use it whenever you need some custom features (proxy, settings, etc). Note: when providing a factory, you are responsible for configuring keep-alive on the returned ClientWebSocket instance.</param>
     public WebSocketConnection(
         Uri url,
         ILogger<WebSocketConnection> logger,
@@ -81,6 +81,10 @@ internal partial class WebSocketConnection
                     //    Options = { KeepAliveInterval = new TimeSpan(0, 0, 5, 0) }
                     //};
                     var client = new ClientWebSocket();
+                    client.Options.KeepAliveInterval = KeepAliveInterval;
+#if NET9_0_OR_GREATER
+                    client.Options.KeepAliveTimeout = KeepAliveTimeout;
+#endif
                     await client.ConnectAsync(uri, token).ConfigureAwait(false);
                     return client;
                 }
@@ -88,6 +92,19 @@ internal partial class WebSocketConnection
     }
 
     public Uri Url { get; set; }
+
+    /// <summary>
+    /// Interval for sending keep-alive frames. Default: 30 seconds.
+    /// Set to TimeSpan.Zero to disable keep-alive.
+    /// </summary>
+    public TimeSpan KeepAliveInterval { get; set; } = WebSocket.DefaultKeepAliveInterval;
+
+    /// <summary>
+    /// Timeout for expecting a PONG response to a PING keep-alive frame (.NET 9+).
+    /// Set to a positive finite TimeSpan to enable PING/PONG keep-alive strategy.
+    /// Default: 20 seconds.
+    /// </summary>
+    public TimeSpan KeepAliveTimeout { get; set; } = TimeSpan.FromSeconds(20);
 
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.39.0
+  changelogEntry:
+    - summary: |
+        Configure PING/PONG keep-alive on `ClientWebSocket`. The default connection factory
+        now sets `KeepAliveInterval` (default: 30 s) and, on .NET 9+, `KeepAliveTimeout`
+        (default: 20 s) to enable the PING/PONG keep-alive strategy that detects unresponsive
+        servers at the transport level. Both values are exposed as public properties on
+        `WebSocketConnection` for caller customization.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.38.1
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -196,7 +196,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         Status = ConnectionStatus.Connecting;
 
-        _webSocket = new WebSocketConnection(_uri, () => new ClientWebSocket())
+        _webSocket = new WebSocketConnection(_uri)
         {
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -80,10 +80,6 @@ internal partial class WebSocketConnection
             ?? (
                 async (uri, token) =>
                 {
-                    //var client = new ClientWebSocket
-                    //{
-                    //    Options = { KeepAliveInterval = new TimeSpan(0, 0, 5, 0) }
-                    //};
                     var client = new ClientWebSocket();
                     client.Options.KeepAliveInterval = KeepAliveInterval;
 #if NET9_0_OR_GREATER

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -40,7 +40,7 @@ internal partial class WebSocketConnection
     /// A simple websocket client with built-in reconnection and error handling
     /// </summary>
     /// <param name="url">Target websocket url (wss://)</param>
-    /// <param name="clientFactory">Optional factory for native ClientWebSocket, use it whenever you need some custom features (proxy, settings, etc)</param>
+    /// <param name="clientFactory">Optional factory for native ClientWebSocket, use it whenever you need some custom features (proxy, settings, etc). Note: when providing a factory, you are responsible for configuring keep-alive on the returned ClientWebSocket instance.</param>
     public WebSocketConnection(Uri url, Func<ClientWebSocket>? clientFactory = null)
         : this(url, null, GetClientFactory(clientFactory)) { }
 
@@ -49,7 +49,7 @@ internal partial class WebSocketConnection
     /// </summary>
     /// <param name="url">Target websocket url (wss://)</param>
     /// <param name="logger">Logger instance, can be null</param>
-    /// <param name="clientFactory">Optional factory for native ClientWebSocket, use it whenever you need some custom features (proxy, settings, etc)</param>
+    /// <param name="clientFactory">Optional factory for native ClientWebSocket, use it whenever you need some custom features (proxy, settings, etc). Note: when providing a factory, you are responsible for configuring keep-alive on the returned ClientWebSocket instance.</param>
     public WebSocketConnection(
         Uri url,
         ILogger<WebSocketConnection> logger,
@@ -85,6 +85,10 @@ internal partial class WebSocketConnection
                     //    Options = { KeepAliveInterval = new TimeSpan(0, 0, 5, 0) }
                     //};
                     var client = new ClientWebSocket();
+                    client.Options.KeepAliveInterval = KeepAliveInterval;
+#if NET9_0_OR_GREATER
+                    client.Options.KeepAliveTimeout = KeepAliveTimeout;
+#endif
                     await client.ConnectAsync(uri, token).ConfigureAwait(false);
                     return client;
                 }
@@ -92,6 +96,19 @@ internal partial class WebSocketConnection
     }
 
     public Uri Url { get; set; }
+
+    /// <summary>
+    /// Interval for sending keep-alive frames. Default: 30 seconds.
+    /// Set to TimeSpan.Zero to disable keep-alive.
+    /// </summary>
+    public TimeSpan KeepAliveInterval { get; set; } = WebSocket.DefaultKeepAliveInterval;
+
+    /// <summary>
+    /// Timeout for expecting a PONG response to a PING keep-alive frame (.NET 9+).
+    /// Set to a positive finite TimeSpan to enable PING/PONG keep-alive strategy.
+    /// Default: 20 seconds.
+    /// </summary>
+    public TimeSpan KeepAliveTimeout { get; set; } = TimeSpan.FromSeconds(20);
 
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }


### PR DESCRIPTION
## Description

Configure transport-level PING/PONG keep-alive on `ClientWebSocket` for generated C# SDKs. The default PONG-only strategy cannot detect unresponsive servers; the PING/PONG strategy (available in .NET 9+) sends PING frames and expects PONG responses within a timeout, enabling dead connection detection.

## Changes Made

- Added `KeepAliveInterval` (default: 30s) and `KeepAliveTimeout` (default: 20s) public properties to `WebSocketConnection`
- Default connection factory now applies `KeepAliveInterval` to `ClientWebSocket.Options` and conditionally applies `KeepAliveTimeout` behind `#if NET9_0_OR_GREATER`
- Changed `WebSocketClient.ConnectAsync` to use the default connection factory (no `clientFactory` arg) so keep-alive settings are applied automatically
- Updated XML docs on `clientFactory` constructor overloads to note that callers providing their own factory are responsible for configuring keep-alive
- Removed stale commented-out keep-alive code that was superseded by the new implementation
- Added `versions.yml` entry for 2.39.0

## Important review notes

- **Behavioral change in `WebSocketClient.Template.cs`**: Previously passed `() => new ClientWebSocket()` which went through `GetClientFactory` and bypassed the default connection factory. Now uses the no-arg constructor so the default lambda (which configures keep-alive) is used. Both paths create a bare `ClientWebSocket` and connect — functionally equivalent, but now keep-alive is applied.
- `KeepAliveTimeout` property is always declared but only *applied* inside `#if NET9_0_OR_GREATER` — on older frameworks the property exists but is a no-op. XML doc marks it as "(.NET 9+)".

## Human review checklist

- [ ] Verify the constructor chain: `new WebSocketConnection(_uri)` → `clientFactory` is `null` → `GetClientFactory(null)` returns `null` → 3-arg constructor uses default lambda with keep-alive. Confirm no unintended side effects from the path change.
- [ ] Confirm `KeepAliveInterval` / `KeepAliveTimeout` properties are initialized before the `_connectionFactory` lambda is ever invoked (lambda runs at `StartClient` time, not construction time, so property initializers have completed).
- [ ] Check that `WebSocket.DefaultKeepAliveInterval` is the right default (it's 30s on all supported .NET versions).

## Testing

- [x] Seed tests pass for `websocket`, `websocket-bearer-auth`, and `websocket-inferred-auth` fixtures
- [x] Verified generated output contains `KeepAliveInterval`, `KeepAliveTimeout`, and `#if NET9_0_OR_GREATER` guard
- [x] Lint passes (`pnpm run check`)

Link to Devin session: https://app.devin.ai/sessions/6dce36a9b6c043ccaffe967222d7aedd
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
