### PR TITLE
feat(csharp): add exponential backoff reconnection strategy for WebSocket connections

### DIFF
--- a/generators/csharp/base/src/AsIs.ts
+++ b/generators/csharp/base/src/AsIs.ts
@@ -57,6 +57,7 @@ export const AsIsFiles = {
         Query: "WebSockets/Query.Template.cs",
         ReconnectionInfo: "WebSockets/ReconnectionInfo.Template.cs",
         ReconnectionType: "WebSockets/ReconnectionType.Template.cs",
+        ReconnectStrategy: "WebSockets/ReconnectStrategy.Template.cs",
         RequestMessage: "WebSockets/RequestMessage.Template.cs",
         WebSocketClient: "WebSockets/WebSocketClient.Template.cs",
         WebSocketConnection: "WebSockets/WebSocketConnection.Template.cs",

--- a/generators/csharp/base/src/asIs/WebSockets/ReconnectStrategy.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/ReconnectStrategy.Template.cs
@@ -5,12 +5,17 @@ namespace <%= namespace%>.WebSockets;
 /// <summary>
 /// Configures the backoff strategy for automatic reconnection.
 /// </summary>
-internal class ReconnectStrategy
+public class ReconnectStrategy
 {
     private readonly Random _jitterRandom = new();
 
     private int _attemptsMade;
     private TimeSpan _currentInterval;
+
+    /// <summary>
+    /// Gets the number of reconnection attempts made since the last reset.
+    /// </summary>
+    public int AttemptsMade => _attemptsMade;
 
     /// <summary>
     /// Initial delay before the first reconnection attempt.
@@ -81,9 +86,4 @@ internal class ReconnectStrategy
         _currentInterval = MinReconnectInterval;
     }
 
-    /// <summary>
-    /// Returns true if the maximum number of attempts has been reached.
-    /// </summary>
-    public bool AreAttemptsExhausted =>
-        MaxAttempts.HasValue && _attemptsMade >= MaxAttempts.Value;
 }

--- a/generators/csharp/base/src/asIs/WebSockets/ReconnectStrategy.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/ReconnectStrategy.Template.cs
@@ -1,0 +1,89 @@
+// ReSharper disable All
+#pragma warning disable
+namespace <%= namespace%>.WebSockets;
+
+/// <summary>
+/// Configures the backoff strategy for automatic reconnection.
+/// </summary>
+internal class ReconnectStrategy
+{
+    private static readonly Random _jitterRandom = new();
+
+    private int _attemptsMade;
+    private TimeSpan _currentInterval;
+
+    /// <summary>
+    /// Initial delay before the first reconnection attempt.
+    /// Default: 1 second.
+    /// </summary>
+    public TimeSpan MinReconnectInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Maximum delay between reconnection attempts.
+    /// Default: 60 seconds.
+    /// </summary>
+    public TimeSpan MaxReconnectInterval { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Maximum number of reconnection attempts before giving up.
+    /// Set to null for unlimited attempts. Default: null.
+    /// </summary>
+    public int? MaxAttempts { get; set; }
+
+    /// <summary>
+    /// Add random jitter (0-25% of interval) to prevent thundering herd.
+    /// Default: true.
+    /// </summary>
+    public bool UseJitter { get; set; } = true;
+
+    /// <summary>
+    /// Get the next reconnection delay and increment the attempt counter.
+    /// Returns null if max attempts have been exhausted.
+    /// </summary>
+    public TimeSpan? GetNextDelay()
+    {
+        if (MaxAttempts.HasValue && _attemptsMade >= MaxAttempts.Value)
+        {
+            return null; // exhausted
+        }
+
+        if (_attemptsMade == 0)
+        {
+            _currentInterval = MinReconnectInterval;
+        }
+        else
+        {
+            // Exponential backoff: double the interval, capped at max
+            _currentInterval = TimeSpan.FromMilliseconds(
+                Math.Min(
+                    _currentInterval.TotalMilliseconds * 2,
+                    MaxReconnectInterval.TotalMilliseconds));
+        }
+
+        _attemptsMade++;
+
+        if (UseJitter)
+        {
+            // Add 0-25% random jitter
+            var jitterMs = _currentInterval.TotalMilliseconds * 0.25 * _jitterRandom.NextDouble();
+            return _currentInterval + TimeSpan.FromMilliseconds(jitterMs);
+        }
+
+        return _currentInterval;
+    }
+
+    /// <summary>
+    /// Reset the attempt counter and interval. Call after successful connection.
+    /// </summary>
+    public void Reset()
+    {
+        _attemptsMade = 0;
+        _currentInterval = MinReconnectInterval;
+    }
+
+    /// <summary>
+    /// Returns true if the maximum number of attempts has been reached.
+    /// </summary>
+    public bool AreAttemptsExhausted =>
+        MaxAttempts.HasValue && _attemptsMade >= MaxAttempts.Value;
+}

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketClient.Template.cs
@@ -38,6 +38,14 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     public TimeSpan? LostReconnectTimeout { get; set; }
 
     /// <summary>
+    /// Strategy for reconnection backoff delays.
+    /// Controls interval growth, jitter, and max attempts.
+    /// Set to null to use fixed-interval reconnection (legacy behavior).
+    /// Default: exponential backoff, 1s → 60s, unlimited attempts, with jitter.
+    /// </summary>
+    public ReconnectStrategy? Backoff { get; set; } = new ReconnectStrategy();
+
+    /// <summary>
     /// Initializes a new instance of the WebSocketClient class.
     /// </summary>
     /// <param name="uri">The WebSocket URI to connect to.</param>
@@ -264,6 +272,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
             ReconnectTimeout = ReconnectTimeout,
             ErrorReconnectTimeout = ErrorReconnectTimeout,
             LostReconnectTimeout = LostReconnectTimeout,
+            Backoff = Backoff,
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -644,11 +644,18 @@ internal partial class WebSocketConnection
                     Backoff.MaxAttempts);
                 IsStarted = false;
                 _reconnecting = false;
