### PR TITLE
feat(csharp): support HTTP/2 WebSockets via SocketsHttpHandler

### DIFF
--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -26,6 +26,13 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     }
 
     /// <summary>
+    /// Optional HttpMessageInvoker for HTTP/2 WebSocket connections.
+    /// When set, enables multiplexing multiple WebSocket streams over a single TCP connection.
+    /// Requires .NET 7+.
+    /// </summary>
+    public System.Net.Http.HttpMessageInvoker? HttpInvoker { get; set; }
+
+    /// <summary>
     /// Gets the current connection status of the WebSocket.
     /// </summary>
     public ConnectionStatus Status
@@ -182,6 +189,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         _webSocket = new WebSocketConnection(_uri, () => new ClientWebSocket())
         {
+            HttpInvoker = HttpInvoker,
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -35,6 +35,7 @@ internal partial class WebSocketConnection
     private WebSocket _client;
     private CancellationTokenSource _cancellation;
     private CancellationTokenSource _cancellationTotal;
+    private readonly Func<ClientWebSocket>? _clientFactory;
 
     /// <summary>
     /// A simple websocket client with built-in reconnection and error handling
@@ -42,7 +43,7 @@ internal partial class WebSocketConnection
     /// <param name="url">Target websocket url (wss://)</param>
     /// <param name="clientFactory">Optional factory for native ClientWebSocket, use it whenever you need some custom features (proxy, settings, etc). Note: when providing a factory, you are responsible for configuring keep-alive on the returned ClientWebSocket instance.</param>
     public WebSocketConnection(Uri url, Func<ClientWebSocket>? clientFactory = null)
-        : this(url, null, GetClientFactory(clientFactory)) { }
+        : this(url, null, null, clientFactory) { }
 
     /// <summary>
     /// A simple websocket client with built-in reconnection and error handling
@@ -55,7 +56,7 @@ internal partial class WebSocketConnection
         ILogger<WebSocketConnection> logger,
         Func<ClientWebSocket>? clientFactory = null
     )
-        : this(url, logger, GetClientFactory(clientFactory)) { }
+        : this(url, logger, null, clientFactory) { }
 
     /// <summary>
     /// A simple websocket client with built-in reconnection and error handling
@@ -68,15 +69,24 @@ internal partial class WebSocketConnection
         ILogger<WebSocketConnection> logger,
         Func<Uri, CancellationToken, global::System.Threading.Tasks.Task<WebSocket>> connectionFactory
     )
