### PR TITLE
feat(csharp): wire up WebSocket reconnection logic

### DIFF
--- a/generators/csharp/base/src/asIs/WebSockets/ReconnectionInfo.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/ReconnectionInfo.Template.cs
@@ -6,7 +6,7 @@ namespace <%= namespace%>.WebSockets;
 /// Contains information about a WebSocket reconnection event.
 /// Provides details about the reason for reconnection.
 /// </summary>
-internal class ReconnectionInfo
+public class ReconnectionInfo
 {
     /// <summary>
     /// Initializes a new instance of the ReconnectionInfo class.

--- a/generators/csharp/base/src/asIs/WebSockets/ReconnectionType.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/ReconnectionType.Template.cs
@@ -5,7 +5,7 @@ namespace <%= namespace%>.WebSockets;
 /// <summary>
 /// Specifies the type of reconnection that occurred in a WebSocket connection.
 /// </summary>
-internal enum ReconnectionType
+public enum ReconnectionType
 {
     /// <summary>
     /// Initial connection to the WebSocket stream.

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -20,6 +20,24 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     public bool IsReconnectionEnabled { get; set; }
 
     /// <summary>
+    /// Time to wait before reconnecting if no message comes from the server.
+    /// Set null to disable. Default: 1 minute.
+    /// </summary>
+    public TimeSpan? ReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Time to wait before reconnecting if the last reconnection attempt failed.
+    /// Set null to disable. Default: 1 minute.
+    /// </summary>
+    public TimeSpan? ErrorReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Time to wait before reconnecting if the connection is lost with a transient error.
+    /// Set null to disable (reconnect immediately). Default: null.
+    /// </summary>
+    public TimeSpan? LostReconnectTimeout { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the WebSocketClient class.
     /// </summary>
     /// <param name="uri">The WebSocket URI to connect to.</param>
@@ -189,6 +207,9 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
         _webSocket = new WebSocketConnection(_uri, () => new ClientWebSocket())
         {
             IsReconnectionEnabled = IsReconnectionEnabled,
+            ReconnectTimeout = ReconnectTimeout,
+            ErrorReconnectTimeout = ErrorReconnectTimeout,
+            LostReconnectTimeout = LostReconnectTimeout,
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -234,6 +234,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
             },
             DisconnectionHappened = async d =>
             {
+                Status = ConnectionStatus.Disconnected;
                 await Closed
                     .RaiseEvent(
                         new Closed { Code = (int?)d.CloseStatus, Reason = d.CloseStatusDescription }

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -15,6 +15,11 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     private readonly Func<Stream, global::System.Threading.Tasks.Task> _onTextMessage;
 
     /// <summary>
+    /// Enable or disable automatic reconnection. Default: false.
+    /// </summary>
+    public bool IsReconnectionEnabled { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the WebSocketClient class.
     /// </summary>
     /// <param name="uri">The WebSocket URI to connect to.</param>
@@ -148,6 +153,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
         ExceptionOccurred.Dispose();
         Closed.Dispose();
         Connected.Dispose();
+        Reconnecting.Dispose();
     }
 
     /// <summary>
@@ -182,6 +188,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         _webSocket = new WebSocketConnection(_uri, () => new ClientWebSocket())
         {
+            IsReconnectionEnabled = IsReconnectionEnabled,
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>
@@ -196,6 +203,11 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
                         new Closed { Code = (int?)d.CloseStatus, Reason = d.CloseStatusDescription }
                     )
                     .ConfigureAwait(false);
+            },
+            ReconnectionHappened = async info =>
+            {
+                Status = ConnectionStatus.Connected;
+                await Reconnecting.RaiseEvent(info).ConfigureAwait(false);
             },
         };
 
@@ -226,6 +238,11 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     /// Event that is raised when an exception occurs during WebSocket operations.
     /// </summary>
     public readonly Event<Exception> ExceptionOccurred = new();
+
+    /// <summary>
+    /// Event that is raised when the WebSocket connection is re-established after a disconnect.
+    /// </summary>
+    public readonly Event<ReconnectionInfo> Reconnecting = new();
 
     /// <summary>
     /// Event that is raised when a property value changes.

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -362,7 +362,6 @@ internal partial class WebSocketConnection
             IsStarted = true;
             _lastReceivedMsg = DateTime.UtcNow;
             ActivateLastChance();
-            await OnReconnectionHappened(ReconnectionInfo.Create(ReconnectionType.Initial)).ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -531,7 +530,7 @@ internal partial class WebSocketConnection
 
         _reconnecting = true;
 
-        var disType = (DisconnectionType)(int)type;
+        var disType = ToDisconnectionType(type);
         var disInfo = DisconnectionInfo.Create(disType, _client, causedException);
         if (type != ReconnectionType.Error
             && _client?.State != WebSocketState.CloseReceived
@@ -557,7 +556,8 @@ internal partial class WebSocketConnection
         }
 
         _cancellation = new CancellationTokenSource();
-        await StartClient(Url, _cancellation.Token, failFast: false).ConfigureAwait(false);
+        await StartClient(Url, _cancellation.Token, failFast).ConfigureAwait(false);
+        await OnReconnectionHappened(ReconnectionInfo.Create(type)).ConfigureAwait(false);
         _reconnecting = false;
     }
 
@@ -567,6 +567,17 @@ internal partial class WebSocketConnection
         var differentClient = client != _client;
         return inProgress || differentClient;
     }
+
+    private static DisconnectionType ToDisconnectionType(ReconnectionType type) => type switch
+    {
+        ReconnectionType.Initial => DisconnectionType.Exit,
+        ReconnectionType.Lost => DisconnectionType.Lost,
+        ReconnectionType.NoMessageReceived => DisconnectionType.NoMessageReceived,
+        ReconnectionType.Error => DisconnectionType.Error,
+        ReconnectionType.ByUser => DisconnectionType.ByUser,
+        ReconnectionType.ByServer => DisconnectionType.ByServer,
+        _ => DisconnectionType.Exit
+    };
 
     private void ActivateLastChance()
     {

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -28,10 +28,22 @@ internal partial class WebSocketConnection
 
     private Timer _errorReconnectTimer;
 
+    private DateTime _lastReceivedMsg = DateTime.UtcNow;
+
     private bool _disposing;
     private bool _reconnecting;
     private bool _stopping;
-    private bool _isReconnectionEnabled = true;
+    private bool _isReconnectionEnabled;
+
+    /// <summary>
+    /// Enable or disable automatic reconnection. Default: false.
+    /// </summary>
+    public bool IsReconnectionEnabled
+    {
+        get => _isReconnectionEnabled;
+        set => _isReconnectionEnabled = value;
+    }
+
     private WebSocket _client;
     private CancellationTokenSource _cancellation;
     private CancellationTokenSource _cancellationTotal;
@@ -89,10 +101,29 @@ internal partial class WebSocketConnection
 
     public Uri Url { get; set; }
 
+    /// <summary>
+    /// Time range for how long to wait before reconnecting if no message comes from server.
+    /// Set null to disable. Default: 1 minute.
+    /// </summary>
+    public TimeSpan? ReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Time range for how long to wait before reconnecting if last reconnection failed.
+    /// Set null to disable. Default: 1 minute.
+    /// </summary>
+    public TimeSpan? ErrorReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Time range for how long to wait before reconnecting if connection is lost with a transient error.
+    /// Set null to disable. Default: null/disabled (reconnect immediately).
+    /// </summary>
+    public TimeSpan? LostReconnectTimeout { get; set; }
+
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }
     public Func<DisconnectionInfo, global::System.Threading.Tasks.Task>? DisconnectionHappened { get; set; }
     public Func<Exception, global::System.Threading.Tasks.Task>? ExceptionOccurred { get; set; }
+    public Func<ReconnectionInfo, global::System.Threading.Tasks.Task>? ReconnectionHappened { get; set; }
 
     private global::System.Threading.Tasks.Task OnTextMessageReceived(Stream stream) =>
         TextMessageReceived is null ? global::System.Threading.Tasks.Task.CompletedTask : TextMessageReceived.Invoke(stream);
@@ -105,6 +136,9 @@ internal partial class WebSocketConnection
 
     private global::System.Threading.Tasks.Task OnExceptionOccurred(Exception exception) =>
         ExceptionOccurred is null ? global::System.Threading.Tasks.Task.CompletedTask : ExceptionOccurred.Invoke(exception);
+
+    private global::System.Threading.Tasks.Task OnReconnectionHappened(ReconnectionInfo info) =>
+        ReconnectionHappened is null ? global::System.Threading.Tasks.Task.CompletedTask : ReconnectionHappened.Invoke(info);
 
     /// <summary>
     /// Get or set the name of the current websocket client instance.
@@ -318,10 +352,37 @@ internal partial class WebSocketConnection
 
     private async global::System.Threading.Tasks.Task StartClient(Uri uri, CancellationToken token)
     {
-        _client = await _connectionFactory(uri, token).ConfigureAwait(false);
-        _ = Listen(_client, token);
-        IsRunning = true;
-        IsStarted = true;
+        DeactivateLastChance();
+        try
+        {
+            _client = await _connectionFactory(uri, token).ConfigureAwait(false);
+            _ = Listen(_client, token);
+            IsRunning = true;
+            IsStarted = true;
+            _lastReceivedMsg = DateTime.UtcNow;
+            ActivateLastChance();
+            await OnReconnectionHappened(ReconnectionInfo.Create(ReconnectionType.Initial)).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            IsRunning = _client?.State == WebSocketState.Open;
+            var info = DisconnectionInfo.Create(DisconnectionType.Error, _client, e);
+            await OnDisconnectionHappened(info).ConfigureAwait(false);
+
+            if (info.CancelReconnection) return;
+
+            if (ErrorReconnectTimeout == null) return;
+
+            var timeout = ErrorReconnectTimeout.Value;
+            _errorReconnectTimer?.Dispose();
+            _errorReconnectTimer = new Timer(
+                _ =>
+                {
+                    if (_client != null && ShouldIgnoreReconnection(_client)) return;
+                    _ = ReconnectSynchronized(ReconnectionType.Error, false, e);
+                },
+                null, timeout, Timeout.InfiniteTimeSpan);
+        }
     }
 
     private bool IsClientConnected()
@@ -333,6 +394,7 @@ internal partial class WebSocketConnection
 
     private async global::System.Threading.Tasks.Task Listen(WebSocket client, CancellationToken token)
     {
+        Exception causedException = null;
         try
         {
             // define buffer here and reuse, to avoid more allocation
@@ -358,9 +420,11 @@ internal partial class WebSocketConnection
                     switch (result.MessageType)
                     {
                         case WebSocketMessageType.Text:
+                            _lastReceivedMsg = DateTime.UtcNow;
                             await OnTextMessageReceived(ms).ConfigureAwait(false);
                             break;
                         case WebSocketMessageType.Binary:
+                            _lastReceivedMsg = DateTime.UtcNow;
                             await OnBinaryMessageReceived(ms).ConfigureAwait(false);
                             break;
                         case WebSocketMessageType.Close:
@@ -407,6 +471,119 @@ internal partial class WebSocketConnection
                 e.Message
             );
             await OnExceptionOccurred(e).ConfigureAwait(false);
+            causedException = e;
+        }
+
+        if (ShouldIgnoreReconnection(client) || !IsStarted)
+        {
+            return;
+        }
+
+        if (LostReconnectTimeout.HasValue)
+        {
+            await global::System.Threading.Tasks.Task.Delay(
+                LostReconnectTimeout.Value, token).ConfigureAwait(false);
+        }
+
+        _ = ReconnectSynchronized(ReconnectionType.Lost, false, causedException);
+    }
+
+    public global::System.Threading.Tasks.Task Reconnect() => ReconnectInternal(false);
+    public global::System.Threading.Tasks.Task ReconnectOrFail() => ReconnectInternal(true);
+
+    private async global::System.Threading.Tasks.Task ReconnectInternal(bool failFast)
+    {
+        if (!IsStarted) return;
+        try
+        {
+            await ReconnectSynchronized(ReconnectionType.ByUser, failFast, null).ConfigureAwait(false);
+        }
+        finally
+        {
+            _reconnecting = false;
+        }
+    }
+
+    private async global::System.Threading.Tasks.Task ReconnectSynchronized(
+        ReconnectionType type, bool failFast, Exception? causedException)
+    {
+        using (await _locker.LockAsync())
+        {
+            await Reconnect(type, failFast, causedException);
+        }
+    }
+
+    private async global::System.Threading.Tasks.Task Reconnect(
+        ReconnectionType type, bool failFast, Exception? causedException)
+    {
+        IsRunning = false;
+        if (_disposing || !IsStarted) return;
+
+        _reconnecting = true;
+
+        var disType = (DisconnectionType)(int)type;
+        var disInfo = DisconnectionInfo.Create(disType, _client, causedException);
+        if (type != ReconnectionType.Error
+            && _client?.State != WebSocketState.CloseReceived
+            && _client?.State != WebSocketState.Closed)
+        {
+            await OnDisconnectionHappened(disInfo).ConfigureAwait(false);
+            if (disInfo.CancelReconnection)
+            {
+                _reconnecting = false;
+                return;
+            }
+        }
+
+        _cancellation?.Cancel();
+        try { _client?.Abort(); } catch { /* ignored */ }
+        _client?.Dispose();
+
+        if (type != ReconnectionType.Error && (!_isReconnectionEnabled || disInfo.CancelReconnection))
+        {
+            IsStarted = false;
+            _reconnecting = false;
+            return;
+        }
+
+        _cancellation = new CancellationTokenSource();
+        await StartClient(Url, _cancellation.Token).ConfigureAwait(false);
+        _reconnecting = false;
+    }
+
+    private bool ShouldIgnoreReconnection(WebSocket client)
+    {
+        var inProgress = _disposing || _reconnecting || _stopping;
+        var differentClient = client != _client;
+        return inProgress || differentClient;
+    }
+
+    private void ActivateLastChance()
+    {
+        var timerMs = 1000;
+        _lastChanceTimer = new Timer(LastChance, null, timerMs, timerMs);
+    }
+
+    private void DeactivateLastChance()
+    {
+        _lastChanceTimer?.Dispose();
+        _lastChanceTimer = null;
+    }
+
+    private void LastChance(object? state)
+    {
+        if (!_isReconnectionEnabled || ReconnectTimeout == null)
+        {
+            DeactivateLastChance();
+            return;
+        }
+
+        var timeoutMs = Math.Abs(ReconnectTimeout.Value.TotalMilliseconds);
+        var diffMs = Math.Abs(DateTime.UtcNow.Subtract(_lastReceivedMsg).TotalMilliseconds);
+        if (diffMs > timeoutMs)
+        {
+            DeactivateLastChance();
+            _ = ReconnectSynchronized(ReconnectionType.NoMessageReceived, false, null);
         }
     }
 

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -580,7 +580,10 @@ internal partial class WebSocketConnection
 
         _cancellation = new CancellationTokenSource();
         await StartClient(Url, _cancellation.Token, failFast).ConfigureAwait(false);
-        await OnReconnectionHappened(ReconnectionInfo.Create(type)).ConfigureAwait(false);
+        if (IsRunning)
+        {
+            await OnReconnectionHappened(ReconnectionInfo.Create(type)).ConfigureAwait(false);
+        }
         _reconnecting = false;
     }
 