-                var info = new DisconnectionInfo(
-                    DisconnectionType.Exit, null, null, null, causedException);
+                var info = DisconnectionInfo.Create(
+                    DisconnectionType.Exit, null, causedException);
                 await OnDisconnectionHappened(info).ConfigureAwait(false);
                 return;
             }
+
+            _logger.LogInformation(
+                "Reconnecting in {Delay}ms (attempt {Attempt})",
+                delay.Value.TotalMilliseconds,
+                Backoff.MaxAttempts.HasValue
+                    ? $"{Backoff.AttemptsMade}/{Backoff.MaxAttempts}"
+                    : $"{Backoff.AttemptsMade}");
 
             try
             {

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -644,8 +644,8 @@ internal partial class WebSocketConnection
                     Backoff.MaxAttempts);
                 IsStarted = false;
                 _reconnecting = false;
-                var info = DisconnectionInfo.Create(
-                    DisconnectionType.Exit, _client, causedException);
+                var info = new DisconnectionInfo(
+                    DisconnectionType.Exit, null, null, null, causedException);
                 await OnDisconnectionHappened(info).ConfigureAwait(false);
                 return;
             }

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -474,6 +474,13 @@ internal partial class WebSocketConnection
 
             if (info.CancelReconnection) return;
 
+            if (Backoff != null)
+            {
+                // Let the backoff strategy control retry timing
+                _ = ReconnectSynchronized(ReconnectionType.Error, false, e);
+                return;
+            }
+
             if (ErrorReconnectTimeout == null) return;
 
             var timeout = ErrorReconnectTimeout.Value;

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -169,6 +169,14 @@ internal partial class WebSocketConnection
     /// </summary>
     public TimeSpan? LostReconnectTimeout { get; set; }
 
+    /// <summary>
+    /// Strategy for reconnection backoff delays.
+    /// Controls interval growth, jitter, and max attempts.
+    /// Set to null to use fixed-interval reconnection (legacy behavior).
+    /// Default: exponential backoff, 1s → 60s, unlimited attempts, with jitter.
+    /// </summary>
+    public ReconnectStrategy? Backoff { get; set; } = new ReconnectStrategy();
+
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Optional per-message deflate compression options (RFC 7692).
@@ -624,10 +632,43 @@ internal partial class WebSocketConnection
             return;
         }
 
