### PR TITLE
fix(java-sdk): respect client-class-name config in README exception class references

### DIFF
--- a/generators/java-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/java-v2/sdk/src/SdkGeneratorContext.ts
@@ -239,7 +239,10 @@ export class SdkGeneratorContext extends AbstractJavaGeneratorContext<SdkCustomC
     }
 
     public getApiExceptionClassName(): string {
-        return this.customConfig?.["base-api-exception-class-name"] ?? `${this.getBaseNamePrefix()}ApiException`;
+        return (
+            this.customConfig?.["base-api-exception-class-name"] ??
+            `${this.customConfig?.["client-class-name"] ?? this.getBaseNamePrefix()}ApiException`
+        );
     }
 
     public getHttpResponseClassName(): string {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.0.4
+  changelogEntry:
+    - summary: |
+        Fix generated README referencing incorrect exception class name when
+        `client-class-name` is configured. Previously, the README exception
+        handling snippet always used the default `{Org}{Workspace}ApiException`
+        pattern (e.g., `AndurilApiApiException`) instead of respecting the
+        `client-class-name` override (e.g., `LatticeApiException`). This now
+        matches the actual generated exception class produced by the Java v1
+        generator.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 4.0.3
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/exhaustive/custom-client-class-name/README.md
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/README.md
@@ -90,11 +90,11 @@ Best client = Best
 When the API returns a non-success status code (4xx or 5xx response), an API exception will be thrown.
 
 ```java
-import com.seed.exhaustive.core.SeedExhaustiveApiException;
+import com.seed.exhaustive.core.BestApiException;
 
 try{
     client.endpoints().container().getAndReturnListOfPrimitives(...);
-} catch (SeedExhaustiveApiException e){
+} catch (BestApiException e){
     // Do something with the API exception...
 }
 ```

--- a/seed/java-sdk/java-builder-extension/base-client/README.md
+++ b/seed/java-sdk/java-builder-extension/base-client/README.md
@@ -102,11 +102,11 @@ BaseClient client = BaseClient
 When the API returns a non-success status code (4xx or 5xx response), an API exception will be thrown.
 
 ```java
-import com.seed.builderExtension.core.SeedBuilderExtensionApiException;
+import com.seed.builderExtension.core.BaseClientApiException;
 
 try{
     client.service().hello(...);
-} catch (SeedBuilderExtensionApiException e){
+} catch (BaseClientApiException e){
     // Do something with the API exception...
 }
 ```

--- a/seed/java-sdk/java-builder-extension/extensible-builders/README.md
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/README.md
@@ -102,11 +102,11 @@ BaseClient client = BaseClient
 When the API returns a non-success status code (4xx or 5xx response), an API exception will be thrown.
 
 ```java
-import com.seed.builderExtension.core.SeedBuilderExtensionApiException;
+import com.seed.builderExtension.core.BaseClientApiException;
 
 try{
     client.service().hello(...);
-} catch (SeedBuilderExtensionApiException e){
+} catch (BaseClientApiException e){
     // Do something with the API exception...
 }
 ```


### PR DESCRIPTION
## Description

Refs FER-9149

The Java v2 generator's `getApiExceptionClassName()` was missing the `client-class-name` config as an intermediate fallback when constructing the exception class name for generated READMEs. This caused READMEs to reference incorrect exception class names (e.g., `AndurilApiApiException` instead of `LatticeApiException`) when `client-class-name` is configured.

## Changes Made

- **`generators/java-v2/sdk/src/SdkGeneratorContext.ts`**: Added `client-class-name` as intermediate fallback in `getApiExceptionClassName()`, matching the v1 generator's fallback chain in `ClientPoetClassNameFactory.getApiErrorClassName()`:
  1. `base-api-exception-class-name` (explicit override)
  2. `client-class-name` + `"ApiException"` ← **was missing**
  3. `getBaseNamePrefix()` + `"ApiException"` (org+workspace default)

  This mirrors the pattern already used by `getHttpResponseClassName()` on line 248.

- Updated seed test README snapshots for affected fixtures (`custom-client-class-name`, `base-client`, `extensible-builders`)
- Added version 4.0.4 changelog entry

## Testing

- [ ] Seed test snapshots updated for all affected fixtures
- [x] Lint/biome check passing
- [ ] CI seed tests will validate snapshots match actual generator output

### Human review checklist
- [ ] Verify the fallback chain in `getApiExceptionClassName()` matches v1's `ClientPoetClassNameFactory.getApiErrorClassName()` (line 160-167)
- [ ] Confirm no other methods in `SdkGeneratorContext` are missing the `client-class-name` fallback (note: `getHttpResponseClassName` already handles it correctly)
- [ ] Seed snapshots were updated manually — CI will confirm they match actual generator output

Link to Devin session: https://app.devin.ai/sessions/68e2a97982a44aee8f9e7101f08138af
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
