### PR TITLE
fix(rust): resolve potential panic in `unwrap_or_default` after serde serialization

### DIFF
--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -1505,10 +1505,10 @@ export class SubClientGenerator {
         if (requestBodyParam && endpoint.requestBody) {
             // For referenced body with query parameters, serialize request.body
             if (endpoint.requestBody.type === "reference" && endpoint.queryParameters.length > 0) {
-                return "Some(serde_json::to_value(&request.body).unwrap_or_default())";
+                return "Some(serde_json::to_value(&request.body).map_err(ApiError::Serialization)?)";
             }
             // For other cases, serialize the whole request
-            return "Some(serde_json::to_value(request).unwrap_or_default())";
+            return "Some(serde_json::to_value(request).map_err(ApiError::Serialization)?)";
         }
         return "None";
     }

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.19.10
+  changelogEntry:
+    - summary: |
+        Replace `unwrap_or_default()` with proper error propagation via `map_err(ApiError::Serialization)?`
+        when serializing request bodies with `serde_json::to_value`. Previously, serialization failures
+        were silently swallowed and replaced with a default JSON null value. Now they correctly return
+        an `ApiError::Serialization` error to the caller.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 62
+
 - version: 0.19.9
   changelogEntry:
     - summary: |

--- a/seed/rust-sdk/alias-extends/src/api/resources/mod.rs
+++ b/seed/rust-sdk/alias-extends/src/api/resources/mod.rs
@@ -28,7 +28,7 @@ impl AliasExtendsClient {
             .execute_request(
                 Method::POST,
                 "/extends/extended-inline-request-body",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/any-auth/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/any-auth/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/audiences/src/api/resources/foo/foo.rs
+++ b/seed/rust-sdk/audiences/src/api/resources/foo/foo.rs
@@ -22,7 +22,7 @@ impl FooClient {
             .execute_request(
                 Method::POST,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 QueryBuilder::new()
                     .serialize("optionalString", Some(request.optional_string.clone()))
                     .build(),

--- a/seed/rust-sdk/basic-auth-environment-variables/src/api/resources/basic_auth/basic_auth.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/api/resources/basic_auth/basic_auth.rs
@@ -48,7 +48,7 @@ impl BasicAuthClient {
             .execute_request(
                 Method::POST,
                 "basic-auth",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/basic-auth/src/api/resources/basic_auth/basic_auth.rs
+++ b/seed/rust-sdk/basic-auth/src/api/resources/basic_auth/basic_auth.rs
@@ -48,7 +48,7 @@ impl BasicAuthClient2 {
             .execute_request(
                 Method::POST,
                 "basic-auth",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/bytes-upload/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/bytes-upload/src/api/resources/service/service.rs
@@ -22,7 +22,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "upload-content",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -40,7 +40,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "upload-content-with-query-params",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 QueryBuilder::new()
                     .string("model", model.clone())
                     .string("language", language.clone())

--- a/seed/rust-sdk/client-side-params/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/client-side-params/src/api/resources/service/service.rs
@@ -104,7 +104,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "/api/resources/search",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 QueryBuilder::new()
                     .int("limit", request.limit.clone())
                     .int("offset", request.offset.clone())
@@ -205,7 +205,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "/api/users",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -231,7 +231,7 @@ impl ServiceClient {
             .execute_request(
                 Method::PATCH,
                 &format!("/api/users/{}", user_id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/content-type/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/content-type/src/api/resources/service/service.rs
@@ -22,7 +22,7 @@ impl ServiceClient {
             .execute_request(
                 Method::PATCH,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -51,7 +51,7 @@ impl ServiceClient {
             .execute_request(
                 Method::PATCH,
                 &format!("complex/{}", id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -78,7 +78,7 @@ impl ServiceClient {
             .execute_request(
                 Method::PATCH,
                 &format!("named-mixed/{}", id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -106,7 +106,7 @@ impl ServiceClient {
             .execute_request(
                 Method::PATCH,
                 "optional-merge-patch-test",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -132,7 +132,7 @@ impl ServiceClient {
             .execute_request(
                 Method::PATCH,
                 &format!("regular/{}", id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/cross-package-type-names/src/api/resources/foo/foo.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/resources/foo/foo.rs
@@ -22,7 +22,7 @@ impl FooClient {
             .execute_request(
                 Method::POST,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 QueryBuilder::new()
                     .serialize("optionalString", Some(request.optional_string.clone()))
                     .build(),

--- a/seed/rust-sdk/endpoint-security-auth/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/enum/src/api/resources/inlined_request/inlined_request.rs
+++ b/seed/rust-sdk/enum/src/api/resources/inlined_request/inlined_request.rs
@@ -22,7 +22,7 @@ impl InlinedRequestClient {
             .execute_request(
                 Method::POST,
                 "inlined",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/errors/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/errors/src/api/resources/simple/simple.rs
@@ -22,7 +22,7 @@ impl SimpleClient {
             .execute_request(
                 Method::POST,
                 "foo1",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl SimpleClient {
             .execute_request(
                 Method::POST,
                 "foo2",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -54,7 +54,7 @@ impl SimpleClient {
             .execute_request(
                 Method::POST,
                 "foo3",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/examples/no-custom-config/src/api/resources/mod.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/resources/mod.rs
@@ -45,7 +45,7 @@ impl ExamplesClient {
             .execute_request(
                 Method::POST,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -61,7 +61,7 @@ impl ExamplesClient {
             .execute_request(
                 Method::POST,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/examples/no-custom-config/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/resources/service/service.rs
@@ -38,7 +38,7 @@ impl ServiceClient4 {
             .execute_request(
                 Method::POST,
                 "/movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -73,7 +73,7 @@ impl ServiceClient4 {
             .execute_request(
                 Method::POST,
                 "/big-entity",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -89,7 +89,7 @@ impl ServiceClient4 {
             .execute_request(
                 Method::POST,
                 "/refresh-token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/examples/readme-config/src/api/resources/mod.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/resources/mod.rs
@@ -45,7 +45,7 @@ impl ExamplesClient {
             .execute_request(
                 Method::POST,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -61,7 +61,7 @@ impl ExamplesClient {
             .execute_request(
                 Method::POST,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/examples/readme-config/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/resources/service/service.rs
@@ -38,7 +38,7 @@ impl ServiceClient4 {
             .execute_request(
                 Method::POST,
                 "/movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -73,7 +73,7 @@ impl ServiceClient4 {
             .execute_request(
                 Method::POST,
                 "/big-entity",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -89,7 +89,7 @@ impl ServiceClient4 {
             .execute_request(
                 Method::POST,
                 "/refresh-token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/container/endpoints_container.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/container/endpoints_container.rs
@@ -23,7 +23,7 @@ impl ContainerClient {
             .execute_request(
                 Method::POST,
                 "/container/list-of-primitives",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -39,7 +39,7 @@ impl ContainerClient {
             .execute_request(
                 Method::POST,
                 "/container/list-of-objects",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -55,7 +55,7 @@ impl ContainerClient {
             .execute_request(
                 Method::POST,
                 "/container/set-of-primitives",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -71,7 +71,7 @@ impl ContainerClient {
             .execute_request(
                 Method::POST,
                 "/container/set-of-objects",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -87,7 +87,7 @@ impl ContainerClient {
             .execute_request(
                 Method::POST,
                 "/container/map-prim-to-prim",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -103,7 +103,7 @@ impl ContainerClient {
             .execute_request(
                 Method::POST,
                 "/container/map-prim-to-object",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -119,7 +119,7 @@ impl ContainerClient {
             .execute_request(
                 Method::POST,
                 "/container/map-prim-to-union",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -135,7 +135,7 @@ impl ContainerClient {
             .execute_request(
                 Method::POST,
                 "/container/opt-objects",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/content_type/endpoints_content_type.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/content_type/endpoints_content_type.rs
@@ -22,7 +22,7 @@ impl ContentTypeClient {
             .execute_request(
                 Method::POST,
                 "/foo/bar",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl ContentTypeClient {
             .execute_request(
                 Method::POST,
                 "/foo/baz",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/enum_/endpoints_enum_.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/enum_/endpoints_enum_.rs
@@ -22,7 +22,7 @@ impl EnumClient {
             .execute_request(
                 Method::POST,
                 "/enum",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/http_methods/endpoints_http_methods.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/http_methods/endpoints_http_methods.rs
@@ -38,7 +38,7 @@ impl HttpMethodsClient {
             .execute_request(
                 Method::POST,
                 "/http-methods",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -55,7 +55,7 @@ impl HttpMethodsClient {
             .execute_request(
                 Method::PUT,
                 &format!("/http-methods/{}", id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -72,7 +72,7 @@ impl HttpMethodsClient {
             .execute_request(
                 Method::PATCH,
                 &format!("/http-methods/{}", id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/object/endpoints_object.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/object/endpoints_object.rs
@@ -22,7 +22,7 @@ impl ObjectClient {
             .execute_request(
                 Method::POST,
                 "/object/get-and-return-with-optional-field",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl ObjectClient {
             .execute_request(
                 Method::POST,
                 "/object/get-and-return-with-required-field",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -54,7 +54,7 @@ impl ObjectClient {
             .execute_request(
                 Method::POST,
                 "/object/get-and-return-with-map-of-map",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -70,7 +70,7 @@ impl ObjectClient {
             .execute_request(
                 Method::POST,
                 "/object/get-and-return-nested-with-optional-field",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -90,7 +90,7 @@ impl ObjectClient {
                     "/object/get-and-return-nested-with-required-field/{}",
                     string
                 ),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -106,7 +106,7 @@ impl ObjectClient {
             .execute_request(
                 Method::POST,
                 "/object/get-and-return-nested-with-required-field-list",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -122,7 +122,7 @@ impl ObjectClient {
             .execute_request(
                 Method::POST,
                 "/object/get-and-return-with-unknown-field",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -138,7 +138,7 @@ impl ObjectClient {
             .execute_request(
                 Method::POST,
                 "/object/get-and-return-with-documented-unknown-type",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -154,7 +154,7 @@ impl ObjectClient {
             .execute_request(
                 Method::POST,
                 "/object/get-and-return-map-of-documented-unknown-type",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -181,7 +181,7 @@ impl ObjectClient {
             .execute_request(
                 Method::POST,
                 "/object/get-and-return-with-datetime-like-string",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/params/endpoints_params.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/params/endpoints_params.rs
@@ -194,7 +194,7 @@ impl ParamsClient {
             .execute_request(
                 Method::PUT,
                 &format!("/params/path/{}", param),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -220,7 +220,7 @@ impl ParamsClient {
             .execute_request(
                 Method::PUT,
                 &format!("/params/path/{}", param),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -246,7 +246,7 @@ impl ParamsClient {
             .execute_request(
                 Method::POST,
                 &format!("/params/path/{}", param),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/primitive/endpoints_primitive.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/primitive/endpoints_primitive.rs
@@ -23,7 +23,7 @@ impl PrimitiveClient {
             .execute_request(
                 Method::POST,
                 "/primitive/string",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -39,7 +39,7 @@ impl PrimitiveClient {
             .execute_request(
                 Method::POST,
                 "/primitive/integer",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -55,7 +55,7 @@ impl PrimitiveClient {
             .execute_request(
                 Method::POST,
                 "/primitive/long",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -71,7 +71,7 @@ impl PrimitiveClient {
             .execute_request(
                 Method::POST,
                 "/primitive/double",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -87,7 +87,7 @@ impl PrimitiveClient {
             .execute_request(
                 Method::POST,
                 "/primitive/boolean",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -103,7 +103,7 @@ impl PrimitiveClient {
             .execute_request(
                 Method::POST,
                 "/primitive/datetime",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -119,7 +119,7 @@ impl PrimitiveClient {
             .execute_request(
                 Method::POST,
                 "/primitive/date",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -135,7 +135,7 @@ impl PrimitiveClient {
             .execute_request(
                 Method::POST,
                 "/primitive/uuid",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -151,7 +151,7 @@ impl PrimitiveClient {
             .execute_request_base64(
                 Method::POST,
                 "/primitive/base64",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/union_/endpoints_union_.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/union_/endpoints_union_.rs
@@ -22,7 +22,7 @@ impl UnionClient {
             .execute_request(
                 Method::POST,
                 "/union",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/inlined_requests/inlined_requests.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/inlined_requests/inlined_requests.rs
@@ -31,7 +31,7 @@ impl InlinedRequestsClient {
             .execute_request(
                 Method::POST,
                 "/req-bodies/object",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/no_auth/no_auth.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/no_auth/no_auth.rs
@@ -30,7 +30,7 @@ impl NoAuthClient {
             .execute_request(
                 Method::POST,
                 "/no-auth",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/exhaustive/src/api/resources/req_with_headers/req_with_headers.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/req_with_headers/req_with_headers.rs
@@ -21,7 +21,7 @@ impl ReqWithHeadersClient {
             .execute_request(
                 Method::POST,
                 "/test-headers/custom-header",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/extends/src/api/resources/mod.rs
+++ b/seed/rust-sdk/extends/src/api/resources/mod.rs
@@ -28,7 +28,7 @@ impl ExtendsClient {
             .execute_request(
                 Method::POST,
                 "/extends/extended-inline-request-body",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/extra-properties/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/extra-properties/src/api/resources/user/user.rs
@@ -22,7 +22,7 @@ impl UserClient {
             .execute_request(
                 Method::POST,
                 "/user",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/folders/src/api/resources/folder/service/folder_service.rs
+++ b/seed/rust-sdk/folders/src/api/resources/folder/service/folder_service.rs
@@ -27,7 +27,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "/service",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/idempotency-headers/src/api/resources/payment/payment.rs
+++ b/seed/rust-sdk/idempotency-headers/src/api/resources/payment/payment.rs
@@ -23,7 +23,7 @@ impl PaymentClient {
             .execute_request(
                 Method::POST,
                 "/payment",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/api/resources/imdb/imdb.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/api/resources/imdb/imdb.rs
@@ -31,7 +31,7 @@ impl ImdbClient {
             .execute_request(
                 Method::POST,
                 "/movies/create-movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/api/resources/imdb/imdb.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/api/resources/imdb/imdb.rs
@@ -31,7 +31,7 @@ impl ImdbClient {
             .execute_request(
                 Method::POST,
                 "/movies/create-movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/imdb/imdb/src/api/resources/imdb/imdb.rs
+++ b/seed/rust-sdk/imdb/imdb/src/api/resources/imdb/imdb.rs
@@ -31,7 +31,7 @@ impl ImdbClient {
             .execute_request(
                 Method::POST,
                 "/movies/create-movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/inferred-auth-explicit/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token/refresh",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token/refresh",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token/refresh",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/inferred-auth-implicit/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token/refresh",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/literal/src/api/resources/headers/headers.rs
+++ b/seed/rust-sdk/literal/src/api/resources/headers/headers.rs
@@ -22,7 +22,7 @@ impl HeadersClient {
             .execute_request(
                 Method::POST,
                 "headers",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/literal/src/api/resources/inlined/inlined.rs
+++ b/seed/rust-sdk/literal/src/api/resources/inlined/inlined.rs
@@ -22,7 +22,7 @@ impl InlinedClient {
             .execute_request(
                 Method::POST,
                 "inlined",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/literal/src/api/resources/reference/reference.rs
+++ b/seed/rust-sdk/literal/src/api/resources/reference/reference.rs
@@ -22,7 +22,7 @@ impl ReferenceClient {
             .execute_request(
                 Method::POST,
                 "reference",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/mixed-file-directory/src/api/resources/organization/organization.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api/resources/organization/organization.rs
@@ -31,7 +31,7 @@ impl OrganizationClient {
             .execute_request(
                 Method::POST,
                 "/organizations/",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/multi-line-docs/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/multi-line-docs/src/api/resources/user/user.rs
@@ -60,7 +60,7 @@ impl UserClient {
             .execute_request(
                 Method::POST,
                 "users",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/multi-url-environment-no-default/src/api/resources/ec_2/ec_2.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/api/resources/ec_2/ec_2.rs
@@ -22,7 +22,7 @@ impl Ec2Client {
             .execute_request(
                 Method::POST,
                 "/ec2/boot",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/multi-url-environment-no-default/src/api/resources/s_3/s_3.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/api/resources/s_3/s_3.rs
@@ -22,7 +22,7 @@ impl S3Client {
             .execute_request(
                 Method::POST,
                 "/s3/presigned-url",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/multi-url-environment/src/api/resources/ec_2/ec_2.rs
+++ b/seed/rust-sdk/multi-url-environment/src/api/resources/ec_2/ec_2.rs
@@ -22,7 +22,7 @@ impl Ec2Client {
             .execute_request(
                 Method::POST,
                 "/ec2/boot",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/multi-url-environment/src/api/resources/s_3/s_3.rs
+++ b/seed/rust-sdk/multi-url-environment/src/api/resources/s_3/s_3.rs
@@ -22,7 +22,7 @@ impl S3Client {
             .execute_request(
                 Method::POST,
                 "/s3/presigned-url",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/multiple-request-bodies/src/api/resources/mod.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/api/resources/mod.rs
@@ -28,7 +28,7 @@ impl ApiClient {
             .execute_request(
                 Method::POST,
                 "documents/upload",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -44,7 +44,7 @@ impl ApiClient {
             .execute_request(
                 Method::POST,
                 "documents/upload",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/nullable-allof-extends/src/api/resources/mod.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/api/resources/mod.rs
@@ -52,7 +52,7 @@ impl ApiClient {
             .execute_request(
                 Method::POST,
                 "test",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/nullable-optional/src/api/resources/nullable_optional/nullable_optional.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/resources/nullable_optional/nullable_optional.rs
@@ -56,7 +56,7 @@ impl NullableOptionalClient2 {
             .execute_request(
                 Method::POST,
                 "/api/users",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -82,7 +82,7 @@ impl NullableOptionalClient2 {
             .execute_request(
                 Method::PATCH,
                 &format!("/api/users/{}", user_id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -167,7 +167,7 @@ impl NullableOptionalClient2 {
             .execute_request(
                 Method::POST,
                 "/api/profiles/complex",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -218,7 +218,7 @@ impl NullableOptionalClient2 {
             .execute_request(
                 Method::PATCH,
                 &format!("/api/profiles/complex/{}", profile_id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -243,7 +243,7 @@ impl NullableOptionalClient2 {
             .execute_request(
                 Method::POST,
                 "/api/test/deserialization",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -323,7 +323,7 @@ impl NullableOptionalClient2 {
             .execute_request(
                 Method::PUT,
                 &format!("/api/users/{}/tags", user_id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -348,7 +348,7 @@ impl NullableOptionalClient2 {
             .execute_request(
                 Method::POST,
                 "/api/search",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/nullable-request-body/src/api/resources/test_group/test_group.rs
+++ b/seed/rust-sdk/nullable-request-body/src/api/resources/test_group/test_group.rs
@@ -32,7 +32,7 @@ impl TestGroupClient {
             .execute_request(
                 Method::POST,
                 &format!("optional-request-body/{}", path_param),
-                Some(serde_json::to_value(&request.body).unwrap_or_default()),
+                Some(serde_json::to_value(&request.body).map_err(ApiError::Serialization)?),
                 QueryBuilder::new()
                     .serialize("query_param_object", request.query_param_object.clone())
                     .serialize("query_param_integer", request.query_param_integer.clone())

--- a/seed/rust-sdk/nullable/src/api/resources/nullable/nullable.rs
+++ b/seed/rust-sdk/nullable/src/api/resources/nullable/nullable.rs
@@ -44,7 +44,7 @@ impl NullableClient2 {
             .execute_request(
                 Method::POST,
                 "/users",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -60,7 +60,7 @@ impl NullableClient2 {
             .execute_request(
                 Method::DELETE,
                 "/users",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/oauth-client-credentials/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/optional/src/api/resources/optional/optional.rs
+++ b/seed/rust-sdk/optional/src/api/resources/optional/optional.rs
@@ -23,7 +23,7 @@ impl OptionalClient {
             .execute_request(
                 Method::POST,
                 "send-optional-body",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -39,7 +39,7 @@ impl OptionalClient {
             .execute_request(
                 Method::POST,
                 "send-optional-typed-body",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -67,7 +67,7 @@ impl OptionalClient {
             .execute_request(
                 Method::POST,
                 &format!("deploy/{}/versions/{}", action_id, id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/package-yml/src/api/resources/mod.rs
+++ b/seed/rust-sdk/package-yml/src/api/resources/mod.rs
@@ -34,7 +34,7 @@ impl PackageYmlClient {
             .execute_request(
                 Method::POST,
                 &format!("/{}/", id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/pagination/src/api/resources/complex/complex.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/complex/complex.rs
@@ -23,7 +23,7 @@ impl ComplexClient {
             .execute_request(
                 Method::POST,
                 &format!("{}/conversations/search", index),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/pagination/src/api/resources/inline_users/inline_users/inline_users_inline_users.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/inline_users/inline_users/inline_users_inline_users.rs
@@ -61,7 +61,7 @@ impl InlineUsersClient2 {
             .execute_request(
                 Method::POST,
                 "/inline-users",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -119,7 +119,7 @@ impl InlineUsersClient2 {
             .execute_request(
                 Method::POST,
                 "/inline-users",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/pagination/src/api/resources/users/users.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/users/users.rs
@@ -61,7 +61,7 @@ impl UsersClient {
             .execute_request(
                 Method::POST,
                 "/users",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -88,7 +88,7 @@ impl UsersClient {
             .execute_request(
                 Method::POST,
                 "/users/top-level-cursor",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -146,7 +146,7 @@ impl UsersClient {
             .execute_request(
                 Method::POST,
                 "/users",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/path-parameters/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/path-parameters/src/api/resources/user/user.rs
@@ -40,7 +40,7 @@ impl UserClient {
             .execute_request(
                 Method::POST,
                 &format!("/{}/user/", tenant_id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -58,7 +58,7 @@ impl UserClient {
             .execute_request(
                 Method::PATCH,
                 &format!("/{}/user/{}", tenant_id, user_id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/property-access/src/api/resources/mod.rs
+++ b/seed/rust-sdk/property-access/src/api/resources/mod.rs
@@ -28,7 +28,7 @@ impl PropertyAccessClient {
             .execute_request(
                 Method::POST,
                 "/users",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/request-parameters/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/request-parameters/src/api/resources/user/user.rs
@@ -22,7 +22,7 @@ impl UserClient {
             .execute_request(
                 Method::POST,
                 "/user/username",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 QueryBuilder::new()
                     .serialize("tags", Some(request.tags.clone()))
                     .build(),
@@ -40,7 +40,7 @@ impl UserClient {
             .execute_request(
                 Method::POST,
                 "/user/username-referenced",
-                Some(serde_json::to_value(&request.body).unwrap_or_default()),
+                Some(serde_json::to_value(&request.body).map_err(ApiError::Serialization)?),
                 QueryBuilder::new()
                     .serialize("tags", Some(request.tags.clone()))
                     .build(),
@@ -58,7 +58,7 @@ impl UserClient {
             .execute_request(
                 Method::POST,
                 "/user/username-optional",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/required-nullable/src/api/resources/mod.rs
+++ b/seed/rust-sdk/required-nullable/src/api/resources/mod.rs
@@ -56,7 +56,7 @@ impl ApiClient {
             .execute_request(
                 Method::PATCH,
                 &format!("foo/{}", id),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/response-property/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/response-property/src/api/resources/service/service.rs
@@ -22,7 +22,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -54,7 +54,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -70,7 +70,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -86,7 +86,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -102,7 +102,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -118,7 +118,7 @@ impl ServiceClient {
             .execute_request(
                 Method::POST,
                 "movie",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/api/resources/completions/completions.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/api/resources/completions/completions.rs
@@ -22,7 +22,7 @@ impl CompletionsClient {
             .execute_sse_request(
                 Method::POST,
                 "stream",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
                 Some("[[DONE]]".to_string()),
@@ -39,7 +39,7 @@ impl CompletionsClient {
             .execute_sse_request(
                 Method::POST,
                 "stream-events",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
                 Some("[DONE]".to_string()),

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/api/resources/completions/completions.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/api/resources/completions/completions.rs
@@ -22,7 +22,7 @@ impl CompletionsClient {
             .execute_sse_request(
                 Method::POST,
                 "stream",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
                 Some("[[DONE]]".to_string()),
@@ -39,7 +39,7 @@ impl CompletionsClient {
             .execute_sse_request(
                 Method::POST,
                 "stream-no-terminator",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
                 None,

--- a/seed/rust-sdk/server-url-templating/src/api/resources/mod.rs
+++ b/seed/rust-sdk/server-url-templating/src/api/resources/mod.rs
@@ -50,7 +50,7 @@ impl ApiClient {
             .execute_request(
                 Method::POST,
                 "auth/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/streaming-parameter/src/api/resources/dummy/dummy.rs
+++ b/seed/rust-sdk/streaming-parameter/src/api/resources/dummy/dummy.rs
@@ -22,7 +22,7 @@ impl DummyClient {
             .execute_request(
                 Method::POST,
                 "generate",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/streaming/src/api/resources/dummy/dummy.rs
+++ b/seed/rust-sdk/streaming/src/api/resources/dummy/dummy.rs
@@ -22,7 +22,7 @@ impl DummyClient {
             .execute_request::<StreamResponse>(
                 Method::POST,
                 "generate-stream",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl DummyClient {
             .execute_request(
                 Method::POST,
                 "generate",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/trace/src/api/resources/admin/admin.rs
+++ b/seed/rust-sdk/trace/src/api/resources/admin/admin.rs
@@ -23,7 +23,7 @@ impl AdminClient {
             .execute_request(
                 Method::POST,
                 &format!("/admin/store-test-submission-status/{}", submission_id.0),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -40,7 +40,7 @@ impl AdminClient {
             .execute_request(
                 Method::POST,
                 &format!("/admin/store-test-submission-status-v2/{}", submission_id.0),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -60,7 +60,7 @@ impl AdminClient {
                     "/admin/store-workspace-submission-status/{}",
                     submission_id.0
                 ),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -80,7 +80,7 @@ impl AdminClient {
                     "/admin/store-workspace-submission-status-v2/{}",
                     submission_id.0
                 ),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -101,7 +101,7 @@ impl AdminClient {
                     "/admin/store-test-trace/submission/{}/testCase/{}",
                     submission_id.0, test_case_id
                 ),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -122,7 +122,7 @@ impl AdminClient {
                     "/admin/store-test-trace-v2/submission/{}/testCase/{}",
                     submission_id.0, test_case_id.0
                 ),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -142,7 +142,7 @@ impl AdminClient {
                     "/admin/store-workspace-trace/submission/{}",
                     submission_id.0
                 ),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -162,7 +162,7 @@ impl AdminClient {
                     "/admin/store-workspace-trace-v2/submission/{}",
                     submission_id.0
                 ),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/trace/src/api/resources/homepage/homepage.rs
+++ b/seed/rust-sdk/trace/src/api/resources/homepage/homepage.rs
@@ -31,7 +31,7 @@ impl HomepageClient {
             .execute_request(
                 Method::POST,
                 "/homepage-problems",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/trace/src/api/resources/playlist/playlist.rs
+++ b/seed/rust-sdk/trace/src/api/resources/playlist/playlist.rs
@@ -32,7 +32,7 @@ impl PlaylistClient {
             .execute_request(
                 Method::POST,
                 &format!("/v2/playlist/{}/create", service_param),
-                Some(serde_json::to_value(&request.body).unwrap_or_default()),
+                Some(serde_json::to_value(&request.body).map_err(ApiError::Serialization)?),
                 QueryBuilder::new()
                     .datetime("datetime", request.datetime.clone())
                     .datetime("optionalDatetime", request.optional_datetime.clone())
@@ -126,7 +126,7 @@ impl PlaylistClient {
             .execute_request(
                 Method::PUT,
                 &format!("/v2/playlist/{}/{}", service_param, playlist_id.0),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/trace/src/api/resources/problem/problem.rs
+++ b/seed/rust-sdk/trace/src/api/resources/problem/problem.rs
@@ -31,7 +31,7 @@ impl ProblemClient {
             .execute_request(
                 Method::POST,
                 "/problem-crud/create",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -57,7 +57,7 @@ impl ProblemClient {
             .execute_request(
                 Method::POST,
                 &format!("/problem-crud/update/{}", problem_id.0),
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -107,7 +107,7 @@ impl ProblemClient {
             .execute_request(
                 Method::POST,
                 "/problem-crud/default-starter-files",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/undiscriminated-unions/src/api/resources/union_/union_.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/resources/union_/union_.rs
@@ -22,7 +22,7 @@ impl UnionClient {
             .execute_request(
                 Method::POST,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -47,7 +47,7 @@ impl UnionClient {
             .execute_request(
                 Method::PUT,
                 "/metadata",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -63,7 +63,7 @@ impl UnionClient {
             .execute_request(
                 Method::POST,
                 "/call",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -79,7 +79,7 @@ impl UnionClient {
             .execute_request(
                 Method::POST,
                 "/duplicate",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -95,7 +95,7 @@ impl UnionClient {
             .execute_request(
                 Method::POST,
                 "/nested",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -111,7 +111,7 @@ impl UnionClient {
             .execute_request(
                 Method::POST,
                 "/camel-case",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/unions-with-local-date/src/api/resources/bigunion/bigunion.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/resources/bigunion/bigunion.rs
@@ -33,7 +33,7 @@ impl BigunionClient {
             .execute_request(
                 Method::PATCH,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -49,7 +49,7 @@ impl BigunionClient {
             .execute_request(
                 Method::PATCH,
                 "/many",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/unions-with-local-date/src/api/resources/types/types.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/resources/types/types.rs
@@ -32,7 +32,7 @@ impl TypesClient {
             .execute_request(
                 Method::PATCH,
                 "/time",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/unions-with-local-date/src/api/resources/union_/union_.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/resources/union_/union_.rs
@@ -32,7 +32,7 @@ impl UnionClient {
             .execute_request(
                 Method::PATCH,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/unions/src/api/resources/bigunion/bigunion.rs
+++ b/seed/rust-sdk/unions/src/api/resources/bigunion/bigunion.rs
@@ -33,7 +33,7 @@ impl BigunionClient {
             .execute_request(
                 Method::PATCH,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -49,7 +49,7 @@ impl BigunionClient {
             .execute_request(
                 Method::PATCH,
                 "/many",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/unions/src/api/resources/union_/union_.rs
+++ b/seed/rust-sdk/unions/src/api/resources/union_/union_.rs
@@ -32,7 +32,7 @@ impl UnionClient {
             .execute_request(
                 Method::PATCH,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/unknown/src/api/resources/unknown/unknown.rs
+++ b/seed/rust-sdk/unknown/src/api/resources/unknown/unknown.rs
@@ -22,7 +22,7 @@ impl UnknownClient {
             .execute_request(
                 Method::POST,
                 "",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl UnknownClient {
             .execute_request(
                 Method::POST,
                 "/with-object",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/url-form-encoded/src/api/resources/mod.rs
+++ b/seed/rust-sdk/url-form-encoded/src/api/resources/mod.rs
@@ -28,7 +28,7 @@ impl ApiClient {
             .execute_request(
                 Method::POST,
                 "submit",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -44,7 +44,7 @@ impl ApiClient {
             .execute_request(
                 Method::POST,
                 "token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/validation/src/api/resources/mod.rs
+++ b/seed/rust-sdk/validation/src/api/resources/mod.rs
@@ -28,7 +28,7 @@ impl ValidationClient {
             .execute_request(
                 Method::POST,
                 "/create",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/resources/auth/auth.rs
@@ -22,7 +22,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )
@@ -38,7 +38,7 @@ impl AuthClient {
             .execute_request(
                 Method::POST,
                 "/token/refresh",
-                Some(serde_json::to_value(request).unwrap_or_default()),
+                Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
                 None,
                 options,
             )


### PR DESCRIPTION
## Description

Linear ticket: Closes [FER-9142](https://linear.app/buildwithfern/issue/FER-9142/rust-sdk-resolve-potential-panic-in-unwrap-or-default-after-serde)

Generated Rust SDK client methods used `serde_json::to_value(request).unwrap_or_default()` when serializing request bodies. If serialization ever failed, this would silently swallow the error and substitute `Value::Null`, leading to confusing API behavior rather than a clear error. This replaces it with `.map_err(ApiError::Serialization)?` to properly propagate serialization errors.

## Changes Made

- **`SubClientGenerator.ts`**: Updated `getRequestBody()` to emit `.map_err(ApiError::Serialization)?` instead of `.unwrap_or_default()` for both the `request` and `&request.body` serialization paths.
- **`versions.yml`**: Added version `0.19.10` changelog entry.
- **89 seed fixtures**: Updated generated snapshot files to reflect the new pattern.

> **Note for reviewer**: Other `unwrap_or_default()` calls in the same file (pagination extraction, WebSocket auth) were intentionally left unchanged — they operate on `Option` types (safe defaults), not `Result` types from serde serialization.

## Testing

- [x] TypeScript compilation passes (`pnpm turbo run compile --filter @fern-api/rust-sdk`)
- [x] Verified `ApiError::Serialization(serde_json::Error)` variant already exists in generated error enums
- [x] Confirmed `?` operator is valid in the generated context (enclosing async methods return `Result<T, ApiError>`)

Link to Devin session: https://app.devin.ai/sessions/a8b929fc9109475cb1266d8fbba6f960
Requested by: @iamnamananand996