--- a/generators/csharp/codegen/src/context/generation-info.ts
+++ b/generators/csharp/codegen/src/context/generation-info.ts
@@ -815,6 +815,12 @@ export class Generation {
                 origin: this.model.staticExplicit("Closed"),
                 namespace: this.namespaces.webSocketsCore
             }),
+        /** Reconnection info for WebSocket connections */
+        ReconnectionInfo: () =>
+            this.csharp.classReference({
+                origin: this.model.staticExplicit("ReconnectionInfo"),
+                namespace: this.namespaces.webSocketsCore
+            }),
         /**
          * Custom pagination class for iterating over paged results.
          * @param itemType - The type of items in each page

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -448,6 +448,16 @@ export class WebSocketClientGenerator extends WithGeneration {
             });
         }
 
+        optionsClass.addField({
+            origin: optionsClass.explicit("IsReconnectionEnabled"),
+            access: ast.Access.Public,
+            type: this.Primitive.boolean,
+            summary: "Enable or disable automatic reconnection. Default: false.",
+            get: true,
+            set: true,
+            initializer: this.csharp.codeblock("false")
+        });
+
         return optionsClass;
     }
 
@@ -588,6 +598,7 @@ export class WebSocketClientGenerator extends WithGeneration {
                     })
                 );
                 writer.writeTextStatement("");
+                writer.writeTextStatement("_client.IsReconnectionEnabled = _options.IsReconnectionEnabled");
                 // Note: PropertyChanged event forwarding is handled by the event's add/remove accessors
             }),
             doc: this.csharp.xmlDocBlockOf({ summary: "Constructor with options" })
@@ -984,6 +995,7 @@ export class WebSocketClientGenerator extends WithGeneration {
                     writer.writeTextStatement(`${event.name}.Dispose()`);
                 }
                 writer.writeTextStatement(`UnknownMessage.Dispose()`);
+                writer.writeTextStatement(`Reconnecting.Dispose()`);
             })
         });
     }
@@ -1089,6 +1101,16 @@ export class WebSocketClientGenerator extends WithGeneration {
             summary: "Event that is raised when an exception occurs during WebSocket operations.",
             get: true,
             initializer: this.csharp.codeblock("_client.ExceptionOccurred")
+        });
+
+        // Reconnecting event
+        cls.addField({
+            origin: cls.explicit("Reconnecting"),
+            access: ast.Access.Public,
+            type: this.Types.WebSocketEvent(this.Types.ReconnectionInfo),
+            summary: "Event raised when the WebSocket connection is re-established after a disconnect.",
+            get: true,
+            initializer: this.csharp.codeblock("_client.Reconnecting")
         });
     }
 

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -540,6 +540,38 @@ export class WebSocketClientGenerator extends WithGeneration {
             initializer: this.csharp.codeblock("false")
         });
 
+        optionsClass.addField({
+            origin: optionsClass.explicit("ReconnectTimeout"),
+            access: ast.Access.Public,
+            type: this.System.TimeSpan.asOptional(),
+            summary:
+                "Time to wait before reconnecting if no message comes from the server. Set null to disable. Default: 1 minute.",
+            get: true,
+            set: true,
+            initializer: this.csharp.codeblock("TimeSpan.FromMinutes(1)")
+        });
+
+        optionsClass.addField({
+            origin: optionsClass.explicit("ErrorReconnectTimeout"),
+            access: ast.Access.Public,
+            type: this.System.TimeSpan.asOptional(),
+            summary:
+                "Time to wait before reconnecting if the last reconnection attempt failed. Set null to disable. Default: 1 minute.",
+            get: true,
+            set: true,
+            initializer: this.csharp.codeblock("TimeSpan.FromMinutes(1)")
+        });
+
+        optionsClass.addField({
+            origin: optionsClass.explicit("LostReconnectTimeout"),
+            access: ast.Access.Public,
+            type: this.System.TimeSpan.asOptional(),
+            summary:
+                "Time to wait before reconnecting if the connection is lost with a transient error. Set null to disable (reconnect immediately). Default: null.",
+            get: true,
+            set: true
+        });
+
         return optionsClass;
     }
 
@@ -681,6 +713,9 @@ export class WebSocketClientGenerator extends WithGeneration {
                 );
                 writer.writeTextStatement("");
                 writer.writeTextStatement("_client.IsReconnectionEnabled = _options.IsReconnectionEnabled");
+                writer.writeTextStatement("_client.ReconnectTimeout = _options.ReconnectTimeout");
+                writer.writeTextStatement("_client.ErrorReconnectTimeout = _options.ErrorReconnectTimeout");
+                writer.writeTextStatement("_client.LostReconnectTimeout = _options.LostReconnectTimeout");
                 // Note: PropertyChanged event forwarding is handled by the event's add/remove accessors
             }),
             doc: this.csharp.xmlDocBlockOf({ summary: "Constructor with options" })

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -1112,7 +1112,6 @@ export class WebSocketClientGenerator extends WithGeneration {
                     writer.writeTextStatement(`${event.name}.Dispose()`);
                 }
                 writer.writeTextStatement(`UnknownMessage.Dispose()`);
-                writer.writeTextStatement(`Reconnecting.Dispose()`);
             })
         });
     }
@@ -1278,6 +1277,15 @@ export class WebSocketClientGenerator extends WithGeneration {
             access: ast.Access.Public,
             get: true,
             type: this.Types.WebSocketEvent(this.System.Exception)
+        });
+
+        // Reconnecting event
+        interface_.addField({
+            name: "Reconnecting",
+            enclosingType: interface_,
+            access: ast.Access.Public,
+            get: true,
+            type: this.Types.WebSocketEvent(this.Types.ReconnectionInfo)
         });
 
         // Status property

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 2.47.0
+- version: 2.46.0
   changelogEntry:
     - summary: |
         Wire up WebSocket reconnection logic. The `WebSocketConnection` template now

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.39.0
+  changelogEntry:
+    - summary: |
+        Wire up WebSocket reconnection logic. The `WebSocketConnection` template now
+        contains a complete reconnection implementation ported from the Marfusios library:
+        heartbeat timer (`ReconnectTimeout`), error-retry timer (`ErrorReconnectTimeout`),
+        lost-connection delay (`LostReconnectTimeout`), and `Reconnect()`/`ReconnectOrFail()`
+        public methods. The generated WebSocket API classes expose a `Reconnecting` event
+        and an `IsReconnectionEnabled` option (default: `false`) so callers can opt in to
+        automatic reconnection.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.38.1
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/ReconnectionInfo.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/ReconnectionInfo.cs
@@ -6,7 +6,7 @@ namespace SeedWebsocket.Core.WebSockets;
 /// Contains information about a WebSocket reconnection event.
 /// Provides details about the reason for reconnection.
 /// </summary>
-internal class ReconnectionInfo
+public class ReconnectionInfo
 {
     /// <summary>
     /// Initializes a new instance of the ReconnectionInfo class.

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/ReconnectionType.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/ReconnectionType.cs
@@ -5,7 +5,7 @@ namespace SeedWebsocket.Core.WebSockets;
 /// <summary>
 /// Specifies the type of reconnection that occurred in a WebSocket connection.
 /// </summary>
-internal enum ReconnectionType
+public enum ReconnectionType
 {
     /// <summary>
     /// Initial connection to the WebSocket stream.

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -15,6 +15,11 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     private readonly Func<Stream, global::System.Threading.Tasks.Task> _onTextMessage;
 
     /// <summary>
+    /// Enable or disable automatic reconnection. Default: false.
+    /// </summary>
+    public bool IsReconnectionEnabled { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the WebSocketClient class.
     /// </summary>
     /// <param name="uri">The WebSocket URI to connect to.</param>
@@ -160,6 +165,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
         ExceptionOccurred.Dispose();
         Closed.Dispose();
         Connected.Dispose();
+        Reconnecting.Dispose();
     }
 
     /// <summary>
@@ -198,6 +204,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         _webSocket = new WebSocketConnection(_uri, () => new ClientWebSocket())
         {
+            IsReconnectionEnabled = IsReconnectionEnabled,
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>
@@ -212,6 +219,11 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
                         new Closed { Code = (int?)d.CloseStatus, Reason = d.CloseStatusDescription }
                     )
                     .ConfigureAwait(false);
+            },
+            ReconnectionHappened = async info =>
+            {
+                Status = ConnectionStatus.Connected;
+                await Reconnecting.RaiseEvent(info).ConfigureAwait(false);
             },
         };
 
@@ -242,6 +254,11 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     /// Event that is raised when an exception occurs during WebSocket operations.
     /// </summary>
     public readonly Event<Exception> ExceptionOccurred = new();
+
+    /// <summary>
+    /// Event that is raised when the WebSocket connection is re-established after a disconnect.
+    /// </summary>
+    public readonly Event<ReconnectionInfo> Reconnecting = new();
 
     /// <summary>
     /// Event that is raised when a property value changes.

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -271,6 +271,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
             },
             DisconnectionHappened = async d =>
             {
+                Status = ConnectionStatus.Disconnected;
                 await Closed
                     .RaiseEvent(
                         new Closed { Code = (int?)d.CloseStatus, Reason = d.CloseStatusDescription }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -20,6 +20,24 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     public bool IsReconnectionEnabled { get; set; }
 
     /// <summary>
+    /// Time to wait before reconnecting if no message comes from the server.
+    /// Set null to disable. Default: 1 minute.
+    /// </summary>
+    public TimeSpan? ReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Time to wait before reconnecting if the last reconnection attempt failed.
+    /// Set null to disable. Default: 1 minute.
+    /// </summary>
+    public TimeSpan? ErrorReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Time to wait before reconnecting if the connection is lost with a transient error.
+    /// Set null to disable (reconnect immediately). Default: null.
+    /// </summary>
+    public TimeSpan? LostReconnectTimeout { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the WebSocketClient class.
     /// </summary>
     /// <param name="uri">The WebSocket URI to connect to.</param>
@@ -205,6 +223,9 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
         _webSocket = new WebSocketConnection(_uri)
         {
             IsReconnectionEnabled = IsReconnectionEnabled,
+            ReconnectTimeout = ReconnectTimeout,
+            ErrorReconnectTimeout = ErrorReconnectTimeout,
+            LostReconnectTimeout = LostReconnectTimeout,
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -658,7 +658,10 @@ internal partial class WebSocketConnection
 
         _cancellation = new CancellationTokenSource();
         await StartClient(Url, _cancellation.Token, failFast).ConfigureAwait(false);
-        await OnReconnectionHappened(ReconnectionInfo.Create(type)).ConfigureAwait(false);
+        if (IsRunning)
+        {
+            await OnReconnectionHappened(ReconnectionInfo.Create(type)).ConfigureAwait(false);
+        }
         _reconnecting = false;
     }
 

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -28,10 +28,22 @@ internal partial class WebSocketConnection
 
     private Timer _errorReconnectTimer;
 
+    private DateTime _lastReceivedMsg = DateTime.UtcNow;
+
     private bool _disposing;
     private bool _reconnecting;
     private bool _stopping;
-    private bool _isReconnectionEnabled = true;
+    private bool _isReconnectionEnabled;
+
+    /// <summary>
+    /// Enable or disable automatic reconnection. Default: false.
+    /// </summary>
+    public bool IsReconnectionEnabled
+    {
+        get => _isReconnectionEnabled;
+        set => _isReconnectionEnabled = value;
+    }
+
     private WebSocket _client;
     private CancellationTokenSource _cancellation;
     private CancellationTokenSource _cancellationTotal;
@@ -93,6 +105,24 @@ internal partial class WebSocketConnection
 
     public Uri Url { get; set; }
 
+    /// <summary>
+    /// Time range for how long to wait before reconnecting if no message comes from server.
+    /// Set null to disable. Default: 1 minute.
+    /// </summary>
+    public TimeSpan? ReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Time range for how long to wait before reconnecting if last reconnection failed.
+    /// Set null to disable. Default: 1 minute.
+    /// </summary>
+    public TimeSpan? ErrorReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Time range for how long to wait before reconnecting if connection is lost with a transient error.
+    /// Set null to disable. Default: null/disabled (reconnect immediately).
+    /// </summary>
+    public TimeSpan? LostReconnectTimeout { get; set; }
+
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }
     public Func<
@@ -100,6 +130,10 @@ internal partial class WebSocketConnection
         global::System.Threading.Tasks.Task
     >? DisconnectionHappened { get; set; }
     public Func<Exception, global::System.Threading.Tasks.Task>? ExceptionOccurred { get; set; }
+    public Func<
+        ReconnectionInfo,
+        global::System.Threading.Tasks.Task
+    >? ReconnectionHappened { get; set; }
 
     private global::System.Threading.Tasks.Task OnTextMessageReceived(Stream stream) =>
         TextMessageReceived is null
@@ -120,6 +154,11 @@ internal partial class WebSocketConnection
         ExceptionOccurred is null
             ? global::System.Threading.Tasks.Task.CompletedTask
             : ExceptionOccurred.Invoke(exception);
+
+    private global::System.Threading.Tasks.Task OnReconnectionHappened(ReconnectionInfo info) =>
+        ReconnectionHappened is null
+            ? global::System.Threading.Tasks.Task.CompletedTask
+            : ReconnectionHappened.Invoke(info);
 
     /// <summary>
     /// Get or set the name of the current websocket client instance.
@@ -355,10 +394,44 @@ internal partial class WebSocketConnection
 
     private async global::System.Threading.Tasks.Task StartClient(Uri uri, CancellationToken token)
     {
-        _client = await _connectionFactory(uri, token).ConfigureAwait(false);
-        _ = Listen(_client, token);
-        IsRunning = true;
-        IsStarted = true;
+        DeactivateLastChance();
+        try
+        {
+            _client = await _connectionFactory(uri, token).ConfigureAwait(false);
+            _ = Listen(_client, token);
+            IsRunning = true;
+            IsStarted = true;
+            _lastReceivedMsg = DateTime.UtcNow;
+            ActivateLastChance();
+            await OnReconnectionHappened(ReconnectionInfo.Create(ReconnectionType.Initial))
+                .ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            IsRunning = _client?.State == WebSocketState.Open;
+            var info = DisconnectionInfo.Create(DisconnectionType.Error, _client, e);
+            await OnDisconnectionHappened(info).ConfigureAwait(false);
+
+            if (info.CancelReconnection)
+                return;
+
+            if (ErrorReconnectTimeout == null)
+                return;
+
+            var timeout = ErrorReconnectTimeout.Value;
+            _errorReconnectTimer?.Dispose();
+            _errorReconnectTimer = new Timer(
+                _ =>
+                {
+                    if (_client != null && ShouldIgnoreReconnection(_client))
+                        return;
+                    _ = ReconnectSynchronized(ReconnectionType.Error, false, e);
+                },
+                null,
+                timeout,
+                Timeout.InfiniteTimeSpan
+            );
+        }
     }
 
     private bool IsClientConnected()
@@ -373,6 +446,7 @@ internal partial class WebSocketConnection
         CancellationToken token
     )
     {
+        Exception causedException = null;
         try
         {
             // define buffer here and reuse, to avoid more allocation
@@ -398,9 +472,11 @@ internal partial class WebSocketConnection
                     switch (result.MessageType)
                     {
                         case WebSocketMessageType.Text:
+                            _lastReceivedMsg = DateTime.UtcNow;
                             await OnTextMessageReceived(ms).ConfigureAwait(false);
                             break;
                         case WebSocketMessageType.Binary:
+                            _lastReceivedMsg = DateTime.UtcNow;
                             await OnBinaryMessageReceived(ms).ConfigureAwait(false);
                             break;
                         case WebSocketMessageType.Close:
@@ -447,6 +523,141 @@ internal partial class WebSocketConnection
                 e.Message
             );
             await OnExceptionOccurred(e).ConfigureAwait(false);
+            causedException = e;
+        }
+
+        if (ShouldIgnoreReconnection(client) || !IsStarted)
+        {
+            return;
+        }
+
+        if (LostReconnectTimeout.HasValue)
+        {
+            await global::System
+                .Threading.Tasks.Task.Delay(LostReconnectTimeout.Value, token)
+                .ConfigureAwait(false);
+        }
+
+        _ = ReconnectSynchronized(ReconnectionType.Lost, false, causedException);
+    }
+
+    public global::System.Threading.Tasks.Task Reconnect() => ReconnectInternal(false);
+
+    public global::System.Threading.Tasks.Task ReconnectOrFail() => ReconnectInternal(true);
+
+    private async global::System.Threading.Tasks.Task ReconnectInternal(bool failFast)
+    {
+        if (!IsStarted)
+            return;
+        try
+        {
+            await ReconnectSynchronized(ReconnectionType.ByUser, failFast, null)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            _reconnecting = false;
+        }
+    }
+
+    private async global::System.Threading.Tasks.Task ReconnectSynchronized(
+        ReconnectionType type,
+        bool failFast,
+        Exception? causedException
+    )
+    {
+        using (await _locker.LockAsync())
+        {
+            await Reconnect(type, failFast, causedException);
+        }
+    }
+
+    private async global::System.Threading.Tasks.Task Reconnect(
+        ReconnectionType type,
+        bool failFast,
+        Exception? causedException
+    )
+    {
+        IsRunning = false;
+        if (_disposing || !IsStarted)
+            return;
+
+        _reconnecting = true;
+
+        var disType = (DisconnectionType)(int)type;
+        var disInfo = DisconnectionInfo.Create(disType, _client, causedException);
+        if (
+            type != ReconnectionType.Error
+            && _client?.State != WebSocketState.CloseReceived
+            && _client?.State != WebSocketState.Closed
+        )
+        {
+            await OnDisconnectionHappened(disInfo).ConfigureAwait(false);
+            if (disInfo.CancelReconnection)
+            {
+                _reconnecting = false;
+                return;
+            }
+        }
+
+        _cancellation?.Cancel();
+        try
+        {
+            _client?.Abort();
+        }
+        catch
+        { /* ignored */
+        }
+        _client?.Dispose();
+
+        if (
+            type != ReconnectionType.Error
+            && (!_isReconnectionEnabled || disInfo.CancelReconnection)
+        )
+        {
+            IsStarted = false;
+            _reconnecting = false;
+            return;
+        }
+
+        _cancellation = new CancellationTokenSource();
+        await StartClient(Url, _cancellation.Token).ConfigureAwait(false);
+        _reconnecting = false;
+    }
+
+    private bool ShouldIgnoreReconnection(WebSocket client)
+    {
+        var inProgress = _disposing || _reconnecting || _stopping;
+        var differentClient = client != _client;
+        return inProgress || differentClient;
+    }
+
+    private void ActivateLastChance()
+    {
+        var timerMs = 1000;
+        _lastChanceTimer = new Timer(LastChance, null, timerMs, timerMs);
+    }
+
+    private void DeactivateLastChance()
+    {
+        _lastChanceTimer?.Dispose();
+        _lastChanceTimer = null;
+    }
+
+    private void LastChance(object? state)
+    {
+        if (!_isReconnectionEnabled || ReconnectTimeout == null)
+        {
+            DeactivateLastChance();
+            return;
+        }
+
+        var timeoutMs = Math.Abs(ReconnectTimeout.Value.TotalMilliseconds);
+        var diffMs = Math.Abs(DateTime.UtcNow.Subtract(_lastReceivedMsg).TotalMilliseconds);
+        if (diffMs > timeoutMs)
+        {
+            DeactivateLastChance();
+            _ = ReconnectSynchronized(ReconnectionType.NoMessageReceived, false, null);
         }
     }
 

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -419,8 +419,6 @@ internal partial class WebSocketConnection
             IsStarted = true;
             _lastReceivedMsg = DateTime.UtcNow;
             ActivateLastChance();