+        : this(url, logger, connectionFactory, null) { }
+
+    private WebSocketConnection(
+        Uri url,
+        ILogger<WebSocketConnection> logger,
+        Func<Uri, CancellationToken, global::System.Threading.Tasks.Task<WebSocket>> connectionFactory,
+        Func<ClientWebSocket>? clientFactory
+    )
     {
         _logger = logger ?? NullLogger<WebSocketConnection>.Instance;
         Url = url;
+        _clientFactory = clientFactory;
         _connectionFactory =
             connectionFactory
             ?? (
                 async (uri, token) =>
                 {
-                    var client = new ClientWebSocket();
+                    var client = _clientFactory != null ? _clientFactory() : new ClientWebSocket();
                     client.Options.KeepAliveInterval = KeepAliveInterval;
 #if NET9_0_OR_GREATER
                     client.Options.KeepAliveTimeout = KeepAliveTimeout;
@@ -251,23 +261,6 @@ internal partial class WebSocketConnection
             .ConfigureAwait(false);
         OnDisconnectionHappened(DisconnectionInfo.Create(DisconnectionType.ByUser, _client, null));
         return result;
-    }
-
-    private static Func<Uri, CancellationToken, global::System.Threading.Tasks.Task<WebSocket>> GetClientFactory(
-        Func<ClientWebSocket> clientFactory
-    )
-    {
-        if (clientFactory is null)
-            return null;
-
-        return (
-            async (uri, token) =>
-            {
-                var client = clientFactory();
-                await client.ConnectAsync(uri, token).ConfigureAwait(false);
-                return client;
-            }
-        );
     }
 
     private async global::System.Threading.Tasks.Task StartInternal(bool failFast, CancellationToken cancellationToken = default)

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -76,18 +76,34 @@ internal partial class WebSocketConnection
             ?? (
                 async (uri, token) =>
                 {
-                    //var client = new ClientWebSocket
-                    //{
-                    //    Options = { KeepAliveInterval = new TimeSpan(0, 0, 5, 0) }
-                    //};
                     var client = new ClientWebSocket();
-                    await client.ConnectAsync(uri, token).ConfigureAwait(false);
+                    if (HttpInvoker != null)
+                    {
+#if NET7_0_OR_GREATER
+                        client.Options.HttpVersion = System.Net.HttpVersion.Version20;
+                        client.Options.HttpVersionPolicy = System.Net.Http.HttpVersionPolicy.RequestVersionOrHigher;
+                        await client.ConnectAsync(uri, HttpInvoker, token).ConfigureAwait(false);
+#else
+                        await client.ConnectAsync(uri, token).ConfigureAwait(false);
+#endif
+                    }
+                    else
+                    {
+                        await client.ConnectAsync(uri, token).ConfigureAwait(false);
+                    }
                     return client;
                 }
             );
     }
 
     public Uri Url { get; set; }
+
+    /// <summary>
+    /// Optional HttpMessageInvoker for HTTP/2 WebSocket connections.
+    /// When set, enables multiplexing multiple WebSocket streams over a single TCP connection.
+    /// Requires .NET 7+.
+    /// </summary>
+    public System.Net.Http.HttpMessageInvoker? HttpInvoker { get; set; }
 
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -416,6 +416,15 @@ export class WebSocketClientGenerator extends WithGeneration {
             });
         }
 
+        optionsClass.addField({
+            origin: optionsClass.explicit("HttpInvoker"),
+            access: ast.Access.Public,
+            type: this.Types.Arbitrary("System.Net.Http.HttpMessageInvoker?"),
+            summary: "Optional HTTP/2 handler for multiplexed WebSocket connections (.NET 7+).",
+            get: true,
+            set: true
+        });
+
         for (const queryParameter of this.websocketChannel.queryParameters) {
             // add to the options class
             const type = this.context.csharpTypeMapper.convert({

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -597,6 +597,7 @@ export class WebSocketClientGenerator extends WithGeneration {
                     })
                 );
                 writer.writeTextStatement("");
+                writer.writeTextStatement("_client.HttpInvoker = _options.HttpInvoker");
                 // Note: PropertyChanged event forwarding is handled by the event's add/remove accessors
             }),
             doc: this.csharp.xmlDocBlockOf({ summary: "Constructor with options" })

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.39.0
+  changelogEntry:
+    - summary: |
+        Add support for HTTP/2 WebSockets via `SocketsHttpHandler`. A new `HttpInvoker`
+        property on the WebSocket Options class allows passing an `HttpMessageInvoker` to
+        enable multiplexing multiple WebSocket streams over a single TCP connection. When
+        set, the connection factory configures `HttpVersion.Version20` and uses the
+        `ConnectAsync(Uri, HttpMessageInvoker, CancellationToken)` overload on .NET 7+.
+        On older targets the invoker is ignored and the standard connect path is used.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.38.1
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -26,6 +26,13 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     }
 
     /// <summary>
+    /// Optional HttpMessageInvoker for HTTP/2 WebSocket connections.
+    /// When set, enables multiplexing multiple WebSocket streams over a single TCP connection.
+    /// Requires .NET 7+.
+    /// </summary>
+    public System.Net.Http.HttpMessageInvoker? HttpInvoker { get; set; }
+
+    /// <summary>
     /// Gets the current connection status of the WebSocket.
     /// </summary>
     public ConnectionStatus Status
