### PR TITLE
feat(csharp): add receive hang detection via state monitor task

### DIFF
--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -556,7 +556,7 @@ internal partial class WebSocketConnection
                                 client,
                                 WebSocketCloseStatus.NormalClosure,
                                 "Closing",
-                                receiveCts.Token,
+                                token,
                                 false,
                                 true
                             );

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -472,16 +472,16 @@ internal partial class WebSocketConnection
     internal Exception ListenException { get; set; }
 
     private async global::System.Threading.Tasks.Task MonitorState(
-        WebSocket client, CancellationTokenSource receiveCts, CancellationToken token)
+        WebSocket client, CancellationTokenSource receiveCts)
     {
         if (StateCheckInterval == null) return;
 
         try
         {
-            while (!token.IsCancellationRequested)
+            while (!receiveCts.Token.IsCancellationRequested)
             {
                 await global::System.Threading.Tasks.Task.Delay(
-                    StateCheckInterval.Value, token).ConfigureAwait(false);
+                    StateCheckInterval.Value, receiveCts.Token).ConfigureAwait(false);
 
                 if (client.State == WebSocketState.Closed ||
                     client.State == WebSocketState.Aborted ||
@@ -508,7 +508,7 @@ internal partial class WebSocketConnection
         using var receiveCts = CancellationTokenSource.CreateLinkedTokenSource(token);
 
         // Start the state monitor as a background task
-        var monitorTask = MonitorState(client, receiveCts, token);
+        var monitorTask = MonitorState(client, receiveCts);
 
         Exception causedException = null;
         try

--- a/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
+++ b/generators/csharp/base/src/asIs/WebSockets/WebSocketConnection.Template.cs
@@ -169,6 +169,14 @@ internal partial class WebSocketConnection
     /// </summary>
     public TimeSpan? LostReconnectTimeout { get; set; }
 
+    /// <summary>
+    /// How often to check the WebSocket state for silent disconnections.
+    /// Addresses ReceiveAsync hang when TCP closes without WebSocket notification.
+    /// See: https://github.com/dotnet/runtime/issues/110496
+    /// Set to null to disable. Default: 5 seconds.
+    /// </summary>
+    public TimeSpan? StateCheckInterval { get; set; } = TimeSpan.FromSeconds(5);
+
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Optional per-message deflate compression options (RFC 7692).
@@ -463,8 +471,45 @@ internal partial class WebSocketConnection
 
     internal Exception ListenException { get; set; }
 
+    private async global::System.Threading.Tasks.Task MonitorState(
+        WebSocket client, CancellationTokenSource receiveCts, CancellationToken token)
+    {
+        if (StateCheckInterval == null) return;
+
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                await global::System.Threading.Tasks.Task.Delay(
+                    StateCheckInterval.Value, token).ConfigureAwait(false);
+
+                if (client.State == WebSocketState.Closed ||
+                    client.State == WebSocketState.Aborted ||
+                    client.State == WebSocketState.CloseReceived)
+                {
+                    _logger.LogWarning(
+                        "State monitor detected WebSocket in '{State}' state, "
+                        + "cancelling receive loop",
+                        client.State);
+
+                    // Cancel the ReceiveAsync that may be hung
+                    receiveCts.Cancel();
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+    }
+
     private async global::System.Threading.Tasks.Task Listen(WebSocket client, CancellationToken token)
     {
+        // Create a linked CTS that the state monitor can cancel
+        using var receiveCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+        // Start the state monitor as a background task
+        var monitorTask = MonitorState(client, receiveCts, token);
+
         Exception causedException = null;
         try
         {
@@ -479,7 +524,7 @@ internal partial class WebSocketConnection
                     WebSocketReceiveResult result;
                     while (true)
                     {
-                        result = await client.ReceiveAsync(buffer, token);
+                        result = await client.ReceiveAsync(buffer, receiveCts.Token);
                         ms.Write(buffer.AsSpan(0, result.Count));
 
                         if (result.EndOfMessage)
@@ -511,7 +556,7 @@ internal partial class WebSocketConnection
                                 client,
                                 WebSocketCloseStatus.NormalClosure,
                                 "Closing",
-                                token,
+                                receiveCts.Token,
                                 false,
                                 true
                             );
@@ -520,17 +565,17 @@ internal partial class WebSocketConnection
                         }
                     }
                 }
-            } while (client.State == WebSocketState.Open && !token.IsCancellationRequested);
+            } while (client.State == WebSocketState.Open && !receiveCts.Token.IsCancellationRequested);
         }
-        catch (TaskCanceledException e)
+        catch (TaskCanceledException)
         {
             // task was canceled, ignore
         }
-        catch (OperationCanceledException e)
+        catch (OperationCanceledException)
         {
             // operation was canceled, ignore
         }
-        catch (ObjectDisposedException e)
+        catch (ObjectDisposedException)
         {
             // client was disposed, ignore
         }
@@ -543,6 +588,12 @@ internal partial class WebSocketConnection
             );
             await OnExceptionOccurred(e).ConfigureAwait(false);
             causedException = e;
