### PR TITLE
fix(csharp): reset DeflateOptions to null when EnableCompression is false

### DIFF
--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -1051,12 +1051,9 @@ export class WebSocketClientGenerator extends WithGeneration {
             }),
             body: this.csharp.codeblock((writer) => {
                 writer.writeLine("#if NET6_0_OR_GREATER");
-                writer.writeLine("if (_options.EnableCompression)");
-                writer.pushScope();
                 writer.writeTextStatement(
-                    "_client.DeflateOptions = new System.Net.WebSockets.WebSocketDeflateOptions()"
+                    "_client.DeflateOptions = _options.EnableCompression ? new System.Net.WebSockets.WebSocketDeflateOptions() : null"
                 );
-                writer.popScope();
                 writer.writeLine("#endif");
                 writer.writeTextStatement("await _client.ConnectAsync(cancellationToken).ConfigureAwait(false)");
             })

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.43.1
+  changelogEntry:
+    - summary: |
+        Fix sticky compression on reconnect. `DeflateOptions` is now explicitly reset to
+        `null` when `EnableCompression` is `false`, preventing a previous non-null value
+        from persisting across connection cycles.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.43.0
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -98,10 +98,9 @@ public partial class EmptyRealtimeApi
     public async Task ConnectAsync(CancellationToken cancellationToken = default)
     {
 #if NET6_0_OR_GREATER
-        if (_options.EnableCompression)
-        {
-            _client.DeflateOptions = new System.Net.WebSockets.WebSocketDeflateOptions();
-        }
+        _client.DeflateOptions = _options.EnableCompression
+            ? new System.Net.WebSockets.WebSocketDeflateOptions()
+            : null;
 #endif
         await _client.ConnectAsync(cancellationToken).ConfigureAwait(false);
     }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -216,10 +216,9 @@ public partial class RealtimeApi
     public async Task ConnectAsync(CancellationToken cancellationToken = default)
     {
 #if NET6_0_OR_GREATER
-        if (_options.EnableCompression)
-        {
-            _client.DeflateOptions = new System.Net.WebSockets.WebSocketDeflateOptions();
-        }
+        _client.DeflateOptions = _options.EnableCompression
+            ? new System.Net.WebSockets.WebSocketDeflateOptions()
+            : null;
 #endif
         await _client.ConnectAsync(cancellationToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
## Description

Fixes a bug where `DeflateOptions` was never cleared when `EnableCompression` was set to `false`, causing compression to persist ("stick") across reconnection cycles.

Introduced in #13798 — the generated `ConnectAsync` only set `_client.DeflateOptions` inside an `if (EnableCompression)` block but had no `else` branch to reset it. If a user connected with `EnableCompression = true`, then mutated the options to `false` and called `ConnectAsync` again, the stale `WebSocketDeflateOptions` instance remained on `_client` and was forwarded to the new `WebSocketConnection`.

## Changes Made

- **`WebsocketClientGenerator.ts`**: Replace `if (_options.EnableCompression) { ... }` with a ternary that always assigns `_client.DeflateOptions` — either `new WebSocketDeflateOptions()` or `null`
- **`versions.yml`**: Add 2.43.1 fix entry
- **Seed outputs**: Regenerated `EmptyRealtimeApi.cs` and `RealtimeApi.cs` with the updated ternary pattern

## Testing

- [x] `pnpm seed test --generator csharp-sdk --fixture websocket` — 2/2 passed
- [ ] No runtime reconnection test exists for this scenario; the fix is verified by code inspection (always-assign eliminates stale state by construction)

## Items for Review

- Confirm that assigning `null` to `DeflateOptions` on every `ConnectAsync` call (even when it was already `null`) is acceptable — it should be, since it's just a property setter on the internal `WebSocketClient`.

Link to Devin session: https://app.devin.ai/sessions/d59c146fa05f42d6bf76562db3cf9ce9
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
