### PR TITLE
feat(seed): parallelize script container execution with pooled slots

### DIFF
--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -338,7 +338,8 @@ function addTestCommand(cli: Argv) {
                         argv.skipScripts,
                         taskContextFactory.create("docker-script-runner"),
                         argv["log-level"],
-                        argv.containerRuntime as "docker" | "podman" | undefined
+                        argv.containerRuntime as "docker" | "podman" | undefined,
+                        argv.parallel
                     );
                     testRunner = new ContainerTestRunner({
                         generator,

--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -48,7 +48,7 @@ export async function runWithCustomFixture({
     if (!skipScripts) {
         scriptRunner = local
             ? new LocalScriptRunner(workspace, skipScripts, taskContext, logLevel)
-            : new ContainerScriptRunner(workspace, skipScripts, taskContext, logLevel);
+            : new ContainerScriptRunner(workspace, skipScripts, taskContext, logLevel, undefined, 1);
     }
 
     if (local) {

--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -1,6 +1,6 @@
 import { ContainerRunner } from "@fern-api/core-utils";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { LogLevel } from "@fern-api/logger";
+import { CONSOLE_LOGGER, Logger, LogLevel } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { TaskContext } from "@fern-api/task-context";
 import { writeFile } from "fs/promises";
@@ -12,6 +12,14 @@ import { ScriptRunner } from "./ScriptRunner.js";
 
 interface RunningScriptConfig extends ContainerScriptConfig {
     containerId: string;
+}
+
+/**
+ * A slot represents one set of running containers (one per script config).
+ * Multiple slots form a pool, allowing fixtures to run scripts in parallel.
+ */
+interface ContainerSlot {
+    scripts: RunningScriptConfig[];
 }
 
 interface InternalScriptResult {
@@ -31,17 +39,24 @@ function getCommandsForPhase(commands: ScriptCommands, phase: "build" | "test"):
  */
 export class ContainerScriptRunner extends ScriptRunner {
     private readonly runner: ContainerRunner;
+    private readonly poolSize: number;
     private startContainersFn: Promise<void> | undefined;
-    private scripts: RunningScriptConfig[] = [];
+
+    // Pool of container slots for parallel script execution
+    private allSlots: ContainerSlot[] = [];
+    private availableSlots: ContainerSlot[] = [];
+    private waiters: Array<(slot: ContainerSlot) => void> = [];
 
     constructor(
         workspace: GeneratorWorkspace,
         skipScripts: boolean,
         context: TaskContext,
         logLevel: LogLevel,
-        runner?: ContainerRunner
+        runner?: ContainerRunner,
+        poolSize?: number
     ) {
         super(workspace, skipScripts, context, logLevel);
+        this.poolSize = poolSize ?? 4;
 
         if (runner != null) {
             this.runner = runner;
@@ -78,13 +93,39 @@ export class ContainerScriptRunner extends ScriptRunner {
 
         await this.startContainersFn;
 
+        // No slots available (no scripts configured or skipScripts at class level)
+        if (this.allSlots.length === 0) {
+            return { type: "success" };
+        }
+
+        const slot = await this.acquireSlot();
+        try {
+            return await this.runInSlot({ slot, taskContext, id, outputDir, skipScripts });
+        } finally {
+            this.releaseSlot(slot);
+        }
+    }
+
+    private async runInSlot({
+        slot,
+        taskContext,
+        id,
+        outputDir,
+        skipScripts
+    }: {
+        slot: ContainerSlot;
+        taskContext: TaskContext;
+        id: string;
+        outputDir: AbsoluteFilePath;
+        skipScripts?: boolean | string[];
+    }): Promise<ScriptRunner.RunResponse> {
         let buildTimeMs: number | undefined;
         let testTimeMs: number | undefined;
         let anyBuildCommands = false;
         let anyTestCommands = false;
 
         const buildStartTime = Date.now();
-        for (const script of this.scripts) {
+        for (const script of slot.scripts) {
             if (Array.isArray(skipScripts) && script.name != null && skipScripts.includes(script.name)) {
                 taskContext.logger.info(`Skipping script "${script.name}" for ${id} (configured in fixture)`);
                 continue;
@@ -121,7 +162,7 @@ export class ContainerScriptRunner extends ScriptRunner {
         }
 
         const testStartTime = Date.now();
-        for (const script of this.scripts) {
+        for (const script of slot.scripts) {
             if (Array.isArray(skipScripts) && script.name != null && skipScripts.includes(script.name)) {
                 continue;
             }
@@ -162,10 +203,12 @@ export class ContainerScriptRunner extends ScriptRunner {
 
     public async stop(): Promise<void> {
         const logger = this.shouldStreamOutput() ? this.context.logger : undefined;
-        for (const script of this.scripts) {
-            await loggingExeca(logger, this.runner, ["kill", script.containerId], {
-                doNotPipeOutput: !this.shouldStreamOutput()
-            });
+        for (const slot of this.allSlots) {
+            for (const script of slot.scripts) {
+                await loggingExeca(logger, this.runner, ["kill", script.containerId], {
+                    doNotPipeOutput: !this.shouldStreamOutput()
+                });
+            }
         }
     }
 
@@ -270,12 +313,65 @@ export class ContainerScriptRunner extends ScriptRunner {
         return join(rootDir, RelativeFilePath.of("packages/cli/cli/dist/prod"));
     }
 
+    /**
+     * Acquires a container slot from the pool, waiting if all are busy.
+     */
+    private acquireSlot(): Promise<ContainerSlot> {
+        const available = this.availableSlots.shift();
+        if (available != null) {
+            return Promise.resolve(available);
+        }
+        return new Promise<ContainerSlot>((resolve) => {
+            this.waiters.push(resolve);
+        });
+    }
+
+    /**
+     * Releases a container slot back to the pool, waking up any waiters.
+     */
+    private releaseSlot(slot: ContainerSlot): void {
+        const waiter = this.waiters.shift();
+        if (waiter != null) {
+            waiter(slot);
+        } else {
+            this.availableSlots.push(slot);
+        }
+    }
+
     private async startContainers(context: TaskContext): Promise<void> {
+        const scriptConfigs = this.workspace.workspaceConfig.scripts ?? [];
+        if (scriptConfigs.length === 0) {
+            return;
+        }
+
         const absoluteFilePathToFernCli = await this.buildFernCli(context);
         const cliVolumeBind = `${absoluteFilePathToFernCli}:/fern`;
         const logger = this.shouldStreamOutput() ? context.logger : undefined;
-        // Start running a container for each script instance
-        for (const script of this.workspace.workspaceConfig.scripts ?? []) {
+
+        if (!this.shouldStreamOutput()) {
+            const imageNames = scriptConfigs.map((s) => s.image).join(", ");
+            CONSOLE_LOGGER.info(
+                `Starting ${this.poolSize} script container(s) for [${imageNames}]...`
+            );
+        }
+
+        // Start poolSize slots in parallel, each slot has one container per script config
+        const startPromises: Promise<ContainerSlot>[] = [];
+        for (let i = 0; i < this.poolSize; i++) {
+            startPromises.push(this.startSlot(scriptConfigs, cliVolumeBind, logger));
+        }
+
+        this.allSlots = await Promise.all(startPromises);
+        this.availableSlots = [...this.allSlots];
+    }
+
+    private async startSlot(
+        scriptConfigs: ContainerScriptConfig[],
+        cliVolumeBind: string,
+        logger: Logger | undefined
+    ): Promise<ContainerSlot> {
+        const scripts: RunningScriptConfig[] = [];
+        for (const script of scriptConfigs) {
             const startSeedCommand = await loggingExeca(
                 logger,
                 this.runner,
@@ -296,7 +392,8 @@ export class ContainerScriptRunner extends ScriptRunner {
                 }
             );
             const containerId = startSeedCommand.stdout;
-            this.scripts.push({ ...script, containerId });
+            scripts.push({ ...script, containerId });
         }
+        return { scripts };
     }
 }

--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -119,6 +119,35 @@ export class ContainerScriptRunner extends ScriptRunner {
         outputDir: AbsoluteFilePath;
         skipScripts?: boolean | string[];
     }): Promise<ScriptRunner.RunResponse> {
+        const workDir = id.replace(":", "_");
+        try {
+            return await this.executeScriptsInSlot({ slot, taskContext, id, outputDir, skipScripts });
+        } finally {
+            // Clean up the fixture's working directory to free disk space.
+            // Package manager caches (npm, nuget, yarn, pip, etc.) live in global
+            // paths (e.g. ~/.npm, ~/.nuget) and are preserved across fixtures.
+            for (const script of slot.scripts) {
+                await loggingExeca(undefined, this.runner, ["exec", script.containerId, "rm", "-rf", `/${workDir}`], {
+                    doNotPipeOutput: true,
+                    reject: false
+                });
+            }
+        }
+    }
+
+    private async executeScriptsInSlot({
+        slot,
+        taskContext,
+        id,
+        outputDir,
+        skipScripts
+    }: {
+        slot: ContainerSlot;
+        taskContext: TaskContext;
+        id: string;
+        outputDir: AbsoluteFilePath;
+        skipScripts?: boolean | string[];
+    }): Promise<ScriptRunner.RunResponse> {
         let buildTimeMs: number | undefined;
         let testTimeMs: number | undefined;
         let anyBuildCommands = false;

--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -371,7 +371,9 @@ export class ContainerScriptRunner extends ScriptRunner {
                         await loggingExeca(logger, this.runner, ["kill", script.containerId], {
                             doNotPipeOutput: true
                         }).catch((killError: unknown) => {
-                            CONSOLE_LOGGER.warn(`Best-effort cleanup: failed to kill container ${script.containerId}: ${killError}`);
+                            CONSOLE_LOGGER.warn(
+                                `Best-effort cleanup: failed to kill container ${script.containerId}: ${killError}`
+                            );
                         });
                     }
                 }

--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -350,9 +350,7 @@ export class ContainerScriptRunner extends ScriptRunner {
 
         if (!this.shouldStreamOutput()) {
             const imageNames = scriptConfigs.map((s) => s.image).join(", ");
-            CONSOLE_LOGGER.info(
-                `Starting ${this.poolSize} script container(s) for [${imageNames}]...`
-            );
+            CONSOLE_LOGGER.info(`Starting ${this.poolSize} script container(s) for [${imageNames}]...`);
         }
 
         // Start poolSize slots in parallel, each slot has one container per script config

--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -390,29 +390,43 @@ export class ContainerScriptRunner extends ScriptRunner {
         logger: Logger | undefined
     ): Promise<ContainerSlot> {
         const scripts: RunningScriptConfig[] = [];
-        for (const script of scriptConfigs) {
-            const startSeedCommand = await loggingExeca(
-                logger,
-                this.runner,
-                [
-                    "run",
-                    "--privileged",
-                    "--cgroupns=host",
-                    "-v",
-                    "/sys/fs/cgroup:/sys/fs/cgroup:rw",
-                    "-dit",
-                    "-v",
-                    cliVolumeBind,
-                    script.image,
-                    "/bin/sh"
-                ],
-                {
-                    doNotPipeOutput: !this.shouldStreamOutput()
-                }
-            );
-            const containerId = startSeedCommand.stdout;
-            scripts.push({ ...script, containerId });
+        try {
+            for (const script of scriptConfigs) {
+                const startSeedCommand = await loggingExeca(
+                    logger,
+                    this.runner,
+                    [
+                        "run",
+                        "--privileged",
+                        "--cgroupns=host",
+                        "-v",
+                        "/sys/fs/cgroup:/sys/fs/cgroup:rw",
+                        "-dit",
+                        "-v",
+                        cliVolumeBind,
+                        script.image,
+                        "/bin/sh"
+                    ],
+                    {
+                        doNotPipeOutput: !this.shouldStreamOutput()
+                    }
+                );
+                const containerId = startSeedCommand.stdout;
+                scripts.push({ ...script, containerId });
+            }
+            return { scripts };
+        } catch (error) {
+            // Clean up any containers that started before the failure in this slot
+            for (const script of scripts) {
+                await loggingExeca(logger, this.runner, ["kill", script.containerId], {
+                    doNotPipeOutput: true
+                }).catch((killError: unknown) => {
+                    CONSOLE_LOGGER.warn(
+                        `Failed to kill container ${script.containerId} during slot cleanup: ${killError}`
+                    );
+                });
+            }
+            throw error;
         }
-        return { scripts };
     }
 }

--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -203,13 +203,14 @@ export class ContainerScriptRunner extends ScriptRunner {
 
     public async stop(): Promise<void> {
         const logger = this.shouldStreamOutput() ? this.context.logger : undefined;
-        for (const slot of this.allSlots) {
-            for (const script of slot.scripts) {
-                await loggingExeca(logger, this.runner, ["kill", script.containerId], {
+        const killPromises = this.allSlots.flatMap((slot) =>
+            slot.scripts.map((script) =>
+                loggingExeca(logger, this.runner, ["kill", script.containerId], {
                     doNotPipeOutput: !this.shouldStreamOutput()
-                });
-            }
-        }
+                })
+            )
+        );
+        await Promise.all(killPromises);
     }
 
     protected async initialize(): Promise<void> {

--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -370,8 +370,8 @@ export class ContainerScriptRunner extends ScriptRunner {
                     for (const script of result.value.scripts) {
                         await loggingExeca(logger, this.runner, ["kill", script.containerId], {
                             doNotPipeOutput: true
-                        }).catch(() => {
-                            // Best-effort cleanup
+                        }).catch((killError: unknown) => {
+                            CONSOLE_LOGGER.warn(`Best-effort cleanup: failed to kill container ${script.containerId}: ${killError}`);
                         });
                     }
                 }

--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -359,8 +359,27 @@ export class ContainerScriptRunner extends ScriptRunner {
             startPromises.push(this.startSlot(scriptConfigs, cliVolumeBind, logger));
         }
 
-        this.allSlots = await Promise.all(startPromises);
-        this.availableSlots = [...this.allSlots];
+        try {
+            this.allSlots = await Promise.all(startPromises);
+            this.availableSlots = [...this.allSlots];
+        } catch (error) {
+            // Clean up any containers that started successfully before the failure
+            const settledPromises = await Promise.allSettled(startPromises);
+            for (const result of settledPromises) {
+                if (result.status === "fulfilled") {
+                    for (const script of result.value.scripts) {
+                        await loggingExeca(logger, this.runner, ["kill", script.containerId], {
+                            doNotPipeOutput: true
+                        }).catch(() => {
+                            // Best-effort cleanup
+                        });
+                    }
+                }
+            }
+            this.allSlots = [];
+            this.availableSlots = [];
+            throw error;
+        }
     }
 
     private async startSlot(

--- a/packages/seed/src/commands/test/script-runner/ScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ScriptRunner.ts
@@ -2,7 +2,6 @@ import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { LogLevel } from "@fern-api/logger";
 import { TaskContext } from "@fern-api/task-context";
 import { GeneratorWorkspace } from "../../../loadGeneratorWorkspaces.js";
-import { Semaphore } from "../../../Semaphore.js";
 
 export declare namespace ScriptRunner {
     interface RunArgs {
@@ -33,8 +32,6 @@ export declare namespace ScriptRunner {
  * Abstract base class for running scripts on generated code to verify the output.
  */
 export abstract class ScriptRunner {
-    protected readonly lock = new Semaphore(1);
-
     constructor(
         protected readonly workspace: GeneratorWorkspace,
         protected readonly skipScripts: boolean,


### PR DESCRIPTION
## Description

Script containers (e.g. `csharp-seed`) previously ran with a single container per script config, forcing all fixtures to execute their build/test scripts sequentially through that one container. This was a bottleneck — after 14 generator containers finished in parallel, only 1 script container would be running.

This PR introduces a pool of container "slots" so fixtures can run their scripts in parallel, matching the parallelism already used for generator containers.

## Changes Made

- **`ContainerScriptRunner`**: Replaced the single flat `scripts` array with a pool of `ContainerSlot` objects. Each slot holds one container per script config. Pool size matches the `--parallel` flag.
  - Added `acquireSlot()` / `releaseSlot()` pool management (same pattern as `ReusableContainerExecutionEnvironment`)
  - Extracted script execution into `runInSlot()` → `executeScriptsInSlot()` to operate on a specific slot's containers
  - `startContainers()` now starts `poolSize` slots in parallel via `Promise.all`
  - `stop()` kills all containers in parallel via `Promise.all` (matching `ReusableContainerExecutionEnvironment.stop()`)
  - **Partial failure cleanup**: Both `startContainers()` and `startSlot()` handle partial failures — if a container fails to start, any already-started containers are killed before re-throwing. Kill failures are logged via `CONSOLE_LOGGER.warn`.
  - **Fixture working directory cleanup**: After each fixture's scripts finish (success or failure), `runInSlot` removes the fixture's `/{workDir}` directory from each container in the slot via `rm -rf`. This prevents disk accumulation across fixtures. Global package manager caches (npm, nuget, yarn, pip, etc.) are preserved since they live in global paths (e.g. `~/.npm`, `~/.nuget`), not under the per-fixture working directory.
- **`cli.ts`**: Passes `argv.parallel` as `poolSize` to `ContainerScriptRunner`
- **`runWithCustomFixture.ts`**: Explicitly passes `poolSize: 1` since it runs a single fixture
- **`ScriptRunner`**: Removed unused `Semaphore(1)` lock (dead code — neither subclass ever called `acquire()`)

## Performance (ts-sdk, 50 fixtures across 5 test definitions)

| Mode | Wall-clock time |
|------|----------------|
| Sequential (`--parallel 1`) | **10m 14.9s** |
| Parallel (`--parallel 4`) | **5m 2.2s** |

~2x speedup with 4 parallel slots on an 8-core VM. Individual per-fixture script times are slightly higher due to CPU contention, but total wall-clock time is significantly reduced.

## Human Review Checklist

- [ ] **Resource usage**: Pool size matches `--parallel` (defaults to `min(cpuCount, 16)`). CI hardcodes `--parallel 16`, so this goes from 1 script container to 16. These are idle `/bin/sh` shells (same as generator containers) — minimal memory overhead, but worth confirming CI runners handle the extra containers.
- [ ] **Pool correctness**: `acquireSlot`/`releaseSlot` mirrors `ReusableContainerExecutionEnvironment.acquire`/`release` exactly. Single-threaded JS means no data races. If `stop()` is called while fixtures are in-flight, their `docker exec` will fail and `finally` will call `releaseSlot` on a dead slot — same limitation as `ReusableContainerExecutionEnvironment`. In practice, `stop()` runs only after all fixtures settle.
- [ ] **`stop()` error handling**: `Promise.all` will reject on the first `docker kill` failure without waiting for remaining kills to settle. All kill commands are already dispatched before `await`, so they'll run to completion in the background, but errors from other kills are silently dropped. Same pattern as `ReusableContainerExecutionEnvironment.stop()`.
- [ ] **Fixture cleanup safety**: `workDir` is derived from fixture `id.replace(":", "_")` (e.g. `exhaustive_no-custom-config`). The `rm -rf /{workDir}` is scoped to this fixture-specific top-level directory. Uses `reject: false` so cleanup failure won't break the test run. Verify this doesn't accidentally remove anything outside the fixture directory.
- [ ] **Edge case: no scripts configured**: The `allSlots.length === 0` guard handles both "no script configs" and "class-level skipScripts" cases correctly.

## Testing
- [x] TypeScript compilation passes (`pnpm turbo run compile --filter=@fern-api/seed-cli`)
- [x] Biome formatting passes
- [x] CI passes (292 checks green)
- [x] Manual performance comparison on ts-sdk (sequential vs parallel, see table above)
- [ ] Manual testing with a generator that has multiple script configs per fixture

Link to Devin session: https://app.devin.ai/sessions/bf79cb4929bb4717a9096963b5efb879
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
