### PR TITLE
fix(rust): eliminate unexpected_cfgs warnings for multipart and sse features

### DIFF
--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+{{SERDE_ERROR_IMPORT}}
 use std::{
     pin::Pin,
     str::FromStr,
@@ -187,75 +188,7 @@ impl HttpClient {
         self.parse_response(response).await
     }
 
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
-        self.parse_response(response).await
-    }
-
-    async fn apply_auth_headers(
+{{MULTIPART_METHOD}}    async fn apply_auth_headers(
         &self,
         request: &mut Request,
         options: &Option<RequestOptions>,
@@ -544,97 +477,4 @@ impl HttpClient {
         Ok(ByteStream::new(response))
     }
 
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
-    }
-}
+{{SSE_METHOD}}}

--- a/generators/rust/base/src/project/RustProject.ts
+++ b/generators/rust/base/src/project/RustProject.ts
@@ -137,11 +137,200 @@ export class RustProject extends AbstractProject<AbstractRustGeneratorContext<Ba
             content = content.replace(/\{\{ORDERED_FLOAT_EXPORTS\}\}/g, "");
         }
 
+        // Conditionally include SerdeError import in http_client (only needed for base64 method)
+        if (this.context.usesBase64()) {
+            content = content.replace(/\{\{SERDE_ERROR_IMPORT\}\}/g, "use serde::de::Error as SerdeError;\n");
+        } else {
+            content = content.replace(/\{\{SERDE_ERROR_IMPORT\}\}/g, "");
+        }
+
         // Conditionally include base64 import in http_client
         if (this.context.usesBase64()) {
             content = content.replace(/\{\{BASE64_IMPORT\}\}/g, "use base64::Engine;\n");
         } else {
             content = content.replace(/\{\{BASE64_IMPORT\}\}/g, "");
+        }
+
+        // Conditionally include multipart method in http_client
+        if (this.context.hasFileUploadEndpoints()) {
+            content = content.replace(
+                /\{\{MULTIPART_METHOD\}\}/g,
+                `    /// Execute a multipart/form-data request with the given method, path, and options
+    ///
+    /// This method is used for file uploads using reqwest's built-in multipart support.
+    /// Note: Multipart requests are not retried because they cannot be cloned.
+    ///
+    /// # Example
+    /// \`\`\`no_run
+    /// let form = reqwest::multipart::Form::new()
+    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
+    ///
+    /// let response: MyResponse = client.execute_multipart_request(
+    ///     Method::POST,
+    ///     "/upload",
+    ///     form,
+    ///     None,
+    ///     None,
+    /// ).await?;
+    /// \`\`\`
+    #[cfg(feature = "multipart")]
+    pub async fn execute_multipart_request<T>(
+        &self,
+        method: Method,
+        path: &str,
+        form: reqwest::multipart::Form,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<T, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        // Apply query parameters if provided
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        // Use reqwest's built-in multipart support
+        request = request.multipart(form);
+
+        // Build the request
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        // Apply authentication and headers
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        // Execute directly without retries (multipart requests cannot be cloned)
+        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
+
+        // Check response status
+        if !response.status().is_success() {
+            let status_code = response.status().as_u16();
+            let body = response.text().await.ok();
+            return Err(ApiError::from_response(status_code, body.as_deref()));
+        }
+
+        self.parse_response(response).await
+    }
+
+`
+            );
+        } else {
+            content = content.replace(/\{\{MULTIPART_METHOD\}\}/g, "");
+        }
+
+        // Conditionally include SSE method in http_client
+        if (this.context.hasStreamingEndpoints()) {
+            content = content.replace(
+                /\{\{SSE_METHOD\}\}/g,
+                `    /// Execute a request and return an SSE stream
+    ///
+    /// This method returns an \`SseStream<T>\` that automatically parses
+    /// Server-Sent Events and deserializes the JSON data in each event.
+    ///
+    /// # SSE-Specific Headers
+    ///
+    /// This method automatically sets the following headers **after** applying custom headers,
+    /// which means these headers will override any user-supplied values:
+    /// - \`Accept: text/event-stream\` - Required for SSE protocol
+    /// - \`Cache-Control: no-store\` - Prevents caching of streaming responses
+    ///
+    /// This ensures proper SSE behavior even if custom headers are provided.
+    ///
+    /// # Example
+    /// \`\`\`no_run
+    /// use futures::StreamExt;
+    ///
+    /// let stream = client.execute_sse_request::<CompletionChunk>(
+    ///     Method::POST,
+    ///     "/stream",
+    ///     Some(serde_json::json!({"query": "Hello"})),
+    ///     None,
+    ///     None,
+    ///     Some("[[DONE]]".to_string()),
+    /// ).await?;
+    ///
+    /// let mut stream = std::pin::pin!(stream);
+    /// while let Some(chunk) = stream.next().await {
+    ///     let chunk = chunk?;
+    ///     println!("Received: {:?}", chunk);
+    /// }
+    /// \`\`\`
+    #[cfg(feature = "sse")]
+    pub async fn execute_sse_request<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+        terminator: Option<String>,
+    ) -> Result<crate::SseStream<T>, ApiError>
+    where
+        T: DeserializeOwned + Send + 'static,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        // Apply query parameters if provided
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        // Apply additional query parameters from options
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        // Apply body if provided
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        // Build the request
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        // Apply authentication and headers
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        // SSE-specific headers
+        req.headers_mut().insert(
+            "Accept",
+            "text/event-stream"
+                .parse()
+                .map_err(|_| ApiError::InvalidHeader)?,
+        );
+        req.headers_mut().insert(
+            "Cache-Control",
+            "no-store"
+                .parse()
+                .map_err(|_| ApiError::InvalidHeader)?,
+        );
+
+        // Execute with retries
+        let response = self.execute_with_retries(req, &options).await?;
+
+        // Return SSE stream
+        crate::SseStream::new(response, terminator).await
+    }
+
+`
+            );
+        } else {
+            content = content.replace(/\{\{SSE_METHOD\}\}/g, "");
         }
 
         // Conditionally include base64 method in http_client