+        // Consult backoff strategy for delay
+        if (Backoff != null)
+        {
+            var delay = Backoff.GetNextDelay();
+            if (delay == null)
+            {
+                // Max attempts exhausted
+                _logger.LogWarning(
+                    "Reconnection attempts exhausted after {Attempts} tries",
+                    Backoff.MaxAttempts);
+                IsStarted = false;
+                _reconnecting = false;
+                var info = DisconnectionInfo.Create(
+                    DisconnectionType.Exit, _client, causedException);
+                await OnDisconnectionHappened(info).ConfigureAwait(false);
+                return;
+            }
+
+            try
+            {
+                await global::System.Threading.Tasks.Task.Delay(
+                    delay.Value, _cancellationTotal?.Token ?? CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                _reconnecting = false;
+                return;
+            }
+        }
+
         _cancellation = new CancellationTokenSource();
         await StartClient(Url, _cancellation.Token, failFast).ConfigureAwait(false);
         if (IsRunning)
         {
+            // Reset backoff on successful reconnection
+            Backoff?.Reset();
             await OnReconnectionHappened(ReconnectionInfo.Create(type)).ConfigureAwait(false);
         }
         _reconnecting = false;

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -600,6 +600,19 @@ export class WebSocketClientGenerator extends WithGeneration {
             set: true
         });
 
+        optionsClass.addField({
+            origin: optionsClass.explicit("ReconnectBackoff"),
+            access: ast.Access.Public,
+            type: this.Types.Arbitrary("ReconnectStrategy?"),
+            summary:
+                "Backoff strategy for reconnection delays. Controls interval growth, jitter, and max attempts. " +
+                "Set to null to use fixed-interval reconnection (legacy behavior). " +
+                "Default: exponential backoff, 1s\u219260s, unlimited attempts, with jitter.",
+            get: true,
+            set: true,
+            initializer: this.csharp.codeblock("new ReconnectStrategy()")
+        });
+
         return optionsClass;
     }
 
@@ -745,6 +758,7 @@ export class WebSocketClientGenerator extends WithGeneration {
                 writer.writeTextStatement("_client.ReconnectTimeout = _options.ReconnectTimeout");
                 writer.writeTextStatement("_client.ErrorReconnectTimeout = _options.ErrorReconnectTimeout");
                 writer.writeTextStatement("_client.LostReconnectTimeout = _options.LostReconnectTimeout");
+                writer.writeTextStatement("_client.Backoff = _options.ReconnectBackoff");
                 // Note: PropertyChanged event forwarding is handled by the event's add/remove accessors
             }),
             doc: this.csharp.xmlDocBlockOf({ summary: "Constructor with options" })

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,19 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.47.0
+  changelogEntry:
+    - summary: |
+        Add exponential backoff reconnection strategy for WebSocket connections.
+        A new `ReconnectStrategy` class provides configurable exponential backoff
+        (doubling intervals from 1s to 60s), optional random jitter (0-25%) to
+        prevent thundering herd, and configurable max attempts. The strategy is
+        exposed as a `ReconnectBackoff` property on the generated Options class
+        and wired through `WebSocketClient` to `WebSocketConnection.Reconnect()`.
+        When max attempts are exhausted, reconnection stops and a disconnection
+        event is raised. The backoff resets on successful reconnection.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.46.0
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/ReconnectStrategy.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/ReconnectStrategy.cs
@@ -1,6 +1,6 @@
 // ReSharper disable All
 #pragma warning disable
-namespace <%= namespace%>.WebSockets;
+namespace SeedWebsocket.Core.WebSockets;
 
 /// <summary>
 /// Configures the backoff strategy for automatic reconnection.
@@ -57,7 +57,9 @@ internal class ReconnectStrategy
             _currentInterval = TimeSpan.FromMilliseconds(
                 Math.Min(
                     _currentInterval.TotalMilliseconds * 2,
-                    MaxReconnectInterval.TotalMilliseconds));
+                    MaxReconnectInterval.TotalMilliseconds
+                )
+            );
         }
 
         _attemptsMade++;
@@ -84,6 +86,5 @@ internal class ReconnectStrategy
     /// <summary>
     /// Returns true if the maximum number of attempts has been reached.
     /// </summary>
-    public bool AreAttemptsExhausted =>
-        MaxAttempts.HasValue && _attemptsMade >= MaxAttempts.Value;
+    public bool AreAttemptsExhausted => MaxAttempts.HasValue && _attemptsMade >= MaxAttempts.Value;
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/ReconnectStrategy.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/ReconnectStrategy.cs
@@ -5,12 +5,17 @@ namespace SeedWebsocket.Core.WebSockets;
 /// <summary>
 /// Configures the backoff strategy for automatic reconnection.
 /// </summary>