@@ -198,6 +205,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 
         _webSocket = new WebSocketConnection(_uri, () => new ClientWebSocket())
         {
+            HttpInvoker = HttpInvoker,
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -35,6 +35,7 @@ internal partial class WebSocketConnection
     private WebSocket _client;
     private CancellationTokenSource _cancellation;
     private CancellationTokenSource _cancellationTotal;
+    private readonly Func<ClientWebSocket>? _clientFactory;
 
     /// <summary>
     /// A simple websocket client with built-in reconnection and error handling
@@ -42,7 +43,7 @@ internal partial class WebSocketConnection
     /// <param name="url">Target websocket url (wss://)</param>
     /// <param name="clientFactory">Optional factory for native ClientWebSocket, use it whenever you need some custom features (proxy, settings, etc). Note: when providing a factory, you are responsible for configuring keep-alive on the returned ClientWebSocket instance.</param>
     public WebSocketConnection(Uri url, Func<ClientWebSocket>? clientFactory = null)
-        : this(url, null, GetClientFactory(clientFactory)) { }
+        : this(url, null, null, clientFactory) { }
 
     /// <summary>
     /// A simple websocket client with built-in reconnection and error handling
@@ -55,7 +56,7 @@ internal partial class WebSocketConnection
         ILogger<WebSocketConnection> logger,
         Func<ClientWebSocket>? clientFactory = null
     )
-        : this(url, logger, GetClientFactory(clientFactory)) { }
+        : this(url, logger, null, clientFactory) { }
 
     /// <summary>
     /// A simple websocket client with built-in reconnection and error handling
@@ -72,15 +73,28 @@ internal partial class WebSocketConnection
             global::System.Threading.Tasks.Task<WebSocket>
         > connectionFactory
     )