@@ -208,7 +397,7 @@ export class RustProject extends AbstractProject<AbstractRustGeneratorContext<Ba
         if (this.context.usesDateTime()) {
             content = content.replace(
                 /\{\{QUERY_BUILDER_CHRONO_IMPORT\}\}/g,
-                "use chrono::{DateTime, TimeZone, Utc};\n"
+                "use chrono::{DateTime, TimeZone};\n"
             );
         } else {
             content = content.replace(/\{\{QUERY_BUILDER_CHRONO_IMPORT\}\}/g, "");

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+{{SERDE_ERROR_IMPORT}}
 use std::{
     pin::Pin,
     str::FromStr,
@@ -187,75 +188,7 @@ impl HttpClient {
         self.parse_response(response).await
     }
 
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
-        self.parse_response(response).await
-    }
-
-    async fn apply_auth_headers(
+{{MULTIPART_METHOD}}    async fn apply_auth_headers(
         &self,
         request: &mut Request,
         options: &Option<RequestOptions>,
@@ -544,97 +477,4 @@ impl HttpClient {
         Ok(ByteStream::new(response))
     }
 
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
-    }
-}
+{{SSE_METHOD}}}

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.20.1
+  changelogEntry:
+    - summary: |
+        Fix unexpected_cfgs warnings for multipart and sse features by conditionally including
+        the execute_multipart_request and execute_sse_request methods in http_client.rs only when
+        the corresponding features are needed. Also fix unused Utc import in query_parameter_builder.rs
+        and unused SerdeError import in http_client.rs.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 62
+
 - version: 0.20.0
   changelogEntry:
     - summary: |

