### PR TITLE
feat(cli): add Sentry integration for legacy CLI

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -60,6 +60,8 @@ jobs:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
       AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN_CLI }}
+      FERN_SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -83,6 +85,18 @@ jobs:
         run: |
           git_version="$(./scripts/git-version.sh)"
           pnpm seed publish cli --ver ${git_version} --dev --log-level debug
+
+      - name: Upload Sentry source maps
+        if: ${{ env.FERN_SENTRY_AUTH_TOKEN != '' }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
+        run: |
+          git_version="$(./scripts/git-version.sh)"
+          npx @sentry/cli sourcemaps upload \
+            --org buildwithfern \
+            --project cli \
+            --release "cli@${git_version}" \
+            packages/cli/cli/dist/dev/
 
   live-test:
     if: ${{ inputs.version == null && github.repository == 'fern-api/fern' }}
@@ -115,6 +129,8 @@ jobs:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
       AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN_CLI }}
+      FERN_SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -152,6 +168,19 @@ jobs:
           pnpm seed publish cli --changelog packages/cli/cli/versions.yml --previous-changelog tmp_cli_previous_versions.yml --log-level debug
           pnpm seed register cli
 
+      - name: Upload Sentry source maps
+        if: ${{ env.FERN_SENTRY_AUTH_TOKEN != '' }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
+        run: |
+          pnpm seed:local latest cli -o "version.txt" --changelog packages/cli/cli/versions.yml --previous-changelog tmp_cli_previous_versions.yml
+          cli_version="$(cat version.txt)"
+          npx @sentry/cli sourcemaps upload \
+            --org buildwithfern \
+            --project cli \
+            --release "cli@${cli_version}" \
+            packages/cli/cli/dist/prod/
+
   manual:
     runs-on: ubuntu-latest
     if: ${{ inputs.version != null }}
@@ -159,6 +188,8 @@ jobs:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
       AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN_CLI }}
+      FERN_SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -182,6 +213,17 @@ jobs:
         run: |
           pnpm seed publish cli --ver ${{ inputs.version }} --log-level debug
           pnpm seed register cli
+
+      - name: Upload Sentry source maps
+        if: ${{ env.FERN_SENTRY_AUTH_TOKEN != '' }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
+        run: |
+          npx @sentry/cli sourcemaps upload \
+            --org buildwithfern \
+            --project cli \
+            --release "cli@${{ inputs.version }}" \
+            packages/cli/cli/dist/prod/
 
   bulk-update-cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -61,7 +61,7 @@ jobs:
       AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN_CLI }}
-      FERN_SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -85,18 +85,6 @@ jobs:
         run: |
           git_version="$(./scripts/git-version.sh)"
           pnpm seed publish cli --ver ${git_version} --dev --log-level debug
-
-      - name: Upload Sentry source maps
-        if: ${{ env.FERN_SENTRY_AUTH_TOKEN != '' }}
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
-        run: |
-          git_version="$(./scripts/git-version.sh)"
-          npx @sentry/cli sourcemaps upload \
-            --org buildwithfern \
-            --project cli \
-            --release "cli@${git_version}" \
-            packages/cli/cli/dist/dev/
 
   live-test:
     if: ${{ inputs.version == null && github.repository == 'fern-api/fern' }}
@@ -130,7 +118,7 @@ jobs:
       AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN_CLI }}
-      FERN_SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -168,19 +156,6 @@ jobs:
           pnpm seed publish cli --changelog packages/cli/cli/versions.yml --previous-changelog tmp_cli_previous_versions.yml --log-level debug
           pnpm seed register cli
 
-      - name: Upload Sentry source maps
-        if: ${{ env.FERN_SENTRY_AUTH_TOKEN != '' }}
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
-        run: |
-          pnpm seed:local latest cli -o "version.txt" --changelog packages/cli/cli/versions.yml --previous-changelog tmp_cli_previous_versions.yml
-          cli_version="$(cat version.txt)"
-          npx @sentry/cli sourcemaps upload \
-            --org buildwithfern \
-            --project cli \
-            --release "cli@${cli_version}" \
-            packages/cli/cli/dist/prod/
-
   manual:
     runs-on: ubuntu-latest
     if: ${{ inputs.version != null }}
@@ -189,7 +164,7 @@ jobs:
       AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN_CLI }}
-      FERN_SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -213,17 +188,6 @@ jobs:
         run: |
           pnpm seed publish cli --ver ${{ inputs.version }} --log-level debug
           pnpm seed register cli
