### PR TITLE
fix(seed): skip seed for versions.yml changes; add CI retry logic

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -49,9 +49,19 @@ runs:
           FORMATTED_FIXTURES_COMMAND="--fixture ${{ inputs.fixtures-to-run }}"
         fi
 
-        pnpm seed:local test \
+        SEED_CMD="pnpm seed:local test \
           --generator ${{ inputs.generator-name }} \
           --parallel 16 \
           ${FORMATTED_FIXTURES_COMMAND} \
           ${{ inputs.skip-scripts == 'true' && '--skip-scripts' || '' }} \
-          ${{ inputs.allow-unexpected-failures == 'true' && '--allow-unexpected-failures' || '' }} | tee output.log
+          ${{ inputs.allow-unexpected-failures == 'true' && '--allow-unexpected-failures' || '' }}"
+
+        for attempt in 1 2 3; do
+          if eval "$SEED_CMD" | tee output.log; then
+            break
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "Seed test failed (attempt $attempt/3), retrying in 10s..."
+            sleep 10
+          fi
+        done

--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -60,8 +60,10 @@ runs:
           if eval "$SEED_CMD" | tee output.log; then
             break
           fi
-          if [ "$attempt" -lt 3 ]; then
-            echo "Seed test failed (attempt $attempt/3), retrying in 10s..."
-            sleep 10
+          if [ "$attempt" -eq 3 ]; then
+            echo "Seed test failed after 3 attempts"
+            exit 1
           fi
+          echo "Seed test failed (attempt $attempt/3), retrying in 10s..."
+          sleep 10
         done

--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -31,4 +31,9 @@ runs:
 
     - name: 📥 Install dependencies
       shell: bash
-      run: pnpm install
+      run: |
+        for attempt in 1 2 3; do
+          pnpm install && break
+          echo "pnpm install failed (attempt $attempt/3), retrying in 10s..."
+          sleep 10
+        done

--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -34,6 +34,10 @@ runs:
       run: |
         for attempt in 1 2 3; do
           pnpm install && break
+          if [ "$attempt" -eq 3 ]; then
+            echo "pnpm install failed after 3 attempts"
+            exit 1
+          fi
           echo "pnpm install failed (attempt $attempt/3), retrying in 10s..."
           sleep 10
         done

--- a/packages/seed/src/__test__/affected.test.ts
+++ b/packages/seed/src/__test__/affected.test.ts
@@ -77,6 +77,30 @@ describe("detectAffected", () => {
             expect(result.affectedFixtures).toEqual([]);
         });
 