--- a/seed/rust-sdk/accept-header/src/core/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/alias-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/alias/src/core/http_client.rs
+++ b/seed/rust-sdk/alias/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/any-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -542,97 +475,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/audiences/src/core/http_client.rs
+++ b/seed/rust-sdk/audiences/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/basic-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/bytes-download/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-download/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/bytes-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/circular-references/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/client-side-params/src/core/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/client-side-params/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/client-side-params/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/content-type/src/core/http_client.rs
+++ b/seed/rust-sdk/content-type/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/empty-clients/src/core/http_client.rs
+++ b/seed/rust-sdk/empty-clients/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -542,97 +475,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/enum/src/core/http_client.rs
+++ b/seed/rust-sdk/enum/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -539,97 +540,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/error-property/src/core/http_client.rs
+++ b/seed/rust-sdk/error-property/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/errors/src/core/http_client.rs
+++ b/seed/rust-sdk/errors/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
@@ -5,7 +5,9 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+use serde::de::Error as SerdeError;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -185,74 +187,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -593,97 +527,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
@@ -5,7 +5,9 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+use serde::de::Error as SerdeError;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -185,74 +187,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -593,97 +527,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/examples/readme-config/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/exhaustive/src/core/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/core/http_client.rs
@@ -5,7 +5,9 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+use serde::de::Error as SerdeError;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -185,74 +187,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -593,97 +527,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/exhaustive/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/exhaustive/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/extends/src/core/http_client.rs
+++ b/seed/rust-sdk/extends/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/extra-properties/src/core/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/file-download/src/core/http_client.rs
+++ b/seed/rust-sdk/file-download/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -539,97 +540,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/file-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -539,97 +540,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/folders/src/core/http_client.rs
+++ b/seed/rust-sdk/folders/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -542,97 +475,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/header-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -542,97 +475,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/http-head/src/core/http_client.rs
+++ b/seed/rust-sdk/http-head/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/license/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/license/basic/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
+++ b/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/literal/src/core/http_client.rs
+++ b/seed/rust-sdk/literal/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/literals-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/literals-unions/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/mixed-case/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/mixed-case/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/mixed-case/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/no-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/no-retries/src/core/http_client.rs
+++ b/seed/rust-sdk/no-retries/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/nullable-optional/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/nullable-optional/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/nullable/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/nullable/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/object/src/core/http_client.rs
+++ b/seed/rust-sdk/object/src/core/http_client.rs
@@ -5,7 +5,9 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+use serde::de::Error as SerdeError;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -185,74 +187,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -593,97 +527,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/object/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/object/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/optional/src/core/http_client.rs
+++ b/seed/rust-sdk/optional/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/package-yml/src/core/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/pagination-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/path-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/plain-text/src/core/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/property-access/src/core/http_client.rs
+++ b/seed/rust-sdk/property-access/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/public-object/src/core/http_client.rs
+++ b/seed/rust-sdk/public-object/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/query-parameters-openapi/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/core/http_client.rs
@@ -5,7 +5,9 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+use serde::de::Error as SerdeError;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -185,74 +187,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -593,97 +527,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/query-parameters/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/query-parameters/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/request-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/core/http_client.rs
@@ -5,7 +5,9 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+use serde::de::Error as SerdeError;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -185,74 +187,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -593,97 +527,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/request-parameters/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/request-parameters/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/required-nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/required-nullable/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/response-property/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 

--- a/seed/rust-sdk/server-url-templating/src/core/http_client.rs
+++ b/seed/rust-sdk/server-url-templating/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/simple-fhir/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/trace/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/trace/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/unions/src/core/http_client.rs
+++ b/seed/rust-sdk/unions/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/unions/src/core/query_parameter_builder.rs
+++ b/seed/rust-sdk/unions/src/core/query_parameter_builder.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone};
 use serde::Serialize;
 
 /// Modern query builder with type-safe method chaining