-
-      - name: Upload Sentry source maps
-        if: ${{ env.FERN_SENTRY_AUTH_TOKEN != '' }}
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
-        run: |
-          npx @sentry/cli sourcemaps upload \
-            --org buildwithfern \
-            --project cli \
-            --release "cli@${{ inputs.version }}" \
-            packages/cli/cli/dist/prod/
 
   bulk-update-cli:
     runs-on: ubuntu-latest

--- a/knip.json
+++ b/knip.json
@@ -45,7 +45,8 @@
     "diff",
     "@open-rpc/meta-schema",
     "readable-stream",
-    "zod-to-json-schema"
+    "zod-to-json-schema",
+    "@sentry/cli"
   ],
   "ignore": ["node_modules/**", "**/dist/**", "**/lib/**", "**/generated/**", "**/docker/**", "**/__test__/**"]
 }

--- a/packages/cli/cli/build-utils.mjs
+++ b/packages/cli/cli/build-utils.mjs
@@ -66,6 +66,7 @@ export async function buildCli(config) {
         packageJsonOverrides = {},
         tsupOverrides = {}
     } = config;
+    const version = process.argv[2] || packageJson.version;
 
     // Build with tsup
     await tsup.build({
@@ -77,7 +78,7 @@ export async function buildCli(config) {
         clean: true,
         env: {
             ...env,
-            CLI_VERSION: process.argv[2] || packageJson.version
+            CLI_VERSION: version
         },
         ...tsupOverrides
     });
@@ -104,7 +105,7 @@ export async function buildCli(config) {
 
     // Write package.json
     const outputPackageJson = {
-        version: process.argv[2] || packageJson.version,
+        version,
         repository: packageJson.repository,
         files: ["cli.cjs"],
         dependencies,

--- a/packages/cli/cli/build.dev.mjs
+++ b/packages/cli/cli/build.dev.mjs
@@ -13,6 +13,8 @@ buildCli({
         VENUS_AUDIENCE: "venus-dev",
         LOCAL_STORAGE_FOLDER: ".fern-dev",
         POSTHOG_API_KEY: null,
+        SENTRY_DSN: process.env.SENTRY_DSN ?? "",
+        SENTRY_ENVIRONMENT: "development",
         DOCS_DOMAIN_SUFFIX: "docs.dev.buildwithfern.com",
         DOCS_PREVIEW_BUCKET: "https://dev2-local-preview-bundle2.s3.amazonaws.com/",
         APP_DOCS_TAR_PREVIEW_BUCKET: "https://dev2-local-preview-bundle4.s3.amazonaws.com/",

--- a/packages/cli/cli/build.local.mjs
+++ b/packages/cli/cli/build.local.mjs
@@ -14,6 +14,8 @@ buildCli({
         VENUS_AUDIENCE: "venus-dev",
         LOCAL_STORAGE_FOLDER: ".fern-local",
         POSTHOG_API_KEY: null,
+        SENTRY_DSN: null,
+        SENTRY_ENVIRONMENT: "local",
         DOCS_DOMAIN_SUFFIX: "docs.buildwithfern.com",
         DOCS_PREVIEW_BUCKET: "http://localhost:9090/fdr/",
         APP_DOCS_TAR_PREVIEW_BUCKET: "http://localhost:9090/fdr/",

--- a/packages/cli/cli/build.prod-unminified.mjs
+++ b/packages/cli/cli/build.prod-unminified.mjs
@@ -12,6 +12,8 @@ buildCli({
         VENUS_AUDIENCE: "venus-prod",
         LOCAL_STORAGE_FOLDER: ".fern",
         POSTHOG_API_KEY: process.env.POSTHOG_API_KEY ?? "",
+        SENTRY_DSN: process.env.SENTRY_DSN ?? "",
+        SENTRY_ENVIRONMENT: "production",
         DOCS_DOMAIN_SUFFIX: "docs.buildwithfern.com",
         DOCS_PREVIEW_BUCKET: "https://prod-local-preview-bundle2.s3.amazonaws.com/",
         APP_DOCS_TAR_PREVIEW_BUCKET: "https://prod-local-preview-bundle4.s3.amazonaws.com/",

--- a/packages/cli/cli/build.prod.mjs
+++ b/packages/cli/cli/build.prod.mjs
@@ -13,6 +13,8 @@ buildCli({
         VENUS_AUDIENCE: "venus-prod",
         LOCAL_STORAGE_FOLDER: ".fern",
         POSTHOG_API_KEY: process.env.POSTHOG_API_KEY ?? "",
+        SENTRY_DSN: process.env.SENTRY_DSN ?? "",
+        SENTRY_ENVIRONMENT: "production",
         DOCS_DOMAIN_SUFFIX: "docs.buildwithfern.com",
         DOCS_PREVIEW_BUCKET: "https://prod-local-preview-bundle2.s3.amazonaws.com/",
         APP_DOCS_TAR_PREVIEW_BUCKET: "https://prod-local-preview-bundle4.s3.amazonaws.com/",

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -104,6 +104,7 @@
     "@fern-fern/fiddle-sdk": "catalog:",
     "@fern-fern/generators-sdk": "catalog:",
     "@inquirer/prompts": "catalog:",
+    "@sentry/node": "^10.45.0",
     "@types/axios": "catalog:",
     "@types/boxen": "catalog:",
     "@types/cli-progress": "catalog:",
@@ -117,7 +118,6 @@
     "@types/semver": "catalog:",
     "@types/tar": "catalog:",
     "@types/url-join": "4.0.1",
-
     "@types/ws": "catalog:",
     "@types/yargs": "^17.0.28",
     "axios": "catalog:",
@@ -143,7 +143,6 @@
     "typescript": "catalog:",
     "undici": "catalog:",
     "url-join": "catalog:",
-
     "vitest": "catalog:",
     "ws": "catalog:",
     "yaml": "catalog:",

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -104,6 +104,7 @@
     "@fern-fern/fiddle-sdk": "catalog:",
     "@fern-fern/generators-sdk": "catalog:",
     "@inquirer/prompts": "catalog:",
+    "@sentry/cli": "^2.42.2",
     "@sentry/node": "^10.45.0",
     "@types/axios": "catalog:",
     "@types/boxen": "catalog:",

--- a/packages/cli/cli/src/cli-context/CliContext.ts
+++ b/packages/cli/cli/src/cli-context/CliContext.ts
@@ -8,6 +8,7 @@ import { Workspace } from "@fern-api/workspace-loader";
 import { input, select } from "@inquirer/prompts";
 import chalk from "chalk";
 import { maxBy } from "lodash-es";
+import { SentryClient } from "../telemetry/SentryClient.js";
 import { CliEnvironment } from "./CliEnvironment.js";
 import { StdoutRedirector } from "./StdoutRedirector.js";
 import { TaskContextImpl } from "./TaskContextImpl.js";
@@ -29,6 +30,7 @@ export interface FernUpgradeInfo {
 
 export class CliContext {
     public readonly environment: CliEnvironment;
+    private readonly sentryClient: SentryClient;
 
     private didSucceed = true;
 
@@ -55,6 +57,7 @@ export class CliContext {
             packageVersion,
             cliName
         };
+        this.sentryClient = new SentryClient({ release: `cli@${this.environment.packageVersion}` });
     }
 
     private getPackageName() {
@@ -137,6 +140,7 @@ export class CliContext {
         this.ttyAwareLogger.finish();
         const posthogManager = await getPosthogManager();
         await posthogManager.flush();
+        await this.sentryClient.flush();
         this.exitProgram({ code });
     }
 
@@ -236,6 +240,10 @@ export class CliContext {
         if (!this.isLocal) {
             (await getPosthogManager()).sendEvent(event);
         }
+    }
+
+    public async captureException(error: unknown): Promise<void> {
+        await this.sentryClient.captureException(error);
     }
 
     public readonly logger = createLogger((level, ...args) => this.log(level, ...args));

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -145,6 +145,10 @@ async function runCli() {
         } else if (error instanceof LoggableFernCliError) {
             cliContext.logger.error(`Failed. ${error.log}`);
         } else {
+            // TODO: This is intentionally broad for initial rollout.
+            // We likely capture more than intended; narrow reporting with
+            // explicit error classification once we collect real-world signal.
+            await cliContext.captureException(error);
             cliContext.failWithoutThrowing("Failed.", error);
         }
     }

--- a/packages/cli/cli/src/telemetry/SentryClient.ts
+++ b/packages/cli/cli/src/telemetry/SentryClient.ts
@@ -1,0 +1,41 @@
+import * as Sentry from "@sentry/node";
+
+export class SentryClient {
+    private readonly sentry: Sentry.NodeClient | undefined;
+
+    constructor({ release }: { release: string }) {
+        const isTelemetryEnabled = process.env.FERN_DISABLE_TELEMETRY !== "true";
+        const sentryDsn = process.env.SENTRY_DSN;
+        if (isTelemetryEnabled && sentryDsn != null && sentryDsn.length > 0) {
+            const sentryEnvironment = process.env.SENTRY_ENVIRONMENT;
+            if (sentryEnvironment == null || sentryEnvironment.length === 0) {
+                throw new Error("SENTRY_ENVIRONMENT must be set when SENTRY_DSN is configured");
+            }
+            this.sentry = Sentry.init({
+                dsn: sentryDsn,
+                release,
+                environment: sentryEnvironment,
+                defaultIntegrations: false,
+                tracesSampleRate: 0
+            });
+        }
+    }
+
+    public async captureException(error: unknown): Promise<void> {
+        if (this.sentry == null) {
+            return;
+        }
+        try {
+            this.sentry.captureException(error);
+        } catch {
+            // no-op
+        }
+    }
+
+    public async flush(): Promise<void> {
+        if (this.sentry == null) {
+            return;
+        }
+        await Promise.resolve(this.sentry.flush(2000)).catch(() => undefined);
+    }
+}

--- a/packages/cli/cli/src/telemetry/SentryClient.ts
+++ b/packages/cli/cli/src/telemetry/SentryClient.ts
@@ -16,6 +16,7 @@ export class SentryClient {
                 release,
                 environment: sentryEnvironment,
                 defaultIntegrations: false,
+                integrations: [Sentry.rewriteFramesIntegration()],
                 tracesSampleRate: 0
             });
         }

--- a/packages/cli/cli/src/telemetry/__test__/SentryClient.test.ts
+++ b/packages/cli/cli/src/telemetry/__test__/SentryClient.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSentryCaptureException, mockSentryFlush, mockSentryInit } = vi.hoisted(() => ({
+    mockSentryCaptureException: vi.fn(),
+    mockSentryFlush: vi.fn().mockResolvedValue(true),
+    mockSentryInit: vi.fn(function () {
+        return {
+            captureException: mockSentryCaptureException,
+            flush: mockSentryFlush
+        };
+    })
+}));
+
+vi.mock("@sentry/node", () => ({
+    init: mockSentryInit
+}));
+
+import { SentryClient } from "../SentryClient.js";
+
+describe("SentryClient (cli-v1)", () => {
+    beforeEach(() => {
+        process.env.SENTRY_DSN = "https://example@sentry.io/123";
+        process.env.SENTRY_ENVIRONMENT = "test";
+        delete process.env.FERN_DISABLE_TELEMETRY;
+        mockSentryCaptureException.mockClear();
+        mockSentryFlush.mockClear();
+        mockSentryInit.mockClear();
+    });
+
+    afterEach(() => {
+        delete process.env.SENTRY_DSN;
+        delete process.env.SENTRY_ENVIRONMENT;
+        delete process.env.FERN_DISABLE_TELEMETRY;
+    });
+
+    it("does not initialize Sentry when telemetry is disabled", () => {
+        process.env.FERN_DISABLE_TELEMETRY = "true";
+
+        // eslint-disable-next-line no-new
+        new SentryClient({ release: "cli@1.2.3" });
+
+        expect(mockSentryInit).not.toHaveBeenCalled();
+    });
+
+    it("captures exceptions with Sentry when enabled", async () => {
+        const client = new SentryClient({ release: "cli@1.2.3" });
+
+        await client.captureException(new Error("boom"));
+
+        expect(mockSentryInit).toHaveBeenCalledOnce();
+        expect(mockSentryCaptureException).toHaveBeenCalledOnce();
+    });
+
+    it("flushes the Sentry client", async () => {
+        const client = new SentryClient({ release: "cli@1.2.3" });
+
+        await client.flush();
+
+        expect(mockSentryFlush).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/cli/cli/src/telemetry/__test__/SentryClient.test.ts
+++ b/packages/cli/cli/src/telemetry/__test__/SentryClient.test.ts
@@ -12,7 +12,8 @@ const { mockSentryCaptureException, mockSentryFlush, mockSentryInit } = vi.hoist
 }));
 
 vi.mock("@sentry/node", () => ({
-    init: mockSentryInit
+    init: mockSentryInit,
+    rewriteFramesIntegration: vi.fn().mockReturnValue({})
 }));
 
 import { SentryClient } from "../SentryClient.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4810,6 +4810,9 @@ importers:
       '@inquirer/prompts':
         specifier: 'catalog:'
         version: 7.10.1(@types/node@18.15.3)
+      '@sentry/cli':
+        specifier: ^2.42.2
+        version: 2.58.5
       '@sentry/node':
         specifier: ^10.45.0
         version: 10.45.0
@@ -10738,6 +10741,58 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@sentry/cli-darwin@2.58.5':
+    resolution: {integrity: sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.5':
+    resolution: {integrity: sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.5':
+    resolution: {integrity: sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.5':
+    resolution: {integrity: sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.5':
+    resolution: {integrity: sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.5':
+    resolution: {integrity: sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.5':
+    resolution: {integrity: sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.5':
+    resolution: {integrity: sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.5':
+    resolution: {integrity: sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
   '@sentry/core@10.45.0':
     resolution: {integrity: sha512-s69UXxvefeQxuZ5nY7/THtTrIEvJxNVCp3ns4kwoCw1qMpgpvn/296WCKVmM7MiwnaAdzEKnAvLAwaxZc2nM7Q==}
     engines: {node: '>=18'}
@@ -11209,6 +11264,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -12659,6 +12718,10 @@ packages:
 
   http2-client@1.3.5:
     resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -17693,6 +17756,50 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sentry/cli-darwin@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.5':
+    optional: true
+
+  '@sentry/cli@2.58.5':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.5
+      '@sentry/cli-linux-arm': 2.58.5
+      '@sentry/cli-linux-arm64': 2.58.5
+      '@sentry/cli-linux-i686': 2.58.5
+      '@sentry/cli-linux-x64': 2.58.5
+      '@sentry/cli-win32-arm64': 2.58.5
+      '@sentry/cli-win32-i686': 2.58.5
+      '@sentry/cli-win32-x64': 2.58.5
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@sentry/core@10.45.0': {}
 
   '@sentry/node-core@10.45.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)':
@@ -18268,6 +18375,12 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -19934,6 +20047,13 @@ snapshots:
       - supports-color
 
   http2-client@1.3.5: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4810,6 +4810,9 @@ importers:
       '@inquirer/prompts':
         specifier: 'catalog:'
         version: 7.10.1(@types/node@18.15.3)
+      '@sentry/node':
+        specifier: ^10.45.0
+        version: 10.45.0
       '@types/axios':
         specifier: 'catalog:'
         version: 0.14.4

--- a/seed/fern-cli/seed.yml
+++ b/seed/fern-cli/seed.yml
@@ -6,6 +6,7 @@ publishGa:
     - pnpm install
     - pnpm turbo run dist:cli:prod --filter @fern-api/cli -- $VERSION
     - pnpm --filter @fern-api/cli publish:cli:prod --tag latest
+    - pnpm exec sentry-cli sourcemaps upload --org buildwithfern --project cli --release cli@$VERSION --url-prefix app:/// dist/prod/
 publishRc:
   workingDirectory: packages/cli/cli
   versionSubstitution: $VERSION
@@ -13,6 +14,7 @@ publishRc:
     - pnpm install
     - pnpm turbo run dist:cli:prod --filter @fern-api/cli -- $VERSION
     - pnpm --filter @fern-api/cli publish:cli:prod --tag prerelease
+    - pnpm exec sentry-cli sourcemaps upload --org buildwithfern --project cli --release cli@$VERSION --url-prefix app:/// dist/prod/
 publishDev:
   workingDirectory: packages/cli/cli
   versionSubstitution: $VERSION
@@ -20,3 +22,4 @@ publishDev:
     - pnpm install
     - pnpm turbo run dist:cli:dev --filter @fern-api/cli -- $VERSION
     - pnpm --filter @fern-api/cli publish:cli:dev --access public --tag latest
+    - pnpm exec sentry-cli sourcemaps upload --org buildwithfern --project cli --release cli@$VERSION --url-prefix app:/// dist/dev/


### PR DESCRIPTION
## Summary
- add Sentry runtime reporting to CLI v1 via a dedicated `SentryClient`, while keeping PostHog handling separate in `CliContext`
- capture top-level unexpected CLI v1 errors in `cli.ts` and flush Sentry during CLI shutdown
- wire CLI v1 build-time source map upload with `@sentry/esbuild-plugin` using release name `cli@<version>` when `FERN_SENTRY_AUTH_TOKEN` is present

## Test plan
- [x] `pnpm --filter @fern-api/cli exec vitest --run src/telemetry/__test__/SentryClient.test.ts`
- [x] `pnpm --filter @fern-api/cli dist:cli:dev`
- [ ] verify source map upload in CI with `FERN_SENTRY_AUTH_TOKEN` configured
- [ ] verify events appear in Sentry project `cli` after releasing from this branch stack

Made with [Cursor](https://cursor.com)