+        : this(url, logger, connectionFactory, null) { }
+
+    private WebSocketConnection(
+        Uri url,
+        ILogger<WebSocketConnection> logger,
+        Func<
+            Uri,
+            CancellationToken,
+            global::System.Threading.Tasks.Task<WebSocket>
+        > connectionFactory,
+        Func<ClientWebSocket>? clientFactory
+    )
     {
         _logger = logger ?? NullLogger<WebSocketConnection>.Instance;
         Url = url;
+        _clientFactory = clientFactory;
         _connectionFactory =
             connectionFactory
             ?? (
                 async (uri, token) =>
                 {
-                    var client = new ClientWebSocket();
+                    var client = _clientFactory != null ? _clientFactory() : new ClientWebSocket();
                     client.Options.KeepAliveInterval = KeepAliveInterval;
 #if NET9_0_OR_GREATER
                     client.Options.KeepAliveTimeout = KeepAliveTimeout;
@@ -286,25 +300,6 @@ internal partial class WebSocketConnection
             .ConfigureAwait(false);
         OnDisconnectionHappened(DisconnectionInfo.Create(DisconnectionType.ByUser, _client, null));
         return result;
-    }
-
-    private static Func<
-        Uri,
-        CancellationToken,
-        global::System.Threading.Tasks.Task<WebSocket>
-    > GetClientFactory(Func<ClientWebSocket> clientFactory)
-    {
-        if (clientFactory is null)
-            return null;
-
-        return (
-            async (uri, token) =>
-            {
-                var client = clientFactory();
-                await client.ConnectAsync(uri, token).ConfigureAwait(false);
-                return client;
-            }
-        );
     }
 
     private async global::System.Threading.Tasks.Task StartInternal(

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -80,18 +80,38 @@ internal partial class WebSocketConnection
             ?? (
                 async (uri, token) =>
                 {
-                    //var client = new ClientWebSocket
-                    //{
-                    //    Options = { KeepAliveInterval = new TimeSpan(0, 0, 5, 0) }
-                    //};
                     var client = new ClientWebSocket();
-                    await client.ConnectAsync(uri, token).ConfigureAwait(false);
+                    if (HttpInvoker != null)
+                    {
+#if NET7_0_OR_GREATER
+                        client.Options.HttpVersion = System.Net.HttpVersion.Version20;
+                        client.Options.HttpVersionPolicy = System
+                            .Net
+                            .Http
+                            .HttpVersionPolicy
+                            .RequestVersionOrHigher;
+                        await client.ConnectAsync(uri, HttpInvoker, token).ConfigureAwait(false);
+#else
+                        await client.ConnectAsync(uri, token).ConfigureAwait(false);
+#endif
+                    }
+                    else
+                    {
+                        await client.ConnectAsync(uri, token).ConfigureAwait(false);
+                    }
                     return client;
                 }
             );
     }
 
     public Uri Url { get; set; }
+
+    /// <summary>
+    /// Optional HttpMessageInvoker for HTTP/2 WebSocket connections.
+    /// When set, enables multiplexing multiple WebSocket streams over a single TCP connection.
+    /// Requires .NET 7+.
+    /// </summary>
+    public System.Net.Http.HttpMessageInvoker? HttpInvoker { get; set; }
 
     public Func<Stream, global::System.Threading.Tasks.Task>? TextMessageReceived { get; set; }
     public Func<Stream, global::System.Threading.Tasks.Task>? BinaryMessageReceived { get; set; }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -43,6 +43,7 @@ public partial class EmptyRealtimeApi
         var uri = new UriBuilder(_options.BaseUrl);
         uri.Path = $"{uri.Path.TrimEnd('/')}/empty/realtime";
         _client = new WebSocketClient(uri.Uri, OnTextMessage);
+        _client.HttpInvoker = _options.HttpInvoker;
     }
 
     /// <summary>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -132,5 +132,10 @@ public partial class EmptyRealtimeApi : IAsyncDisposable, IDisposable, INotifyPr
         /// The Websocket URL for the API connection.
         /// </summary>
         public string BaseUrl { get; set; } = "";
+
+        /// <summary>
+        /// Optional HTTP/2 handler for multiplexed WebSocket connections (.NET 7+).
+        /// </summary>
+        public System.Net.Http.HttpMessageInvoker? HttpInvoker { get; set; }
     }
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -275,6 +275,11 @@ public partial class RealtimeApi : IAsyncDisposable, IDisposable, INotifyPropert
         /// </summary>
         public string BaseUrl { get; set; } = "";
 
+        /// <summary>
+        /// Optional HTTP/2 handler for multiplexed WebSocket connections (.NET 7+).
+        /// </summary>
+        public System.Net.Http.HttpMessageInvoker? HttpInvoker { get; set; }
+
         public string? Model { get; set; }
 
         public int? Temperature { get; set; }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -88,6 +88,7 @@ public partial class RealtimeApi
         };
         uri.Path = $"{uri.Path.TrimEnd('/')}/realtime/{Uri.EscapeDataString(_options.SessionId)}";
         _client = new WebSocketClient(uri.Uri, OnTextMessage);
+        _client.HttpInvoker = _options.HttpInvoker;
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

Adds an `HttpInvoker` property to the C# WebSocket infrastructure, enabling HTTP/2 WebSocket connections that can multiplex multiple streams over a single TCP connection via `ConnectAsync(Uri, HttpMessageInvoker, CancellationToken)`.

## Changes Made

- Added `HttpInvoker` (`System.Net.Http.HttpMessageInvoker?`) property to `WebSocketConnection.Template.cs`
- **Replaced the static `GetClientFactory` method with a unified private constructor** that accepts both `connectionFactory` and `clientFactory` parameters. All three public constructors now chain to this single private constructor. The connection factory lambda uses `_clientFactory` (if provided) to create the `ClientWebSocket`, then unconditionally applies KeepAlive and HttpInvoker logic. This fixes a bug where the old `GetClientFactory` produced a factory that bypassed HttpInvoker/KeepAlive configuration entirely.
- Updated the default connection factory to configure `HttpVersion.Version20` and `HttpVersionPolicy.RequestVersionOrHigher` when `HttpInvoker` is set, gated behind `#if NET7_0_OR_GREATER` (falls back to standard `ConnectAsync` on older targets)
- Added `HttpInvoker` property to `WebSocketClient.Template.cs` and wired it through to `WebSocketConnection` via object initializer in `ConnectAsync`
- Added `HttpInvoker` field to the generated WebSocket Options class in `WebsocketClientGenerator.ts`
- Wired `_options.HttpInvoker` → `_client.HttpInvoker` in the generated constructor
- Updated seed snapshots for `websocket` fixture
- Added `versions.yml` entry (v2.42.0)

