### PR TITLE
feat(csharp): add per-send timeout to prevent SendAsync hangs

### DIFF
--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -80,6 +80,14 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
+    /// Maximum time to wait for a single SendAsync call to complete.
+    /// Prevents indefinite hangs when the remote peer dies without closing the connection.
+    /// See: https://github.com/dotnet/runtime/issues/125257
+    /// Default: 30 seconds.
+    /// </summary>
+    public TimeSpan SendTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// Gets the current connection status of the WebSocket.
     /// </summary>
     public ConnectionStatus Status
@@ -260,6 +268,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 #endif
             HttpInvoker = HttpInvoker,
             ConnectTimeout = ConnectTimeout,
+            SendTimeout = SendTimeout,
             IsReconnectionEnabled = IsReconnectionEnabled,
             ReconnectTimeout = ReconnectTimeout,
             ErrorReconnectTimeout = ErrorReconnectTimeout,

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Sending.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Sending.Template.cs
@@ -116,15 +116,29 @@ internal partial class WebSocketConnection
                 throw new ArgumentException($"Unknown message type: {message.GetType()}");
         }
 
-        using var linkedCts = CreateLinkedToken(cancellationToken);
-        await _client
-            .SendAsync(
-                payload,
-                messageType,
-                true,
-                linkedCts?.Token ?? (_cancellation?.Token ?? CancellationToken.None)
-            )
-            .ConfigureAwait(false);
+        using var sendCts = cancellationToken != default
+            ? CancellationTokenSource.CreateLinkedTokenSource(
+                _cancellation?.Token ?? CancellationToken.None, cancellationToken)
+            : CancellationTokenSource.CreateLinkedTokenSource(
+                _cancellation?.Token ?? CancellationToken.None);
+        sendCts.CancelAfter(SendTimeout);
+
+        try
+        {
+            await _client
+                .SendAsync(payload, messageType, true, sendCts.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (sendCts.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "SendAsync timed out after {Timeout}ms, aborting connection",
+                SendTimeout.TotalMilliseconds);
+            _client?.Abort();
+            throw new WebsocketException(
+                $"SendAsync timed out after {SendTimeout.TotalMilliseconds}ms. "
+                + "The remote peer may be unreachable. Connection has been aborted.");
+        }
     }
 
     private async global::System.Threading.Tasks.Task SendInternalSynchronized(ArraySegment<byte> message, CancellationToken cancellationToken = default)
@@ -150,15 +164,34 @@ internal partial class WebSocketConnection
             return;
         }
 
-        using var linkedCts = CreateLinkedToken(cancellationToken);
-        await _client
-            .SendAsync(
-                payload,
-                WebSocketMessageType.Binary,
-                true,
-                linkedCts?.Token ?? (_cancellation?.Token ?? CancellationToken.None)
-            )
-            .ConfigureAwait(false);
+        using var sendCts = cancellationToken != default
+            ? CancellationTokenSource.CreateLinkedTokenSource(
+                _cancellation?.Token ?? CancellationToken.None, cancellationToken)
+            : CancellationTokenSource.CreateLinkedTokenSource(
+                _cancellation?.Token ?? CancellationToken.None);
+        sendCts.CancelAfter(SendTimeout);
+
+        try
+        {
+            await _client
+                .SendAsync(
+                    payload,
+                    WebSocketMessageType.Binary,
+                    true,
+                    sendCts.Token
+                )
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (sendCts.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "SendAsync timed out after {Timeout}ms, aborting connection",
+                SendTimeout.TotalMilliseconds);
+            _client?.Abort();
+            throw new WebsocketException(
+                $"SendAsync timed out after {SendTimeout.TotalMilliseconds}ms. "
+                + "The remote peer may be unreachable. Connection has been aborted.");
+        }
     }
 
     private async global::System.Threading.Tasks.Task SendInternal(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken = default)
@@ -168,20 +201,38 @@ internal partial class WebSocketConnection
             return;
         }
 
