### PR TITLE
feat(csharp): add versions.yml entries for #13811 (tests, bug fixes, net9.0 TFM)

### DIFF
--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.6.0
+  changelogEntry:
+    - summary: |
+        Add `net9.0` target framework to all generated C# model projects. The library
+        now targets `net462;net8.0;net9.0;netstandard2.0`. Test projects now target
+        `net9.0` instead of `net8.0`.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 0.5.1
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 2.53.0
+- version: 2.50.1
   changelogEntry:
     - summary: |
         Add `net9.0` target framework to all generated C# SDK projects. The library
@@ -7,11 +7,6 @@
         code paths such as `ClientWebSocketOptions.KeepAliveTimeout` for transport-level
         dead connection detection. Test projects now target `net9.0` instead of `net8.0`.
       type: feat
-  createdAt: "2026-03-20"
-  irVersion: 65
-
-- version: 2.52.0
-  changelogEntry:
     - summary: |
         Add comprehensive WebSocket unit and end-to-end test templates. All generated
         WebSocket SDKs now ship with 349 tests covering `AsyncLock`, `Event<T>`,
@@ -23,22 +18,12 @@
         Templates are conditionally emitted when the Fern definition includes WebSocket
         endpoints.
       type: feat
-  createdAt: "2026-03-20"
-  irVersion: 65
-
-- version: 2.51.0
-  changelogEntry:
     - summary: |
         Expose `StateCheckInterval` property on `WebSocketClient`. The property
         (default: 5 seconds) forwards to `WebSocketConnection` in `ConnectAsync`,
         allowing callers to control how often the background state monitor polls
         for silent disconnections.
       type: feat
-  createdAt: "2026-03-20"
-  irVersion: 65
-
-- version: 2.50.1
-  changelogEntry:
     - summary: |
         Fix server-initiated close skipping reconnection. When the server sent a
         `WebSocketMessageType.Close` frame, the `Listen()` method used `return`

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 2.51.0
+- version: 2.53.0
   changelogEntry:
     - summary: |
         Add `net9.0` target framework to all generated C# SDK projects. The library
@@ -7,6 +7,52 @@
         code paths such as `ClientWebSocketOptions.KeepAliveTimeout` for transport-level
         dead connection detection. Test projects now target `net9.0` instead of `net8.0`.
       type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
+- version: 2.52.0
+  changelogEntry:
+    - summary: |
+        Add comprehensive WebSocket unit and end-to-end test templates. All generated
+        WebSocket SDKs now ship with 349 tests covering `AsyncLock`, `Event<T>`,
+        `ReconnectStrategy`, `DisconnectionInfo`, `RequestMessage`, `Query`,
+        `WebSocketConnection`, `WebSocketClient`, `ReconnectionInfo`, and
+        `WebsocketException`. End-to-end tests run against an in-process
+        `TestWebSocketServer` and cover echo, rapid-fire, reconnection, server close,
+        abort recovery, concurrent clients, large messages, and full lifecycle.
+        Templates are conditionally emitted when the Fern definition includes WebSocket
+        endpoints.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
+- version: 2.51.0
+  changelogEntry:
+    - summary: |
+        Expose `StateCheckInterval` property on `WebSocketClient`. The property
+        (default: 5 seconds) forwards to `WebSocketConnection` in `ConnectAsync`,
+        allowing callers to control how often the background state monitor polls
+        for silent disconnections.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
+- version: 2.50.1
+  changelogEntry:
+    - summary: |
+        Fix server-initiated close skipping reconnection. When the server sent a
+        `WebSocketMessageType.Close` frame, the `Listen()` method used `return`
+        which exited entirely — bypassing the `ReconnectSynchronized` call. Changed
+        to `break` with a `closedByServer` flag so reconnection executes with
+        `ReconnectionType.ByServer`.
+      type: fix
+    - summary: |
+        Fix `CancelReconnection` flag being ignored for server-initiated close.
+        The `OnDisconnectionHappened` callback fires in the Close handler and the
+        user can set `info.CancelReconnection = true`, but this flag was never
+        checked before calling `ReconnectSynchronized`. Now captured into a local
+        `cancelReconnect` variable and checked before reconnecting.
+      type: fix
   createdAt: "2026-03-20"
   irVersion: 65
 

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.51.0
+  changelogEntry:
+    - summary: |
+        Add `net9.0` target framework to all generated C# SDK projects. The library
+        now targets `net462;net8.0;net9.0;netstandard2.0`, enabling `#if NET9_0_OR_GREATER`
+        code paths such as `ClientWebSocketOptions.KeepAliveTimeout` for transport-level
+        dead connection detection. Test projects now target `net9.0` instead of `net8.0`.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.50.0
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 2.50.1
+- version: 2.51.0
   changelogEntry:
     - summary: |
         Add `net9.0` target framework to all generated C# SDK projects. The library


### PR DESCRIPTION
## Description

Adds the missing `versions.yml` changelog entries for all changes that shipped in #13811: WebSocket tests, bug fixes, `StateCheckInterval` exposure, and the `net9.0` TFM addition.

## Changes Made

- **SDK generator** (`generators/csharp/sdk/versions.yml`): Added single `2.50.1` entry with 5 changelog items:
  - **feat**: `net9.0` TFM addition, activates `#if NET9_0_OR_GREATER` code paths (e.g. `KeepAliveTimeout`)
  - **feat**: 349 WebSocket unit + e2e test templates shipped with all generated WebSocket SDKs
  - **feat**: `StateCheckInterval` property exposed on `WebSocketClient`
  - **fix**: Server-initiated close skipping reconnection (`return` → `break` + `closedByServer` flag)
  - **fix**: `CancelReconnection` flag ignored for server-initiated close
- **Model generator** (`generators/csharp/model/versions.yml`): Added `0.6.0` entry for `net9.0` TFM addition

## Testing

- [ ] Lint passes (`pnpm run check`)
- [ ] Version numbers and `irVersion`/`createdAt` match surrounding entries

## ⚠️ Reviewer Checklist

- [ ] **Version `2.50.1` is a patch bump but includes `feat` items** — verify this is intentional (these are additive changes bundled with the `2.50.0` release in #13811, not standalone minor releases)
- [ ] Changelog text accurately reflects what was shipped in #13811
- [ ] `irVersion: 65` and `createdAt: "2026-03-20"` match surrounding entries
- [ ] No entries were accidentally skipped for changes in #13811

Link to Devin session: https://app.devin.ai/sessions/f9ba9acd4e6f48c39e7706e8c92e36b6
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