-            await OnReconnectionHappened(ReconnectionInfo.Create(ReconnectionType.Initial))
-                .ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -610,7 +608,7 @@ internal partial class WebSocketConnection
 
         _reconnecting = true;
 
-        var disType = (DisconnectionType)(int)type;
+        var disType = ToDisconnectionType(type);
         var disInfo = DisconnectionInfo.Create(disType, _client, causedException);
         if (
             type != ReconnectionType.Error
@@ -647,7 +645,8 @@ internal partial class WebSocketConnection
         }
 
         _cancellation = new CancellationTokenSource();
-        await StartClient(Url, _cancellation.Token, failFast: false).ConfigureAwait(false);
+        await StartClient(Url, _cancellation.Token, failFast).ConfigureAwait(false);
+        await OnReconnectionHappened(ReconnectionInfo.Create(type)).ConfigureAwait(false);
         _reconnecting = false;
     }
 
@@ -657,6 +656,18 @@ internal partial class WebSocketConnection
         var differentClient = client != _client;
         return inProgress || differentClient;
     }
+
+    private static DisconnectionType ToDisconnectionType(ReconnectionType type) =>
+        type switch
+        {
+            ReconnectionType.Initial => DisconnectionType.Exit,
+            ReconnectionType.Lost => DisconnectionType.Lost,
+            ReconnectionType.NoMessageReceived => DisconnectionType.NoMessageReceived,
+            ReconnectionType.Error => DisconnectionType.Error,
+            ReconnectionType.ByUser => DisconnectionType.ByUser,
+            ReconnectionType.ByServer => DisconnectionType.ByServer,
+            _ => DisconnectionType.Exit,
+        };
 
     private void ActivateLastChance()
     {

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -44,6 +44,9 @@ public partial class EmptyRealtimeApi
         uri.Path = $"{uri.Path.TrimEnd('/')}/empty/realtime";
         _client = new WebSocketClient(uri.Uri, OnTextMessage);
         _client.IsReconnectionEnabled = _options.IsReconnectionEnabled;
+        _client.ReconnectTimeout = _options.ReconnectTimeout;
+        _client.ErrorReconnectTimeout = _options.ErrorReconnectTimeout;
+        _client.LostReconnectTimeout = _options.LostReconnectTimeout;
     }
 
     /// <summary>