+        }
+        finally
+        {
+            // Ensure monitor task completes
+            receiveCts.Cancel();
+            try { await monitorTask.ConfigureAwait(false); } catch { }
         }
 
         if (ShouldIgnoreReconnection(client) || !IsStarted)

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,20 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.47.0
+  changelogEntry:
+    - summary: |
+        Add receive hang detection via a background state monitor task. A new
+        `StateCheckInterval` property (default: 5 seconds) controls how often the
+        monitor polls `WebSocket.State`. When the state transitions to `Closed`,
+        `Aborted`, or `CloseReceived` — indicating the TCP connection died without
+        notifying the receive loop — the monitor cancels the pending `ReceiveAsync`
+        via a linked `CancellationTokenSource`. This works around known .NET runtime
+        issues where `ReceiveAsync` hangs indefinitely on silent TCP disconnections
+        (dotnet/runtime#110496) and `Abort()` fails to cancel a pending receive
+        (dotnet/runtime#44272). Set `StateCheckInterval` to `null` to disable.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.46.0
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -625,7 +625,7 @@ internal partial class WebSocketConnection
                                 client,
                                 WebSocketCloseStatus.NormalClosure,
                                 "Closing",
-                                receiveCts.Token,
+                                token,
                                 false,
                                 true
                             );

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -181,6 +181,14 @@ internal partial class WebSocketConnection
     /// </summary>
     public TimeSpan? LostReconnectTimeout { get; set; }
 
+    /// <summary>
+    /// How often to check the WebSocket state for silent disconnections.
+    /// Addresses ReceiveAsync hang when TCP closes without WebSocket notification.
+    /// See: https://github.com/dotnet/runtime/issues/110496
+    /// Set to null to disable. Default: 5 seconds.
+    /// </summary>
+    public TimeSpan? StateCheckInterval { get; set; } = TimeSpan.FromSeconds(5);
+
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Optional per-message deflate compression options (RFC 7692).
@@ -522,11 +530,56 @@ internal partial class WebSocketConnection
 
     internal Exception ListenException { get; set; }
 
+    private async global::System.Threading.Tasks.Task MonitorState(
+        WebSocket client,
+        CancellationTokenSource receiveCts,
+        CancellationToken token
+    )
+    {
+        if (StateCheckInterval == null)
+            return;
+
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                await global::System
+                    .Threading.Tasks.Task.Delay(StateCheckInterval.Value, token)
+                    .ConfigureAwait(false);
+
+                if (
+                    client.State == WebSocketState.Closed
+                    || client.State == WebSocketState.Aborted
+                    || client.State == WebSocketState.CloseReceived
+                )
+                {
+                    _logger.LogWarning(
+                        "State monitor detected WebSocket in '{State}' state, "
+                            + "cancelling receive loop",
+                        client.State
+                    );
+
+                    // Cancel the ReceiveAsync that may be hung
+                    receiveCts.Cancel();
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+    }
+
     private async global::System.Threading.Tasks.Task Listen(
         WebSocket client,
         CancellationToken token
     )
     {
+        // Create a linked CTS that the state monitor can cancel
+        using var receiveCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+        // Start the state monitor as a background task
+        var monitorTask = MonitorState(client, receiveCts, token);
+
         Exception causedException = null;
         try
         {
@@ -541,7 +594,7 @@ internal partial class WebSocketConnection
                     WebSocketReceiveResult result;
                     while (true)
                     {
-                        result = await client.ReceiveAsync(buffer, token);
+                        result = await client.ReceiveAsync(buffer, receiveCts.Token);
                         ms.Write(buffer.AsSpan(0, result.Count));
 
                         if (result.EndOfMessage)
@@ -573,7 +626,7 @@ internal partial class WebSocketConnection
                                 client,
                                 WebSocketCloseStatus.NormalClosure,
                                 "Closing",
-                                token,
+                                receiveCts.Token,
                                 false,
                                 true
                             );
@@ -582,17 +635,19 @@ internal partial class WebSocketConnection
                         }
                     }
                 }
-            } while (client.State == WebSocketState.Open && !token.IsCancellationRequested);
+            } while (
+                client.State == WebSocketState.Open && !receiveCts.Token.IsCancellationRequested
+            );
         }
-        catch (TaskCanceledException e)
+        catch (TaskCanceledException)
         {
             // task was canceled, ignore
         }
-        catch (OperationCanceledException e)
+        catch (OperationCanceledException)
         {
             // operation was canceled, ignore
         }
-        catch (ObjectDisposedException e)
+        catch (ObjectDisposedException)
         {
             // client was disposed, ignore
         }
@@ -605,6 +660,16 @@ internal partial class WebSocketConnection
             );
             await OnExceptionOccurred(e).ConfigureAwait(false);
             causedException = e;
