### PR TITLE
fix(python): add enum handling to construct_type() to prevent Pydantic serialization warnings

### DIFF
--- a/generators/python/core_utilities/shared/unchecked_base_model.py
+++ b/generators/python/core_utilities/shared/unchecked_base_model.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import enum
 import inspect
 import typing
 import uuid
@@ -335,6 +336,12 @@ def construct_type(*, type_: typing.Type[typing.Any], object_: typing.Any) -> ty
 
             return bool(object_)
         except Exception:
+            return object_
+
+    if inspect.isclass(base_type) and issubclass(base_type, enum.Enum):
+        try:
+            return base_type(object_)
+        except (ValueError, KeyError):
             return object_
 
     return object_

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.0.5
+  changelogEntry:
+    - summary: |
+        Add enum handling to `construct_type()` to prevent Pydantic serialization warnings
+        when enum values pass through untyped model construction paths.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 5.0.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Fixes Pydantic serialization warnings that occur when enum values pass through untyped model construction paths in `construct_type()`. Without this fix, raw enum values bypass proper type construction, causing Pydantic to emit warnings during `model_dump()`.

## Changes Made
- **`unchecked_base_model.py`**: Added enum detection in `construct_type()` — when the base type is an `enum.Enum` subclass, the value is properly constructed as the enum member (with a fallback to the raw value if construction fails)
- **`versions.yml`**: Added v5.0.5 changelog entry for the fix

## Testing
- [x] Manual testing with enum models that previously triggered Pydantic warnings
- [x] Fallback behavior verified for invalid enum values (gracefully returns raw value)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