-internal class ReconnectStrategy
+public class ReconnectStrategy
 {
     private readonly Random _jitterRandom = new();
 
     private int _attemptsMade;
     private TimeSpan _currentInterval;
+
+    /// <summary>
+    /// Gets the number of reconnection attempts made since the last reset.
+    /// </summary>
+    public int AttemptsMade => _attemptsMade;
 
     /// <summary>
     /// Initial delay before the first reconnection attempt.
@@ -82,9 +87,4 @@ internal class ReconnectStrategy
         _attemptsMade = 0;
         _currentInterval = MinReconnectInterval;
     }
-
-    /// <summary>
-    /// Returns true if the maximum number of attempts has been reached.
-    /// </summary>
-    public bool AreAttemptsExhausted => MaxAttempts.HasValue && _attemptsMade >= MaxAttempts.Value;
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketClient.cs
@@ -38,6 +38,14 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
     public TimeSpan? LostReconnectTimeout { get; set; }
 
     /// <summary>
+    /// Strategy for reconnection backoff delays.
+    /// Controls interval growth, jitter, and max attempts.
+    /// Set to null to use fixed-interval reconnection (legacy behavior).
+    /// Default: exponential backoff, 1s → 60s, unlimited attempts, with jitter.
+    /// </summary>
+    public ReconnectStrategy? Backoff { get; set; } = new ReconnectStrategy();
+
+    /// <summary>
     /// Initializes a new instance of the WebSocketClient class.
     /// </summary>
     /// <param name="uri">The WebSocket URI to connect to.</param>
@@ -280,6 +288,7 @@ internal sealed class WebSocketClient : IAsyncDisposable, IDisposable, INotifyPr
             ReconnectTimeout = ReconnectTimeout,
             ErrorReconnectTimeout = ErrorReconnectTimeout,
             LostReconnectTimeout = LostReconnectTimeout,
+            Backoff = Backoff,
             ExceptionOccurred = ExceptionOccurred.RaiseEvent,
             TextMessageReceived = _onTextMessage,
             BinaryMessageReceived = stream =>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -729,16 +729,18 @@ internal partial class WebSocketConnection
                 );
                 IsStarted = false;
                 _reconnecting = false;
-                var info = new DisconnectionInfo(
-                    DisconnectionType.Exit,
-                    null,
-                    null,
-                    null,
-                    causedException
-                );
+                var info = DisconnectionInfo.Create(DisconnectionType.Exit, null, causedException);
                 await OnDisconnectionHappened(info).ConfigureAwait(false);
                 return;
             }
+
+            _logger.LogInformation(
+                "Reconnecting in {Delay}ms (attempt {Attempt})",
+                delay.Value.TotalMilliseconds,
+                Backoff.MaxAttempts.HasValue
+                    ? $"{Backoff.AttemptsMade}/{Backoff.MaxAttempts}"
+                    : $"{Backoff.AttemptsMade}"
+            );
 
             try
             {

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -181,6 +181,14 @@ internal partial class WebSocketConnection
     /// </summary>
     public TimeSpan? LostReconnectTimeout { get; set; }
 
+    /// <summary>
+    /// Strategy for reconnection backoff delays.
+    /// Controls interval growth, jitter, and max attempts.
+    /// Set to null to use fixed-interval reconnection (legacy behavior).
+    /// Default: exponential backoff, 1s → 60s, unlimited attempts, with jitter.
+    /// </summary>
+    public ReconnectStrategy? Backoff { get; set; } = new ReconnectStrategy();
+
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Optional per-message deflate compression options (RFC 7692).
@@ -708,10 +716,52 @@ internal partial class WebSocketConnection
             return;
         }
 