+        }
+        finally
+        {
+            // Ensure monitor task completes
+            receiveCts.Cancel();
+            try
+            {
+                await monitorTask.ConfigureAwait(false);
+            }
+            catch { }
         }
 
         if (ShouldIgnoreReconnection(client) || !IsStarted)

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/WebSockets/WebSocketConnection.cs
@@ -532,8 +532,7 @@ internal partial class WebSocketConnection
 
     private async global::System.Threading.Tasks.Task MonitorState(
         WebSocket client,
-        CancellationTokenSource receiveCts,
-        CancellationToken token
+        CancellationTokenSource receiveCts
     )
     {
         if (StateCheckInterval == null)
@@ -541,10 +540,10 @@ internal partial class WebSocketConnection
 
         try
         {
-            while (!token.IsCancellationRequested)
+            while (!receiveCts.Token.IsCancellationRequested)
             {
                 await global::System
-                    .Threading.Tasks.Task.Delay(StateCheckInterval.Value, token)
+                    .Threading.Tasks.Task.Delay(StateCheckInterval.Value, receiveCts.Token)
                     .ConfigureAwait(false);
 
                 if (
@@ -578,7 +577,7 @@ internal partial class WebSocketConnection
         using var receiveCts = CancellationTokenSource.CreateLinkedTokenSource(token);
 
         // Start the state monitor as a background task
-        var monitorTask = MonitorState(client, receiveCts, token);
+        var monitorTask = MonitorState(client, receiveCts);
 
         Exception causedException = null;
         try


### PR DESCRIPTION
## Description

Refs [dotnet/runtime#110496](https://github.com/dotnet/runtime/issues/110496), [dotnet/runtime#44272](https://github.com/dotnet/runtime/issues/44272)

`ReceiveAsync` can hang indefinitely when the TCP connection closes at the OS level but the WebSocket state doesn't update. Additionally, `WebSocket.Abort()` does not interrupt a pending `ReceiveAsync`. This PR adds a background state monitor task that periodically polls `WebSocket.State` and cancels the receive loop when a silent disconnection is detected.

## Changes Made

- **`StateCheckInterval` property**: New configurable `TimeSpan?` property (default: 5 seconds). Set to `null` to disable the monitor.
- **`MonitorState` method**: Background task that checks `WebSocket.State` on the configured interval. When the state transitions to `Closed`, `Aborted`, or `CloseReceived`, it cancels the receive CTS to unblock a hung `ReceiveAsync`. Uses `receiveCts.Token` for both its loop condition and delay, so `Listen`'s `finally` block can cancel it immediately.
- **`Listen` method refactored**: Creates a linked `CancellationTokenSource` (`receiveCts`) that the monitor can cancel independently of the parent token. `ReceiveAsync` and the loop condition use `receiveCts.Token`. The `StopInternal` call in the Close-frame path intentionally uses the original parent `token` to prevent the monitor from interrupting the graceful close handshake. A `finally` block cancels and awaits the monitor before `using var` disposes the CTS.
- Minor: removed unused exception variables in catch blocks.
- Updated `versions.yml` to `2.47.0`.
- Updated seed snapshot for `csharp-sdk/websocket/with-websockets`.

## Design Decisions

| Decision | Rationale |
|---|---|
| **5 s default** (vs PureWebSockets' 200 ms) | General SDK default; lower latency available via config. Negligible overhead. |
| **States checked**: `Closed`, `Aborted`, `CloseReceived` | These are the three terminal/server-initiated states. `CloseSent` is our own close (normal flow). `None`/`Connecting` don't occur during an active receive. |
| **`StopInternal` uses parent `token`** in Close path | Prevents the monitor (which detects `CloseReceived`) from racing with and cancelling the graceful close handshake. |

## Human Review Checklist

- [ ] **Close-frame race**: Confirm `StopInternal` in the `WebSocketMessageType.Close` case passes the original `token`, not `receiveCts.Token`. The monitor detects `CloseReceived` and would cancel `receiveCts`, interrupting `CloseOutputAsync` if it were used there.
- [ ] **CancellationToken wiring**: Confirm `MonitorState` uses `receiveCts.Token` (not parent `token`) for both its `while` condition and `Task.Delay`, so `Listen`'s `finally { receiveCts.Cancel(); await monitorTask; }` completes immediately.
- [ ] **Disposal ordering**: `using var receiveCts` disposes at method exit, *after* the explicit `finally` block awaits the monitor. Verify no `ObjectDisposedException` path.
- [ ] **No runtime test coverage**: This is a template file tested only via seed code generation. There are no integration tests exercising the monitor under a real silent-disconnect scenario.

## Testing

- [x] `pnpm seed test --generator csharp-sdk --fixture websocket` — 2/2 passed
- [x] `pnpm seed test --generator csharp-sdk --fixture websocket-bearer-auth` — 1/1 passed
- [x] `pnpm seed test --generator csharp-sdk --fixture websocket-inferred-auth` — 1/1 passed
- [x] `pnpm run check` (Biome lint) — passed
- [ ] No runtime/integration tests (template file; tested via code generation only)

Link to Devin session: https://app.devin.ai/sessions/994122f80d9948e89da9c664b391f857
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