--- a/seed/rust-sdk/unknown/src/core/http_client.rs
+++ b/seed/rust-sdk/unknown/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
+++ b/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/validation/src/core/http_client.rs
+++ b/seed/rust-sdk/validation/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/variables/src/core/http_client.rs
+++ b/seed/rust-sdk/variables/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/version-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/version/src/core/http_client.rs
+++ b/seed/rust-sdk/version/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/webhook-audience/src/core/http_client.rs
+++ b/seed/rust-sdk/webhook-audience/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/webhooks/src/core/http_client.rs
+++ b/seed/rust-sdk/webhooks/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }

--- a/seed/rust-sdk/websocket/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket/src/core/http_client.rs
@@ -4,7 +4,8 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
-use serde::de::{DeserializeOwned, Error as SerdeError};
+use serde::de::DeserializeOwned;
+
 use std::{
     pin::Pin,
     str::FromStr,
@@ -184,74 +185,6 @@ impl HttpClient {
 
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
-        self.parse_response(response).await
-    }
-
-    /// Execute a multipart/form-data request with the given method, path, and options
-    ///
-    /// This method is used for file uploads using reqwest's built-in multipart support.
-    /// Note: Multipart requests are not retried because they cannot be cloned.
-    ///
-    /// # Example
-    /// ```no_run
-    /// let form = reqwest::multipart::Form::new()
-    ///     .part("file", reqwest::multipart::Part::bytes(vec![1, 2, 3]));
-    ///
-    /// let response: MyResponse = client.execute_multipart_request(
-    ///     Method::POST,
-    ///     "/upload",
-    ///     form,
-    ///     None,
-    ///     None,
-    /// ).await?;
-    /// ```
-    #[cfg(feature = "multipart")]
-    pub async fn execute_multipart_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        form: reqwest::multipart::Form,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-    ) -> Result<T, ApiError>
-    where
-        T: DeserializeOwned,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Use reqwest's built-in multipart support
-        request = request.multipart(form);
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // Execute directly without retries (multipart requests cannot be cloned)
-        let response = self.client.execute(req).await.map_err(ApiError::Network)?;
-
-        // Check response status
-        if !response.status().is_success() {
-            let status_code = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(ApiError::from_response(status_code, body.as_deref()));
-        }
-
         self.parse_response(response).await
     }
 
@@ -539,97 +472,5 @@ impl HttpClient {
 
         // Return streaming response
         Ok(ByteStream::new(response))
-    }
-
-    /// Execute a request and return an SSE stream
-    ///
-    /// This method returns an `SseStream<T>` that automatically parses
-    /// Server-Sent Events and deserializes the JSON data in each event.
-    ///
-    /// # SSE-Specific Headers
-    ///
-    /// This method automatically sets the following headers **after** applying custom headers,
-    /// which means these headers will override any user-supplied values:
-    /// - `Accept: text/event-stream` - Required for SSE protocol
-    /// - `Cache-Control: no-store` - Prevents caching of streaming responses
-    ///
-    /// This ensures proper SSE behavior even if custom headers are provided.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use futures::StreamExt;
-    ///
-    /// let stream = client.execute_sse_request::<CompletionChunk>(
-    ///     Method::POST,
-    ///     "/stream",
-    ///     Some(serde_json::json!({"query": "Hello"})),
-    ///     None,
-    ///     None,
-    ///     Some("[[DONE]]".to_string()),
-    /// ).await?;
-    ///
-    /// let mut stream = std::pin::pin!(stream);
-    /// while let Some(chunk) = stream.next().await {
-    ///     let chunk = chunk?;
-    ///     println!("Received: {:?}", chunk);
-    /// }
-    /// ```
-    #[cfg(feature = "sse")]
-    pub async fn execute_sse_request<T>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<serde_json::Value>,
-        query_params: Option<Vec<(String, String)>>,
-        options: Option<RequestOptions>,
-        terminator: Option<String>,
-    ) -> Result<crate::SseStream<T>, ApiError>
-    where
-        T: DeserializeOwned + Send + 'static,
-    {
-        let url = join_url(&self.config.base_url, path);
-        let mut request = self.client.request(method, &url);
-
-        // Apply query parameters if provided
-        if let Some(params) = query_params {
-            request = request.query(&params);
-        }
-
-        // Apply additional query parameters from options
-        if let Some(opts) = &options {
-            if !opts.additional_query_params.is_empty() {
-                request = request.query(&opts.additional_query_params);
-            }
-        }
-
-        // Apply body if provided
-        if let Some(body) = body {
-            request = request.json(&body);
-        }
-
-        // Build the request
-        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
-
-        // Apply authentication and headers
-        self.apply_auth_headers(&mut req, &options).await?;
-        self.apply_custom_headers(&mut req, &options)?;
-
-        // SSE-specific headers
-        req.headers_mut().insert(
-            "Accept",
-            "text/event-stream"
-                .parse()
-                .map_err(|_| ApiError::InvalidHeader)?,
-        );
-        req.headers_mut().insert(
-            "Cache-Control",
-            "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
-        );
-
-        // Execute with retries
-        let response = self.execute_with_retries(req, &options).await?;
-
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
     }
 }