+        // Consult backoff strategy for delay
+        if (Backoff != null)
+        {
+            var delay = Backoff.GetNextDelay();
+            if (delay == null)
+            {
+                // Max attempts exhausted
+                _logger.LogWarning(
+                    "Reconnection attempts exhausted after {Attempts} tries",
+                    Backoff.MaxAttempts
+                );
+                IsStarted = false;
+                _reconnecting = false;
+                var info = new DisconnectionInfo(
+                    DisconnectionType.Exit,
+                    null,
+                    null,
+                    null,
+                    causedException
+                );
+                await OnDisconnectionHappened(info).ConfigureAwait(false);
+                return;
+            }
+
+            try
+            {
+                await global::System
+                    .Threading.Tasks.Task.Delay(
+                        delay.Value,
+                        _cancellationTotal?.Token ?? CancellationToken.None
+                    )
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                _reconnecting = false;
+                return;
+            }
+        }
+
         _cancellation = new CancellationTokenSource();
         await StartClient(Url, _cancellation.Token, failFast).ConfigureAwait(false);
         if (IsRunning)
         {
+            // Reset backoff on successful reconnection
+            Backoff?.Reset();
             await OnReconnectionHappened(ReconnectionInfo.Create(type)).ConfigureAwait(false);
         }
         _reconnecting = false;

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -528,6 +528,13 @@ internal partial class WebSocketConnection
             if (info.CancelReconnection)
                 return;
 
+            if (Backoff != null)
+            {
+                // Let the backoff strategy control retry timing
+                _ = ReconnectSynchronized(ReconnectionType.Error, false, e);
+                return;
+            }
+
             if (ErrorReconnectTimeout == null)
                 return;
 

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -196,6 +196,7 @@ internal partial class WebSocketConnection
     /// Set to null to disable. Default: 5 seconds.
     /// </summary>
     public TimeSpan? StateCheckInterval { get; set; } = TimeSpan.FromSeconds(5);
+
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Optional per-message deflate compression options (RFC 7692).

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -48,6 +48,7 @@ public partial class EmptyRealtimeApi
         _client.ReconnectTimeout = _options.ReconnectTimeout;
         _client.ErrorReconnectTimeout = _options.ErrorReconnectTimeout;
         _client.LostReconnectTimeout = _options.LostReconnectTimeout;
+        _client.Backoff = _options.ReconnectBackoff;
     }
 
     /// <summary>
@@ -191,5 +192,10 @@ public partial class EmptyRealtimeApi
         /// Time to wait before reconnecting if the connection is lost with a transient error. Set null to disable (reconnect immediately). Default: null.
         /// </summary>
         public TimeSpan? LostReconnectTimeout { get; set; }
+
+        /// <summary>
+        /// Backoff strategy for reconnection delays. Controls interval growth, jitter, and max attempts. Set to null to use fixed-interval reconnection (legacy behavior). Default: exponential backoff, 1s→60s, unlimited attempts, with jitter.
+        /// </summary>
+        public ReconnectStrategy? ReconnectBackoff { get; set; } = new ReconnectStrategy();
     }
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -93,6 +93,7 @@ public partial class RealtimeApi
         _client.ReconnectTimeout = _options.ReconnectTimeout;
         _client.ErrorReconnectTimeout = _options.ErrorReconnectTimeout;
         _client.LostReconnectTimeout = _options.LostReconnectTimeout;
+        _client.Backoff = _options.ReconnectBackoff;
     }
 
     /// <summary>
@@ -341,5 +342,10 @@ public partial class RealtimeApi
         /// Time to wait before reconnecting if the connection is lost with a transient error. Set null to disable (reconnect immediately). Default: null.
         /// </summary>
         public TimeSpan? LostReconnectTimeout { get; set; }
+
+        /// <summary>
+        /// Backoff strategy for reconnection delays. Controls interval growth, jitter, and max attempts. Set to null to use fixed-interval reconnection (legacy behavior). Default: exponential backoff, 1s→60s, unlimited attempts, with jitter.
+        /// </summary>
+        public ReconnectStrategy? ReconnectBackoff { get; set; } = new ReconnectStrategy();
     }
 }


### PR DESCRIPTION
## Description

Adds an exponential backoff reconnection strategy to the C# WebSocket generator, replacing the fixed-interval reconnection approach that causes thundering herd problems when servers recover from outages.

## Changes Made

- **New `ReconnectStrategy.Template.cs`**: Configurable backoff strategy with exponential interval doubling (1s → 60s default), 0–25% random jitter, optional max attempts, and reset-on-success. Exposes `AttemptsMade` for observability.
- **`WebSocketConnection.Template.cs`**: Added `Backoff` property; `Reconnect()` now consults `Backoff.GetNextDelay()` before reconnecting, logs each attempt with delay/attempt info, and calls `Backoff.Reset()` on success. When max attempts are exhausted, raises a disconnection event and stops. `StartClient` catch block bypasses `ErrorReconnectTimeout` timer when `Backoff` is set, letting the backoff strategy control retry timing exclusively.
- **`WebSocketClient.Template.cs`**: Added `Backoff` property, wired through to `WebSocketConnection` in `ConnectAsync`
- **`WebsocketClientGenerator.ts`**: Exposes `ReconnectBackoff` on the generated Options class and wires it to `_client.Backoff` in the constructor
- **`AsIs.ts`**: Registered the new template
- **`versions.yml`**: Added v2.50.0 changelog entry