+        it("skips all seed tests when only versions.yml files change", () => {
+            const result = detectAffected(
+                ["generators/csharp/sdk/versions.yml", "generators/csharp/model/versions.yml"],
+                ALL_GENERATORS
+            );
+
+            expect(result.allGeneratorsAffected).toBe(false);
+            expect(result.allFixturesAffected).toBe(false);
+            expect(result.affectedGenerators).toEqual([]);
+            expect(result.generatorsWithAllFixtures).toEqual([]);
+            expect(result.affectedFixtures).toEqual([]);
+        });
+
+        it("skips seed for versions.yml but still detects other generator changes", () => {
+            const result = detectAffected(
+                ["generators/csharp/sdk/versions.yml", "generators/python/src/generator.ts"],
+                ALL_GENERATORS
+            );
+
+            expect(result.affectedGenerators).toContain("python-sdk");
+            expect(result.affectedGenerators).not.toContain("csharp-sdk");
+            expect(result.affectedGenerators).not.toContain("csharp-model");
+        });
+
         it("skips all seed tests when only CLI code changes", () => {
             const result = detectAffected(
                 ["packages/cli/cli/src/commands/check.ts", "packages/cli/cli/src/cli.ts"],
@@ -690,5 +714,24 @@ describe("end-to-end scenario tests", () => {
         expect(names).toContain("fastapi");
         expect(names).not.toContain("ts-sdk");
         expect(names).not.toContain("java-sdk");
+    });
+
+    it("scenario: versions.yml changes are fully ignored for seed detection", () => {
+        const changedFiles = [
+            "generators/csharp/sdk/versions.yml",
+            "generators/csharp/model/versions.yml",
+            "generators/python/sdk/versions.yml"
+        ];
+        const affected = detectAffected(changedFiles, ALL_GENERATORS);
+
+        // No generators should run
+        const generators = resolveAffectedGenerators(affected, ALL_GENERATORS);
+        expect(generators).toHaveLength(0);
+
+        // No fixtures should be resolved
+        for (const gen of ALL_GENERATORS) {
+            const fixtures = resolveAffectedFixtures(affected, ALL_FIXTURES, gen.workspaceName);
+            expect(fixtures).toEqual([]);
+        }
     });
 });

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -27,6 +27,13 @@ export interface AffectedResult {
 }
 
 /**
+ * Files that should never trigger seed tests, even if they live under
+ * a generator source path.  These are metadata / changelog files that
+ * do not affect generated code.
+ */
+const IGNORED_FILENAMES = ["versions.yml"];
+
+/**
  * Paths that, when changed, affect ALL generators and ALL fixtures.
  * These are infrastructure-level changes that feed into IR generation
  * or affect how seed tests execute. Includes:
@@ -194,6 +201,11 @@ export function detectAffected(changedFiles: string[], allGenerators: GeneratorW
 
     // === GENERATOR DETECTION (git diff path matching) ===
     for (const file of changedFiles) {
+        // Skip metadata files that live under generator paths but don't affect codegen
+        const basename = file.split("/").pop() ?? "";
+        if (IGNORED_FILENAMES.includes(basename)) {
+            continue;
+        }
         for (const [generatorName, sourcePaths] of Object.entries(GENERATOR_SOURCE_PATHS)) {
             if (!allGeneratorNames.includes(generatorName)) {
                 continue;


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/pull/13839

Two improvements to seed CI reliability:

1. **Skip seed for `versions.yml` changes**: Changes to `versions.yml` files (changelog metadata) under generator source paths were incorrectly triggering seed test runs. For example, a PR that only modifies `generators/csharp/sdk/versions.yml` would cause all csharp-sdk and csharp-model seed tests to run because `generators/csharp/` is in `GENERATOR_SOURCE_PATHS`.

2. **Retry transient CI failures**: Added retry loops (up to 3 attempts, 10s delay) for `pnpm install` and the seed test command to handle transient npm registry errors and Docker Hub connectivity issues.

## Changes Made

- Added an `IGNORED_FILENAMES` constant (`["versions.yml"]`) in the affected detection logic
- In the generator detection loop, files matching an ignored filename are skipped before checking against `GENERATOR_SOURCE_PATHS`
- Added 3 new test cases covering: versions.yml-only changes, mixed versions.yml + real source changes, and an end-to-end scenario
- Added retry loop (3 attempts) around `pnpm install` in `.github/actions/install/action.yaml`
- Added retry loop (3 attempts) around seed test command in `.github/actions/cached-seed/action.yaml`

## Testing

- [x] Unit tests added (3 new cases in `affected.test.ts`)
- [x] All 53 affected detection tests pass
- [x] `pnpm run check` (biome lint) passes

## Reviewer Checklist

- [ ] The `versions.yml` ignore is **only** applied in the generator detection section — not in global infrastructure, test definition, or seed.yml detection. Verify this scoping is correct (it should be, since `versions.yml` files only live under `generators/`)
- [ ] The filename match is exact (`versions.yml`) — confirm no other files could be unintentionally caught
- [ ] **Retry exit codes**: Verify that if all 3 retry attempts fail, the CI step still exits with a non-zero code. The `pnpm install` loop uses `&& break` and the seed test loop uses `if/break` — confirm that with GitHub Actions' default `bash -e -o pipefail`, a final failed attempt correctly propagates the failure rather than silently succeeding

Link to Devin session: https://app.devin.ai/sessions/cd828cad9fdd4eca9d2c89b804e000d3
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