@@ -77,7 +80,6 @@ public partial class EmptyRealtimeApi
     private void DisposeEvents()
     {
         UnknownMessage.Dispose();
-        Reconnecting.Dispose();
     }
 
     /// <summary>
@@ -148,5 +150,20 @@ public partial class EmptyRealtimeApi
         /// Enable or disable automatic reconnection. Default: false.
         /// </summary>
         public bool IsReconnectionEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Time to wait before reconnecting if no message comes from the server. Set null to disable. Default: 1 minute.
+        /// </summary>
+        public TimeSpan? ReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Time to wait before reconnecting if the last reconnection attempt failed. Set null to disable. Default: 1 minute.
+        /// </summary>
+        public TimeSpan? ErrorReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Time to wait before reconnecting if the connection is lost with a transient error. Set null to disable (reconnect immediately). Default: null.
+        /// </summary>
+        public TimeSpan? LostReconnectTimeout { get; set; }
     }
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -39,6 +39,7 @@ public partial class EmptyRealtimeApi : IAsyncDisposable, IDisposable, INotifyPr
         var uri = new UriBuilder(_options.BaseUrl);
         uri.Path = $"{uri.Path.TrimEnd('/')}/empty/realtime";
         _client = new WebSocketClient(uri.Uri, OnTextMessage);
