### PR TITLE
chore(ci): auto-clean orphaned seed folders on main instead of failing

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Check for orphaned seed folders (PRs only)
         if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
         shell: bash
         env:
           FORCE_COLOR: "2"

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -75,10 +75,10 @@ jobs:
           FORCE_COLOR: "2"
         run: |
           pnpm seed:local clean
-          if [ -n "$(git status --porcelain)" ]; then
+          if [ -n "$(git status --porcelain seed/)" ]; then
             git config --global user.name 'github-actions[bot]'
             git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-            git add -A
+            git add seed/
             git commit -m "chore(seed): auto-clean orphaned seed folders"
             git push
           else

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -60,12 +60,30 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
-      - name: Check for orphaned seed folders
+      - name: Check for orphaned seed folders (PRs only)
+        if: ${{ github.event_name == 'pull_request' }}
         shell: bash
         env:
           FORCE_COLOR: "2"
         run: |
           pnpm seed:local clean --dry-run
+
+      - name: Auto-clean orphaned seed folders (main only)
+        if: ${{ github.event_name != 'pull_request' }}
+        shell: bash
+        env:
+          FORCE_COLOR: "2"
+        run: |
+          pnpm seed:local clean
+          if [ -n "$(git status --porcelain)" ]; then
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git add -A
+            git commit -m "chore(seed): auto-clean orphaned seed folders"
+            git push
+          else
+            echo "No orphaned seed folders found."
+          fi
 
   get-all-test-matrices:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Instead of failing CI when orphaned seed folders are detected, automatically clean them up on `main` (commit + push the deletions) and allow the check to warn without blocking on PRs.

## Changes Made

- Split the `check-orphaned-seed-folders` step into two conditional steps:
  - **PRs** (`pull_request` events): Run `pnpm seed:local clean --dry-run` with `continue-on-error: true` — logs orphaned folders as a warning but does **not** block the workflow
  - **Main / workflow_dispatch** (non-PR events): Run `pnpm seed:local clean` to delete orphaned folders, then auto-commit and push via `github-actions[bot]` if any were removed
- Scoped `git add` and `git status --porcelain` to `seed/` only to prevent unrelated build artifacts from leaking into the auto-commit

## Updates Since Last Revision

- Added `continue-on-error: true` to the PR dry-run step per reviewer feedback (orphaned folders should warn, not fail)
- Changed `git add -A` → `git add seed/` and `git status --porcelain` → `git status --porcelain seed/` to scope changes strictly to the seed directory

## Review Checklist

- [ ] Verify `actions/checkout@v5` provides a token with push permissions on main (other jobs in `ci.yml` use the same `github-actions[bot]` commit-and-push pattern successfully)
- [ ] `continue-on-error: true` on PRs means orphaned folder warnings could be missed by PR authors — is a warning sufficient, or should there be a PR comment?
- [ ] Concurrent pushes to main could race with the auto-commit — the workflow's `concurrency` group should prevent this, but worth confirming

## Testing

- [ ] CI workflow syntax is valid (GitHub Actions will validate on the PR)
- [ ] Actual auto-clean behavior will be verified once merged and a push to `main` triggers the workflow with orphaned folders present

Link to Devin session: https://app.devin.ai/sessions/9b9560e22b3347aba111d437a5181f96
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
