### PR TITLE
fix(rust): use `&str` instead of `&String` in generated code

### DIFF
--- a/generators/rust/model/src/__test__/snapshots/union-types/types_vehicle.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_vehicle.rs
@@ -32,7 +32,7 @@ pub enum Vehicle {
 }
 
 impl Vehicle {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
                     Self::Car { id, .. } => id,
                     Self::Motorcycle { id, .. } => id,
@@ -40,7 +40,7 @@ impl Vehicle {
                 }
     }
 
-    pub fn get_manufacturer(&self) -> &String {
+    pub fn get_manufacturer(&self) -> &str {
         match self {
                     Self::Car { manufacturer, .. } => manufacturer,
                     Self::Motorcycle { manufacturer, .. } => manufacturer,

--- a/generators/rust/model/src/__test__/snapshots/union-types/vehicle.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/vehicle.rs
@@ -32,7 +32,7 @@ pub enum Vehicle {
 }
 
 impl Vehicle {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
                     Self::Car { id, .. } => id,
                     Self::Motorcycle { id, .. } => id,
@@ -40,7 +40,7 @@ impl Vehicle {
                 }
     }
 
-    pub fn get_manufacturer(&self) -> &String {
+    pub fn get_manufacturer(&self) -> &str {
         match self {
                     Self::Car { manufacturer, .. } => manufacturer,
                     Self::Motorcycle { manufacturer, .. } => manufacturer,

--- a/generators/rust/model/src/union/UndiscriminatedUnionGenerator.ts
+++ b/generators/rust/model/src/union/UndiscriminatedUnionGenerator.ts
@@ -285,7 +285,10 @@ export class UndiscriminatedUnionGenerator {
                 generatedMethods.add(methodName);
                 generatedMethods.add(ownedMethodName);
 
-                writer.writeBlock(`pub fn ${methodName}(&self) -> Option<&${memberType.toString()}>`, () => {
+                // Use &str instead of &String for idiomatic Rust (more flexible, accepts both &String and literals)
+                const borrowedType = memberType.toString() === "String" ? "&str" : `&${memberType.toString()}`;
+
+                writer.writeBlock(`pub fn ${methodName}(&self) -> Option<${borrowedType}>`, () => {
                     writer.writeLine("match self {");
                     writer.writeLine(`            Self::${variantName}(value) => Some(value),`);
                     writer.writeLine("            _ => None,");

--- a/generators/rust/model/src/union/UnionGenerator.ts
+++ b/generators/rust/model/src/union/UnionGenerator.ts
@@ -413,7 +413,10 @@ export class UnionGenerator {
                 const fieldType = generateRustTypeForTypeReference(property.valueType, this.context);
                 const methodName = `get_${fieldName}`;
 
-                writer.writeBlock(`pub fn ${methodName}(&self) -> &${fieldType.toString()}`, () => {
+                // Use &str instead of &String for idiomatic Rust (more flexible, accepts both &String and literals)
+                const returnType = fieldType.toString() === "String" ? "&str" : `&${fieldType.toString()}`;
+
+                writer.writeBlock(`pub fn ${methodName}(&self) -> ${returnType}`, () => {
                     writer.writeLine("match self {");
 
                     this.unionTypeDeclaration.types.forEach((unionType) => {

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.1.4
+  changelogEntry:
+    - summary: |
+        Use `&str` instead of `&String` in generated union getter methods and undiscriminated
+        union accessor methods. `&str` is more idiomatic Rust and more flexible, accepting
+        both `&String` and string literals.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 61
+
 - version: 0.1.3
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -929,7 +929,8 @@ export class SubClientGenerator {
             let paramType = param.type.toString();
 
             if (param.isRef) {
-                paramType = `&${paramType}`;
+                // Use &str instead of &String for idiomatic Rust (more flexible, accepts both &String and literals)
+                paramType = paramType === "String" ? "&str" : `&${paramType}`;
             }
 
             if (param.optional) {
@@ -943,7 +944,8 @@ export class SubClientGenerator {
         if (requestBodyParam) {
             let paramType = requestBodyParam.type.toString();
             if (requestBodyParam.isRef) {
-                paramType = `&${paramType}`;
+                // Use &str instead of &String for idiomatic Rust
+                paramType = paramType === "String" ? "&str" : `&${paramType}`;
             }
             methodParams.push(`${requestBodyParam.name}: ${paramType}`);
         }

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.19.10
+  changelogEntry:
+    - summary: |
+        Use `&str` instead of `&String` in generated method signatures, union getter methods,
+        and undiscriminated union accessor methods. `&str` is more idiomatic Rust and more
+        flexible, accepting both `&String` and string literals.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 62
+
 - version: 0.19.9
   changelogEntry:
     - summary: |

--- a/seed/rust-model/circular-references/src/ast_json_like.rs
+++ b/seed/rust-model/circular-references/src/ast_json_like.rs
@@ -64,7 +64,7 @@ impl JsonLike {
                 }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/exhaustive/src/types_union_mixed_type.rs
+++ b/seed/rust-model/exhaustive/src/types_union_mixed_type.rs
@@ -58,7 +58,7 @@ impl MixedType {
                 }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/literal/src/inlined_undiscriminated_literal.rs
+++ b/seed/rust-model/literal/src/inlined_undiscriminated_literal.rs
@@ -42,7 +42,7 @@ impl UndiscriminatedLiteral {
     }
 
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,
@@ -56,7 +56,7 @@ impl UndiscriminatedLiteral {
                 }
     }
 
-    pub fn as_literal1(&self) -> Option<&String> {
+    pub fn as_literal1(&self) -> Option<&str> {
         match self {
                     Self::Literal1(value) => Some(value),
                     _ => None,
@@ -70,7 +70,7 @@ impl UndiscriminatedLiteral {
                 }
     }
 
-    pub fn as_literal2(&self) -> Option<&String> {
+    pub fn as_literal2(&self) -> Option<&str> {
         match self {
                     Self::Literal2(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/literals-unions/src/literals_union_over_literal.rs
+++ b/seed/rust-model/literals-unions/src/literals_union_over_literal.rs
@@ -18,7 +18,7 @@ impl UnionOverLiteral {
     }
 
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/property-access/src/user_or_admin_discriminated.rs
+++ b/seed/rust-model/property-access/src/user_or_admin_discriminated.rs
@@ -23,7 +23,7 @@ pub enum UserOrAdminDiscriminated {
 }
 
 impl UserOrAdminDiscriminated {
-    pub fn get_normal(&self) -> &String {
+    pub fn get_normal(&self) -> &str {
         match self {
                     Self::User { normal, .. } => normal,
                     Self::Admin { normal, .. } => normal,

--- a/seed/rust-model/query-parameters-openapi-as-objects/src/search_request_neighbor.rs
+++ b/seed/rust-model/query-parameters-openapi-as-objects/src/search_request_neighbor.rs
@@ -58,7 +58,7 @@ impl SearchRequestNeighbor {
                 }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/query-parameters-openapi-as-objects/src/search_request_neighbor_required.rs
+++ b/seed/rust-model/query-parameters-openapi-as-objects/src/search_request_neighbor_required.rs
@@ -58,7 +58,7 @@ impl SearchRequestNeighborRequired {
                 }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/query-parameters-openapi/src/search_request_neighbor.rs
+++ b/seed/rust-model/query-parameters-openapi/src/search_request_neighbor.rs
@@ -58,7 +58,7 @@ impl SearchRequestNeighbor {
                 }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/query-parameters-openapi/src/search_request_neighbor_required.rs
+++ b/seed/rust-model/query-parameters-openapi/src/search_request_neighbor_required.rs
@@ -58,7 +58,7 @@ impl SearchRequestNeighborRequired {
                 }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/undiscriminated-unions/src/union_key.rs
+++ b/seed/rust-model/undiscriminated-unions/src/union_key.rs
@@ -32,7 +32,7 @@ impl Key {
                 }
     }
 
-    pub fn as_literal1(&self) -> Option<&String> {
+    pub fn as_literal1(&self) -> Option<&str> {
         match self {
                     Self::Literal1(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/undiscriminated-unions/src/union_my_union.rs
+++ b/seed/rust-model/undiscriminated-unions/src/union_my_union.rs
@@ -42,7 +42,7 @@ impl MyUnion {
     }
 
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/undiscriminated-unions/src/union_nested_union_root.rs
+++ b/seed/rust-model/undiscriminated-unions/src/union_nested_union_root.rs
@@ -24,7 +24,7 @@ impl NestedUnionRoot {
     }
 
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/undiscriminated-unions/src/union_union_with_duplicate_types.rs
+++ b/seed/rust-model/undiscriminated-unions/src/union_union_with_duplicate_types.rs
@@ -30,7 +30,7 @@ impl UnionWithDuplicateTypes {
     }
 
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/undiscriminated-unions/src/union_union_with_identical_primitives.rs
+++ b/seed/rust-model/undiscriminated-unions/src/union_union_with_identical_primitives.rs
@@ -52,7 +52,7 @@ impl UnionWithIdenticalPrimitives {
                 }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/undiscriminated-unions/src/union_union_with_identical_strings.rs
+++ b/seed/rust-model/undiscriminated-unions/src/union_union_with_identical_strings.rs
@@ -12,7 +12,7 @@ impl UnionWithIdenticalStrings {
     }
 
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/undiscriminated-unions/src/union_union_with_reserved_names.rs
+++ b/seed/rust-model/undiscriminated-unions/src/union_union_with_reserved_names.rs
@@ -24,7 +24,7 @@ impl UnionWithReservedNames {
     }
 
 
-    pub fn as_literal0(&self) -> Option<&String> {
+    pub fn as_literal0(&self) -> Option<&str> {
         match self {
                     Self::Literal0(value) => Some(value),
                     _ => None,
@@ -38,7 +38,7 @@ impl UnionWithReservedNames {
                 }
     }
 
-    pub fn as_literal1(&self) -> Option<&String> {
+    pub fn as_literal1(&self) -> Option<&str> {
         match self {
                     Self::Literal1(value) => Some(value),
                     _ => None,
@@ -52,7 +52,7 @@ impl UnionWithReservedNames {
                 }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/undiscriminated-unions/src/union_union_with_type_aliases.rs
+++ b/seed/rust-model/undiscriminated-unions/src/union_union_with_type_aliases.rs
@@ -24,7 +24,7 @@ impl UnionWithTypeAliases {
     }
 
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
                     Self::String(value) => Some(value),
                     _ => None,

--- a/seed/rust-model/unions-with-local-date/src/bigunion_big_union.rs
+++ b/seed/rust-model/unions-with-local-date/src/bigunion_big_union.rs
@@ -440,7 +440,7 @@ pub enum BigUnion {
 }
 
 impl BigUnion {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
                     Self::NormalSweet { id, .. } => id,
                     Self::ThankfulFactor { id, .. } => id,

--- a/seed/rust-model/unions-with-local-date/src/types_union_with_base_properties.rs
+++ b/seed/rust-model/unions-with-local-date/src/types_union_with_base_properties.rs
@@ -24,7 +24,7 @@ pub enum UnionWithBaseProperties {
 }
 
 impl UnionWithBaseProperties {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
                     Self::Integer { id, .. } => id,
                     Self::String { id, .. } => id,

--- a/seed/rust-model/unions-with-local-date/src/types_union_with_literal.rs
+++ b/seed/rust-model/unions-with-local-date/src/types_union_with_literal.rs
@@ -11,7 +11,7 @@ pub enum UnionWithLiteral {
 }
 
 impl UnionWithLiteral {
-    pub fn get_base(&self) -> &String {
+    pub fn get_base(&self) -> &str {
         match self {
                     Self::Fern { base, .. } => base,
                 }

--- a/seed/rust-model/unions-with-local-date/src/union_shape.rs
+++ b/seed/rust-model/unions-with-local-date/src/union_shape.rs
@@ -19,7 +19,7 @@ pub enum Shape {
 }
 
 impl Shape {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
                     Self::Circle { id, .. } => id,
                     Self::Square { id, .. } => id,

--- a/seed/rust-model/unions/src/bigunion_big_union.rs
+++ b/seed/rust-model/unions/src/bigunion_big_union.rs
@@ -440,7 +440,7 @@ pub enum BigUnion {
 }
 
 impl BigUnion {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
                     Self::NormalSweet { id, .. } => id,
                     Self::ThankfulFactor { id, .. } => id,

--- a/seed/rust-model/unions/src/types_union_with_base_properties.rs
+++ b/seed/rust-model/unions/src/types_union_with_base_properties.rs
@@ -24,7 +24,7 @@ pub enum UnionWithBaseProperties {
 }
 
 impl UnionWithBaseProperties {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
                     Self::Integer { id, .. } => id,
                     Self::String { id, .. } => id,

--- a/seed/rust-model/unions/src/types_union_with_literal.rs
+++ b/seed/rust-model/unions/src/types_union_with_literal.rs
@@ -11,7 +11,7 @@ pub enum UnionWithLiteral {
 }
 
 impl UnionWithLiteral {
-    pub fn get_base(&self) -> &String {
+    pub fn get_base(&self) -> &str {
         match self {
                     Self::Fern { base, .. } => base,
                 }

--- a/seed/rust-model/unions/src/union_shape.rs
+++ b/seed/rust-model/unions/src/union_shape.rs
@@ -19,7 +19,7 @@ pub enum Shape {
 }
 
 impl Shape {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
                     Self::Circle { id, .. } => id,
                     Self::Square { id, .. } => id,

--- a/seed/rust-sdk/api-wide-base-path/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/api/resources/service/service.rs
@@ -14,10 +14,10 @@ impl ServiceClient {
 
     pub async fn post(
         &self,
-        path_param: &String,
-        service_param: &String,
+        path_param: &str,
+        service_param: &str,
         endpoint_param: i64,
-        resource_param: &String,
+        resource_param: &str,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client

--- a/seed/rust-sdk/bytes-download/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/bytes-download/src/api/resources/service/service.rs
@@ -20,7 +20,7 @@ impl ServiceClient {
 
     pub async fn download(
         &self,
-        id: &String,
+        id: &str,
         options: Option<RequestOptions>,
     ) -> Result<ByteStream, ApiError> {
         self.http_client

--- a/seed/rust-sdk/bytes-upload/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/bytes-upload/src/api/resources/service/service.rs
@@ -31,7 +31,7 @@ impl ServiceClient {
 
     pub async fn upload_with_query_params(
         &self,
-        model: &String,
+        model: &str,
         language: &Option<String>,
         request: &Vec<u8>,
         options: Option<RequestOptions>,

--- a/seed/rust-sdk/circular-references/src/api/types/ast_json_like.rs
+++ b/seed/rust-sdk/circular-references/src/api/types/ast_json_like.rs
@@ -63,7 +63,7 @@ impl JsonLike {
         }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/client-side-params/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/client-side-params/src/api/resources/service/service.rs
@@ -66,7 +66,7 @@ impl ServiceClient {
     /// JSON response from the API
     pub async fn get_resource(
         &self,
-        resource_id: &String,
+        resource_id: &str,
         request: &GetResourceQueryRequest,
         options: Option<RequestOptions>,
     ) -> Result<Resource, ApiError> {
@@ -169,7 +169,7 @@ impl ServiceClient {
     /// JSON response from the API
     pub async fn get_user_by_id(
         &self,
-        user_id: &String,
+        user_id: &str,
         request: &GetUserByIdQueryRequest,
         options: Option<RequestOptions>,
     ) -> Result<User, ApiError> {
@@ -223,7 +223,7 @@ impl ServiceClient {
     /// JSON response from the API
     pub async fn update_user(
         &self,
-        user_id: &String,
+        user_id: &str,
         request: &UpdateUserRequest,
         options: Option<RequestOptions>,
     ) -> Result<User, ApiError> {
@@ -249,7 +249,7 @@ impl ServiceClient {
     /// Empty response
     pub async fn delete_user(
         &self,
-        user_id: &String,
+        user_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client
@@ -307,7 +307,7 @@ impl ServiceClient {
     /// JSON response from the API
     pub async fn get_connection(
         &self,
-        connection_id: &String,
+        connection_id: &str,
         request: &GetConnectionQueryRequest,
         options: Option<RequestOptions>,
     ) -> Result<Connection, ApiError> {
@@ -379,7 +379,7 @@ impl ServiceClient {
     /// JSON response from the API
     pub async fn get_client(
         &self,
-        client_id: &String,
+        client_id: &str,
         request: &GetClientQueryRequest,
         options: Option<RequestOptions>,
     ) -> Result<Client, ApiError> {

--- a/seed/rust-sdk/content-type/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/content-type/src/api/resources/service/service.rs
@@ -43,7 +43,7 @@ impl ServiceClient {
     /// Empty response
     pub async fn patch_complex(
         &self,
-        id: &String,
+        id: &str,
         request: &PatchComplexRequest,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
@@ -70,7 +70,7 @@ impl ServiceClient {
     /// Empty response
     pub async fn named_patch_with_mixed(
         &self,
-        id: &String,
+        id: &str,
         request: &NamedMixedPatchRequest,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
@@ -124,7 +124,7 @@ impl ServiceClient {
     /// Empty response
     pub async fn regular_patch(
         &self,
-        id: &String,
+        id: &str,
         request: &RegularPatchRequest,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {

--- a/seed/rust-sdk/examples/no-custom-config/src/api/resources/file/notification/service/file_notification_service.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/resources/file/notification/service/file_notification_service.rs
@@ -15,7 +15,7 @@ impl ServiceClient {
 
     pub async fn get_exception(
         &self,
-        notification_id: &String,
+        notification_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<Exception, ApiError> {
         self.http_client

--- a/seed/rust-sdk/examples/no-custom-config/src/api/resources/file/service/file_service.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/resources/file/service/file_service.rs
@@ -25,7 +25,7 @@ impl ServiceClient2 {
     /// JSON response from the API
     pub async fn get_file(
         &self,
-        filename: &String,
+        filename: &str,
         options: Option<RequestOptions>,
     ) -> Result<File, ApiError> {
         self.http_client

--- a/seed/rust-sdk/examples/no-custom-config/src/api/resources/health/service/health_service.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/resources/health/service/health_service.rs
@@ -22,11 +22,7 @@ impl ServiceClient3 {
     /// # Returns
     ///
     /// Empty response
-    pub async fn check(
-        &self,
-        id: &String,
-        options: Option<RequestOptions>,
-    ) -> Result<(), ApiError> {
+    pub async fn check(&self, id: &str, options: Option<RequestOptions>) -> Result<(), ApiError> {
         self.http_client
             .execute_request(Method::GET, &format!("/check/{}", id), None, None, options)
             .await

--- a/seed/rust-sdk/examples/no-custom-config/src/api/resources/mod.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/resources/mod.rs
@@ -38,7 +38,7 @@ impl ExamplesClient {
 
     pub async fn echo(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<String, ApiError> {
         self.http_client

--- a/seed/rust-sdk/examples/readme-config/src/api/resources/file/notification/service/file_notification_service.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/resources/file/notification/service/file_notification_service.rs
@@ -15,7 +15,7 @@ impl ServiceClient {
 
     pub async fn get_exception(
         &self,
-        notification_id: &String,
+        notification_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<Exception, ApiError> {
         self.http_client

--- a/seed/rust-sdk/examples/readme-config/src/api/resources/file/service/file_service.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/resources/file/service/file_service.rs
@@ -25,7 +25,7 @@ impl ServiceClient2 {
     /// JSON response from the API
     pub async fn get_file(
         &self,
-        filename: &String,
+        filename: &str,
         options: Option<RequestOptions>,
     ) -> Result<File, ApiError> {
         self.http_client

--- a/seed/rust-sdk/examples/readme-config/src/api/resources/health/service/health_service.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/resources/health/service/health_service.rs
@@ -22,11 +22,7 @@ impl ServiceClient3 {
     /// # Returns
     ///
     /// Empty response
-    pub async fn check(
-        &self,
-        id: &String,
-        options: Option<RequestOptions>,
-    ) -> Result<(), ApiError> {
+    pub async fn check(&self, id: &str, options: Option<RequestOptions>) -> Result<(), ApiError> {
         self.http_client
             .execute_request(Method::GET, &format!("/check/{}", id), None, None, options)
             .await

--- a/seed/rust-sdk/examples/readme-config/src/api/resources/mod.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/resources/mod.rs
@@ -38,7 +38,7 @@ impl ExamplesClient {
 
     pub async fn echo(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<String, ApiError> {
         self.http_client

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/http_methods/endpoints_http_methods.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/http_methods/endpoints_http_methods.rs
@@ -15,7 +15,7 @@ impl HttpMethodsClient {
 
     pub async fn test_get(
         &self,
-        id: &String,
+        id: &str,
         options: Option<RequestOptions>,
     ) -> Result<String, ApiError> {
         self.http_client
@@ -47,7 +47,7 @@ impl HttpMethodsClient {
 
     pub async fn test_put(
         &self,
-        id: &String,
+        id: &str,
         request: &ObjectWithRequiredField,
         options: Option<RequestOptions>,
     ) -> Result<ObjectWithOptionalField, ApiError> {
@@ -64,7 +64,7 @@ impl HttpMethodsClient {
 
     pub async fn test_patch(
         &self,
-        id: &String,
+        id: &str,
         request: &ObjectWithOptionalField,
         options: Option<RequestOptions>,
     ) -> Result<ObjectWithOptionalField, ApiError> {
@@ -81,7 +81,7 @@ impl HttpMethodsClient {
 
     pub async fn test_delete(
         &self,
-        id: &String,
+        id: &str,
         options: Option<RequestOptions>,
     ) -> Result<bool, ApiError> {
         self.http_client

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/object/endpoints_object.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/object/endpoints_object.rs
@@ -79,7 +79,7 @@ impl ObjectClient {
 
     pub async fn get_and_return_nested_with_required_field(
         &self,
-        string: &String,
+        string: &str,
         request: &NestedObjectWithRequiredField,
         options: Option<RequestOptions>,
     ) -> Result<NestedObjectWithRequiredField, ApiError> {

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/params/endpoints_params.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/params/endpoints_params.rs
@@ -24,7 +24,7 @@ impl ParamsClient {
     /// JSON response from the API
     pub async fn get_with_path(
         &self,
-        param: &String,
+        param: &str,
         options: Option<RequestOptions>,
     ) -> Result<String, ApiError> {
         self.http_client
@@ -49,7 +49,7 @@ impl ParamsClient {
     /// JSON response from the API
     pub async fn get_with_inline_path(
         &self,
-        param: &String,
+        param: &str,
         options: Option<RequestOptions>,
     ) -> Result<String, ApiError> {
         self.http_client
@@ -130,7 +130,7 @@ impl ParamsClient {
     /// Empty response
     pub async fn get_with_path_and_query(
         &self,
-        param: &String,
+        param: &str,
         request: &GetWithPathAndQueryQueryRequest,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
@@ -158,7 +158,7 @@ impl ParamsClient {
     /// Empty response
     pub async fn get_with_inline_path_and_query(
         &self,
-        param: &String,
+        param: &str,
         request: &GetWithInlinePathAndQueryQueryRequest,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
@@ -186,8 +186,8 @@ impl ParamsClient {
     /// JSON response from the API
     pub async fn modify_with_path(
         &self,
-        param: &String,
-        request: &String,
+        param: &str,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<String, ApiError> {
         self.http_client
@@ -212,8 +212,8 @@ impl ParamsClient {
     /// JSON response from the API
     pub async fn modify_with_inline_path(
         &self,
-        param: &String,
-        request: &String,
+        param: &str,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<String, ApiError> {
         self.http_client
@@ -238,7 +238,7 @@ impl ParamsClient {
     /// JSON response from the API
     pub async fn upload_with_path(
         &self,
-        param: &String,
+        param: &str,
         request: &Vec<u8>,
         options: Option<RequestOptions>,
     ) -> Result<ObjectWithRequiredField, ApiError> {

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/primitive/endpoints_primitive.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/primitive/endpoints_primitive.rs
@@ -16,7 +16,7 @@ impl PrimitiveClient {
 
     pub async fn get_and_return_string(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<String, ApiError> {
         self.http_client

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/put/endpoints_put.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/put/endpoints_put.rs
@@ -15,7 +15,7 @@ impl PutClient {
 
     pub async fn add(
         &self,
-        id: &String,
+        id: &str,
         options: Option<RequestOptions>,
     ) -> Result<PutResponse, ApiError> {
         self.http_client

--- a/seed/rust-sdk/exhaustive/src/api/resources/req_with_headers/req_with_headers.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/req_with_headers/req_with_headers.rs
@@ -14,7 +14,7 @@ impl ReqWithHeadersClient {
 
     pub async fn get_with_custom_header(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client

--- a/seed/rust-sdk/exhaustive/src/api/types/types_union_mixed_type.rs
+++ b/seed/rust-sdk/exhaustive/src/api/types/types_union_mixed_type.rs
@@ -57,7 +57,7 @@ impl MixedType {
         }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/idempotency-headers/src/api/resources/payment/payment.rs
+++ b/seed/rust-sdk/idempotency-headers/src/api/resources/payment/payment.rs
@@ -32,7 +32,7 @@ impl PaymentClient {
 
     pub async fn delete(
         &self,
-        payment_id: &String,
+        payment_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client

--- a/seed/rust-sdk/literal/src/api/resources/path/path.rs
+++ b/seed/rust-sdk/literal/src/api/resources/path/path.rs
@@ -15,7 +15,7 @@ impl PathClient {
 
     pub async fn send(
         &self,
-        id: &String,
+        id: &str,
         options: Option<RequestOptions>,
     ) -> Result<SendResponse, ApiError> {
         self.http_client

--- a/seed/rust-sdk/literal/src/api/types/inlined_undiscriminated_literal.rs
+++ b/seed/rust-sdk/literal/src/api/types/inlined_undiscriminated_literal.rs
@@ -41,7 +41,7 @@ impl UndiscriminatedLiteral {
         matches!(self, Self::Boolean(_))
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,
@@ -55,7 +55,7 @@ impl UndiscriminatedLiteral {
         }
     }
 
-    pub fn as_literal1(&self) -> Option<&String> {
+    pub fn as_literal1(&self) -> Option<&str> {
         match self {
             Self::Literal1(value) => Some(value),
             _ => None,
@@ -69,7 +69,7 @@ impl UndiscriminatedLiteral {
         }
     }
 
-    pub fn as_literal2(&self) -> Option<&String> {
+    pub fn as_literal2(&self) -> Option<&str> {
         match self {
             Self::Literal2(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/literals-unions/src/api/types/literals_union_over_literal.rs
+++ b/seed/rust-sdk/literals-unions/src/api/types/literals_union_over_literal.rs
@@ -17,7 +17,7 @@ impl UnionOverLiteral {
         matches!(self, Self::LiteralString(_))
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/mixed-case/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/mixed-case/src/api/resources/service/service.rs
@@ -15,7 +15,7 @@ impl ServiceClient {
 
     pub async fn get_resource(
         &self,
-        resource_id: &String,
+        resource_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<Resource, ApiError> {
         self.http_client

--- a/seed/rust-sdk/multi-line-docs/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/multi-line-docs/src/api/resources/user/user.rs
@@ -27,7 +27,7 @@ impl UserClient {
     /// Empty response
     pub async fn get_user(
         &self,
-        user_id: &String,
+        user_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client

--- a/seed/rust-sdk/nullable-optional/src/api/resources/nullable_optional/nullable_optional.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/resources/nullable_optional/nullable_optional.rs
@@ -24,7 +24,7 @@ impl NullableOptionalClient2 {
     /// JSON response from the API
     pub async fn get_user(
         &self,
-        user_id: &String,
+        user_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<UserResponse, ApiError> {
         self.http_client
@@ -74,7 +74,7 @@ impl NullableOptionalClient2 {
     /// JSON response from the API
     pub async fn update_user(
         &self,
-        user_id: &String,
+        user_id: &str,
         request: &UpdateUserRequest,
         options: Option<RequestOptions>,
     ) -> Result<UserResponse, ApiError> {
@@ -185,7 +185,7 @@ impl NullableOptionalClient2 {
     /// JSON response from the API
     pub async fn get_complex_profile(
         &self,
-        profile_id: &String,
+        profile_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<ComplexProfile, ApiError> {
         self.http_client
@@ -210,7 +210,7 @@ impl NullableOptionalClient2 {
     /// JSON response from the API
     pub async fn update_complex_profile(
         &self,
-        profile_id: &String,
+        profile_id: &str,
         request: &UpdateComplexProfileRequest,
         options: Option<RequestOptions>,
     ) -> Result<ComplexProfile, ApiError> {
@@ -290,7 +290,7 @@ impl NullableOptionalClient2 {
     /// JSON response from the API
     pub async fn get_notification_settings(
         &self,
-        user_id: &String,
+        user_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<Option<NotificationMethod>, ApiError> {
         self.http_client
@@ -315,7 +315,7 @@ impl NullableOptionalClient2 {
     /// JSON response from the API
     pub async fn update_tags(
         &self,
-        user_id: &String,
+        user_id: &str,
         request: &UpdateTagsRequest,
         options: Option<RequestOptions>,
     ) -> Result<Vec<String>, ApiError> {

--- a/seed/rust-sdk/nullable-request-body/src/api/resources/test_group/test_group.rs
+++ b/seed/rust-sdk/nullable-request-body/src/api/resources/test_group/test_group.rs
@@ -24,7 +24,7 @@ impl TestGroupClient {
     /// JSON response from the API
     pub async fn test_method_name(
         &self,
-        path_param: &String,
+        path_param: &str,
         request: &TestMethodNameRequest,
         options: Option<RequestOptions>,
     ) -> Result<serde_json::Value, ApiError> {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/service/service.rs
@@ -14,7 +14,7 @@ impl ServiceClient {
 
     pub async fn post(
         &self,
-        endpoint_param: &String,
+        endpoint_param: &str,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client

--- a/seed/rust-sdk/optional/src/api/resources/optional/optional.rs
+++ b/seed/rust-sdk/optional/src/api/resources/optional/optional.rs
@@ -58,8 +58,8 @@ impl OptionalClient {
     /// JSON response from the API
     pub async fn send_optional_nullable_with_all_optional_properties(
         &self,
-        action_id: &String,
-        id: &String,
+        action_id: &str,
+        id: &str,
         request: &Option<DeployParams>,
         options: Option<RequestOptions>,
     ) -> Result<DeployResponse, ApiError> {

--- a/seed/rust-sdk/package-yml/src/api/resources/mod.rs
+++ b/seed/rust-sdk/package-yml/src/api/resources/mod.rs
@@ -26,7 +26,7 @@ impl PackageYmlClient {
 
     pub async fn echo(
         &self,
-        id: &String,
+        id: &str,
         request: &EchoRequest,
         options: Option<RequestOptions>,
     ) -> Result<String, ApiError> {

--- a/seed/rust-sdk/package-yml/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/package-yml/src/api/resources/service/service.rs
@@ -14,8 +14,8 @@ impl ServiceClient {
 
     pub async fn nop(
         &self,
-        id: &String,
-        nested_id: &String,
+        id: &str,
+        nested_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client

--- a/seed/rust-sdk/pagination/src/api/resources/complex/complex.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/complex/complex.rs
@@ -15,7 +15,7 @@ impl ComplexClient {
 
     pub async fn search(
         &self,
-        index: &String,
+        index: &str,
         request: &SearchRequest,
         options: Option<RequestOptions>,
     ) -> Result<PaginatedConversationResponse, ApiError> {

--- a/seed/rust-sdk/path-parameters/src/api/resources/organizations/organizations.rs
+++ b/seed/rust-sdk/path-parameters/src/api/resources/organizations/organizations.rs
@@ -15,8 +15,8 @@ impl OrganizationsClient {
 
     pub async fn get_organization(
         &self,
-        tenant_id: &String,
-        organization_id: &String,
+        tenant_id: &str,
+        organization_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<Organization, ApiError> {
         self.http_client
@@ -32,9 +32,9 @@ impl OrganizationsClient {
 
     pub async fn get_organization_user(
         &self,
-        tenant_id: &String,
-        organization_id: &String,
-        user_id: &String,
+        tenant_id: &str,
+        organization_id: &str,
+        user_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<User, ApiError> {
         self.http_client
@@ -53,8 +53,8 @@ impl OrganizationsClient {
 
     pub async fn search_organizations(
         &self,
-        tenant_id: &String,
-        organization_id: &String,
+        tenant_id: &str,
+        organization_id: &str,
         request: &SearchOrganizationsQueryRequest,
         options: Option<RequestOptions>,
     ) -> Result<Vec<Organization>, ApiError> {

--- a/seed/rust-sdk/path-parameters/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/path-parameters/src/api/resources/user/user.rs
@@ -15,8 +15,8 @@ impl UserClient {
 
     pub async fn get_user(
         &self,
-        tenant_id: &String,
-        user_id: &String,
+        tenant_id: &str,
+        user_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<User, ApiError> {
         self.http_client
@@ -32,7 +32,7 @@ impl UserClient {
 
     pub async fn create_user(
         &self,
-        tenant_id: &String,
+        tenant_id: &str,
         request: &User,
         options: Option<RequestOptions>,
     ) -> Result<User, ApiError> {
@@ -49,8 +49,8 @@ impl UserClient {
 
     pub async fn update_user(
         &self,
-        tenant_id: &String,
-        user_id: &String,
+        tenant_id: &str,
+        user_id: &str,
         request: &User,
         options: Option<RequestOptions>,
     ) -> Result<User, ApiError> {
@@ -67,8 +67,8 @@ impl UserClient {
 
     pub async fn search_users(
         &self,
-        tenant_id: &String,
-        user_id: &String,
+        tenant_id: &str,
+        user_id: &str,
         request: &SearchUsersQueryRequest,
         options: Option<RequestOptions>,
     ) -> Result<Vec<User>, ApiError> {
@@ -96,8 +96,8 @@ impl UserClient {
     /// JSON response from the API
     pub async fn get_user_metadata(
         &self,
-        tenant_id: &String,
-        user_id: &String,
+        tenant_id: &str,
+        user_id: &str,
         version: i64,
         options: Option<RequestOptions>,
     ) -> Result<User, ApiError> {
@@ -123,10 +123,10 @@ impl UserClient {
     /// JSON response from the API
     pub async fn get_user_specifics(
         &self,
-        tenant_id: &String,
-        user_id: &String,
+        tenant_id: &str,
+        user_id: &str,
         version: i64,
-        thought: &String,
+        thought: &str,
         options: Option<RequestOptions>,
     ) -> Result<User, ApiError> {
         self.http_client

--- a/seed/rust-sdk/property-access/src/api/types/user_or_admin_discriminated.rs
+++ b/seed/rust-sdk/property-access/src/api/types/user_or_admin_discriminated.rs
@@ -23,7 +23,7 @@ pub enum UserOrAdminDiscriminated {
 }
 
 impl UserOrAdminDiscriminated {
-    pub fn get_normal(&self) -> &String {
+    pub fn get_normal(&self) -> &str {
         match self {
             Self::User { normal, .. } => normal,
             Self::Admin { normal, .. } => normal,

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/types/search_request_neighbor.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/types/search_request_neighbor.rs
@@ -57,7 +57,7 @@ impl SearchRequestNeighbor {
         }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/types/search_request_neighbor_required.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/types/search_request_neighbor_required.rs
@@ -57,7 +57,7 @@ impl SearchRequestNeighborRequired {
         }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/query-parameters-openapi/src/api/types/search_request_neighbor.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/api/types/search_request_neighbor.rs
@@ -57,7 +57,7 @@ impl SearchRequestNeighbor {
         }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/query-parameters-openapi/src/api/types/search_request_neighbor_required.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/api/types/search_request_neighbor_required.rs
@@ -57,7 +57,7 @@ impl SearchRequestNeighborRequired {
         }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/required-nullable/src/api/resources/mod.rs
+++ b/seed/rust-sdk/required-nullable/src/api/resources/mod.rs
@@ -48,7 +48,7 @@ impl ApiClient {
 
     pub async fn update_foo(
         &self,
-        id: &String,
+        id: &str,
         request: &UpdateFooRequest,
         options: Option<RequestOptions>,
     ) -> Result<Foo, ApiError> {

--- a/seed/rust-sdk/response-property/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/response-property/src/api/resources/service/service.rs
@@ -15,7 +15,7 @@ impl ServiceClient {
 
     pub async fn get_movie(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<Response, ApiError> {
         self.http_client
@@ -31,7 +31,7 @@ impl ServiceClient {
 
     pub async fn get_movie_docs(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<Response, ApiError> {
         self.http_client
@@ -47,7 +47,7 @@ impl ServiceClient {
 
     pub async fn get_movie_name(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<StringResponse, ApiError> {
         self.http_client
@@ -63,7 +63,7 @@ impl ServiceClient {
 
     pub async fn get_movie_metadata(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<Response, ApiError> {
         self.http_client
@@ -79,7 +79,7 @@ impl ServiceClient {
 
     pub async fn get_optional_movie(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<Option<Response>, ApiError> {
         self.http_client
@@ -95,7 +95,7 @@ impl ServiceClient {
 
     pub async fn get_optional_movie_docs(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<OptionalWithDocs, ApiError> {
         self.http_client
@@ -111,7 +111,7 @@ impl ServiceClient {
 
     pub async fn get_optional_movie_name(
         &self,
-        request: &String,
+        request: &str,
         options: Option<RequestOptions>,
     ) -> Result<OptionalStringResponse, ApiError> {
         self.http_client

--- a/seed/rust-sdk/server-url-templating/src/api/resources/mod.rs
+++ b/seed/rust-sdk/server-url-templating/src/api/resources/mod.rs
@@ -27,7 +27,7 @@ impl ApiClient {
 
     pub async fn get_user(
         &self,
-        user_id: &String,
+        user_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<User, ApiError> {
         self.http_client

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/api/resources/user/user.rs
@@ -13,11 +13,7 @@ impl UserClient {
         })
     }
 
-    pub async fn get(
-        &self,
-        id: &String,
-        options: Option<RequestOptions>,
-    ) -> Result<User, ApiError> {
+    pub async fn get(&self, id: &str, options: Option<RequestOptions>) -> Result<User, ApiError> {
         self.http_client
             .execute_request(Method::GET, &format!("/users/{}", id), None, None, options)
             .await

--- a/seed/rust-sdk/simple-api/basic/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/simple-api/basic/src/api/resources/user/user.rs
@@ -13,11 +13,7 @@ impl UserClient {
         })
     }
 
-    pub async fn get(
-        &self,
-        id: &String,
-        options: Option<RequestOptions>,
-    ) -> Result<User, ApiError> {
+    pub async fn get(&self, id: &str, options: Option<RequestOptions>) -> Result<User, ApiError> {
         self.http_client
             .execute_request(Method::GET, &format!("/users/{}", id), None, None, options)
             .await

--- a/seed/rust-sdk/simple-fhir/src/api/resources/mod.rs
+++ b/seed/rust-sdk/simple-fhir/src/api/resources/mod.rs
@@ -21,7 +21,7 @@ impl ApiClient {
 
     pub async fn get_account(
         &self,
-        account_id: &String,
+        account_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<Account, ApiError> {
         self.http_client

--- a/seed/rust-sdk/trace/src/api/resources/admin/admin.rs
+++ b/seed/rust-sdk/trace/src/api/resources/admin/admin.rs
@@ -90,7 +90,7 @@ impl AdminClient {
     pub async fn store_traced_test_case(
         &self,
         submission_id: &SubmissionId,
-        test_case_id: &String,
+        test_case_id: &str,
         request: &StoreTracedTestCaseRequest,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {

--- a/seed/rust-sdk/trace/src/api/resources/submission/submission.rs
+++ b/seed/rust-sdk/trace/src/api/resources/submission/submission.rs
@@ -49,7 +49,7 @@ impl SubmissionClient {
     /// JSON response from the API
     pub async fn get_execution_session(
         &self,
-        session_id: &String,
+        session_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<Option<ExecutionSessionResponse>, ApiError> {
         self.http_client
@@ -74,7 +74,7 @@ impl SubmissionClient {
     /// Empty response
     pub async fn stop_execution_session(
         &self,
-        session_id: &String,
+        session_id: &str,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client

--- a/seed/rust-sdk/undiscriminated-unions/src/api/types/union_key.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/types/union_key.rs
@@ -31,7 +31,7 @@ impl Key {
         }
     }
 
-    pub fn as_literal1(&self) -> Option<&String> {
+    pub fn as_literal1(&self) -> Option<&str> {
         match self {
             Self::Literal1(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/undiscriminated-unions/src/api/types/union_my_union.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/types/union_my_union.rs
@@ -41,7 +41,7 @@ impl MyUnion {
         matches!(self, Self::StringSet(_))
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/undiscriminated-unions/src/api/types/union_nested_union_root.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/types/union_nested_union_root.rs
@@ -23,7 +23,7 @@ impl NestedUnionRoot {
         matches!(self, Self::NestedUnionL1(_))
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/undiscriminated-unions/src/api/types/union_union_with_duplicate_types.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/types/union_union_with_duplicate_types.rs
@@ -29,7 +29,7 @@ impl UnionWithDuplicateTypes {
         matches!(self, Self::StringSet(_))
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/undiscriminated-unions/src/api/types/union_union_with_identical_primitives.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/types/union_union_with_identical_primitives.rs
@@ -51,7 +51,7 @@ impl UnionWithIdenticalPrimitives {
         }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/undiscriminated-unions/src/api/types/union_union_with_identical_strings.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/types/union_union_with_identical_strings.rs
@@ -11,7 +11,7 @@ impl UnionWithIdenticalStrings {
         matches!(self, Self::String(_))
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/undiscriminated-unions/src/api/types/union_union_with_reserved_names.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/types/union_union_with_reserved_names.rs
@@ -23,7 +23,7 @@ impl UnionWithReservedNames {
         matches!(self, Self::String(_))
     }
 
-    pub fn as_literal0(&self) -> Option<&String> {
+    pub fn as_literal0(&self) -> Option<&str> {
         match self {
             Self::Literal0(value) => Some(value),
             _ => None,
@@ -37,7 +37,7 @@ impl UnionWithReservedNames {
         }
     }
 
-    pub fn as_literal1(&self) -> Option<&String> {
+    pub fn as_literal1(&self) -> Option<&str> {
         match self {
             Self::Literal1(value) => Some(value),
             _ => None,
@@ -51,7 +51,7 @@ impl UnionWithReservedNames {
         }
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/undiscriminated-unions/src/api/types/union_union_with_type_aliases.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/types/union_union_with_type_aliases.rs
@@ -23,7 +23,7 @@ impl UnionWithTypeAliases {
         matches!(self, Self::Name(_))
     }
 
-    pub fn as_string(&self) -> Option<&String> {
+    pub fn as_string(&self) -> Option<&str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,

--- a/seed/rust-sdk/unions-with-local-date/src/api/resources/bigunion/bigunion.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/resources/bigunion/bigunion.rs
@@ -16,7 +16,7 @@ impl BigunionClient {
 
     pub async fn get(
         &self,
-        id: &String,
+        id: &str,
         options: Option<RequestOptions>,
     ) -> Result<BigUnion, ApiError> {
         self.http_client

--- a/seed/rust-sdk/unions-with-local-date/src/api/resources/types/types.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/resources/types/types.rs
@@ -15,7 +15,7 @@ impl TypesClient {
 
     pub async fn get(
         &self,
-        id: &String,
+        id: &str,
         options: Option<RequestOptions>,
     ) -> Result<UnionWithTime, ApiError> {
         self.http_client

--- a/seed/rust-sdk/unions-with-local-date/src/api/resources/union_/union_.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/resources/union_/union_.rs
@@ -13,11 +13,7 @@ impl UnionClient {
         })
     }
 
-    pub async fn get(
-        &self,
-        id: &String,
-        options: Option<RequestOptions>,
-    ) -> Result<Shape, ApiError> {
+    pub async fn get(&self, id: &str, options: Option<RequestOptions>) -> Result<Shape, ApiError> {
         self.http_client
             .execute_request(Method::GET, &format!("/{}", id), None, None, options)
             .await

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/bigunion_big_union.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/bigunion_big_union.rs
@@ -440,7 +440,7 @@ pub enum BigUnion {
 }
 
 impl BigUnion {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
             Self::NormalSweet { id, .. } => id,
             Self::ThankfulFactor { id, .. } => id,

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_base_properties.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_base_properties.rs
@@ -18,7 +18,7 @@ pub enum UnionWithBaseProperties {
 }
 
 impl UnionWithBaseProperties {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
             Self::Integer { id, .. } => id,
             Self::String { id, .. } => id,

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_literal.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_literal.rs
@@ -8,7 +8,7 @@ pub enum UnionWithLiteral {
 }
 
 impl UnionWithLiteral {
-    pub fn get_base(&self) -> &String {
+    pub fn get_base(&self) -> &str {
         match self {
             Self::Fern { base, .. } => base,
         }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/union_shape.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/union_shape.rs
@@ -19,7 +19,7 @@ pub enum Shape {
 }
 
 impl Shape {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
             Self::Circle { id, .. } => id,
             Self::Square { id, .. } => id,

--- a/seed/rust-sdk/unions/src/api/resources/bigunion/bigunion.rs
+++ b/seed/rust-sdk/unions/src/api/resources/bigunion/bigunion.rs
@@ -16,7 +16,7 @@ impl BigunionClient {
 
     pub async fn get(
         &self,
-        id: &String,
+        id: &str,
         options: Option<RequestOptions>,
     ) -> Result<BigUnion, ApiError> {
         self.http_client

--- a/seed/rust-sdk/unions/src/api/resources/union_/union_.rs
+++ b/seed/rust-sdk/unions/src/api/resources/union_/union_.rs
@@ -13,11 +13,7 @@ impl UnionClient {
         })
     }
 
-    pub async fn get(
-        &self,
-        id: &String,
-        options: Option<RequestOptions>,
-    ) -> Result<Shape, ApiError> {
+    pub async fn get(&self, id: &str, options: Option<RequestOptions>) -> Result<Shape, ApiError> {
         self.http_client
             .execute_request(Method::GET, &format!("/{}", id), None, None, options)
             .await

--- a/seed/rust-sdk/unions/src/api/types/bigunion_big_union.rs
+++ b/seed/rust-sdk/unions/src/api/types/bigunion_big_union.rs
@@ -440,7 +440,7 @@ pub enum BigUnion {
 }
 
 impl BigUnion {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
             Self::NormalSweet { id, .. } => id,
             Self::ThankfulFactor { id, .. } => id,

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_base_properties.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_base_properties.rs
@@ -18,7 +18,7 @@ pub enum UnionWithBaseProperties {
 }
 
 impl UnionWithBaseProperties {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
             Self::Integer { id, .. } => id,
             Self::String { id, .. } => id,

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_literal.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_literal.rs
@@ -8,7 +8,7 @@ pub enum UnionWithLiteral {
 }
 
 impl UnionWithLiteral {
-    pub fn get_base(&self) -> &String {
+    pub fn get_base(&self) -> &str {
         match self {
             Self::Fern { base, .. } => base,
         }

--- a/seed/rust-sdk/unions/src/api/types/union_shape.rs
+++ b/seed/rust-sdk/unions/src/api/types/union_shape.rs
@@ -19,7 +19,7 @@ pub enum Shape {
 }
 
 impl Shape {
-    pub fn get_id(&self) -> &String {
+    pub fn get_id(&self) -> &str {
         match self {
             Self::Circle { id, .. } => id,
             Self::Square { id, .. } => id,

--- a/seed/rust-sdk/variables/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/variables/src/api/resources/service/service.rs
@@ -14,7 +14,7 @@ impl ServiceClient {
 
     pub async fn post(
         &self,
-        endpoint_param: &String,
+        endpoint_param: &str,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-9144](https://linear.app/buildwithfern/issue/FER-9144/rust-sdk-use-andstr-everywhere-instead-of-andstring)

Replace `&String` with `&str` in all generated Rust code. `&str` is more idiomatic Rust — it is strictly more flexible than `&String` since it accepts both `&String` and string literals without requiring callers to allocate.

## Changes Made
- **`SubClientGenerator.ts`**: When building method parameters (path params and request body), emit `&str` instead of `&String` when the underlying type is `String`
- **`UnionGenerator.ts`**: Discriminated union getter methods now return `&str` instead of `&String` for String-typed base properties
- **`UndiscriminatedUnionGenerator.ts`**: Undiscriminated union accessor methods now return `Option<&str>` instead of `Option<&String>` for String-typed variants
- Updated `versions.yml` for both `rust-sdk` (0.19.11) and `rust-model` (0.1.4)
- Updated all seed test snapshots (~95 files)

## Human Review Checklist
- [ ] Verify the string comparison (`=== "String"`) correctly identifies all cases where `&String` was being emitted. Are there type aliases or wrapper types that could produce a `String` type string representation but be missed by this check?
- [ ] Are there other code paths in the generators (beyond these 3 files) that could emit `&String`? A grep for `` `&${`` patterns in the rust generator source may surface additional locations.
- [ ] The seed tests validate snapshot correctness but don't compile the generated Rust code — confirm the `&str` return types are compatible with the match arm expressions (returning references to owned `String` fields auto-derefs to `&str`, so this should be fine).

## Testing
- [x] Compilation checks passed (`pnpm turbo run compile --filter @fern-api/rust-sdk --filter @fern-api/rust-model`)
- [x] Seed tests passed: `rust-model` 106/106, `rust-sdk` 115/115
- [ ] Updated README.md generator (not applicable)

Link to Devin session: https://app.devin.ai/sessions/2c4c02f5c85d422683119fc34020456c
Requested by: @iamnamananand996