+        _client.IsReconnectionEnabled = _options.IsReconnectionEnabled;
     }
 
     /// <summary>
@@ -62,11 +63,17 @@ public partial class EmptyRealtimeApi : IAsyncDisposable, IDisposable, INotifyPr
     public Event<Exception> ExceptionOccurred => _client.ExceptionOccurred;
 
     /// <summary>
+    /// Event raised when the WebSocket connection is re-established after a disconnect.
+    /// </summary>
+    public Event<ReconnectionInfo> Reconnecting => _client.Reconnecting;
+
+    /// <summary>
     /// Disposes of event subscriptions
     /// </summary>
     private void DisposeEvents()
     {
         UnknownMessage.Dispose();
+        Reconnecting.Dispose();
     }
 
     /// <summary>
@@ -132,5 +139,10 @@ public partial class EmptyRealtimeApi : IAsyncDisposable, IDisposable, INotifyPr
         /// The Websocket URL for the API connection.
         /// </summary>
         public string BaseUrl { get; set; } = "";
+
+        /// <summary>
+        /// Enable or disable automatic reconnection. Default: false.
+        /// </summary>
+        public bool IsReconnectionEnabled { get; set; } = false;
     }
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/IEmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/IEmptyRealtimeApi.cs
@@ -7,6 +7,7 @@ public partial interface IEmptyRealtimeApi : IAsyncDisposable, IDisposable
     public Event<Connected> Connected { get; }
     public Event<Closed> Closed { get; }
     public Event<Exception> ExceptionOccurred { get; }