### Updates since last revision

- **Fixed double-delay on error reconnections**: When `Backoff` is non-null, `StartClient`'s catch block now fire-and-forgets `ReconnectSynchronized(Error, ...)` immediately instead of scheduling via `_errorReconnectTimer`. The backoff delay inside `Reconnect()` controls retry timing exclusively, so the effective delay is just the backoff interval (1s→2s→4s→…→60s), not `ErrorReconnectTimeout + backoff_delay`.
- **Version bumped to 2.50.0**: Main took 2.47.0–2.49.0 for StateCheckInterval, bounded send queue, and SendTimeout features; merge conflicts resolved.

### Previous fixes (already applied)

- **Fixed CS0050 accessibility error**: `ReconnectStrategy` changed from `internal` to `public`
- **Fixed ObjectDisposedException**: Exhaustion path uses `DisconnectionInfo.Create(type, null, exception)` for null-safe construction
- **Fixed thread-unsafe Random**: `_jitterRandom` changed from `static` to instance field
- **Added per-attempt logging**: Each attempt logs delay and attempt number
- **Added `AttemptsMade` property**: Public read-only for observability
- **Removed `AreAttemptsExhausted`**: Dead code removed

## Human Review Checklist

- [x] ~~Seed snapshots not updated~~ — regenerated and committed
- [x] ~~Thread-unsafe static Random~~ — changed to instance field
- [x] ~~ObjectDisposedException on disposed `_client`~~ — uses `DisconnectionInfo.Create` with null client
- [x] ~~CS0050 accessibility error~~ — `ReconnectStrategy` changed to `public`
- [x] ~~Double-delay on error reconnections~~ — `StartClient` catch block now bypasses `ErrorReconnectTimeout` when `Backoff` is set
- [ ] **Fire-and-forget re-entry**: When `Backoff` is set and `StartClient` fails, the catch block does `_ = ReconnectSynchronized(Error, ...)`. Since `Reconnect()` (the caller of `StartClient`) already holds `AsyncLock` via `ReconnectSynchronized`, the fire-and-forget task will queue behind the lock until `Reconnect()` returns. Verify this doesn't cause unexpected behavior (e.g., rapid re-entry if `Reconnect()` returns quickly after `StartClient` failure)
- [ ] **Default behavior change**: `Backoff` defaults to `new ReconnectStrategy()` on both `WebSocketClient` and `WebSocketConnection`, so all reconnections now use exponential backoff by default. Users can set `ReconnectBackoff = null` on Options for legacy fixed-interval behavior. Verify this default-on is desired vs opt-in
- [ ] **Null handling in exhaustion path**: When backoff is exhausted, `DisconnectionInfo.Create` is called with `null` client, producing null `CloseStatus`/`CloseStatusDescription`/`SubProtocol`. Verify downstream `OnDisconnectionHappened` handlers and the `Closed` event handler tolerate nulls
- [ ] **Backoff reset scope**: `Backoff.Reset()` is only called when `IsRunning` is true after `StartClient` — confirm this is the right condition (only reset on truly successful reconnection)
- [ ] **Property naming**: Public API uses `ReconnectBackoff` (Options class) while internals use `Backoff` — intentional for clarity but verify consistency is acceptable
- [ ] **Thread safety**: `ReconnectStrategy` mutable fields (`_attemptsMade`, `_currentInterval`) are unprotected, but `Reconnect()` is called under `AsyncLock` via `ReconnectSynchronized` — confirm this is sufficient

## Testing
- [x] Lint/typecheck passes (`pnpm run check`)
- [x] Seed test snapshots regenerated for `websocket` fixture (2/2 passed)
- [ ] No unit tests for `ReconnectStrategy` logic (exponential growth bounds, jitter range, max attempts exhaustion, reset behavior)
- [ ] Manual testing not applicable (template code generation)

Link to Devin session: https://app.devin.ai/sessions/5195c5adb8664a428826045a822b29a3
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