-        using var linkedCts = CreateLinkedToken(cancellationToken);
-        var token = linkedCts?.Token ?? (_cancellation?.Token ?? CancellationToken.None);
+        using var sendCts = cancellationToken != default
+            ? CancellationTokenSource.CreateLinkedTokenSource(
+                _cancellation?.Token ?? CancellationToken.None, cancellationToken)
+            : CancellationTokenSource.CreateLinkedTokenSource(
+                _cancellation?.Token ?? CancellationToken.None);
+        sendCts.CancelAfter(SendTimeout);
+
+        try
+        {
 #if NET6_0_OR_GREATER
-        await _client
-            .SendAsync(
-                payload,
-                WebSocketMessageType.Binary,
-                true,
-                token
-            )
-            .ConfigureAwait(false);
+            await _client
+                .SendAsync(
+                    payload,
+                    WebSocketMessageType.Binary,
+                    true,
+                    sendCts.Token
+                )
+                .ConfigureAwait(false);
 #else
-        await SendInternal(new ArraySegment<byte>(payload.ToArray()), cancellationToken).ConfigureAwait(false);
+            await SendInternal(new ArraySegment<byte>(payload.ToArray()), cancellationToken).ConfigureAwait(false);
 #endif
+        }
+        catch (OperationCanceledException) when (sendCts.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "SendAsync timed out after {Timeout}ms, aborting connection",
+                SendTimeout.TotalMilliseconds);
+            _client?.Abort();
+            throw new WebsocketException(
+                $"SendAsync timed out after {SendTimeout.TotalMilliseconds}ms. "
+                + "The remote peer may be unreachable. Connection has been aborted.");
+        }
     }
 
     private CancellationTokenSource? CreateLinkedToken(CancellationToken cancellationToken)

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Sending.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Sending.Template.cs
@@ -129,7 +129,10 @@ internal partial class WebSocketConnection
                 .SendAsync(payload, messageType, true, sendCts.Token)
                 .ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (sendCts.IsCancellationRequested)
+        catch (OperationCanceledException) when (
+            sendCts.IsCancellationRequested
+            && !cancellationToken.IsCancellationRequested
+            && !(_cancellation?.IsCancellationRequested ?? false))
         {
             _logger.LogWarning(
                 "SendAsync timed out after {Timeout}ms, aborting connection",
@@ -182,7 +185,10 @@ internal partial class WebSocketConnection
                 )
                 .ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (sendCts.IsCancellationRequested)
+        catch (OperationCanceledException) when (
+            sendCts.IsCancellationRequested
+            && !cancellationToken.IsCancellationRequested
+            && !(_cancellation?.IsCancellationRequested ?? false))
         {
             _logger.LogWarning(
                 "SendAsync timed out after {Timeout}ms, aborting connection",
@@ -220,10 +226,20 @@ internal partial class WebSocketConnection
                 )
                 .ConfigureAwait(false);
 #else
-            await SendInternal(new ArraySegment<byte>(payload.ToArray()), cancellationToken).ConfigureAwait(false);
+            await _client
+                .SendAsync(
+                    new ArraySegment<byte>(payload.ToArray()),
+                    WebSocketMessageType.Binary,
+                    true,
+                    sendCts.Token
+                )
+                .ConfigureAwait(false);
 #endif
         }
-        catch (OperationCanceledException) when (sendCts.IsCancellationRequested)
+        catch (OperationCanceledException) when (
+            sendCts.IsCancellationRequested
+            && !cancellationToken.IsCancellationRequested
+            && !(_cancellation?.IsCancellationRequested ?? false))
         {
             _logger.LogWarning(
                 "SendAsync timed out after {Timeout}ms, aborting connection",
@@ -233,19 +249,6 @@ internal partial class WebSocketConnection
                 $"SendAsync timed out after {SendTimeout.TotalMilliseconds}ms. "
                 + "The remote peer may be unreachable. Connection has been aborted.");
         }
-    }
-
-    private CancellationTokenSource? CreateLinkedToken(CancellationToken cancellationToken)
-    {
-        if (cancellationToken == default)
-        {
-            return null;
-        }
-
-        var internalToken = _cancellation?.Token ?? CancellationToken.None;
-        return internalToken != CancellationToken.None
-            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, internalToken)
-            : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     }
 
     private async global::System.Threading.Tasks.Task DrainTextQueue(CancellationToken token)

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -169,6 +169,14 @@ internal partial class WebSocketConnection
     /// </summary>
     public TimeSpan? LostReconnectTimeout { get; set; }
 
+    /// <summary>
+    /// Maximum time to wait for a single SendAsync call to complete.
+    /// Prevents indefinite hangs when the remote peer dies without closing the connection.
+    /// See: https://github.com/dotnet/runtime/issues/125257
+    /// Default: 30 seconds.
+    /// </summary>
+    public TimeSpan SendTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Optional per-message deflate compression options (RFC 7692).

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.47.0
+  changelogEntry:
+    - summary: |
+        Add per-send timeout to prevent `SendAsync` hangs. A new `SendTimeout` property
+        (default: 30 seconds) on `WebSocketConnection` wraps every `SendAsync` call with a
+        linked `CancellationTokenSource` that fires `CancelAfter(SendTimeout)`. When the
+        timeout elapses the connection is aborted and a `WebsocketException` is thrown,
+        preventing a single dead connection from blocking the send lock for up to 30 minutes.
+        See: https://github.com/dotnet/runtime/issues/125257
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.46.0
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -80,6 +80,14 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
+    /// Maximum time to wait for a single SendAsync call to complete.
+    /// Prevents indefinite hangs when the remote peer dies without closing the connection.
+    /// See: https://github.com/dotnet/runtime/issues/125257
+    /// Default: 30 seconds.
+    /// </summary>
+    public TimeSpan SendTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// Gets the current connection status of the WebSocket.
     /// </summary>
     public ConnectionStatus Status