+    public Event<ReconnectionInfo> Reconnecting { get; }
     public ConnectionStatus Status { get; }
     Task ConnectAsync(CancellationToken cancellationToken = default);
 

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/IRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/IRealtimeApi.cs
@@ -7,6 +7,7 @@ public partial interface IRealtimeApi : IAsyncDisposable, IDisposable
     public Event<Connected> Connected { get; }
     public Event<Closed> Closed { get; }
     public Event<Exception> ExceptionOccurred { get; }
+    public Event<ReconnectionInfo> Reconnecting { get; }
     public ConnectionStatus Status { get; }
     Task ConnectAsync(CancellationToken cancellationToken = default);
 

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -89,6 +89,9 @@ public partial class RealtimeApi
         uri.Path = $"{uri.Path.TrimEnd('/')}/realtime/{Uri.EscapeDataString(_options.SessionId)}";
         _client = new WebSocketClient(uri.Uri, OnTextMessage);
         _client.IsReconnectionEnabled = _options.IsReconnectionEnabled;
+        _client.ReconnectTimeout = _options.ReconnectTimeout;
+        _client.ErrorReconnectTimeout = _options.ErrorReconnectTimeout;
+        _client.LostReconnectTimeout = _options.LostReconnectTimeout;
     }
 
     /// <summary>