**Full plumbing chain:** `Options.HttpInvoker` → generated constructor sets `_client.HttpInvoker` → `WebSocketClient.ConnectAsync` sets `_webSocket.HttpInvoker` via object initializer → `WebSocketConnection` connection factory reads `HttpInvoker` at connect-time and uses it with `#if NET7_0_OR_GREATER` guard.

## Testing

- [x] `pnpm run check` (biome lint) passes
- [x] Seed tests pass for `websocket` (2/2)
- [x] Verified generated output contains `HttpInvoker` property on Options class, wiring in constructors, and `#if NET7_0_OR_GREATER` guards in `WebSocketConnection.cs`

## ⚠️ Human Review Checklist

- **Constructor refactoring — behavioral change for custom `clientFactory` callers**: The old `GetClientFactory` created a connection factory that called the user's factory then did a plain `ConnectAsync(uri, token)` — the user was fully responsible for configuring keep-alive and other options. The new unified lambda now **also** sets `KeepAliveInterval` (and `KeepAliveTimeout` on .NET 9+) on the `ClientWebSocket` returned by the user's factory. This means user-configured keep-alive values on their custom `ClientWebSocket` will be **overwritten** by the lambda. The param doc still says _"when providing a factory, you are responsible for configuring keep-alive"_, but the code no longer honors that contract. Verify this behavioral change is acceptable, or whether the KeepAlive lines should be skipped when `_clientFactory != null`.
- **Pre-processor directive correctness**: `#if NET7_0_OR_GREATER` is the guard for `ClientWebSocket.Options.HttpVersion`, `HttpVersionPolicy`, and the `ConnectAsync(Uri, HttpMessageInvoker, CancellationToken)` overload. Microsoft docs confirm all three were introduced in .NET 7, but this cannot be compile-tested in this environment.
- **Silent fallback on older targets**: When `HttpInvoker` is set but the runtime is pre-.NET 7, the `#else` branch silently ignores `HttpInvoker` and uses standard `ConnectAsync`. This matches the existing pattern for `KeepAliveTimeout` (silently ignored on pre-.NET 9). Confirm this is acceptable vs. logging a warning.
- **Closure capture**: The connection factory lambda reads `HttpInvoker` from the `WebSocketConnection` instance at connect-time (not construction-time). This is intentional — object initializers set properties after the constructor runs, so construction-time would always see `null`.
- **Caller owns `HttpInvoker` lifetime**: The WebSocket infrastructure does not dispose the `HttpMessageInvoker`. The caller is responsible for its lifecycle. This is standard .NET convention for shared/injected dependencies.
- **[.NET 7 breaking change](https://github.com/dotnet/docs/issues/31430)**: Setting `HttpVersion` to HTTP/2 *without* passing an invoker throws `ArgumentException`. Our code only sets `HttpVersion`/`HttpVersionPolicy` inside the `if (HttpInvoker != null)` block and always passes the invoker in that same branch, so this is safe. However, users who set incompatible `ClientWebSocketOptions` (e.g. `Proxy`, `Credentials`) via a custom `clientFactory` *and* also set `HttpInvoker` will get an `ArgumentException` from the .NET runtime — this is expected behavior and not something we can guard against.

Link to Devin session: https://app.devin.ai/sessions/31650460e6b24149a13406d1270dce07
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
