### PR TITLE
fix(rust): Avoid `#[serde(transparent)]` for discriminator enums

### DIFF
--- a/generators/rust/model/src/__test__/generateModels.test.ts
+++ b/generators/rust/model/src/__test__/generateModels.test.ts
@@ -127,4 +127,17 @@ describe("generateModels type-specific tests", () => {
         const hasTaggedUnion = files.some((file) => file.fileContents.includes("#[serde(tag ="));
         expect(hasTaggedUnion).toBeTruthy();
     });
+
+    it("should not apply serde(transparent) to single-property structs with enum fields", async () => {
+        const context = await createSampleGeneratorContext("undiscriminated-union-types");
+        const files = generateModels({ context });
+
+        // EventPayload has a single enum-typed field and is a member of an undiscriminated union.
+        // It must NOT get #[serde(transparent)] because that would serialize as
+        // just the enum variant string instead of {"type":"text.done"}.
+        const eventPayloadFile = files.find((f) => f.filename.toLowerCase().includes("event_payload"));
+        expect(eventPayloadFile).toBeDefined();
+        expect(eventPayloadFile?.fileContents).not.toContain("#[serde(transparent)]");
+        expect(eventPayloadFile?.fileContents).toContain("struct EventPayload");
+    });
 });

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_event_message.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_event_message.rs
@@ -1,0 +1,16 @@
+pub use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(tag = "type")]
+pub enum EventMessage {
+        #[serde(rename = "payload")]
+        Payload {
+            #[serde(flatten)]
+            data: EventPayload,
+        },
+
+        #[serde(rename = "raw")]
+        Raw {
+            value: String,
+        },
+}

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_event_payload.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_event_payload.rs
@@ -1,0 +1,6 @@
+pub use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct EventPayload {
+    pub r#type: EventType,
+}

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_event_type.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_event_type.rs
@@ -1,0 +1,21 @@
+pub use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum EventType {
+    #[serde(rename = "text.delta")]
+    TextDelta,
+    #[serde(rename = "text.done")]
+    TextDone,
+    #[serde(rename = "error")]
+    Error,
+}
+impl fmt::Display for EventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::TextDelta => "text.delta",
+            Self::TextDone => "text.done",
+            Self::Error => "error",
+        };
+        write!(f, "{}", s)
+    }
+}

--- a/generators/rust/model/src/__test__/test-definitions/undiscriminated-union-types/definition/types.yml
+++ b/generators/rust/model/src/__test__/test-definitions/undiscriminated-union-types/definition/types.yml
@@ -59,3 +59,22 @@ types:
       error: string
       code: integer
       details: optional<list<string>>
+
+  # Undiscriminated union with a single-enum-property member.
+  # The EventPayload struct has one field whose type is an enum.
+  # It must NOT get #[serde(transparent)] because that would serialize
+  # as just the enum string instead of {"type":"text.done"}.
+  EventMessage:
+    union:
+      payload: EventPayload
+      raw: string
+
+  EventPayload:
+    properties:
+      type: EventType
+
+  EventType:
+    enum:
+      - text.delta
+      - text.done
+      - error

--- a/generators/rust/model/src/object/StructGenerator.ts
+++ b/generators/rust/model/src/object/StructGenerator.ts
@@ -223,6 +223,16 @@ export class StructGenerator {
         if (this.objectTypeDeclaration.properties.length !== 1 || this.objectTypeDeclaration.extends.length > 0) {
             return false;
         }
+        // Don't apply transparent if the single property is an enum type.
+        // Enums serialize as their variant string (e.g. "text.done"), so transparent
+        // would lose the enclosing object structure (e.g. {"type":"text.done"}).
+        const singleProperty = this.objectTypeDeclaration.properties[0]!;
+        if (singleProperty.valueType.type === "named") {
+            const referencedType = this.context.ir.types[singleProperty.valueType.typeId];
+            if (referencedType?.shape.type === "enum") {
+                return false;
+            }
+        }
         // Check if this type is referenced by any undiscriminated union
         const typeId = Object.entries(this.context.ir.types).find(([_, type]) => type === this.typeDeclaration)?.[0];
         return typeId != null && this.context.undiscriminatedUnionMemberTypeIds.has(typeId);

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.1.6
+  changelogEntry:
+    - summary: |
+        Avoid applying `#[serde(transparent)]` to single-property structs whose sole field is an
+        enum type. When used inside undiscriminated unions, transparent serialization would serialize
+        the struct as just the inner enum variant string instead of the expected object wrapper.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 61
+
 - version: 0.1.5
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes incorrect serialization of single-property structs whose sole field is an enum type when used inside undiscriminated unions in Rust.

When `#[serde(transparent)]` is applied to a struct like `EventPayload { type: EventType }`, serde serializes it as just the inner enum variant string (e.g. `"text.done"`) instead of the expected object `{"type":"text.done"}`. This PR adds a guard to skip the transparent optimization when the single property references an enum type.

## Changes Made

- Added an enum-type check in `StructGenerator.ts` → the transparent-eligibility logic now returns `false` when the single property's resolved type is an enum
- Added test definition types (`EventMessage`, `EventPayload`, `EventType`) to the `undiscriminated-union-types` fixture
- Added corresponding snapshot files for the new types
- Added a unit test asserting `EventPayload` does **not** receive `#[serde(transparent)]`
- Added `versions.yml` entry for Rust model generator v0.1.6

## Testing

- [x] Unit test added (`should not apply serde(transparent) to single-property structs with enum fields`)
- [ ] Manual testing completed

## Review Checklist

- [ ] The enum guard (`singleProperty.valueType.type === "named"` + `referencedType?.shape.type === "enum"`) only checks direct enum shapes. Should this also cover **aliases to enums** or other named types that serialize as scalars?
- [ ] Confirm that non-enum single-property structs in undiscriminated unions still correctly receive `#[serde(transparent)]` (no regression).
- [ ] The existing `Object.entries(...).find(([_, type]) => type === this.typeDeclaration)` below the new code uses reference equality — worth verifying this is reliable in all cases.

Link to Devin session: https://app.devin.ai/sessions/b823053f0b6d4ccbb64c72b51801e566
Requested by: @iamnamananand996