@@ -129,7 +132,6 @@ public partial class RealtimeApi
         FlushedEvent.Dispose();
         ErrorEvent.Dispose();
         UnknownMessage.Dispose();
-        Reconnecting.Dispose();
     }
 
     /// <summary>
@@ -298,5 +300,20 @@ public partial class RealtimeApi
         /// Enable or disable automatic reconnection. Default: false.
         /// </summary>
         public bool IsReconnectionEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Time to wait before reconnecting if no message comes from the server. Set null to disable. Default: 1 minute.
+        /// </summary>
+        public TimeSpan? ReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Time to wait before reconnecting if the last reconnection attempt failed. Set null to disable. Default: 1 minute.
+        /// </summary>
+        public TimeSpan? ErrorReconnectTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Time to wait before reconnecting if the connection is lost with a transient error. Set null to disable (reconnect immediately). Default: null.
+        /// </summary>
+        public TimeSpan? LostReconnectTimeout { get; set; }
     }
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -84,6 +84,7 @@ public partial class RealtimeApi : IAsyncDisposable, IDisposable, INotifyPropert
         };
         uri.Path = $"{uri.Path.TrimEnd('/')}/realtime/{Uri.EscapeDataString(_options.SessionId)}";
         _client = new WebSocketClient(uri.Uri, OnTextMessage);
+        _client.IsReconnectionEnabled = _options.IsReconnectionEnabled;
     }
 
     /// <summary>
@@ -107,6 +108,11 @@ public partial class RealtimeApi : IAsyncDisposable, IDisposable, INotifyPropert
     public Event<Exception> ExceptionOccurred => _client.ExceptionOccurred;
 
     /// <summary>
+    /// Event raised when the WebSocket connection is re-established after a disconnect.
+    /// </summary>
+    public Event<ReconnectionInfo> Reconnecting => _client.Reconnecting;
+
+    /// <summary>
     /// Disposes of event subscriptions
     /// </summary>
     private void DisposeEvents()