@@ -276,6 +284,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
 #endif
             HttpInvoker = HttpInvoker,
             ConnectTimeout = ConnectTimeout,
+            SendTimeout = SendTimeout,
             IsReconnectionEnabled = IsReconnectionEnabled,
             ReconnectTimeout = ReconnectTimeout,
             ErrorReconnectTimeout = ErrorReconnectTimeout,

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.Sending.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.Sending.cs
@@ -136,15 +136,39 @@ internal partial class WebSocketConnection
                 throw new ArgumentException($"Unknown message type: {message.GetType()}");
         }
 
-        using var linkedCts = CreateLinkedToken(cancellationToken);
-        await _client
-            .SendAsync(
-                payload,
-                messageType,
-                true,
-                linkedCts?.Token ?? (_cancellation?.Token ?? CancellationToken.None)
+        using var sendCts =
+            cancellationToken != default
+                ? CancellationTokenSource.CreateLinkedTokenSource(
+                    _cancellation?.Token ?? CancellationToken.None,
+                    cancellationToken
+                )
+                : CancellationTokenSource.CreateLinkedTokenSource(
+                    _cancellation?.Token ?? CancellationToken.None
+                );
+        sendCts.CancelAfter(SendTimeout);
+
+        try
+        {
+            await _client
+                .SendAsync(payload, messageType, true, sendCts.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+            when (sendCts.IsCancellationRequested
+                && !cancellationToken.IsCancellationRequested
+                && !(_cancellation?.IsCancellationRequested ?? false)
             )
-            .ConfigureAwait(false);
+        {
+            _logger.LogWarning(
+                "SendAsync timed out after {Timeout}ms, aborting connection",
+                SendTimeout.TotalMilliseconds
+            );
+            _client?.Abort();
+            throw new WebsocketException(
+                $"SendAsync timed out after {SendTimeout.TotalMilliseconds}ms. "
+                    + "The remote peer may be unreachable. Connection has been aborted."
+            );
+        }
     }
 
     private async global::System.Threading.Tasks.Task SendInternalSynchronized(
@@ -179,15 +203,39 @@ internal partial class WebSocketConnection
             return;
         }
 
-        using var linkedCts = CreateLinkedToken(cancellationToken);
-        await _client
-            .SendAsync(
-                payload,
-                WebSocketMessageType.Binary,
-                true,
-                linkedCts?.Token ?? (_cancellation?.Token ?? CancellationToken.None)
+        using var sendCts =
+            cancellationToken != default
+                ? CancellationTokenSource.CreateLinkedTokenSource(
+                    _cancellation?.Token ?? CancellationToken.None,
+                    cancellationToken
+                )
+                : CancellationTokenSource.CreateLinkedTokenSource(
+                    _cancellation?.Token ?? CancellationToken.None
+                );
+        sendCts.CancelAfter(SendTimeout);
+
+        try
+        {
+            await _client
+                .SendAsync(payload, WebSocketMessageType.Binary, true, sendCts.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+            when (sendCts.IsCancellationRequested
+                && !cancellationToken.IsCancellationRequested
+                && !(_cancellation?.IsCancellationRequested ?? false)
             )
-            .ConfigureAwait(false);
+        {
+            _logger.LogWarning(
+                "SendAsync timed out after {Timeout}ms, aborting connection",
+                SendTimeout.TotalMilliseconds
+            );
+            _client?.Abort();
+            throw new WebsocketException(
+                $"SendAsync timed out after {SendTimeout.TotalMilliseconds}ms. "
+                    + "The remote peer may be unreachable. Connection has been aborted."
+            );
+        }
     }
 
     private async global::System.Threading.Tasks.Task SendInternal(
@@ -200,29 +248,50 @@ internal partial class WebSocketConnection
             return;
         }
 
-        using var linkedCts = CreateLinkedToken(cancellationToken);
-        var token = linkedCts?.Token ?? (_cancellation?.Token ?? CancellationToken.None);
-#if NET6_0_OR_GREATER
-        await _client
-            .SendAsync(payload, WebSocketMessageType.Binary, true, token)
-            .ConfigureAwait(false);
-#else
-        await SendInternal(new ArraySegment<byte>(payload.ToArray()), cancellationToken)
-            .ConfigureAwait(false);
-#endif
-    }
+        using var sendCts =
+            cancellationToken != default
+                ? CancellationTokenSource.CreateLinkedTokenSource(
+                    _cancellation?.Token ?? CancellationToken.None,
+                    cancellationToken
+                )
+                : CancellationTokenSource.CreateLinkedTokenSource(
+                    _cancellation?.Token ?? CancellationToken.None
+                );
+        sendCts.CancelAfter(SendTimeout);
 
-    private CancellationTokenSource? CreateLinkedToken(CancellationToken cancellationToken)
-    {
-        if (cancellationToken == default)
+        try
         {
-            return null;
+#if NET6_0_OR_GREATER
+            await _client
+                .SendAsync(payload, WebSocketMessageType.Binary, true, sendCts.Token)
+                .ConfigureAwait(false);
+#else
+            await _client
+                .SendAsync(
+                    new ArraySegment<byte>(payload.ToArray()),
+                    WebSocketMessageType.Binary,
+                    true,
+                    sendCts.Token
+                )
+                .ConfigureAwait(false);
+#endif
         }
-
-        var internalToken = _cancellation?.Token ?? CancellationToken.None;
-        return internalToken != CancellationToken.None
-            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, internalToken)
-            : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        catch (OperationCanceledException)
+            when (sendCts.IsCancellationRequested
+                && !cancellationToken.IsCancellationRequested
+                && !(_cancellation?.IsCancellationRequested ?? false)
+            )
+        {
+            _logger.LogWarning(
+                "SendAsync timed out after {Timeout}ms, aborting connection",
+                SendTimeout.TotalMilliseconds
+            );
+            _client?.Abort();
+            throw new WebsocketException(
+                $"SendAsync timed out after {SendTimeout.TotalMilliseconds}ms. "
+                    + "The remote peer may be unreachable. Connection has been aborted."
+            );
+        }
     }
 
     private async global::System.Threading.Tasks.Task DrainTextQueue(CancellationToken token)

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -181,6 +181,14 @@ internal partial class WebSocketConnection
     /// </summary>
     public TimeSpan? LostReconnectTimeout { get; set; }
 
+    /// <summary>
+    /// Maximum time to wait for a single SendAsync call to complete.
+    /// Prevents indefinite hangs when the remote peer dies without closing the connection.
+    /// See: https://github.com/dotnet/runtime/issues/125257
+    /// Default: 30 seconds.
+    /// </summary>
+    public TimeSpan SendTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Optional per-message deflate compression options (RFC 7692).


### PR DESCRIPTION
## Description

Refs https://github.com/dotnet/runtime/issues/125257

`ClientWebSocket.SendAsync` has no write timeout. When the remote peer dies (network cable unplugged, process crash without FIN), `SendAsync` blocks until OS TCP keep-alive detects the dead connection (13–30 min on Linux, ~21 s on Windows). This blocks the send lock (`_locker`) for that entire duration, freezing all queued sends.

This PR adds a configurable per-send timeout that wraps every `SendAsync` call, aborting the connection promptly when the remote peer is unreachable.

## Changes Made

- Added `SendTimeout` property (default: 30 seconds) to `WebSocketConnection.Template.cs`
- Updated all three `SendInternal` overloads in `WebSocketConnection.Sending.Template.cs` to wrap `SendAsync` with a linked `CancellationTokenSource` + `CancelAfter(SendTimeout)`
- On timeout: logs a warning, calls `_client.Abort()`, and throws `WebsocketException`
- Bumped version to `2.47.0` in `versions.yml`

## Human Review Checklist

- [ ] **Catch filter breadth**: The `when (sendCts.IsCancellationRequested)` filter catches cancellation from *any* linked source (caller token, internal `_cancellation`, *and* timeout). This means an explicit caller cancellation will also log "timed out" and abort the connection. Verify this is acceptable behavior vs. only catching timeout-specific cancellations.
- [ ] **Dead code**: `CreateLinkedToken()` (line 238–249 of Sending template) is no longer called by any `SendInternal` overload. Consider removing or keeping for potential future use.
- [ ] **Double timeout in legacy path**: The `ReadOnlyMemory<byte>` overload's `#else` branch delegates to `SendInternal(ArraySegment<byte>, cancellationToken)`, which creates its own timeout CTS — resulting in nested timeouts on pre-.NET 6.
- [ ] **Seed snapshot updates**: Seed tests for `websocket`, `websocket-bearer-auth`, and `websocket-inferred-auth` fixtures may need regeneration to reflect the template changes.

## Testing

- [x] Lint/format checks pass (`pnpm run check`)
- [ ] Seed test regeneration with websocket fixtures (pending)

Link to Devin session: https://app.devin.ai/sessions/6a7abbae3fb44153a83809d7154bbe4c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