### PR DESCRIPTION
## Description

Fixes `unexpected_cfgs` warnings (`multipart`, `sse`) and `unused import: Utc` warning emitted when building generated Rust SDKs that don't use file upload or streaming endpoints (e.g., `@fern-demo/xai-rust-internal`).

## Changes Made

- **`http_client.rs` template**: Replaced the always-present `execute_multipart_request` and `execute_sse_request` method blocks with `{{MULTIPART_METHOD}}` and `{{SSE_METHOD}}` template variables. Previously these methods (guarded by `#[cfg(feature = "multipart")]` / `#[cfg(feature = "sse")]`) were always emitted, but the corresponding Cargo features were only declared when the API actually had file-upload/streaming endpoints — triggering Rust 1.80+'s `unexpected_cfgs` lint.
- **`http_client.rs` template**: Made `use serde::de::Error as SerdeError` conditional via `{{SERDE_ERROR_IMPORT}}` (only needed when the `{{BASE64_METHOD}}` is present).
- **`RustProject.ts`**: Added template variable replacements gated on `hasFileUploadEndpoints()`, `hasStreamingEndpoints()`, and `usesBase64()` respectively. Follows the existing `{{BASE64_METHOD}}` pattern.
- **`query_parameter_builder.rs` template**: Removed unused `Utc` from the chrono import (`use chrono::{DateTime, TimeZone, Utc}` → `use chrono::{DateTime, TimeZone}`).
- Regenerated all 115 rust-sdk seed fixture snapshots.
- Added `versions.yml` entry (0.20.1, type: fix).

## Important review points

1. **`{{MULTIPART_METHOD}}    async fn apply_auth_headers(`** on one line in the template — verify the replacement produces correct whitespace in both the included and excluded cases.
2. **`{{SSE_METHOD}}}`** — the trailing `}` closes the `impl HttpClient` block. Verify the SSE template replacement ends cleanly so the brace lands on its own line.
3. **`SerdeError` import is now coupled to `usesBase64()`** — if a future method needs `SerdeError` without base64, this will need updating. Acceptable trade-off for now.

## Testing

- [x] All 115 rust-sdk seed tests pass (`node packages/seed/dist/cli.cjs test --generator rust-sdk --local`)
- [x] Verified `file-upload` fixture retains `execute_multipart_request`; `streaming` fixture retains `execute_sse_request`
- [x] Verified `basic-auth` fixture no longer contains multipart/SSE methods or unused imports
- [x] `pnpm run check` (biome lint) passes cleanly

Link to Devin session: https://app.devin.ai/sessions/d957d7f03b524fdf8ab8c38315d8c5c7
Requested by: @iamnamananand996