@@ -119,6 +125,7 @@ public partial class RealtimeApi : IAsyncDisposable, IDisposable, INotifyPropert
         FlushedEvent.Dispose();
         ErrorEvent.Dispose();
         UnknownMessage.Dispose();
+        Reconnecting.Dispose();
     }
 
     /// <summary>
@@ -282,5 +289,10 @@ public partial class RealtimeApi : IAsyncDisposable, IDisposable, INotifyPropert
         public string? LanguageCode { get; set; }
 
         public required string SessionId { get; set; }
+
+        /// <summary>
+        /// Enable or disable automatic reconnection. Default: false.
+        /// </summary>
+        public bool IsReconnectionEnabled { get; set; } = false;
     }
 }


### PR DESCRIPTION
## Description

Wires up the reconnection logic that was scaffolded but never implemented in the C# WebSocket templates. The fields `_isReconnectionEnabled`, `_reconnecting`, `_errorReconnectTimer`, `_lastChanceTimer`, and the `ReconnectionType`/`ReconnectionInfo`/`DisconnectionInfo` types were all shipped but dead code. This PR ports the reconnection implementation from the Marfusios WebsocketClient library (without Rx).

## Changes Made

### Template files
- **`WebSocketConnection.Template.cs`**: Added timeout properties (`ReconnectTimeout`, `ErrorReconnectTimeout`, `LostReconnectTimeout`), heartbeat "last chance" timer, `Reconnect()`/`ReconnectOrFail()` public methods, error handling in `StartClient` (with `failFast` support and `ConnectTimeout` via linked `CancellationTokenSource`), reconnection trigger at end of `Listen` loop, `ReconnectionHappened` callback with `IsRunning` guard, `_lastReceivedMsg` tracking, and explicit `ToDisconnectionType` enum mapping
- **`WebSocketClient.Template.cs`**: Added `IsReconnectionEnabled` and timeout forwarding properties, `Reconnecting` event, wired `ReconnectionHappened` callback to set status and raise event, `DisconnectionHappened` callback now sets `Status = Disconnected`, added dispose for `Reconnecting` event
- **`ReconnectionInfo.Template.cs`** / **`ReconnectionType.Template.cs`**: Changed from `internal` to `public` — required because `Event<ReconnectionInfo>` is exposed as a public property on generated API classes
- **Default changed**: `_isReconnectionEnabled` defaults to `false` (was `true`) — Fern SDK clients should opt in explicitly since APIs may require re-handshake after reconnect

### Generator
- **`WebsocketClientGenerator.ts`**: Added `IsReconnectionEnabled`, `ReconnectTimeout`, `ErrorReconnectTimeout`, `LostReconnectTimeout` options to generated Options class, `Reconnecting` event forwarder + interface declaration, constructor wiring
- **`generation-info.ts`**: Registered `ReconnectionInfo` type reference

### Seed output
- Updated `websocket/with-websockets` fixture snapshots

## Updates since initial revision
- **`failFast` now wired through**: `StartClient` re-throws on error when `failFast=true`, schedules error reconnect timer otherwise
- **`OnReconnectionHappened` only fires on successful reconnection**: Guarded by `if (IsRunning)` — prevents `Status = Connected` corruption when `StartClient` catches an exception internally
- **Explicit `ToDisconnectionType` mapping**: Replaced fragile `(DisconnectionType)(int)type` cast with a `switch` expression
- **`Task.Delay` cancellation handled**: Wrapped in `try-catch (OperationCanceledException)` at end of `Listen` loop
- **Merged with main**: Incorporated `ConnectTimeout`, `HttpInvoker`, and `DeflateOptions` features into reconnection templates
- **`Reconnecting` event added to generated interfaces**: `IRealtimeApi`, `IEmptyRealtimeApi`
- **`ReconnectionInfo` / `ReconnectionType` made `public`**: Fixes `CS0053` — these types are exposed via `Event<ReconnectionInfo>` on public API classes
- **`DisconnectionHappened` sets `Status = Disconnected`**: Ensures `ReconnectionHappened`'s `Status = Connected` assignment actually triggers `PropertyChanged`, and `EnsureConnected()` correctly blocks sends while disconnected

## Human Review Checklist
- [ ] **`ReconnectionInfo` / `ReconnectionType` are now `public`** — These were previously `internal`. Confirm this is acceptable for the public API surface. They must be public because `Event<ReconnectionInfo>` is a public property, but verify no other internal types leak through.
- [ ] **`DisconnectionHappened` → `Status = Disconnected` during reconnection** — While reconnecting, `Status` is `Disconnected` until `ReconnectionHappened` fires. Any code calling `EnsureConnected()` during this window will throw. Verify this is the desired behavior (fail-fast) vs. queueing sends.
- [ ] **`OnReconnectionHappened` guard relies on `IsRunning`** — After a failed `StartClient` (exception caught, `failFast=false`), `IsRunning` is set to `_client?.State == WebSocketState.Open` which should be false. Verify there are no edge cases where `IsRunning` is true despite a partial connection failure.
- [ ] **Race between `Listen` and `Reconnect`** — `Reconnect` cancels `_cancellation` and creates a new one before calling `StartClient`. If `Listen` is still unwinding on the old token, verify the `ShouldIgnoreReconnection` guard (checks `_reconnecting` and `client != _client`) prevents double-reconnect.
- [ ] **`_reconnecting` reset in both `ReconnectInternal.finally` and end of `Reconnect`** — `ReconnectInternal` sets `_reconnecting = false` in its `finally` block, but `Reconnect` also sets it to `false` at the end. Confirm the double-reset is harmless and doesn't mask errors if `Reconnect` throws mid-way.
- [ ] **No runtime/integration tests** — only seed snapshot tests were run. Reconnection behavior is not exercised.

## Testing
- [x] `pnpm run check` (biome lint) passes
- [x] `pnpm seed test --generator csharp-sdk --fixture websocket` — 2/2 pass
- [x] All CI checks pass (63/63 including all seed-test-results)
- [ ] No unit or integration tests for reconnection behavior (template files are not directly testable in this repo)

Link to Devin session: https://app.devin.ai/sessions/329c72ab0b994f19a37399561954c27d
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
